### PR TITLE
[cli] ai-gateway: extract shared buildQuota helper

### DIFF
--- a/.changeset/ai-gateway-quota-helper.md
+++ b/.changeset/ai-gateway-quota-helper.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Refactor AI Gateway API key quota construction into a shared `buildQuota` helper so `ai-gateway api-keys create` and future commands build the same `aiGatewayQuota` payload. No user-facing behavior change.

--- a/packages/cli/src/commands/ai-gateway/api-keys-create.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys-create.ts
@@ -13,9 +13,11 @@ import { isAPIError } from '../../util/errors-ts';
 import { getCommandNamePlain } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
-import type { AiGatewayQuota } from '../../util/ai-gateway/create-api-key';
-
-const VALID_REFRESH_PERIODS = ['daily', 'weekly', 'monthly', 'none'] as const;
+import {
+  buildQuota,
+  isValidRefreshPeriod,
+  VALID_REFRESH_PERIODS,
+} from '../../util/ai-gateway/quota';
 
 export default async function create(client: Client, argv: string[]) {
   const telemetry = new AiGatewayApiKeysCreateTelemetryClient({
@@ -69,12 +71,7 @@ export default async function create(client: Client, argv: string[]) {
   }
 
   // Validate --refresh-period if provided
-  if (
-    refreshPeriod &&
-    !VALID_REFRESH_PERIODS.includes(
-      refreshPeriod as (typeof VALID_REFRESH_PERIODS)[number]
-    )
-  ) {
+  if (refreshPeriod && !isValidRefreshPeriod(refreshPeriod)) {
     const message = `Invalid refresh period "${refreshPeriod}". Must be one of: ${VALID_REFRESH_PERIODS.join(', ')}.`;
     outputAgentError(
       client,
@@ -97,18 +94,7 @@ export default async function create(client: Client, argv: string[]) {
   }
 
   // Build aiGatewayQuota only when any quota flag is provided
-  const effectiveRefreshPeriod =
-    refreshPeriod && refreshPeriod !== 'none' ? refreshPeriod : undefined;
-  const aiGatewayQuota: AiGatewayQuota | undefined =
-    budget !== undefined || effectiveRefreshPeriod || includeByok
-      ? {
-          ...(budget !== undefined && { limitAmount: budget }),
-          ...(effectiveRefreshPeriod && {
-            refreshPeriod: effectiveRefreshPeriod,
-          }),
-          ...(includeByok && { includeByokInQuota: true }),
-        }
-      : undefined;
+  const aiGatewayQuota = buildQuota({ budget, refreshPeriod, includeByok });
 
   // Ensure a team is selected; fail in non-interactive/piped mode if missing
   if (!client.config.currentTeam) {

--- a/packages/cli/src/util/ai-gateway/quota.ts
+++ b/packages/cli/src/util/ai-gateway/quota.ts
@@ -1,0 +1,33 @@
+import type { AiGatewayQuota } from './create-api-key';
+
+export const VALID_REFRESH_PERIODS = [
+  'daily',
+  'weekly',
+  'monthly',
+  'none',
+] as const;
+
+export type RefreshPeriod = (typeof VALID_REFRESH_PERIODS)[number];
+
+export function isValidRefreshPeriod(period: string): period is RefreshPeriod {
+  return (VALID_REFRESH_PERIODS as readonly string[]).includes(period);
+}
+
+export function buildQuota(opts: {
+  budget?: number;
+  refreshPeriod?: string;
+  includeByok?: boolean;
+}): AiGatewayQuota | undefined {
+  const effectiveRefresh =
+    opts.refreshPeriod && opts.refreshPeriod !== 'none'
+      ? opts.refreshPeriod
+      : undefined;
+  if (opts.budget === undefined && !effectiveRefresh && !opts.includeByok) {
+    return undefined;
+  }
+  return {
+    ...(opts.budget !== undefined && { limitAmount: opts.budget }),
+    ...(effectiveRefresh && { refreshPeriod: effectiveRefresh }),
+    ...(opts.includeByok && { includeByokInQuota: true }),
+  };
+}


### PR DESCRIPTION
## Summary

Extract the AI Gateway API-key **quota** construction into a shared helper so `ai-gateway api-keys create` and the `coding-agents connect` command build the same `aiGatewayQuota` payload from the same validation.

- New `src/util/ai-gateway/quota.ts`: `buildQuota`, `isValidRefreshPeriod`, `VALID_REFRESH_PERIODS`.
- `ai-gateway api-keys create` now consumes the helper instead of inline logic.

Behavior-preserving refactor — no user-facing change. Covered by the existing `api-keys-create.test.ts`.

---
**Stack — merge in order:**
1. #16851 — quota helper (base `main`)
2. #16852 — `coding-agents connect` framework + Claude Code
3. #16856 — macOS Keychain storage
4. #16853 — Codex
5. #16854 — OpenCode
6. #16855 — Pi
