### PR TITLE
[services] Fix django services when using static assets and vc dev.

### DIFF
--- a/.changeset/witty-onions-care.md
+++ b/.changeset/witty-onions-care.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Fix django services when using static assets and vc dev.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -415,7 +415,7 @@ jobs:
 
       - name: Install Ruby + Bundler
         if: ${{ matrix.packageName == 'vercel' }}
-        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: '3.3'
 

--- a/packages/python/src/django.ts
+++ b/packages/python/src/django.ts
@@ -80,6 +80,7 @@ export interface DjangoCollectStaticResult {
 export async function runDjangoCollectStatic(
   venvPath: string,
   workPath: string,
+  djangoPath: string,
   env: NodeJS.ProcessEnv,
   outputStaticDir: string,
   settingsModule: string,
@@ -125,7 +126,7 @@ export async function runDjangoCollectStatic(
       | (string | [string, string])[]
       | undefined) ?? [];
   const staticSourceDirs = [
-    ...installedApps.map(app => join(workPath, ...app.split('.'), 'static')),
+    ...installedApps.map(app => join(djangoPath, ...app.split('.'), 'static')),
     // TODO: Deal with optional prefixes in STATICFILES_DIRS.
     ...staticfilesDirs.map(d => (Array.isArray(d) ? d[1] : d)),
   ].filter(d => fs.existsSync(d));
@@ -139,11 +140,11 @@ export async function runDjangoCollectStatic(
     );
     await execa(pythonPath, ['manage.py', 'collectstatic', '--noinput'], {
       env: { ...env, DJANGO_SETTINGS_MODULE: settingsModule },
-      cwd: workPath,
+      cwd: djangoPath,
     });
     return {
       staticSourceDirs,
-      staticRoot: staticRoot ? resolve(workPath, staticRoot) : null,
+      staticRoot: staticRoot ? resolve(djangoPath, staticRoot) : null,
       cdnOutputDir: null,
       manifestRelPath: null,
     };
@@ -165,7 +166,7 @@ export async function runDjangoCollectStatic(
   // directly at the Vercel Build Output static directory.
   const staticOutputDir = join(outputStaticDir, staticUrlPath);
   await fs.promises.mkdir(staticOutputDir, { recursive: true });
-  const shimPath = join(workPath, '_vercel_collectstatic_settings.py');
+  const shimPath = join(djangoPath, '_vercel_collectstatic_settings.py');
   const shimLines = [
     `from ${settingsModule} import *`,
     `STATIC_ROOT = ${JSON.stringify(staticOutputDir)}`,
@@ -182,7 +183,7 @@ export async function runDjangoCollectStatic(
         ...env,
         DJANGO_SETTINGS_MODULE: '_vercel_collectstatic_settings',
       },
-      cwd: workPath,
+      cwd: djangoPath,
     });
   } finally {
     await fs.promises.unlink(shimPath).catch(() => {});
@@ -199,7 +200,7 @@ export async function runDjangoCollectStatic(
   let manifestRelPath: string | null = null;
   if (MANIFEST_STORAGE_BACKENDS.includes(storageBackend) && staticRoot) {
     const manifestSrc = join(staticOutputDir, 'staticfiles.json');
-    const resolvedStaticRoot = resolve(workPath, staticRoot);
+    const resolvedStaticRoot = resolve(djangoPath, staticRoot);
     const manifestDest = join(resolvedStaticRoot, 'staticfiles.json');
     await fs.promises.mkdir(resolvedStaticRoot, { recursive: true });
     await fs.promises.copyFile(manifestSrc, manifestDest);
@@ -209,7 +210,7 @@ export async function runDjangoCollectStatic(
 
   return {
     staticSourceDirs,
-    staticRoot: staticRoot ? resolve(workPath, staticRoot) : null,
+    staticRoot: staticRoot ? resolve(djangoPath, staticRoot) : null,
     cdnOutputDir: outputStaticDir,
     manifestRelPath,
   };

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -179,6 +179,7 @@ interface FrameworkHookContext {
 
 interface FrameworkHookResult {
   entrypoint?: PythonEntrypoint;
+  extraPythonPath?: string;
 }
 
 interface DjangoFrameworkHookResult extends FrameworkHookResult {
@@ -273,7 +274,11 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
         djangoVersion
       );
     }
-    return { entrypoint: resolvedEntrypoint, djangoStatic };
+    return {
+      entrypoint: resolvedEntrypoint,
+      djangoStatic,
+      extraPythonPath: baseDir ? join(workPath, baseDir) : undefined,
+    };
   },
 };
 

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -207,16 +207,17 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
     detected,
   }): Promise<DjangoFrameworkHookResult | void> => {
     let baseDir: string | undefined = detected?.baseDir;
-    if (!baseDir) {
+    if (baseDir === undefined) {
       if (!fs.existsSync(join(workPath, 'manage.py'))) {
         debug('Django hook: no manage.py detected, skipping');
         return;
       }
       baseDir = '';
     }
+    const djangoPath = join(workPath, baseDir);
     let settingsResult;
     try {
-      settingsResult = await getDjangoSettings(workPath, pythonEnv);
+      settingsResult = await getDjangoSettings(djangoPath, pythonEnv);
     } catch (err: any) {
       let detail: string;
       if (err?.code === 'ENOENT') {
@@ -226,7 +227,7 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
       }
       throw new NowBuildError({
         code: 'DJANGO_SETTINGS_FAILED',
-        message: `Failed to read Django application settings from ${workPath}/manage.py:\n${detail}`,
+        message: `Failed to read Django application settings from ${djangoPath}/manage.py:\n${detail}`,
       });
     }
     debug(`Django settings: ${JSON.stringify(settingsResult)}`);
@@ -264,6 +265,7 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
       djangoStatic = await runDjangoCollectStatic(
         venvPath,
         workPath,
+        djangoPath,
         pythonEnv,
         outputStaticDir,
         settingsModule,

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -171,8 +171,7 @@ async function addVendorBytecodeWithinCapacity({
 
 interface FrameworkHookContext {
   pythonEnv: NodeJS.ProcessEnv;
-  projectDir: string;
-  workPath?: string;
+  workPath: string;
   venvPath?: string;
   entrypoint: string | undefined;
   detected: DetectedPythonEntrypoint | undefined;
@@ -203,18 +202,21 @@ export async function runFrameworkHook(
 const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
   django: async ({
     pythonEnv,
-    projectDir,
     workPath,
     venvPath,
     detected,
   }): Promise<DjangoFrameworkHookResult | void> => {
-    if (detected?.baseDir === undefined) {
-      debug('Django hook: no manage.py detected, skipping');
-      return;
+    let baseDir: string | undefined = detected?.baseDir;
+    if (!baseDir) {
+      if (!fs.existsSync(join(workPath, 'manage.py'))) {
+        debug('Django hook: no manage.py detected, skipping');
+        return;
+      }
+      baseDir = '';
     }
     let settingsResult;
     try {
-      settingsResult = await getDjangoSettings(projectDir, pythonEnv);
+      settingsResult = await getDjangoSettings(workPath, pythonEnv);
     } catch (err: any) {
       let detail: string;
       if (err?.code === 'ENOENT') {
@@ -224,7 +226,7 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
       }
       throw new NowBuildError({
         code: 'DJANGO_SETTINGS_FAILED',
-        message: `Failed to read Django application settings from ${projectDir}/manage.py:\n${detail}`,
+        message: `Failed to read Django application settings from ${workPath}/manage.py:\n${detail}`,
       });
     }
     debug(`Django settings: ${JSON.stringify(settingsResult)}`);
@@ -234,7 +236,6 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
     }
 
     let resolvedEntrypoint: PythonEntrypoint | undefined;
-    const baseDir = detected?.baseDir ?? '';
     const asgiApp = djangoSettings['ASGI_APPLICATION'];
     if (typeof asgiApp === 'string') {
       const parts = asgiApp.split('.');
@@ -843,7 +844,6 @@ export const build: BuildVX = async ({
   // Run per-framework hooks (e.g. entrypoint detection and collectstatic for Django).
   const hookResult = await runFrameworkHook(framework, {
     pythonEnv,
-    projectDir: join(workPath, entryDirectory),
     workPath,
     venvPath,
     entrypoint,

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -675,7 +675,6 @@ export const startDevServer: StartDevServer = async opts => {
   } else {
     const hookResult = await runFrameworkHook(framework, {
       pythonEnv: env,
-      projectDir: join(workPath, detected?.baseDir ?? ''),
       workPath,
       entrypoint,
       detected: detected ?? undefined,

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -670,10 +670,11 @@ export const startDevServer: StartDevServer = async opts => {
       : undefined,
     service
   );
+  let hookResult: Awaited<ReturnType<typeof runFrameworkHook>>;
   if (detected?.entrypoint) {
     resolved = detected.entrypoint;
   } else {
-    const hookResult = await runFrameworkHook(framework, {
+    hookResult = await runFrameworkHook(framework, {
       pythonEnv: env,
       workPath,
       entrypoint,
@@ -870,6 +871,10 @@ export const startDevServer: StartDevServer = async opts => {
 
       if (devShim.extraPythonPath) {
         pathParts.push(devShim.extraPythonPath);
+      }
+
+      if (hookResult?.extraPythonPath) {
+        pathParts.push(hookResult.extraPythonPath);
       }
 
       const existingPythonPath = env.PYTHONPATH || '';

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -670,7 +670,7 @@ export const startDevServer: StartDevServer = async opts => {
       : undefined,
     service
   );
-  let hookResult: Awaited<ReturnType<typeof runFrameworkHook>>;
+  let hookResult: Awaited<ReturnType<typeof runFrameworkHook>> | undefined;
   if (detected?.entrypoint) {
     resolved = detected.entrypoint;
   } else {

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1715,7 +1715,7 @@ describe('Django entrypoint discovery', () => {
     });
     // Simulate collectstatic succeeding
     vi.mocked(runDjangoCollectStatic).mockImplementationOnce(
-      async (_venvPath, _workPath, _env, outputStaticDir) => {
+      async (_venvPath, _workPath, _djangoPath, _env, outputStaticDir) => {
         fs.mkdirSync(path.join(outputStaticDir, 'static'), { recursive: true });
         fs.writeFileSync(
           path.join(outputStaticDir, 'static', 'app.css'),


### PR DESCRIPTION
- When a django service has an explicit entrypoint, `detectPythonEntrypoint` returned without setting `baseDir` resulting in the django framework hook returning early and no static assets being bundled.
- When `manage.py` is in a subdir, `collectstatic` would output static files to the wrong directory.
- When `manage.py` is in a subdir,  `vc dev` was not able to load the app's entrypoint