### PR TITLE
Support generated stable services config

### DIFF
--- a/.changeset/stable-generated-services.md
+++ b/.changeset/stable-generated-services.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Support lazily generated Build Output `services` configs during `vc build`.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -170,7 +170,7 @@ interface BuildOutputConfig {
   crons?: Cron[];
   experimentalServices?: ExperimentalServices;
   experimentalServicesV2?: ExperimentalServicesV2;
-  services?: Service[];
+  services?: ExperimentalServicesV2 | Service[];
   deploymentId?: string;
 }
 
@@ -1574,8 +1574,15 @@ async function doBuild(
                   outputConfig.experimentalServicesV2;
               }
               if (
+                hasGeneratedServicesConfig(outputConfig) &&
+                !hasGeneratedServicesConfig(buildOutputConfig)
+              ) {
+                buildOutputConfig.services = outputConfig.services;
+              }
+              if (
                 hasNonEmptyObject(buildOutputConfig.experimentalServices) ||
-                hasNonEmptyObject(buildOutputConfig.experimentalServicesV2)
+                hasNonEmptyObject(buildOutputConfig.experimentalServicesV2) ||
+                hasGeneratedServicesConfig(buildOutputConfig)
               ) {
                 await fs.writeJSON(buildOutputConfigPath, buildOutputConfig, {
                   spaces: 2,
@@ -1747,45 +1754,40 @@ async function doBuild(
       generatedConfigs.push(defaultGeneratedConfig);
     }
 
-    const generatedExperimentalServicesV2Config =
-      getGeneratedExperimentalServicesV2Config([
-        ...generatedConfigs,
-        ...buildResults.values(),
-      ]);
+    const generatedServicesConfig = getGeneratedServicesConfig([
+      ...generatedConfigs,
+      ...buildResults.values(),
+    ]);
     const generatedExperimentalServicesV1Config =
       getGeneratedExperimentalServicesV1Config([
         ...generatedConfigs,
         ...buildResults.values(),
       ]);
 
-    if (
-      generatedExperimentalServicesV2Config ||
-      generatedExperimentalServicesV1Config
-    ) {
-      if (generatedExperimentalServicesV2Config) {
+    if (generatedServicesConfig || generatedExperimentalServicesV1Config) {
+      if (generatedServicesConfig) {
         nestExperimentalServicesV2Output = true;
       }
       detectedExperimentalServicesV1Config =
         generatedExperimentalServicesV1Config;
-      detectedExperimentalServicesV2Config =
-        generatedExperimentalServicesV2Config;
-      detectedExperimentalServicesV2RootRoutes =
-        generatedExperimentalServicesV2Config
-          ? generatedConfigs.find(
-              config =>
-                hasNonEmptyObject(config?.experimentalServicesV2) &&
-                Array.isArray(config?.routes)
-            )?.routes
-          : undefined;
+      detectedExperimentalServicesV2Config = generatedServicesConfig;
+      detectedExperimentalServicesV2RootRoutes = generatedServicesConfig
+        ? generatedConfigs.find(
+            config =>
+              (hasGeneratedServicesConfig(config) ||
+                hasNonEmptyObject(config?.experimentalServicesV2)) &&
+              Array.isArray(config?.routes)
+          )?.routes
+        : undefined;
       const generatedBuilders = await span
         .child('vc.detectGeneratedServices')
         .trace(() =>
           detectBuilders(files, pkg, {
             ...localConfig,
-            services: undefined,
-            ...(generatedExperimentalServicesV2Config
+            ...(generatedServicesConfig
               ? {
-                  experimentalServicesV2: generatedExperimentalServicesV2Config,
+                  services: generatedServicesConfig,
+                  experimentalServicesV2: undefined,
                 }
               : {
                   experimentalServicesV2: undefined,
@@ -1846,7 +1848,7 @@ async function doBuild(
       for (const service of detectedResolvedServices || []) {
         const alreadyExecutedBuild = getAlreadyExecutedBuild(service.builder);
         if (alreadyExecutedBuild) {
-          if (generatedExperimentalServicesV2Config) {
+          if (generatedServicesConfig) {
             output.warn(getGeneratedServiceAlreadyBuiltWarning(service));
             continue;
           }
@@ -2643,10 +2645,23 @@ function getGeneratedExperimentalServicesV1Config(
   return undefined;
 }
 
-function getGeneratedExperimentalServicesV2Config(
+function hasGeneratedServicesConfig(
+  result: BuildResult | BuildOutputConfig | null | undefined
+): result is (BuildResult | BuildOutputConfig) & {
+  services: ExperimentalServicesV2;
+} {
+  return (
+    result != null && 'services' in result && hasNonEmptyObject(result.services)
+  );
+}
+
+function getGeneratedServicesConfig(
   buildResults: Iterable<BuildResult | BuildOutputConfig | null | undefined>
 ): ExperimentalServicesV2 | undefined {
   for (const result of buildResults) {
+    if (hasGeneratedServicesConfig(result)) {
+      return result.services;
+    }
     if (
       result &&
       'experimentalServicesV2' in result &&

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -3120,6 +3120,99 @@ writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }, nul
     }
   });
 
+  it('should detect generated services from build output config', async () => {
+    const cwd = await getWriteableDirectory();
+    const output = join(cwd, '.vercel', 'output');
+    await fs.ensureDir(join(cwd, '.vercel'));
+    await fs.writeJSON(join(cwd, '.vercel', 'project.json'), {
+      orgId: '.',
+      projectId: '.',
+      settings: {
+        framework: null,
+        installCommand: '',
+      },
+    });
+    await fs.writeJSON(join(cwd, 'package.json'), {
+      private: true,
+      scripts: {
+        build: 'node build.mjs',
+      },
+    });
+    await fs.outputFile(
+      join(cwd, 'build.mjs'),
+      `
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outputDir = join(process.cwd(), '.vercel', 'output');
+mkdirSync(join(outputDir, 'static'), { recursive: true });
+writeFileSync(join(outputDir, 'static', 'index.html'), 'root output');
+writeFileSync(
+  join(outputDir, 'config.json'),
+  JSON.stringify({
+    version: 3,
+    routes: [{ src: '^/api/(.*)$', service: 'backend' }],
+    services: {
+      backend: {
+        root: 'backend',
+        entrypoint: 'package.json',
+        framework: 'vite'
+      }
+    }
+  }, null, 2)
+);
+`
+    );
+    await fs.outputJSON(join(cwd, 'backend', 'package.json'), {
+      private: true,
+      scripts: {
+        build: 'node build.mjs',
+      },
+    });
+    await fs.outputFile(
+      join(cwd, 'backend', 'build.mjs'),
+      `
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outputDir = join(process.cwd(), '.vercel', 'output');
+mkdirSync(join(outputDir, 'static'), { recursive: true });
+writeFileSync(join(outputDir, 'static', 'backend.html'), 'backend output');
+writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }, null, 2));
+`
+    );
+
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
+
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.experimentalServicesV2).toEqual({
+      backend: expect.objectContaining({
+        root: 'backend',
+        framework: 'vite',
+      }),
+    });
+    expect(config.services).toEqual([
+      expect.objectContaining({
+        schema: 'experimentalServicesV2',
+        name: 'backend',
+      }),
+    ]);
+    expect(config.routes).toEqual(
+      expect.arrayContaining([{ src: '^/api/(.*)$', service: 'backend' }])
+    );
+    expect(await fs.readFile(join(output, 'static/index.html'), 'utf8')).toBe(
+      'root output'
+    );
+    expect(
+      await fs.readFile(
+        join(output, 'services/backend/static/backend.html'),
+        'utf8'
+      )
+    ).toBe('backend output');
+  });
+
   it('should detect generated experimentalServicesV2 from default output when using --output', async () => {
     const cwd = await getWriteableDirectory();
     const output = join(cwd, 'custom-output');


### PR DESCRIPTION
## Summary
- detect lazily generated Build Output services configs in vc build
- keep experimentalServicesV2 lazy discovery as a fallback
- add CLI coverage for generated stable services building nested service output

## Tests
- ../../node_modules/.bin/vitest run --config ./vitest.config.mts test/unit/commands/build/index.test.ts -t "should detect generated services from build output config|should detect generated experimentalServicesV2 from default output when using --output"