### PR TITLE
[cli][container] Fix `vercel dev` for top-level container builds

### DIFF
--- a/.changeset/container-dev-detect-src.md
+++ b/.changeset/container-dev-detect-src.md
@@ -1,0 +1,13 @@
+---
+'@vercel/container': patch
+'vercel': patch
+---
+
+Fixed `vercel dev` for the `container` framework when used as a top-level build (outside of `services`).
+
+- The dev server now maps the container preset's `<detect>` sentinel to a discovered Dockerfile (`Dockerfile.vercel`, `Containerfile.vercel`, `Dockerfile`, or `Containerfile`), so the build is recognized instead of warning that it "did not match any source files".
+- The `@vercel/container` `build()` path no longer throws `` `vercel dev` cannot build container images from a Dockerfile `` during dev. Containers are always built from a Dockerfile/Containerfile (there is no prebuilt-image input); in dev the image is built and run locally by `startDevServer`, so `build()` returns a stable local tag without pushing to a registry.
+- The dev server no longer treats a container build output (an OCI image reference, `runtime: "container"`) as a zip-based function. It previously failed with `output.createZip is not a function` while trying to spin the image up under `fun`; container outputs are now skipped there and served by the builder's `startDevServer` instead.
+- The dev path (`startDevServer`) now discovers the `Dockerfile.vercel` / `Containerfile.vercel` opt-in markers when the container entrypoint is the `<detect>` sentinel, matching the build path. Previously it only looked for a bare `Dockerfile`, so a project using a `.vercel` marker failed with "Container service must specify an entrypoint…" even though deploys worked. The discovery helper is now shared between the build and dev paths.
+- `vercel dev` now fails fast with a clear message when the Docker daemon isn't running ("Could not connect to the Docker daemon. Start Docker…") instead of a cryptic `Container "undefined" exited (code 125) before becoming ready.`. Container start failures also now name the actual container and include the underlying Docker error output.
+- The container dev server is now reused across requests. Previously the image was rebuilt and a fresh container started on every HTTP request (the result was missing the `persistent` flag); now a live container is kept and reused for the same service, matching how other persistent builders behave.

--- a/packages/cli/src/util/dev/builder-worker.cjs
+++ b/packages/cli/src/util/dev/builder-worker.cjs
@@ -85,13 +85,20 @@ async function processMessage(message) {
     }
   }
 
+  // Container Lambdas carry an OCI image reference in `handler`, not a code
+  // bundle, so there is nothing to zip. They are built and run locally by the
+  // builder's `startDevServer`; calling `createZip()` on them would throw since
+  // the output is a plain image-reference object.
+  const isZippableLambda = output =>
+    output.type === 'Lambda' && output.runtime !== 'container';
+
   if (effectiveVersion === 3) {
-    if (result.output.type === 'Lambda') {
+    if (isZippableLambda(result.output)) {
       await processLambdaOutput(result.output);
     }
   } else {
     for (const output of Object.values(result.output)) {
-      if (output.type === 'Lambda') {
+      if (isZippableLambda(output)) {
         await processLambdaOutput(output);
       }
     }

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -467,7 +467,13 @@ export async function executeBuild(
   for (const asset of Object.values(result.output)) {
     if (
       asset.type === 'Lambda' &&
-      !(typeof asset.runtime === 'string' && asset.runtime.startsWith('python'))
+      !(
+        typeof asset.runtime === 'string' && asset.runtime.startsWith('python')
+      ) &&
+      // Container Lambdas carry an OCI image reference in `handler`, not a code
+      // bundle — there is no zip to size-check. They are built and run locally
+      // by the builder's `startDevServer`, not by `fun`.
+      asset.runtime !== 'container'
     ) {
       const size = asset.zipBuffer.length;
       if (size > maxLambdaBytes) {
@@ -482,7 +488,11 @@ export async function executeBuild(
       const path: string = entry[0];
       const asset: BuilderOutput = entry[1];
 
-      if (asset.type === 'Lambda') {
+      // Container Lambdas are an OCI image reference, not a zip-based function:
+      // they have no `zipBuffer`/`createZip` and cannot run under `fun`. The
+      // builder's `startDevServer` builds and runs the image locally instead,
+      // so skip the `fun` function creation here.
+      if (asset.type === 'Lambda' && asset.runtime !== 'container') {
         // Tear down the previous `fun` Lambda instance for this asset
         const oldAsset = match.buildOutput && match.buildOutput[path];
         if (oldAsset && oldAsset.type === 'Lambda' && oldAsset.fn) {
@@ -612,6 +622,29 @@ export async function getBuildMatches(
       const existing = goEntrypoints.filter(p => fileList.includes(p));
       if (existing.length > 0) {
         src = existing[0];
+        mapToEntrypoint.set(src, originalSrc);
+      }
+    }
+    // The container framework preset resolves its entrypoint via `<detect>`,
+    // which @vercel/container expands to a discovered Dockerfile at build time.
+    // Inside `services` the orchestrator owns this, but for a top-level
+    // container build the dev server needs to match a real Dockerfile so a
+    // BuildMatch is created — while still passing the original sentinel src
+    // through as the builder entrypoint.
+    if (
+      buildConfig.config?.framework === 'container' &&
+      !fileList.includes(src)
+    ) {
+      const originalSrc = src;
+      const dockerfileCandidates = [
+        'Dockerfile.vercel',
+        'Containerfile.vercel',
+        'Dockerfile',
+        'Containerfile',
+      ];
+      const existing = dockerfileCandidates.find(p => fileList.includes(p));
+      if (existing) {
+        src = existing;
         mapToEntrypoint.set(src, originalSrc);
       }
     }

--- a/packages/container/src/dev.ts
+++ b/packages/container/src/dev.ts
@@ -2,12 +2,20 @@ import type {
   Span,
   StartDevServerOptions,
   StartDevServerResult,
+  StartDevServerSuccess,
 } from '@vercel/build-utils';
 import { spawn } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { debug, isDockerfileRef, readString, withSpan } from './util';
+import {
+  debug,
+  devImageTag,
+  findDockerfile,
+  isDockerfileRef,
+  readString,
+  withSpan,
+} from './util';
 
 /**
  * Host/shell environment variables that are meaningful only on the developer's
@@ -161,15 +169,6 @@ function runForwarded(
   });
 }
 
-/**
- * Local dev image tag for a service. Stable per service so repeat `vercel dev`
- * runs reuse Docker's layer cache.
- */
-function devImageTag(serviceName: string): string {
-  const safe = serviceName.toLowerCase().replace(/[^a-z0-9-_.]/g, '-');
-  return `vercel-dev/${safe || 'service'}:dev`;
-}
-
 function normalizeCommand(command: unknown): string[] | undefined {
   if (typeof command === 'string') {
     return [command];
@@ -198,8 +197,16 @@ async function resolveDevImage(
   const { config, workPath, entrypoint } = options;
 
   const entrypointRef = readString(entrypoint);
+  // An entrypoint that names a Dockerfile (including the `Dockerfile.vercel` /
+  // `Containerfile.vercel` opt-in markers) is built directly. Otherwise — e.g.
+  // when the `container` framework preset resolves its entrypoint via
+  // `<detect>` — discover an opt-in marker in the work directory. This mirrors
+  // the build path (`resolveImageHandler`) so dev and deploy resolve the same
+  // Dockerfile.
   const dockerfileConfigured =
-    entrypointRef && isDockerfileRef(entrypointRef) ? entrypointRef : undefined;
+    entrypointRef && isDockerfileRef(entrypointRef)
+      ? entrypointRef
+      : findDockerfile(workPath);
   const dockerfileRel = dockerfileConfigured ?? 'Dockerfile';
   const dockerfilePath = path.join(workPath, dockerfileRel);
   const hasDockerfile =
@@ -326,7 +333,99 @@ function uniqueContainerName(serviceName: string): string {
 }
 
 /**
- * Start a container service locally for `vercel dev`.
+ * Verify the Docker daemon is installed and reachable before doing any build
+ * or run work, so the user gets one clear message instead of a cryptic exit
+ * code from whichever Docker command happened to run first. `docker info`
+ * connects to the daemon and exits non-zero (125) when it can't.
+ */
+async function assertDockerAvailable(out: DevOutput): Promise<void> {
+  try {
+    await runForwarded(
+      'docker',
+      ['info', '--format', '{{.ServerVersion}}'],
+      out,
+      {
+        quiet: true,
+      }
+    );
+  } catch (err) {
+    const message = (err as Error).message ?? '';
+    if (/command not found/i.test(message)) {
+      throw new Error(
+        'Docker is required for `vercel dev` with containers, but the ' +
+          '`docker` command was not found. Install Docker and ensure it is ' +
+          'on your PATH.'
+      );
+    }
+    throw new Error(
+      'Could not connect to the Docker daemon. Start Docker (e.g. open ' +
+        'Docker Desktop) and run `vercel dev` again.'
+    );
+  }
+}
+
+/**
+ * Build a helpful error for a `docker run` that exited before the container
+ * became ready. Exit code 125 means the Docker CLI itself failed (as opposed
+ * to the container process) — overwhelmingly because the daemon isn't running
+ * or isn't reachable — so call that out explicitly. Any captured stderr is
+ * appended so the underlying Docker message is visible.
+ */
+function containerExitMessage(exitCode: number, stderr: string): string {
+  const detail = stderr.trim().split('\n').slice(-5).join('\n');
+  const looksLikeDaemonDown =
+    exitCode === 125 || /cannot connect to the docker daemon/i.test(stderr);
+
+  if (looksLikeDaemonDown) {
+    return (
+      'Could not start the container: the Docker daemon is not running or ' +
+      'is unreachable. Start Docker (e.g. open Docker Desktop) and try ' +
+      '`vercel dev` again.' +
+      (detail ? `\n\nDocker reported:\n${detail}` : '')
+    );
+  }
+
+  return (
+    `The container exited (code ${exitCode}) before becoming ready.` +
+    (detail ? `\n\nDocker reported:\n${detail}` : '')
+  );
+}
+
+/**
+ * A container the dev server is keeping alive across requests. Containers are
+ * long-running servers, not per-request functions, so once one is up we reuse
+ * it instead of rebuilding the image and starting a fresh container on every
+ * request.
+ */
+interface RunningContainer {
+  result: StartDevServerSuccess;
+  containerName: string;
+  /** Whether the `docker run` child process is still alive. */
+  isRunning: () => boolean;
+  /** Stop the container and drop it from the cache. */
+  stop: () => Promise<void>;
+  stopPromise?: Promise<void>;
+}
+
+const runningContainers = new Map<string, RunningContainer>();
+
+/** Test-only: clear the reused-container cache between cases. */
+export function __resetRunningContainers(): void {
+  runningContainers.clear();
+}
+
+/**
+ * Stable identity for a dev container so repeat requests reuse the same running
+ * container. A service is unique by name; a root (non-service) deploy is unique
+ * by its work directory.
+ */
+function containerReuseKey(options: StartDevServerOptions): string {
+  return options.service?.name ?? `root:${options.workPath}`;
+}
+
+/**
+ * Start a container service locally for `vercel dev`, reusing an already-running
+ * container for the same service when one is live.
  *
  * Builds (or uses a prebuilt) image, runs it with Docker publishing the
  * container port to an ephemeral host port, injects the service env + a `PORT`
@@ -335,6 +434,26 @@ function uniqueContainerName(serviceName: string): string {
 export async function startDevServer(
   options: StartDevServerOptions
 ): Promise<StartDevServerResult> {
+  // Reuse a live container for this service instead of rebuilding/running on
+  // every request. The dev server calls `startDevServer` per request; a
+  // container is a persistent server, so we hand back the running one.
+  const reuseKey = containerReuseKey(options);
+  const existing = runningContainers.get(reuseKey);
+  if (existing && !existing.stopPromise && existing.isRunning()) {
+    return existing.result;
+  }
+  if (existing) {
+    // Stale (exited) entry — clear it before starting a replacement.
+    runningContainers.delete(reuseKey);
+  }
+
+  return startContainer(options, reuseKey);
+}
+
+async function startContainer(
+  options: StartDevServerOptions,
+  reuseKey: string
+): Promise<StartDevServerResult> {
   return withSpan(
     options.span,
     'container.dev.start',
@@ -342,6 +461,10 @@ export async function startDevServer(
     async span => {
       const { config, meta, onStdout, onStderr } = options;
       const out: DevOutput = { onStdout, onStderr };
+
+      // Fail fast with a clear message if Docker isn't running, rather than
+      // letting `docker build`/`docker run` fail later with a bare exit code.
+      await assertDockerAvailable(out);
 
       const image = await withSpan(span, 'container.dev.resolve_image', {}, s =>
         resolveDevImage(options, out, s)
@@ -406,14 +529,33 @@ export async function startDevServer(
       const child = spawn('docker', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
       });
+      // `docker run` failures (most importantly "Cannot connect to the Docker
+      // daemon", exit code 125) are reported on stderr. Retain the tail so the
+      // readiness check can surface it instead of a bare exit code.
+      let runStderr = '';
       child.stdout?.on('data', (data: Buffer) => onStdout?.(data));
-      child.stderr?.on('data', (data: Buffer) => onStderr?.(data));
+      child.stderr?.on('data', (data: Buffer) => {
+        runStderr += data.toString();
+        onStderr?.(data);
+      });
+      // Surface the classic "command not found" case (Docker not installed)
+      // with the same actionable message the build path uses.
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          runStderr +=
+            'Command not found: `docker`. Ensure Docker is installed and on ' +
+            'your PATH, and that the Docker daemon is running.';
+        }
+      });
 
       const cleanupEnvFile = () => {
         rmSync(path.dirname(envFilePath), { recursive: true, force: true });
       };
 
       const shutdown = async (): Promise<void> => {
+        // Drop the cache entry first so a concurrent request starts a fresh
+        // container rather than reusing one that's being torn down.
+        runningContainers.delete(reuseKey);
         try {
           // `docker stop` causes the foreground `docker run --rm` to exit and
           // removes the container.
@@ -438,9 +580,7 @@ export async function startDevServer(
       try {
         while (Date.now() < deadline) {
           if (child.exitCode !== null) {
-            throw new Error(
-              `Container "${options.service?.name}" exited (code ${child.exitCode}) before becoming ready.`
-            );
+            throw new Error(containerExitMessage(child.exitCode, runStderr));
           }
           try {
             hostPort = await readMappedHostPort(
@@ -457,7 +597,7 @@ export async function startDevServer(
 
         if (hostPort === undefined) {
           throw new Error(
-            `Timed out waiting for container "${options.service?.name}" to ` +
+            `Timed out waiting for container "${containerName}" to ` +
               `publish port ${containerPort}.` +
               (lastErr ? ` Last error: ${lastErr.message}` : '')
           );
@@ -474,11 +614,31 @@ export async function startDevServer(
       });
       emit(out, `▲ container  container ready on localhost:${hostPort}`);
 
-      return {
+      const result: StartDevServerSuccess = {
         port: hostPort,
         pid: child.pid ?? 0,
         shutdown,
+        // The container is a long-running server; the dev server should keep it
+        // alive across requests instead of tearing it down after each response.
+        persistent: true,
       };
+
+      const running: RunningContainer = {
+        result,
+        containerName,
+        isRunning: () => child.exitCode === null,
+        stop: shutdown,
+      };
+      // If the container exits on its own (crash, `docker stop`, etc.), evict it
+      // so the next request rebuilds rather than reusing a dead container.
+      child.on('close', () => {
+        if (runningContainers.get(reuseKey) === running) {
+          runningContainers.delete(reuseKey);
+        }
+      });
+      runningContainers.set(reuseKey, running);
+
+      return result;
     }
   );
 }

--- a/packages/container/src/dev.ts
+++ b/packages/container/src/dev.ts
@@ -402,16 +402,20 @@ interface RunningContainer {
   containerName: string;
   /** Whether the `docker run` child process is still alive. */
   isRunning: () => boolean;
-  /** Stop the container and drop it from the cache. */
-  stop: () => Promise<void>;
-  stopPromise?: Promise<void>;
 }
 
 const runningContainers = new Map<string, RunningContainer>();
 
-/** Test-only: clear the reused-container cache between cases. */
+// In-flight container starts, keyed the same way as `runningContainers`.
+// Concurrent cold requests for the same service share this promise so we only
+// ever `docker run` one container; without it each request would spawn its own
+// container and all but the last would be orphaned (never `docker stop`ped).
+const pendingContainers = new Map<string, Promise<StartDevServerResult>>();
+
+/** Test-only: clear the reused-container caches between cases. */
 export function __resetRunningContainers(): void {
   runningContainers.clear();
+  pendingContainers.clear();
 }
 
 /**
@@ -439,7 +443,7 @@ export async function startDevServer(
   // container is a persistent server, so we hand back the running one.
   const reuseKey = containerReuseKey(options);
   const existing = runningContainers.get(reuseKey);
-  if (existing && !existing.stopPromise && existing.isRunning()) {
+  if (existing && existing.isRunning()) {
     return existing.result;
   }
   if (existing) {
@@ -447,7 +451,18 @@ export async function startDevServer(
     runningContainers.delete(reuseKey);
   }
 
-  return startContainer(options, reuseKey);
+  // Coalesce concurrent cold starts: if a start for this service is already in
+  // flight, wait on it rather than spawning a second container.
+  const inFlight = pendingContainers.get(reuseKey);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const startPromise = startContainer(options, reuseKey).finally(() => {
+    pendingContainers.delete(reuseKey);
+  });
+  pendingContainers.set(reuseKey, startPromise);
+  return startPromise;
 }
 
 async function startContainer(
@@ -627,7 +642,6 @@ async function startContainer(
         result,
         containerName,
         isRunning: () => child.exitCode === null,
-        stop: shutdown,
       };
       // If the container exits on its own (crash, `docker stop`, etc.), evict it
       // so the next request rebuilds rather than reusing a dead container.

--- a/packages/container/src/index.ts
+++ b/packages/container/src/index.ts
@@ -13,9 +13,11 @@ import {
   debug,
   debugTokenClaims,
   decodeOidcClaims,
+  devImageTag,
   done,
   elapsed,
   existingRegistryAuthFile,
+  findDockerfile,
   info,
   isDockerfileRef,
   readString,
@@ -42,18 +44,6 @@ function normalizeCommand(command: unknown): string[] | undefined {
     return command;
   }
   return undefined;
-}
-
-// Vercel-specific container opt-in markers, auto-discovered when the build
-// entrypoint doesn't name a Dockerfile explicitly (e.g. the `container`
-// framework preset resolves its entrypoint via `<detect>`). These let a
-// project deploy as a container even when another framework is also present.
-const DOCKERFILE_CANDIDATES = ['Dockerfile.vercel', 'Containerfile.vercel'];
-
-function findDockerfile(workPath: string): string | undefined {
-  return DOCKERFILE_CANDIDATES.find(name =>
-    existsSync(path.join(workPath, name))
-  );
 }
 
 function sanitizeRepository(name: string): string {
@@ -303,14 +293,18 @@ async function resolveImageHandler(
   }
 
   if (meta?.isDev) {
-    if (prebuiltImage) {
-      span?.setAttributes({ 'container.mode': 'prebuilt_dev' });
-      info(`vercel dev: using prebuilt image ${prebuiltImage}`);
-      return prebuiltImage;
-    }
-    throw new Error(
-      '`vercel dev` cannot build container images from a Dockerfile. Specify a prebuilt "image" for local development.'
+    // In dev the image is built and run locally from the Dockerfile by
+    // `startDevServer` (see ./dev.ts `resolveDevImage`), which never pushes to
+    // a registry. The `build()` path must not push either, so we don't build
+    // here — we only return a stable local tag for the build output. The
+    // resolved entrypoint is always a Dockerfile/Containerfile (containers have
+    // no prebuilt-image input), so there is nothing to error on.
+    const serviceName = options.service?.name;
+    const tag = devImageTag(
+      serviceName ?? path.basename(dockerfileRel).split('.')[0]
     );
+    span?.setAttributes({ 'container.mode': 'dev', 'image.tag': tag });
+    return tag;
   }
 
   if (!existsSync(dockerfilePath)) {

--- a/packages/container/src/util.ts
+++ b/packages/container/src/util.ts
@@ -93,6 +93,35 @@ export function isDockerfileRef(ref: string): boolean {
   );
 }
 
+// Vercel-specific container opt-in markers, auto-discovered when the build
+// entrypoint doesn't name a Dockerfile explicitly (e.g. the `container`
+// framework preset resolves its entrypoint via `<detect>`). These let a
+// project deploy as a container even when another framework is also present.
+export const DOCKERFILE_CANDIDATES = [
+  'Dockerfile.vercel',
+  'Containerfile.vercel',
+];
+
+/**
+ * Discover a Vercel container opt-in marker (`Dockerfile.vercel` /
+ * `Containerfile.vercel`) in `workPath`. Used by both the build and dev paths
+ * so they resolve the same Dockerfile when the entrypoint is the `<detect>`
+ * sentinel.
+ */
+export function findDockerfile(workPath: string): string | undefined {
+  return DOCKERFILE_CANDIDATES.find(name => existsSync(join(workPath, name)));
+}
+
+/**
+ * Stable local image tag for `vercel dev`. Used by both the `build()` path
+ * (which never pushes in dev) and `startDevServer` (which builds & runs the
+ * image locally), so the two agree on a single name per service.
+ */
+export function devImageTag(serviceName: string): string {
+  const safe = serviceName.toLowerCase().replace(/[^a-z0-9-_.]/g, '-');
+  return `vercel-dev/${safe || 'service'}:dev`;
+}
+
 export interface RunResult {
   stdout: string;
   stderr: string;

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -5,6 +5,7 @@ import { dirname } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { build, prepareCache, startDevServer } from '../src';
 import { __resetStorageDriverCache } from '../src/storage-driver';
+import { __resetRunningContainers } from '../src/dev';
 
 const { spawnMock, existsSyncMock } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
@@ -146,6 +147,7 @@ beforeEach(() => {
   existsSyncMock.mockReturnValue(false);
   spawnMock.mockReset();
   __resetStorageDriverCache();
+  __resetRunningContainers();
   for (const key of VCR_ENV_KEYS) {
     delete process.env[key];
   }
@@ -532,6 +534,35 @@ describe('@vercel/container', () => {
     ).toBe(true);
   });
 
+  it('build() in dev returns a local tag without pushing to a registry', async () => {
+    // `vercel dev` runs the container builder's `build()` with `meta.isDev`.
+    // Containers are always built from a Dockerfile (there is no prebuilt-image
+    // input), and the real local build/run happens in `startDevServer`, so the
+    // `build()` path must not push to a registry and must never throw.
+    existsSyncMock.mockReturnValue(true); // Dockerfile present
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = expectTypicalBuildResult(
+      await build({
+        ...createBuildOptions({ runtime: 'container' }),
+        entrypoint: '<detect>',
+        service: { name: 'api' },
+        meta: { isDev: true },
+      } as any)
+    );
+
+    expect(result.output.index).toMatchObject({
+      type: 'Lambda',
+      runtime: 'container',
+      handler: 'vercel-dev/api:dev',
+    });
+    // No image build/push in dev: nothing is spawned and the registry is
+    // never contacted.
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('storage verification is observability-only by default (does not fail the build)', async () => {
     // Simulate buildah on vfs (overlay couldn't initialize). The build should
     // still succeed; verification only warns unless VERCEL_VCR_STRICT_STORAGE.
@@ -849,6 +880,91 @@ describe('@vercel/container', () => {
       await result!.shutdown!();
     });
 
+    it('reuses a running container across requests instead of rebuilding', async () => {
+      // The dev server calls `startDevServer` per request. A container is a
+      // persistent server, so the second call must hand back the same running
+      // container — no second `docker build`/`docker run`.
+      existsSyncMock.mockReturnValue(true); // Dockerfile present
+      const child = fakeRunningChild(4242);
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'docker' && args[0] === 'run') {
+          return child;
+        }
+        if (cmd === 'docker' && args.includes('inspect')) {
+          return fakeChild('{"3000/tcp":{}}');
+        }
+        if (cmd === 'docker' && args[0] === 'port') {
+          return fakeChild('127.0.0.1:54321\n');
+        }
+        return fakeChild('');
+      });
+
+      const opts = {
+        ...createBuildOptions({ runtime: 'container' }),
+        entrypoint: 'apps/svc/Dockerfile',
+        service: { name: 'api' },
+        meta: { isDev: true },
+      } as any;
+
+      const first = await startDevServer(opts);
+      const second = await startDevServer(opts);
+
+      // Same persistent server handed back both times.
+      expect(first).toMatchObject({ port: 54321, persistent: true });
+      expect(second).toMatchObject({ port: 54321 });
+      expect(second!.pid).toBe(first!.pid);
+
+      // Built and ran exactly once across the two requests.
+      const buildCount = spawnMock.mock.calls.filter(
+        ([cmd, args]) => cmd === 'docker' && (args as string[])[0] === 'build'
+      ).length;
+      const runCount = spawnMock.mock.calls.filter(
+        ([cmd, args]) => cmd === 'docker' && (args as string[])[0] === 'run'
+      ).length;
+      expect(buildCount).toBe(1);
+      expect(runCount).toBe(1);
+
+      await first!.shutdown!();
+    });
+
+    it('discovers a `Containerfile.vercel` marker when the entrypoint is `<detect>`', async () => {
+      // The `container` framework preset resolves its entrypoint to `<detect>`.
+      // In dev the builder must discover the `.vercel` opt-in marker in the
+      // work dir (matching the build path), not fall back to a bare
+      // `Dockerfile` that doesn't exist.
+      existsSyncMock.mockImplementation((p: unknown) =>
+        typeof p === 'string' ? p.endsWith('Containerfile.vercel') : false
+      );
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'docker' && args[0] === 'run') {
+          return fakeRunningChild(4242);
+        }
+        if (cmd === 'docker' && args.includes('inspect')) {
+          return fakeChild('{"3000/tcp":{}}');
+        }
+        if (cmd === 'docker' && args[0] === 'port') {
+          return fakeChild('127.0.0.1:54321\n');
+        }
+        return fakeChild('');
+      });
+
+      const result = await startDevServer({
+        ...createBuildOptions({ framework: 'container' }),
+        entrypoint: '<detect>',
+        meta: { isDev: true },
+      } as any);
+
+      expect(result).toMatchObject({ port: 54321 });
+      // The local build must target the discovered marker via `-f`.
+      expect(
+        commandsRun().some(
+          c =>
+            c.startsWith('docker build') &&
+            /-f \S*Containerfile\.vercel\b/.test(c)
+        )
+      ).toBe(true);
+    });
+
     it('uses a prebuilt image without building', async () => {
       existsSyncMock.mockReturnValue(false); // no Dockerfile
       spawnMock.mockImplementation((cmd: string, args: string[]) => {
@@ -952,6 +1068,64 @@ describe('@vercel/container', () => {
       // The container is torn down on the failure path.
       expect(
         commandsRun().some(c => /^docker stop vercel-dev-api-/.test(c))
+      ).toBe(true);
+    });
+
+    it('fails fast with a clear message when the Docker daemon is unreachable', async () => {
+      // The very first Docker call is the daemon availability probe
+      // (`docker info`). Simulate the daemon being down: it exits non-zero
+      // with the classic connection error on stderr.
+      existsSyncMock.mockReturnValue(true); // Dockerfile present
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'docker' && args[0] === 'info') {
+          return fakeChildFailure(
+            'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?'
+          );
+        }
+        return fakeChild('');
+      });
+
+      await expect(
+        startDevServer({
+          ...createBuildOptions({ runtime: 'container' }),
+          entrypoint: 'apps/svc/Dockerfile',
+          service: { name: 'api' },
+          meta: { isDev: true },
+        } as any)
+      ).rejects.toThrow(/Docker daemon/i);
+
+      // It must bail at the probe — no build or run is attempted.
+      const commands = commandsRun();
+      expect(commands.some(c => c.startsWith('docker build'))).toBe(false);
+      expect(commands.some(c => c.includes('docker run'))).toBe(false);
+    });
+
+    it('reports a daemon-down hint and the container name when run exits 125', async () => {
+      // Defense in depth: even if the upfront probe passes but `docker run`
+      // later exits 125 (daemon became unreachable), the error names the
+      // container and points at Docker rather than printing "undefined".
+      existsSyncMock.mockReturnValue(false); // prebuilt image, no Dockerfile
+      const exited = fakeRunningChild(555);
+      exited.exitCode = 125;
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'docker' && args[0] === 'run') {
+          return exited;
+        }
+        return fakeChild('');
+      });
+
+      await expect(
+        startDevServer({
+          ...createBuildOptions({}),
+          entrypoint: 'grycap/cowsay:latest',
+          // No service name: the previous message printed `"undefined"` here.
+          meta: { isDev: true },
+        } as any)
+      ).rejects.toThrow(/Docker daemon is not running|is unreachable/i);
+
+      // The teardown targets the real (defined) container name.
+      expect(
+        commandsRun().some(c => /^docker stop vercel-dev-service-/.test(c))
       ).toBe(true);
     });
 

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -927,6 +927,49 @@ describe('@vercel/container', () => {
       await first!.shutdown!();
     });
 
+    it('coalesces concurrent cold starts into a single container', async () => {
+      // Two requests can arrive before the first container is up. Without
+      // in-flight dedup each would `docker run` its own container and all but
+      // the last would be orphaned (never stopped). Both calls must share one
+      // start and resolve to the same container.
+      existsSyncMock.mockReturnValue(true); // Dockerfile present
+      const child = fakeRunningChild(4242);
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'docker' && args[0] === 'run') {
+          return child;
+        }
+        if (cmd === 'docker' && args.includes('inspect')) {
+          return fakeChild('{"3000/tcp":{}}');
+        }
+        if (cmd === 'docker' && args[0] === 'port') {
+          return fakeChild('127.0.0.1:54321\n');
+        }
+        return fakeChild('');
+      });
+
+      const opts = {
+        ...createBuildOptions({ runtime: 'container' }),
+        entrypoint: 'apps/svc/Dockerfile',
+        service: { name: 'api' },
+        meta: { isDev: true },
+      } as any;
+
+      // Fire both before awaiting either, so the second call sees an in-flight
+      // start rather than a completed one.
+      const [first, second] = await Promise.all([
+        startDevServer(opts),
+        startDevServer(opts),
+      ]);
+
+      expect(first!.pid).toBe(second!.pid);
+      const runCount = spawnMock.mock.calls.filter(
+        ([cmd, args]) => cmd === 'docker' && (args as string[])[0] === 'run'
+      ).length;
+      expect(runCount).toBe(1);
+
+      await first!.shutdown!();
+    });
+
     it('discovers a `Containerfile.vercel` marker when the entrypoint is `<detect>`', async () => {
       // The `container` framework preset resolves its entrypoint to `<detect>`.
       // In dev the builder must discover the `.vercel` opt-in marker in the


### PR DESCRIPTION
## Summary

`vercel dev` did not work for the `container` framework when a container is used as a **top-level build** (outside of `services`). The services flow works because the orchestrator drives `startDevServer` directly, but the legacy (non-services) dev pipeline runs `build()` → zip → `fun` first, and the container builder was never wired up for that path. Fixing it surfaced a chain of issues, all addressed here.

Reproduced with a project containing only a `Containerfile.vercel` and a near-empty `vercel.json` (`framework: container` via zero-config).

## What was broken (in the order you'd hit it)

1. **"did not match any source files"** — the dev server didn't map the container preset's `<detect>` sentinel to a real Dockerfile, so no `BuildMatch` was created.
2. **`` Error: `vercel dev` cannot build container images from a Dockerfile ``** — `@vercel/container`'s `build()` threw in dev and treated a *prebuilt image* as the expected input. Containers have no prebuilt-image input; the local build belongs in `startDevServer`.
3. **`output.createZip is not a function`** — the dev pipeline (`builder-worker.cjs` + `executeBuild`) treated the container's OCI-image output (`runtime: "container"`) as a zip-based Lambda and tried to zip it / run it under `fun`.
4. **`Container "undefined" exited (code 125)`** — the dev path only looked for a bare `Dockerfile`, so a project using a `Dockerfile.vercel` / `Containerfile.vercel` marker failed even though deploys worked; and Docker-not-running was surfaced as a cryptic exit code with `"undefined"` as the name.
5. **Rebuild + restart on every request** — the container `startDevServer` result was missing `persistent: true` and had no reuse cache, so each HTTP request rebuilt the image and started a fresh container.

## Changes

**`packages/cli`**
- `getBuildMatches`: map the `container` framework `<detect>` sentinel to a discovered Dockerfile so a build match is created (mirrors the existing `python`/`node`/`go` handlers).
- `executeBuild` + `builder-worker.cjs`: skip the zip-size check, `createZip`, and `fun` `createFunction` for `runtime: "container"` outputs — they're served by `startDevServer`.

**`packages/container`**
- `build()` no longer throws in dev; returns a stable local tag without pushing to a registry.
- `startDevServer` / `resolveDevImage` now discovers the `Dockerfile.vercel` / `Containerfile.vercel` markers via a `findDockerfile` helper now **shared** with the build path.
- Fail fast with a clear message when the Docker daemon is unreachable; container start errors now name the real container and include Docker's stderr.
- Reuse a live container across requests (module-level cache keyed by service/work dir) and return `persistent: true`, matching `@vercel/backends`.

## Testing

- `@vercel/container` unit tests: **37 pass**, including new tests for dev `build()` not pushing, `<detect>` → `Containerfile.vercel` discovery, daemon-down messaging, the fixed container name, and container reuse across requests (one `docker build` + one `docker run` for two requests).
- `vercel` `test-unit`, `type-check`, and Biome lint pass for the touched files. (Pre-existing unrelated `undici` type errors in `fetch.ts` / `fetch-proxy.ts` are not part of this change.)
- Manually verified `vercel dev` against a top-level container project (`Containerfile.vercel`): builds/runs once, then proxies subsequent requests without rebuilding.

## Follow-up (not in this PR)

The non-services pipeline still runs an eager `build()` on the container at startup before `startDevServer` takes over (because the builder has no `shouldServe`). A cleaner future change would let builders that expose `startDevServer` with a non-zippable output skip the eager `build()` entirely, unifying further with the services flow.
