### PR TITLE
[cli] ai-gateway: add coding-agents connect framework + Claude Code

### DIFF
--- a/.changeset/ai-gateway-coding-agents-connect.md
+++ b/.changeset/ai-gateway-coding-agents-connect.md
@@ -1,0 +1,11 @@
+---
+'vercel': minor
+---
+
+Add `vercel ai-gateway coding-agents connect` to connect local coding agents to the AI Gateway. This change ships the command framework and Claude Code support; Codex, OpenCode, and Pi are added in follow-up changes.
+
+For each selected agent it configures only the gateway's base URL and authentication — it never pins a default model, so you keep choosing your own. It provisions a new API key (or reuses one with `--key`); a new key supports an optional name (`--name`), spend limit (`--budget` / `--refresh-period` / `--include-byok`), and expiry (`--expiration` `7d|30d|60d|90d|1y|none`).
+
+Interactively it asks which agents to connect (pre-selecting the ones detected locally), then the key's name, team, quota, and expiry, shows the planned changes and a summary, and asks before applying. `--yes` runs without prompts using the detected agents and defaults; `--dry-run` previews without writing; existing files are backed up (`.bak`) and unparseable configs are skipped rather than clobbered. A `--non-interactive` run emits a structured JSON result. The full key is never printed — only a masked form.
+
+Config locations follow each agent's own conventions: it honors their native relocation env vars (e.g. `CLAUDE_CONFIG_DIR`) and `ZDOTDIR`/fish for the shell rc. For bespoke setups you can override any agent's config file with `--agent-config <id>=<path>` (repeatable) and the shell rc with `--shell-rc <path>`; interactively it offers a custom path when an agent isn't found at its default location. Adding a new agent is a single module under `util/ai-gateway/coding-agents/agents`.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-connect.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-connect.ts
@@ -1,0 +1,405 @@
+import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import {
+  isValidRefreshPeriod,
+  VALID_REFRESH_PERIODS,
+} from '../../util/ai-gateway/quota';
+import {
+  isValidExpiry,
+  presetToExpiresAt,
+  VALID_EXPIRY_VALUES,
+} from '../../util/ai-gateway/expiry';
+import { resolveAgents } from '../../util/ai-gateway/coding-agents/resolve';
+import { getAgentById } from '../../util/ai-gateway/coding-agents/agents';
+import {
+  ensureTeam,
+  createKey,
+  promptKeyName,
+  promptQuota,
+  promptExpiry,
+  type KeySource,
+} from '../../util/ai-gateway/coding-agents/key-source';
+import {
+  buildSetupPlan,
+  applyPlan,
+} from '../../util/ai-gateway/coding-agents/apply';
+import {
+  printResolvedState,
+  printPlan,
+  printNotes,
+  printKey,
+} from '../../util/ai-gateway/coding-agents/render';
+import { runMachine } from '../../util/ai-gateway/coding-agents/machine';
+import { KEY_PLACEHOLDER } from '../../util/ai-gateway/coding-agents/gateway';
+import {
+  outputAgentError,
+  shouldEmitNonInteractiveCommandError,
+} from '../../util/agent-output';
+import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
+import { connectSubcommand } from './command';
+import { AiGatewayCodingAgentsConnectTelemetryClient } from '../../util/telemetry/commands/ai-gateway/coding-agents-connect';
+
+export default async function codingAgentsConnect(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AiGatewayCodingAgentsConnectTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(connectSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { flags: opts } = parsedArgs;
+
+  const agentFlags = opts['--agent'] as string[] | undefined;
+  const all = opts['--all'] as boolean | undefined;
+  const providedKey = opts['--key'] as string | undefined;
+  const budget = opts['--budget'] as number | undefined;
+  const refreshPeriod = opts['--refresh-period'] as string | undefined;
+  const includeByok = opts['--include-byok'] as boolean | undefined;
+  const expiration = opts['--expiration'] as string | undefined;
+  const name = opts['--name'] as string | undefined;
+  const dryRun = opts['--dry-run'] as boolean | undefined;
+  const noBackup = opts['--no-backup'] as boolean | undefined;
+  const agentConfig = opts['--agent-config'] as string[] | undefined;
+  const shellRcOverride = opts['--shell-rc'] as string | undefined;
+  const yes = opts['--yes'] as boolean | undefined;
+
+  telemetry.trackCliOptionAgent(agentFlags as [string] | undefined);
+  telemetry.trackCliFlagAll(all);
+  telemetry.trackCliOptionKey(providedKey);
+  telemetry.trackCliOptionBudget(budget);
+  telemetry.trackCliOptionRefreshPeriod(refreshPeriod);
+  telemetry.trackCliFlagIncludeByok(includeByok);
+  telemetry.trackCliOptionExpiration(expiration);
+  telemetry.trackCliOptionName(name);
+  telemetry.trackCliFlagDryRun(dryRun);
+  telemetry.trackCliFlagNoBackup(noBackup);
+  telemetry.trackCliOptionAgentConfig(agentConfig);
+  telemetry.trackCliOptionShellRc(shellRcOverride);
+  telemetry.trackCliFlagYes(yes);
+
+  const machine = shouldEmitNonInteractiveCommandError(client);
+  const canPrompt = Boolean(client.stdin.isTTY) && !machine;
+  const home = homedir();
+
+  if (budget !== undefined && (!Number.isFinite(budget) || budget < 1)) {
+    return failValidation(
+      client,
+      machine,
+      AGENT_REASON.INVALID_BUDGET,
+      'Budget must be a positive number in dollars (minimum 1).'
+    );
+  }
+  if (refreshPeriod && !isValidRefreshPeriod(refreshPeriod)) {
+    return failValidation(
+      client,
+      machine,
+      AGENT_REASON.INVALID_REFRESH_PERIOD,
+      `Invalid refresh period "${refreshPeriod}". Must be one of: ${VALID_REFRESH_PERIODS.join(', ')}.`
+    );
+  }
+  if (expiration && !isValidExpiry(expiration)) {
+    return failValidation(
+      client,
+      machine,
+      AGENT_REASON.INVALID_EXPIRATION,
+      `Invalid expiration "${expiration}". Must be one of: ${VALID_EXPIRY_VALUES.join(', ')}.`
+    );
+  }
+  const flagExpiresAt =
+    expiration && expiration !== 'none'
+      ? presetToExpiresAt(expiration)
+      : undefined;
+
+  // Parse `--agent-config <id>=<path>` overrides up front. Validate the format
+  // and that each id is a known agent; the "must be selected" check happens
+  // after agent resolution.
+  const overrides: Record<string, string> = {};
+  for (const pair of agentConfig ?? []) {
+    const eq = pair.indexOf('=');
+    const id = eq > 0 ? pair.slice(0, eq).trim().toLowerCase() : '';
+    const path = eq > 0 ? pair.slice(eq + 1).trim() : '';
+    if (!id || !path) {
+      return failValidation(
+        client,
+        machine,
+        AGENT_REASON.INVALID_ARGUMENTS,
+        `Invalid --agent-config "${pair}". Use <agent>=<path>, e.g. claude-code=/path/settings.json.`
+      );
+    }
+    if (!getAgentById(id)) {
+      return failValidation(
+        client,
+        machine,
+        AGENT_REASON.INVALID_ARGUMENTS,
+        `Unknown agent "${id}" in --agent-config.`
+      );
+    }
+    overrides[id] = resolve(path);
+  }
+
+  if (dryRun && !machine) {
+    output.log(
+      `${chalk.bold('Dry run')} — previewing changes only. No files will be written and no API key will be created.`
+    );
+  }
+
+  const selection = await resolveAgents({
+    client,
+    agentFlags,
+    all,
+    canPrompt,
+    yes: Boolean(yes),
+    home,
+  });
+  if ('error' in selection) {
+    if (machine) {
+      outputAgentError(client, {
+        status: AGENT_STATUS.ERROR,
+        reason: selection.reason,
+        message: selection.error,
+      });
+    }
+    output.error(selection.error);
+    return 1;
+  }
+  const { selected, guidance, unsupported } = selection;
+  for (const note of guidance) {
+    output.warn(note);
+  }
+
+  // A path override only makes sense for an agent we're actually configuring.
+  for (const id of Object.keys(overrides)) {
+    if (!selected.some(a => a.id === id)) {
+      return failValidation(
+        client,
+        machine,
+        AGENT_REASON.INVALID_ARGUMENTS,
+        `--agent-config set for "${id}", which isn't selected. Add --agent ${id} (or --all).`
+      );
+    }
+  }
+
+  const willCreate = !providedKey;
+  let keyName = name;
+  let keyBudget = budget;
+  let keyRefresh = refreshPeriod;
+  let keyExpiresAt = flagExpiresAt;
+  if (willCreate && (!dryRun || canPrompt)) {
+    const promptCreate = canPrompt && !yes;
+
+    if (promptCreate && keyName === undefined) {
+      keyName = await promptKeyName(client);
+    }
+
+    const teamError = await ensureTeam(client, {
+      machine,
+      canPrompt,
+      yes: Boolean(yes),
+    });
+    if (teamError) {
+      return teamError;
+    }
+
+    if (promptCreate) {
+      if (keyBudget === undefined && keyRefresh === undefined) {
+        const quota = await promptQuota(client);
+        keyBudget = quota.budget;
+        keyRefresh = quota.refreshPeriod;
+      }
+      if (keyExpiresAt === undefined && !expiration) {
+        keyExpiresAt = await promptExpiry(client);
+      }
+    }
+  }
+  // If a selected agent isn't at its default/native location, offer custom
+  // paths (opt-in, so normal setups aren't interrupted). Flags pin paths in
+  // either mode; this just surfaces the option interactively.
+  if (canPrompt && !yes) {
+    const missing = selected.filter(
+      a =>
+        !overrides[a.id] &&
+        !existsSync(dirname(a.configPath({ apiKey: '', home })))
+    );
+    if (missing.length > 0) {
+      const customize = await client.input.confirm(
+        "Some agents weren't found at their default location. Set custom config paths?",
+        false
+      );
+      if (customize) {
+        for (const agent of missing) {
+          const resolved = agent.configPath({
+            apiKey: '',
+            home,
+          });
+          const answer = await client.input.text({
+            message: `${agent.displayName} config path`,
+            default: resolved,
+          });
+          const picked = answer.trim();
+          if (picked && resolve(picked) !== resolved) {
+            overrides[agent.id] = resolve(picked);
+          }
+        }
+      }
+    }
+  }
+  const previewKey = providedKey ?? KEY_PLACEHOLDER;
+
+  const previewPlan = await buildSetupPlan(selected, {
+    apiKey: previewKey,
+    home,
+    overrides,
+    shellRcOverride,
+  });
+
+  const changed = previewPlan.changes.filter(
+    c => c.status === 'create' || c.status === 'update'
+  );
+  const errored = previewPlan.changes.filter(c => c.status === 'error');
+
+  if (machine) {
+    return runMachine({
+      client,
+      selected,
+      unsupported,
+      previewPlan,
+      dryRun: Boolean(dryRun),
+      backup: !noBackup,
+      keySource: providedKey ? { key: providedKey, created: false } : null,
+      createKey: () =>
+        createKey(client, {
+          name: keyName,
+          budget: keyBudget,
+          refreshPeriod: keyRefresh,
+          includeByok,
+          expiresAt: keyExpiresAt,
+        }),
+      overrides,
+      shellRcOverride,
+      home,
+    });
+  }
+
+  if (changed.length === 0 && errored.length === 0) {
+    output.log(
+      'All selected agents are already configured for the AI Gateway.'
+    );
+    if (providedKey) {
+      printKey(providedKey);
+    }
+    return 0;
+  }
+
+  printPlan(previewPlan, previewKey);
+  printResolvedState({
+    selected,
+    willCreate,
+    name: keyName,
+    budget: keyBudget,
+    refreshPeriod: keyRefresh,
+    expiresAt: keyExpiresAt,
+  });
+
+  if (dryRun) {
+    output.log(
+      `Dry run — no files written. Re-run without ${chalk.bold('--dry-run')} to apply.`
+    );
+    return 0;
+  }
+
+  if (changed.length > 0 && canPrompt && !yes) {
+    const confirmed = await client.input.confirm('Apply these changes?', true);
+    if (!confirmed) {
+      output.log('Aborted. No files were changed.');
+      return 0;
+    }
+  }
+
+  let keySource: KeySource;
+  try {
+    keySource = providedKey
+      ? { key: providedKey, created: false }
+      : {
+          key: await createKey(client, {
+            name: keyName,
+            budget: keyBudget,
+            refreshPeriod: keyRefresh,
+            includeByok,
+            expiresAt: keyExpiresAt,
+          }),
+          created: true,
+        };
+  } catch (err) {
+    output.stopSpinner();
+    if (isAPIError(err)) {
+      output.error(err.message);
+      return 1;
+    }
+    throw err;
+  }
+
+  const applyPlanResult = await buildSetupPlan(selected, {
+    apiKey: keySource.key,
+    home,
+    overrides,
+    shellRcOverride,
+  });
+
+  const results = await applyPlan(applyPlanResult, { backup: !noBackup });
+
+  // 6. Report.
+  output.print('\n');
+  for (const result of results) {
+    printAlignedLabel(
+      result.action === 'created' ? 'Created' : 'Updated',
+      result.path,
+      { gutter: '✓' }
+    );
+  }
+  for (const change of errored) {
+    output.warn(
+      `Skipped ${change.label} (${change.path}): ${change.error}. Fix or remove the file, then re-run.`
+    );
+  }
+  if (results.some(r => r.backupPath)) {
+    output.log(chalk.dim('Previous files saved alongside as .bak'));
+  }
+
+  printNotes(applyPlanResult);
+  printKey(keySource.key);
+  return 0;
+}
+
+function failValidation(
+  client: Client,
+  machine: boolean,
+  reason: string,
+  message: string
+): number {
+  if (machine) {
+    outputAgentError(client, {
+      status: AGENT_STATUS.ERROR,
+      reason,
+      message,
+    });
+  }
+  output.error(message);
+  return 1;
+}

--- a/packages/cli/src/commands/ai-gateway/coding-agents.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents.ts
@@ -1,0 +1,82 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import getSubcommand from '../../util/get-subcommand';
+import { type Command, help } from '../help';
+import connect from './coding-agents-connect';
+import { codingAgentsSubcommand, connectSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { getCommandAliases } from '..';
+import { AiGatewayCodingAgentsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/coding-agents';
+import { printError } from '../../util/error';
+
+const COMMAND_CONFIG = {
+  connect: getCommandAliases(connectSubcommand),
+};
+
+export default async function codingAgents(client: Client) {
+  const telemetry = new AiGatewayCodingAgentsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(
+    codingAgentsSubcommand.options
+  );
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const subArgs = parsedArgs.args.slice(2);
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    subArgs,
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('ai-gateway coding-agents', subcommand);
+    output.print(
+      help(codingAgentsSubcommand, { columns: client.stderr.columns })
+    );
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        parent: codingAgentsSubcommand,
+        columns: client.stderr.columns,
+      })
+    );
+  }
+
+  switch (subcommand) {
+    case 'connect':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway coding-agents',
+          subcommandOriginal
+        );
+        printHelp(connectSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandConnect(subcommandOriginal);
+      return connect(client, args);
+    default:
+      output.error(getInvalidSubcommand(COMMAND_CONFIG));
+      output.print(
+        help(codingAgentsSubcommand, { columns: client.stderr.columns })
+      );
+      return 2;
+  }
+}

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -229,12 +229,144 @@ export const rulesSubcommand = {
   examples: [],
 } as const;
 
+export const connectSubcommand = {
+  name: 'connect',
+  aliases: [],
+  description:
+    'Connect local coding agents (Claude Code, Codex, OpenCode, Pi) to the AI Gateway',
+  arguments: [],
+  options: [
+    {
+      name: 'agent',
+      shorthand: null,
+      type: [String],
+      argument: 'NAME',
+      deprecated: false,
+      description:
+        'Coding agent to configure, repeatable (claude-code, codex, opencode, pi)',
+    },
+    {
+      name: 'all',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Configure every supported coding agent',
+    },
+    {
+      name: 'key',
+      shorthand: null,
+      type: String,
+      argument: 'KEY',
+      deprecated: false,
+      description: 'Use an existing AI Gateway API key instead of creating one',
+    },
+    {
+      name: 'budget',
+      shorthand: null,
+      type: Number,
+      argument: 'AMOUNT',
+      deprecated: false,
+      description:
+        'Quota budget in dollars for a newly created key (minimum 1)',
+    },
+    {
+      name: 'refresh-period',
+      shorthand: null,
+      type: String,
+      argument: 'PERIOD',
+      deprecated: false,
+      description:
+        'Quota refresh cadence for a new key: daily, weekly, monthly, or none',
+    },
+    {
+      name: 'include-byok',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Include BYOK usage in the new key quota',
+    },
+    {
+      name: 'expiration',
+      shorthand: null,
+      type: String,
+      argument: 'PERIOD',
+      deprecated: false,
+      description:
+        'Expiry for a new key: 7d, 30d, 60d, 90d, 1y, or none (default: none)',
+    },
+    {
+      name: 'name',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+      description: 'Name for a newly created API key',
+    },
+    {
+      name: 'dry-run',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Show what would change without writing any files',
+    },
+    {
+      name: 'no-backup',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Do not write .bak backups of changed files',
+    },
+    {
+      name: 'agent-config',
+      shorthand: null,
+      type: [String],
+      argument: 'AGENT=PATH',
+      deprecated: false,
+      description:
+        "Override an agent's config file path, e.g. claude-code=/path/settings.json (repeatable)",
+    },
+    {
+      name: 'shell-rc',
+      shorthand: null,
+      type: String,
+      argument: 'PATH',
+      deprecated: false,
+      description: 'Shell rc file to write the env exports into',
+    },
+    yesOption,
+  ],
+  examples: [
+    {
+      name: 'Connect all detected coding agents (creates a key)',
+      value: `${packageName} ai-gateway coding-agents connect`,
+    },
+    {
+      name: 'Connect specific agents with a budgeted key',
+      value: `${packageName} ai-gateway coding-agents connect --agent claude-code --agent codex --budget 500 --refresh-period monthly`,
+    },
+    {
+      name: 'Reuse an existing key and preview changes only',
+      value: `${packageName} ai-gateway coding-agents connect --key <key> --dry-run`,
+    },
+  ],
+} as const;
+
+export const codingAgentsSubcommand = {
+  name: 'coding-agents',
+  aliases: [],
+  description: 'Connect local coding agents to the AI Gateway',
+  arguments: [],
+  subcommands: [connectSubcommand],
+  options: [],
+  examples: [],
+} as const;
+
 export const aiGatewayCommand = {
   name: 'ai-gateway',
   aliases: [],
   description: 'Manage AI Gateway resources',
   arguments: [],
-  subcommands: [apiKeysSubcommand, rulesSubcommand],
+  subcommands: [apiKeysSubcommand, rulesSubcommand, codingAgentsSubcommand],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/ai-gateway/index.ts
+++ b/packages/cli/src/commands/ai-gateway/index.ts
@@ -4,10 +4,12 @@ import getSubcommand from '../../util/get-subcommand';
 import { printError } from '../../util/error';
 import apiKeys from './api-keys';
 import rules from './rules';
+import codingAgents from './coding-agents';
 import {
   aiGatewayCommand,
   apiKeysSubcommand,
   rulesSubcommand,
+  codingAgentsSubcommand,
 } from './command';
 import { help } from '../help';
 import { getCommandAliases } from '..';
@@ -18,6 +20,7 @@ import output from '../../output-manager';
 const COMMAND_CONFIG = {
   'api-keys': getCommandAliases(apiKeysSubcommand),
   rules: getCommandAliases(rulesSubcommand),
+  'coding-agents': getCommandAliases(codingAgentsSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -58,6 +61,9 @@ export default async function main(client: Client) {
     case 'rules':
       telemetry.trackCliSubcommandRules(subcommandOriginal);
       return rules(client);
+    case 'coding-agents':
+      telemetry.trackCliSubcommandCodingAgents(subcommandOriginal);
+      return codingAgents(client);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('ai-gateway', subcommandOriginal);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ try {
 {
   const SILENCED_ERRORS = [
     'DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.',
+    'DeprecationWarning: `url.parse()` behavior is not standardized',
   ];
 
   // biome-ignore lint/suspicious/noConsole: intentional console usage
@@ -55,7 +56,6 @@ import { parseArguments } from './util/get-args';
 import getUser from './util/get-user';
 import getTeams from './util/teams/get-teams';
 import Client from './util/client';
-import { setFetchDispatcher } from './util/fetch';
 import { printError } from './util/error';
 import reportError from './util/report-error';
 import earlyGetConfig from './util/get-config';
@@ -544,16 +544,10 @@ const main = async () => {
     `Agent/TTY/nonInteractive: isAgent=${isAgent} agentName=${detectedAgent?.name ?? 'none'} stdin.isTTY=${String(process.stdin?.isTTY)} --non-interactive=${nonInteractiveFlag} explicitFalse=${explicitNonInteractiveFalse} => nonInteractive=${nonInteractive}`
   );
 
-  // Only load proxy support if proxy env vars are configured (saves startup time).
-  const proxyConfigured = hasProxyConfig();
-  const agent = proxyConfigured
+  // Only load proxy-agent if proxy env vars are configured (saves ~60ms startup)
+  const agent = hasProxyConfig()
     ? new (await import('proxy-agent')).ProxyAgent({ keepAlive: true })
     : new HttpsAgent({ keepAlive: true });
-
-  if (proxyConfigured) {
-    const { EnvProxyDispatcher } = await import('./util/fetch-proxy');
-    setFetchDispatcher(new EnvProxyDispatcher());
-  }
 
   client = new Client({
     agent,

--- a/packages/cli/src/util/agent-output-constants.ts
+++ b/packages/cli/src/util/agent-output-constants.ts
@@ -80,6 +80,7 @@ export const AGENT_REASON = {
   // AI Gateway
   INVALID_BUDGET: 'invalid_budget',
   INVALID_REFRESH_PERIOD: 'invalid_refresh_period',
+  INVALID_EXPIRATION: 'invalid_expiration',
   // Redirects
   REDIRECT_NOT_FOUND: 'redirect_not_found',
   VERSION_NOT_FOUND: 'version_not_found',

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -1,0 +1,55 @@
+import { join } from 'node:path';
+import type { CodingAgent } from '../types';
+import { mergeJson, pathExists } from '../config-files';
+import { GATEWAY_ANTHROPIC_BASE_URL } from '../gateway';
+
+/**
+ * Claude Code reads env vars from the `env` object in `~/.claude/settings.json`.
+ * It speaks the gateway's Anthropic-compatible endpoint, so the base URL has NO
+ * `/v1` (the Anthropic SDK appends `/v1/messages`). `ANTHROPIC_API_KEY` must be
+ * emptied because it takes precedence over `ANTHROPIC_AUTH_TOKEN`.
+ *
+ * Docs: https://vercel.com/docs/ai-gateway/coding-agents/claude-code
+ */
+/** Config dir: `$CLAUDE_CONFIG_DIR` (Claude Code's own override) or `~/.claude`. */
+function claudeDir(home: string): string {
+  const dir = process.env.CLAUDE_CONFIG_DIR;
+  return dir && dir.trim() ? dir : join(home, '.claude');
+}
+
+export const claudeCode: CodingAgent = {
+  id: 'claude-code',
+  displayName: 'Claude Code',
+
+  async detect(home) {
+    return pathExists(claudeDir(home));
+  },
+
+  configPath(ctx) {
+    return (
+      ctx.overrides?.['claude-code'] ??
+      join(claudeDir(ctx.home), 'settings.json')
+    );
+  },
+
+  buildPlan(ctx) {
+    const path = this.configPath(ctx);
+    const env: Record<string, string> = {
+      ANTHROPIC_BASE_URL: GATEWAY_ANTHROPIC_BASE_URL,
+      ANTHROPIC_API_KEY: '',
+      ANTHROPIC_AUTH_TOKEN: ctx.apiKey,
+    };
+    return {
+      fileChanges: [
+        {
+          path,
+          label: 'Claude Code settings',
+          format: 'json',
+          transform: current => mergeJson(current, { env }),
+        },
+      ],
+      envExports: [],
+      notes: ['Restart Claude Code to pick up the new settings.'],
+    };
+  },
+};

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -1,0 +1,24 @@
+import type { CodingAgent } from '../types';
+import { claudeCode } from './claude-code';
+
+/**
+ * Registry of supported coding agents. Add a new agent by exporting a
+ * `CodingAgent` from a file in this folder and appending it here.
+ */
+export const CODING_AGENTS: CodingAgent[] = [claudeCode];
+
+/** Default targets when the user does not pass `--agent` (excludes experimental). */
+export const DEFAULT_AGENTS = CODING_AGENTS.filter(a => !a.experimental);
+
+export function getAgentById(id: string): CodingAgent | undefined {
+  return CODING_AGENTS.find(a => a.id === id);
+}
+
+/**
+ * Agents we know about but cannot safely configure from a config file. Listed so
+ * the command can give actionable guidance instead of a generic "unknown agent".
+ */
+export const UNSUPPORTED_AGENTS: Record<string, string> = {
+  cursor:
+    'Cursor stores model settings in a SQLite database with no safely writable config, and its "Override OpenAI Base URL" GUI option is known to break other models. Set the base URL to https://ai-gateway.vercel.sh/v1 manually in Settings → Models if you want to try it.',
+};

--- a/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
@@ -1,0 +1,217 @@
+import { join } from 'node:path';
+import type { CodingAgent, EnvExport, FileFormat, SetupContext } from './types';
+import {
+  readFileOrNull,
+  backupFile,
+  writeConfigFile,
+  upsertManagedBlock,
+} from './config-files';
+
+export type ChangeStatus = 'create' | 'update' | 'unchanged' | 'error';
+
+export interface PlannedChange {
+  path: string;
+  label: string;
+  format: FileFormat;
+  owners: string[];
+  current: string | null;
+  next: string | null;
+  status: ChangeStatus;
+  error?: string;
+  mode?: number;
+}
+
+export interface AgentNotes {
+  id: string;
+  displayName: string;
+  notes: string[];
+}
+
+export interface SetupPlan {
+  changes: PlannedChange[];
+  notes: AgentNotes[];
+  shellRcPath?: string;
+}
+
+export function detectShellRc(home: string, override?: string): string {
+  if (override && override.trim()) return override;
+  const shell = process.env.SHELL ?? '';
+  if (shell.includes('fish')) {
+    const xdg = process.env.XDG_CONFIG_HOME;
+    const base = xdg && xdg.startsWith('/') ? xdg : join(home, '.config');
+    return join(base, 'fish', 'config.fish');
+  }
+  if (shell.includes('zsh')) {
+    // Honor ZDOTDIR, where zsh users relocate their rc files.
+    const zdot = process.env.ZDOTDIR;
+    return join(zdot && zdot.trim() ? zdot : home, '.zshrc');
+  }
+  if (shell.includes('bash')) return join(home, '.bashrc');
+  return join(home, '.profile');
+}
+
+/** POSIX single-quote: wrap in '…' and emit literal quotes via the '\'' idiom. */
+function shellQuote(value: string): string {
+  return `'${value.split("'").join("'\\''")}'`;
+}
+
+/** fish single-quote: only `\` and `'` are special inside '…'. */
+function fishQuote(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function envBlockBody(exports: EnvExport[], fish: boolean): string {
+  const lines = [
+    '# Managed by `vercel ai-gateway coding-agents connect` — safe to remove this block.',
+  ];
+  for (const e of exports) {
+    lines.push(
+      fish
+        ? `set -gx ${e.name} ${fishQuote(e.value)}`
+        : `export ${e.name}=${shellQuote(e.value)}`
+    );
+  }
+  return lines.join('\n');
+}
+
+interface PendingChange {
+  path: string;
+  label: string;
+  format: FileFormat;
+  mode?: number;
+  owner: string;
+  transform(current: string | null): string;
+}
+
+export async function buildSetupPlan(
+  agents: CodingAgent[],
+  ctx: SetupContext
+): Promise<SetupPlan> {
+  const pending: PendingChange[] = [];
+  const envExports: EnvExport[] = [];
+  const notes: AgentNotes[] = [];
+
+  for (const agent of agents) {
+    const plan = agent.buildPlan(ctx);
+    for (const fc of plan.fileChanges) {
+      pending.push({ ...fc, owner: agent.displayName });
+    }
+    for (const ee of plan.envExports) {
+      if (!envExports.some(x => x.name === ee.name)) {
+        envExports.push(ee);
+      }
+    }
+    if (plan.notes.length) {
+      notes.push({
+        id: agent.id,
+        displayName: agent.displayName,
+        notes: plan.notes,
+      });
+    }
+  }
+
+  let shellRcPath: string | undefined;
+  if (envExports.length) {
+    shellRcPath = detectShellRc(ctx.home, ctx.shellRcOverride);
+    const body = envBlockBody(envExports, shellRcPath.endsWith('.fish'));
+    pending.push({
+      path: shellRcPath,
+      label: 'Shell environment',
+      format: 'shell',
+      owner: 'Environment',
+      transform: current => upsertManagedBlock(current, body),
+    });
+  }
+
+  const byPath = new Map<
+    string,
+    {
+      label: string;
+      format: FileFormat;
+      mode?: number;
+      owners: string[];
+      transforms: Array<(current: string | null) => string>;
+    }
+  >();
+  for (const p of pending) {
+    const entry = byPath.get(p.path) ?? {
+      label: p.label,
+      format: p.format,
+      mode: p.mode,
+      owners: [],
+      transforms: [],
+    };
+    if (!entry.owners.includes(p.owner)) entry.owners.push(p.owner);
+    entry.transforms.push(p.transform);
+    byPath.set(p.path, entry);
+  }
+
+  const changes: PlannedChange[] = [];
+  for (const [path, entry] of byPath) {
+    const current = await readFileOrNull(path);
+    let next: string | null = null;
+    let status: ChangeStatus;
+    let error: string | undefined;
+    try {
+      let acc: string | null = current;
+      for (const transform of entry.transforms) {
+        acc = transform(acc);
+      }
+      next = acc;
+      status =
+        current === null ? 'create' : next === current ? 'unchanged' : 'update';
+    } catch (err) {
+      status = 'error';
+      error = err instanceof Error ? err.message : String(err);
+    }
+    changes.push({
+      path,
+      label: entry.label,
+      format: entry.format,
+      mode: entry.mode,
+      owners: entry.owners,
+      current,
+      next,
+      status,
+      error,
+    });
+  }
+
+  return { changes, notes, shellRcPath };
+}
+
+export interface ApplyResult {
+  path: string;
+  label: string;
+  owners: string[];
+  action: 'created' | 'updated';
+  backupPath?: string;
+}
+
+export async function applyPlan(
+  plan: SetupPlan,
+  options: { backup: boolean }
+): Promise<ApplyResult[]> {
+  const results: ApplyResult[] = [];
+  for (const change of plan.changes) {
+    if (
+      (change.status !== 'create' && change.status !== 'update') ||
+      change.next === null
+    ) {
+      continue;
+    }
+    let backupPath: string | undefined;
+    if (options.backup && change.current !== null) {
+      backupPath = await backupFile(change.path);
+    }
+    await writeConfigFile(change.path, change.next, change.mode);
+    results.push({
+      path: change.path,
+      label: change.label,
+      owners: change.owners,
+      action: change.status === 'create' ? 'created' : 'updated',
+      backupPath,
+    });
+  }
+  return results;
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
@@ -1,0 +1,115 @@
+import { readFile, writeFile, mkdir, copyFile, access } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { parse as tomlParse, stringify as tomlStringify } from 'smol-toml';
+
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readFileOrNull(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+}
+
+type JsonObject = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+export function deepMerge(base: JsonObject, patch: JsonObject): JsonObject {
+  const out: JsonObject = { ...base };
+  for (const [key, patchValue] of Object.entries(patch)) {
+    const baseValue = out[key];
+    if (isPlainObject(baseValue) && isPlainObject(patchValue)) {
+      out[key] = deepMerge(baseValue, patchValue);
+    } else {
+      out[key] = patchValue;
+    }
+  }
+  return out;
+}
+
+export function mergeJson(current: string | null, patch: JsonObject): string {
+  let parsed: JsonObject = {};
+  if (current && current.trim()) {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(current);
+    } catch (err) {
+      throw new Error(
+        `existing file is not valid JSON (${(err as Error).message})`
+      );
+    }
+    if (!isPlainObject(raw)) {
+      throw new Error('existing file is not a JSON object');
+    }
+    parsed = raw;
+  }
+  return `${JSON.stringify(deepMerge(parsed, patch), null, 2)}\n`;
+}
+
+export function mergeToml(current: string | null, patch: JsonObject): string {
+  let parsed: JsonObject = {};
+  if (current && current.trim()) {
+    try {
+      parsed = tomlParse(current) as JsonObject;
+    } catch (err) {
+      throw new Error(
+        `existing file is not valid TOML (${(err as Error).message})`
+      );
+    }
+  }
+  return `${tomlStringify(deepMerge(parsed, patch))}\n`;
+}
+
+export const MANAGED_BLOCK_START = '# >>> vercel ai-gateway >>>';
+export const MANAGED_BLOCK_END = '# <<< vercel ai-gateway <<<';
+
+export function upsertManagedBlock(
+  current: string | null,
+  body: string
+): string {
+  const block = `${MANAGED_BLOCK_START}\n${body}\n${MANAGED_BLOCK_END}`;
+  const existing = current ?? '';
+  const start = existing.indexOf(MANAGED_BLOCK_START);
+  const end = existing.indexOf(MANAGED_BLOCK_END);
+  if (start !== -1 && end !== -1 && end > start) {
+    const before = existing.slice(0, start);
+    const after = existing.slice(end + MANAGED_BLOCK_END.length);
+    return `${before}${block}${after}`;
+  }
+  const prefix = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+  return `${existing}${prefix}${block}\n`;
+}
+
+export async function backupFile(path: string): Promise<string> {
+  const backupPath = `${path}.bak`;
+  await copyFile(path, backupPath);
+  return backupPath;
+}
+
+export async function writeConfigFile(
+  path: string,
+  content: string,
+  mode?: number
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, mode === undefined ? 'utf8' : { mode });
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/diff.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/diff.ts
@@ -1,0 +1,124 @@
+import chalk from 'chalk';
+import { maskSecret } from './gateway';
+
+interface DiffLine {
+  type: ' ' | '-' | '+';
+  text: string;
+}
+
+function diffLines(before: string, after: string): DiffLine[] {
+  const a = before.length ? before.split('\n') : [];
+  const b = after.length ? after.split('\n') : [];
+  const m = a.length;
+  const n = b.length;
+  const lcs: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array<number>(n + 1).fill(0)
+  );
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      lcs[i][j] =
+        a[i] === b[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      out.push({ type: ' ', text: a[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ type: '-', text: a[i] });
+      i++;
+    } else {
+      out.push({ type: '+', text: b[j] });
+      j++;
+    }
+  }
+  while (i < m) out.push({ type: '-', text: a[i++] });
+  while (j < n) out.push({ type: '+', text: b[j++] });
+  return out;
+}
+
+function maskKnownSecrets(text: string, secrets: string[]): string {
+  let masked = text;
+  for (const secret of secrets) {
+    if (secret) {
+      masked = masked.split(secret).join(maskSecret(secret));
+    }
+  }
+  return masked;
+}
+
+function redactSecretFields(text: string): string {
+  return text
+    .replace(
+      /("(?:ANTHROPIC_AUTH_TOKEN|ANTHROPIC_API_KEY|apiKey|key)"\s*:\s*)"((?:[^"\\]|\\.)+)"/g,
+      (_match, prefix, value) => `${prefix}"${maskSecret(value)}"`
+    )
+    .replace(
+      /(export\s+AI_GATEWAY_API_KEY=)(["'])((?:(?!\2).)+)(\2)/g,
+      (_match, prefix, quote, value, close) =>
+        `${prefix}${quote}${maskSecret(value)}${close}`
+    );
+}
+
+function mask(text: string, secrets: string[]): string {
+  return redactSecretFields(maskKnownSecrets(text, secrets));
+}
+
+export interface RenderDiffOptions {
+  secrets?: string[];
+  context?: number;
+  indent?: string;
+}
+
+export function renderDiff(
+  before: string,
+  after: string,
+  options: RenderDiffOptions = {}
+): string {
+  const { secrets = [], context = 2, indent = '  ' } = options;
+  const lines = diffLines(before, after);
+  if (!lines.some(l => l.type !== ' ')) {
+    return '';
+  }
+
+  const keep = new Array<boolean>(lines.length).fill(false);
+  lines.forEach((line, idx) => {
+    if (line.type !== ' ') {
+      for (
+        let k = Math.max(0, idx - context);
+        k <= Math.min(lines.length - 1, idx + context);
+        k++
+      ) {
+        keep[k] = true;
+      }
+    }
+  });
+
+  const rendered: string[] = [];
+  let collapsed = false;
+  lines.forEach((line, idx) => {
+    if (!keep[idx]) {
+      if (!collapsed) {
+        rendered.push(chalk.dim(`${indent}  ⋯`));
+        collapsed = true;
+      }
+      return;
+    }
+    collapsed = false;
+    const text = mask(line.text, secrets);
+    if (line.type === '+') {
+      rendered.push(chalk.green(`${indent}+ ${text}`));
+    } else if (line.type === '-') {
+      rendered.push(chalk.red(`${indent}- ${text}`));
+    } else {
+      rendered.push(chalk.dim(`${indent}  ${text}`));
+    }
+  });
+  return rendered.join('\n');
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/gateway.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/gateway.ts
@@ -1,0 +1,13 @@
+export const GATEWAY_OPENAI_BASE_URL = 'https://ai-gateway.vercel.sh/v1';
+export const GATEWAY_ANTHROPIC_BASE_URL = 'https://ai-gateway.vercel.sh';
+
+export const GATEWAY_API_KEY_ENV = 'AI_GATEWAY_API_KEY';
+
+export const KEY_PLACEHOLDER = '__AI_GATEWAY_API_KEY__';
+
+export function maskSecret(secret: string): string {
+  if (!secret) return secret;
+  if (secret === KEY_PLACEHOLDER) return '••••';
+  if (secret.length <= 8) return '••••';
+  return `${secret.slice(0, 4)}••••${secret.slice(-4)}`;
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
@@ -1,0 +1,183 @@
+import { hostname, userInfo } from 'node:os';
+import chalk from 'chalk';
+import type Client from '../../client';
+import output from '../../../output-manager';
+import { getCommandName } from '../../pkg-name';
+import createApiKeyRequest from '../create-api-key';
+import selectOrg from '../../input/select-org';
+import { buildQuota } from '../quota';
+import {
+  EXPIRY_PRESETS,
+  DEFAULT_EXPIRY_PRESET,
+  presetToExpiresAt,
+} from '../expiry';
+import { outputAgentError } from '../../agent-output';
+import { AGENT_STATUS, AGENT_REASON } from '../../agent-output-constants';
+
+export interface KeySource {
+  key: string;
+  created: boolean;
+}
+
+const CHILD_PROMPT = chalk.dim('↳');
+
+export interface KeyOptions {
+  name?: string;
+  budget?: number;
+  refreshPeriod?: string;
+  includeByok?: boolean;
+  expiresAt?: number;
+}
+
+export function defaultKeyName(): string {
+  let host = '';
+  let user = '';
+  try {
+    host = hostname();
+  } catch {}
+  try {
+    user = userInfo().username;
+  } catch {}
+  const device = host.split('.')[0].replace(/[-_]+/g, ' ').trim();
+  const who = user.trim();
+  if (who && device) return `[${who}'s ${device}] Coding Agents`;
+  if (device) return `[${device}] Coding Agents`;
+  if (who) return `[${who}] Coding Agents`;
+  return 'Coding Agents';
+}
+
+export async function promptKeyName(client: Client): Promise<string> {
+  const fallback = defaultKeyName();
+  const answer = await client.input.text({
+    message:
+      'An AI Gateway API key will be created to use with your coding agents. What should it be called?',
+    default: fallback,
+  });
+  return answer.trim() || fallback;
+}
+
+export async function promptQuota(client: Client): Promise<{
+  budget?: number;
+  refreshPeriod?: string;
+}> {
+  const wantsQuota = await client.input.confirm(
+    'Set a spend limit (quota) for this key?',
+    false
+  );
+  if (!wantsQuota) {
+    return {};
+  }
+  const amount = await client.input.text({
+    message: `${CHILD_PROMPT} Spend limit in USD`,
+    default: '100',
+    validate: value => {
+      const n = Number(value);
+      return Number.isFinite(n) && n >= 1
+        ? true
+        : 'Enter a number of dollars (minimum 1).';
+    },
+  });
+  const refreshPeriod = await client.input.select<string>({
+    message: `${CHILD_PROMPT} How often should the limit reset?`,
+    choices: [
+      { name: 'Never (one-time limit)', value: 'none' },
+      { name: 'Daily', value: 'daily' },
+      { name: 'Weekly', value: 'weekly' },
+      { name: 'Monthly', value: 'monthly' },
+    ],
+    default: 'none',
+  });
+  return { budget: Number(amount), refreshPeriod };
+}
+
+export async function promptExpiry(
+  client: Client
+): Promise<number | undefined> {
+  const wantsExpiry = await client.input.confirm(
+    'Set an expiration for this key?',
+    false
+  );
+  if (!wantsExpiry) {
+    return undefined;
+  }
+  const preset = await client.input.select<string>({
+    message: `${CHILD_PROMPT} Expires in`,
+    choices: EXPIRY_PRESETS.map(p => ({ name: p.label, value: p.value })),
+    default: DEFAULT_EXPIRY_PRESET,
+  });
+  return presetToExpiresAt(preset);
+}
+
+function hasExplicitScopeFlag(argv: string[]): boolean {
+  const args = argv.slice(2);
+  return args.some(
+    a =>
+      a === '--scope' ||
+      a === '-S' ||
+      a === '--team' ||
+      a === '-T' ||
+      a.startsWith('--scope=') ||
+      a.startsWith('--team=')
+  );
+}
+
+export async function ensureTeam(
+  client: Client,
+  opts: { machine: boolean; canPrompt: boolean; yes: boolean }
+): Promise<number | undefined> {
+  const { machine, canPrompt, yes } = opts;
+
+  if (canPrompt && !yes && !hasExplicitScopeFlag(client.argv)) {
+    const org = await selectOrg(
+      client,
+      'What team should the API key be under?'
+    );
+    client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+    return undefined;
+  }
+
+  // Non-interactive, an explicit scope, or `--yes`: use the resolved scope.
+  if (hasExplicitScopeFlag(client.argv) || client.config.currentTeam) {
+    return undefined;
+  }
+
+  const message =
+    'No team selected. Pass --scope <team-slug> or run `vercel switch` first.';
+  if (machine) {
+    outputAgentError(client, {
+      status: AGENT_STATUS.ERROR,
+      reason: AGENT_REASON.MISSING_SCOPE,
+      message,
+      next: [
+        {
+          command: getCommandName(
+            'ai-gateway coding-agents connect --scope <team-slug>'
+          ),
+        },
+      ],
+    });
+  }
+  output.error(message);
+  return 1;
+}
+
+export async function createKey(
+  client: Client,
+  opts: KeyOptions
+): Promise<string> {
+  output.spinner('Creating AI Gateway API key');
+  try {
+    const result = await createApiKeyRequest(client, {
+      name: opts.name,
+      aiGatewayQuota: buildQuota({
+        budget: opts.budget,
+        refreshPeriod: opts.refreshPeriod,
+        includeByok: opts.includeByok,
+      }),
+      ...(opts.expiresAt !== undefined && { expiresAt: opts.expiresAt }),
+    });
+    return result.apiKeyString;
+  } finally {
+    output.stopSpinner();
+  }
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -1,0 +1,112 @@
+import type Client from '../../client';
+import { isAPIError } from '../../errors-ts';
+import { outputAgentError } from '../../agent-output';
+import { AGENT_STATUS, AGENT_REASON } from '../../agent-output-constants';
+import { UNSUPPORTED_AGENTS } from './agents';
+import { buildSetupPlan, applyPlan, type SetupPlan } from './apply';
+import type { KeySource } from './key-source';
+import type { CodingAgent } from './types';
+
+export async function runMachine(args: {
+  client: Client;
+  selected: CodingAgent[];
+  unsupported: string[];
+  previewPlan: SetupPlan;
+  dryRun: boolean;
+  backup: boolean;
+  keySource: KeySource | null;
+  createKey: () => Promise<string>;
+  overrides?: Record<string, string>;
+  shellRcOverride?: string;
+  home: string;
+}): Promise<number> {
+  const { client, selected, previewPlan, dryRun, backup, home } = args;
+
+  const errored = previewPlan.changes.filter(c => c.status === 'error');
+  const skipped: Array<{ target: string; reason: string; message?: string }> =
+    errored.map(c => ({
+      target: c.path,
+      reason: 'unparseable_config',
+      message: c.error,
+    }));
+  for (const id of args.unsupported) {
+    skipped.push({
+      target: id,
+      reason: 'not_automatable',
+      message: UNSUPPORTED_AGENTS[id],
+    });
+  }
+
+  if (dryRun) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: AGENT_STATUS.OK,
+          reason: 'dry_run',
+          message:
+            'Previewing AI Gateway coding-agent setup. No files written.',
+          changes: previewPlan.changes.map(c => ({
+            agent: c.owners.join(', '),
+            file: c.path,
+            action:
+              c.status === 'create'
+                ? 'would_create'
+                : c.status === 'update'
+                  ? 'would_update'
+                  : c.status,
+          })),
+          skipped,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  let key: string;
+  try {
+    key = args.keySource ? args.keySource.key : await args.createKey();
+  } catch (err) {
+    if (isAPIError(err)) {
+      outputAgentError(client, {
+        status: AGENT_STATUS.ERROR,
+        reason: err.status === 403 ? 'forbidden' : AGENT_REASON.API_ERROR,
+        message: err.message,
+      });
+    }
+    throw err;
+  }
+
+  const finalPlan = await buildSetupPlan(selected, {
+    apiKey: key,
+    home,
+    overrides: args.overrides,
+    shellRcOverride: args.shellRcOverride,
+  });
+  const results = await applyPlan(finalPlan, { backup });
+
+  client.stdout.write(
+    `${JSON.stringify(
+      {
+        status: AGENT_STATUS.OK,
+        reason: 'coding_agents_configured',
+        message: `Configured ${results.length} file(s) across ${selected.length} agent(s) to use the AI Gateway.`,
+        apiKey: key,
+        configured: results.map(r => ({
+          agent: r.owners.join(', '),
+          file: r.path,
+          action: r.action,
+          backup: r.backupPath,
+        })),
+        skipped,
+        notes: finalPlan.notes.flatMap(n =>
+          n.notes.map(line => `${n.displayName}: ${line}`)
+        ),
+      },
+      null,
+      2
+    )}\n`
+  );
+  return 0;
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/render.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/render.ts
@@ -1,0 +1,94 @@
+import chalk from 'chalk';
+import output from '../../../output-manager';
+import { printAlignedLabel } from '../../output/print-aligned-label';
+import { renderDiff } from './diff';
+import { maskSecret } from './gateway';
+import type { SetupPlan } from './apply';
+import type { CodingAgent } from './types';
+
+export function printResolvedState(args: {
+  selected: CodingAgent[];
+  willCreate: boolean;
+  name?: string;
+  budget?: number;
+  refreshPeriod?: string;
+  expiresAt?: number;
+}): void {
+  const { selected, willCreate, name, budget, refreshPeriod, expiresAt } = args;
+  output.print(chalk.bold('Summary\n'));
+  printAlignedLabel('Agents', selected.map(a => a.displayName).join(', '));
+  if (!willCreate) {
+    printAlignedLabel('API key', 'Using provided key');
+    output.print('\n');
+    return;
+  }
+  printAlignedLabel(
+    'API key',
+    name ? `Creating new key "${name}"` : 'Creating new key'
+  );
+  let spendLimit = 'Unlimited';
+  if (budget !== undefined) {
+    const period =
+      refreshPeriod && refreshPeriod !== 'none' ? refreshPeriod : '';
+    spendLimit = period ? `$${budget}/${period}` : `$${budget}`;
+  }
+  printAlignedLabel('Spend limit', spendLimit);
+  printAlignedLabel(
+    'Expires',
+    expiresAt !== undefined
+      ? new Date(expiresAt).toISOString().slice(0, 10)
+      : 'Never'
+  );
+  output.print('\n');
+}
+
+export function printPlan(plan: SetupPlan, previewKey: string): void {
+  output.print(chalk.bold('Planned changes\n'));
+  for (const change of plan.changes) {
+    if (change.status === 'unchanged') {
+      output.print(
+        `${chalk.dim('=')} ${chalk.dim(`${change.label} (unchanged)`)}  ${chalk.dim(change.path)}\n`
+      );
+      continue;
+    }
+    if (change.status === 'error') {
+      output.print(
+        `${chalk.red('!')} ${chalk.bold(change.label)}  ${chalk.dim(change.path)}\n`
+      );
+      output.print(chalk.red(`    cannot edit: ${change.error}\n`));
+      continue;
+    }
+    const verb = change.status === 'create' ? 'create' : 'update';
+    output.print(
+      `${chalk.cyan(verb === 'create' ? '+' : '~')} ${chalk.bold(change.label)} (${verb})  ${chalk.dim(change.path)}\n`
+    );
+    const diff = renderDiff(change.current ?? '', change.next ?? '', {
+      secrets: [previewKey],
+    });
+    if (diff) {
+      output.print(`${diff}\n`);
+    }
+  }
+  output.print('\n');
+}
+
+export function printNotes(plan: SetupPlan): void {
+  if (plan.notes.length === 0) {
+    return;
+  }
+  output.print('\n');
+  for (const note of plan.notes) {
+    for (const line of note.notes) {
+      output.log(`${note.displayName}: ${line}`);
+    }
+  }
+}
+
+export function printKey(key: string): void {
+  output.print('\n');
+  output.log(
+    chalk.dim(
+      `AI Gateway API key ${maskSecret(key)} written to the configs above — keep it secret.`
+    )
+  );
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/resolve.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/resolve.ts
@@ -1,0 +1,95 @@
+import type Client from '../../client';
+import { AGENT_REASON } from '../../agent-output-constants';
+import { DEFAULT_AGENTS, getAgentById, UNSUPPORTED_AGENTS } from './agents';
+import type { CodingAgent } from './types';
+
+export type ResolveResult =
+  | { selected: CodingAgent[]; guidance: string[]; unsupported: string[] }
+  | { error: string; reason: string };
+
+export async function resolveAgents(args: {
+  client: Client;
+  agentFlags?: string[];
+  all?: boolean;
+  canPrompt: boolean;
+  yes?: boolean;
+  home: string;
+}): Promise<ResolveResult> {
+  const { client, agentFlags, all, canPrompt, yes, home } = args;
+  const guidance: string[] = [];
+  const unsupported: string[] = [];
+
+  if (agentFlags && agentFlags.length > 0) {
+    const selected: CodingAgent[] = [];
+    const unknown: string[] = [];
+    for (const raw of agentFlags) {
+      const id = raw.toLowerCase();
+      const agent = getAgentById(id);
+      if (agent) {
+        if (!selected.includes(agent)) selected.push(agent);
+      } else if (UNSUPPORTED_AGENTS[id]) {
+        unsupported.push(id);
+        guidance.push(`${id}: ${UNSUPPORTED_AGENTS[id]}`);
+      } else {
+        unknown.push(raw);
+      }
+    }
+    if (unknown.length > 0) {
+      const known = DEFAULT_AGENTS.map(a => a.id).join(', ');
+      return {
+        error: `Unknown agent(s): ${unknown.join(', ')}. Supported: ${known}.`,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+      };
+    }
+    if (selected.length === 0) {
+      return {
+        error: 'No configurable agents selected.',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+      };
+    }
+    return { selected, guidance, unsupported };
+  }
+
+  if (all) {
+    return { selected: DEFAULT_AGENTS, guidance, unsupported };
+  }
+
+  if (!canPrompt) {
+    return { selected: DEFAULT_AGENTS, guidance, unsupported };
+  }
+
+  const detected = await Promise.all(DEFAULT_AGENTS.map(a => a.detect(home)));
+
+  if (yes) {
+    const selected = DEFAULT_AGENTS.filter((_, i) => detected[i]);
+    if (selected.length === 0) {
+      return {
+        error:
+          'No coding agents detected on this machine. Pass --agent <name> (repeatable) or --all.',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+      };
+    }
+    return { selected, guidance, unsupported };
+  }
+
+  const choices = DEFAULT_AGENTS.map((agent, i) => ({
+    name: agent.displayName,
+    value: agent.id,
+    checked: detected[i],
+  }));
+  const picked = await client.input.checkbox<string>({
+    message:
+      'Which coding agents should use the AI Gateway? The ones detected on your machine are pre-selected.',
+    choices,
+  });
+  const selected = picked
+    .map(id => getAgentById(id))
+    .filter((a): a is CodingAgent => Boolean(a));
+  if (selected.length === 0) {
+    return {
+      error: 'Select at least one agent to configure.',
+      reason: AGENT_REASON.INVALID_ARGUMENTS,
+    };
+  }
+  return { selected, guidance, unsupported };
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/types.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/types.ts
@@ -1,0 +1,39 @@
+export interface SetupContext {
+  apiKey: string;
+  home: string;
+  /** Per-agent config-file path overrides, keyed by agent id. */
+  overrides?: Record<string, string>;
+  /** Override for the shell rc file env exports are written into. */
+  shellRcOverride?: string;
+}
+
+export type FileFormat = 'json' | 'toml' | 'shell';
+
+export interface FileChange {
+  path: string;
+  label: string;
+  format: FileFormat;
+  mode?: number;
+  transform(current: string | null): string;
+}
+
+export interface EnvExport {
+  name: string;
+  value: string;
+}
+
+export interface AgentPlan {
+  fileChanges: FileChange[];
+  envExports: EnvExport[];
+  notes: string[];
+}
+
+export interface CodingAgent {
+  id: string;
+  displayName: string;
+  experimental?: boolean;
+  detect(home: string): Promise<boolean>;
+  /** Resolved config-file path: override > native env var > home default. */
+  configPath(ctx: SetupContext): string;
+  buildPlan(ctx: SetupContext): AgentPlan;
+}

--- a/packages/cli/src/util/ai-gateway/create-api-key.ts
+++ b/packages/cli/src/util/ai-gateway/create-api-key.ts
@@ -10,6 +10,7 @@ type CreateApiKeyRequest = {
   purpose: 'ai-gateway';
   name?: string;
   aiGatewayQuota?: AiGatewayQuota;
+  expiresAt?: number;
 };
 
 type CreateApiKeyApiKey = {
@@ -28,7 +29,11 @@ export type CreateApiKeyResponse = {
 
 export default async function createApiKey(
   client: Client,
-  payload: { name?: string; aiGatewayQuota?: AiGatewayQuota }
+  payload: {
+    name?: string;
+    aiGatewayQuota?: AiGatewayQuota;
+    expiresAt?: number;
+  }
 ): Promise<CreateApiKeyResponse> {
   return await client.fetch<CreateApiKeyResponse>('/v1/api-keys', {
     method: 'POST',

--- a/packages/cli/src/util/ai-gateway/expiry.ts
+++ b/packages/cli/src/util/ai-gateway/expiry.ts
@@ -1,0 +1,57 @@
+/**
+ * Optional expiry for AI Gateway API keys. The API accepts an `expiresAt` Unix
+ * millisecond timestamp at creation only. These presets mirror the dashboard's
+ * "AI Gateway → New API Key" expiry options so the two surfaces stay in sync.
+ */
+export const EXPIRY_PRESETS = [
+  { label: '7 days', value: '7d' },
+  { label: '30 days', value: '30d' },
+  { label: '60 days', value: '60d' },
+  { label: '90 days', value: '90d' },
+  { label: '1 year', value: '1y' },
+] as const;
+
+export type ExpiryPreset = (typeof EXPIRY_PRESETS)[number]['value'];
+
+/** Default highlighted option once the user opts into an expiry. */
+export const DEFAULT_EXPIRY_PRESET: ExpiryPreset = '30d';
+
+/** Accepted `--expiration` values: any preset, or `none` for no expiry. */
+export const VALID_EXPIRY_VALUES = [
+  ...EXPIRY_PRESETS.map(p => p.value),
+  'none',
+] as const;
+
+export function isValidExpiry(value: string): boolean {
+  return (VALID_EXPIRY_VALUES as readonly string[]).includes(value);
+}
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Resolves a preset to an absolute `expiresAt` timestamp (ms), or `undefined`
+ * for `none`. Day presets add fixed 24h spans; `1y` adds a calendar year, both
+ * matching the dashboard.
+ */
+export function presetToExpiresAt(
+  value: string,
+  now: number = Date.now()
+): number | undefined {
+  switch (value) {
+    case '7d':
+      return now + 7 * DAY_MS;
+    case '30d':
+      return now + 30 * DAY_MS;
+    case '60d':
+      return now + 60 * DAY_MS;
+    case '90d':
+      return now + 90 * DAY_MS;
+    case '1y': {
+      const date = new Date(now);
+      date.setFullYear(date.getFullYear() + 1);
+      return date.getTime();
+    }
+    default:
+      return undefined;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-connect.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-connect.ts
@@ -1,0 +1,95 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { connectSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayCodingAgentsConnectTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof connectSubcommand>
+{
+  trackCliOptionAgent(agents: [string] | undefined) {
+    if (agents && agents.length) {
+      for (const agent of agents) {
+        this.trackCliOption({ option: 'agent', value: agent });
+      }
+    }
+  }
+
+  trackCliFlagAll(all: boolean | undefined) {
+    if (all) {
+      this.trackCliFlag('all');
+    }
+  }
+
+  trackCliOptionKey(key: string | undefined) {
+    if (key) {
+      this.trackCliOption({ option: 'key', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionBudget(budget: number | undefined) {
+    if (budget !== undefined) {
+      this.trackCliOption({ option: 'budget', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionRefreshPeriod(refreshPeriod: string | undefined) {
+    if (refreshPeriod) {
+      this.trackCliOption({
+        option: 'refresh-period',
+        value: refreshPeriod,
+      });
+    }
+  }
+
+  trackCliFlagIncludeByok(includeByok: boolean | undefined) {
+    if (includeByok) {
+      this.trackCliFlag('include-byok');
+    }
+  }
+
+  trackCliOptionExpiration(expiration: string | undefined) {
+    if (expiration) {
+      this.trackCliOption({ option: 'expiration', value: expiration });
+    }
+  }
+
+  trackCliOptionName(name: string | undefined) {
+    if (name) {
+      this.trackCliOption({ option: 'name', value: this.redactedValue });
+    }
+  }
+
+  trackCliFlagDryRun(dryRun: boolean | undefined) {
+    if (dryRun) {
+      this.trackCliFlag('dry-run');
+    }
+  }
+
+  trackCliFlagNoBackup(noBackup: boolean | undefined) {
+    if (noBackup) {
+      this.trackCliFlag('no-backup');
+    }
+  }
+
+  trackCliOptionAgentConfig(agentConfig: string[] | undefined) {
+    if (agentConfig && agentConfig.length) {
+      // Local paths may be sensitive; record only that the option was used.
+      this.trackCliOption({
+        option: 'agent-config',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionShellRc(shellRc: string | undefined) {
+    if (shellRc) {
+      this.trackCliOption({ option: 'shell-rc', value: this.redactedValue });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents.ts
@@ -1,0 +1,15 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { codingAgentsSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayCodingAgentsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof codingAgentsSubcommand>
+{
+  trackCliSubcommandConnect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'connect',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/index.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/index.ts
@@ -19,4 +19,11 @@ export class AiGatewayTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandCodingAgents(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'coding-agents',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
@@ -1,0 +1,639 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import { buildSetupPlan } from '../../../../src/util/ai-gateway/coding-agents/apply';
+import { claudeCode } from '../../../../src/util/ai-gateway/coding-agents/agents/claude-code';
+
+const CREATED_KEY = 'vck_CreatedSecretKey1234';
+const mockApiKeyResponse = {
+  apiKeyString: CREATED_KEY,
+  apiKey: {
+    id: '5d9f2ebd38dd',
+    name: 'my-key',
+    partialKey: 'vck',
+    teamId: 'team_abc',
+    purpose: 'ai-gateway',
+    createdAt: 1700000000000,
+  },
+};
+
+let lastCreateBody: Record<string, unknown> | undefined;
+function useCreateApiKey(response = mockApiKeyResponse) {
+  lastCreateBody = undefined;
+  client.scenario.post('/v1/api-keys', (req, res) => {
+    lastCreateBody = req.body;
+    res.json(response);
+  });
+}
+
+let home: string;
+let savedEnv: Record<string, string | undefined>;
+
+function claudeSettingsPath() {
+  return join(home, '.claude', 'settings.json');
+}
+function codexConfigPath() {
+  return join(home, '.codex', 'config.toml');
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'vc-setup-agents-'));
+  savedEnv = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    SHELL: process.env.SHELL,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+    CODEX_HOME: process.env.CODEX_HOME,
+    PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+    ZDOTDIR: process.env.ZDOTDIR,
+  };
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.SHELL = '/bin/bash';
+  for (const v of [
+    'XDG_CONFIG_HOME',
+    'CLAUDE_CONFIG_DIR',
+    'CODEX_HOME',
+    'PI_CODING_AGENT_DIR',
+    'ZDOTDIR',
+  ]) {
+    delete process.env[v];
+  }
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe('ai-gateway coding-agents connect', () => {
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'coding-agents', 'connect', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+    });
+  });
+
+  describe('non-interactive with an existing key', () => {
+    it('configures Claude Code and emits JSON with the key', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        'vck_DummyKey0001',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_BASE_URL).toBe(
+        'https://ai-gateway.vercel.sh'
+      );
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('vck_DummyKey0001');
+      expect(settings.env.ANTHROPIC_API_KEY).toBe('');
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.status).toBe('ok');
+      expect(out.reason).toBe('coding_agents_configured');
+      expect(out.apiKey).toBe('vck_DummyKey0001');
+      expect(out.configured).toHaveLength(1);
+      expect(out.configured[0].action).toBe('created');
+    });
+  });
+
+  describe('non-interactive key creation', () => {
+    it('mints a budgeted key and writes it everywhere', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--agent',
+        'claude-code',
+        '--budget',
+        '500',
+        '--refresh-period',
+        'monthly'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      expect(lastCreateBody?.purpose).toBe('ai-gateway');
+      expect(lastCreateBody?.aiGatewayQuota).toMatchObject({
+        limitAmount: 500,
+        refreshPeriod: 'monthly',
+      });
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.apiKey).toBe(CREATED_KEY);
+    });
+  });
+
+  describe('--dry-run', () => {
+    it('writes nothing and reports the planned changes', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--dry-run',
+        '--key',
+        'vck_DummyKey0004',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.reason).toBe('dry_run');
+      expect(out.changes[0].action).toBe('would_create');
+    });
+
+    it('prompts for name, team, quota, and expiry in order', async () => {
+      useUser();
+      useTeam();
+      // Found at its default location, so the custom-path prompt stays quiet.
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--dry-run',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stderr).toOutput('previewing changes only');
+      await expect(client.stderr).toOutput('use with your coding agents');
+      client.stdin.write('\n');
+      // Then team.
+      await expect(client.stderr).toOutput(
+        'What team should the API key be under?'
+      );
+      client.stdin.write('\n'); // accept default scope
+      // Then quota (defaults to no).
+      await expect(client.stderr).toOutput('Set a spend limit');
+      client.stdin.write('\n');
+      // Then expiry (defaults to no).
+      await expect(client.stderr).toOutput('Set an expiration');
+      client.stdin.write('\n');
+
+      // With neither set, the summary spells out the absence of limits.
+      await expect(client.stderr).toOutput('Unlimited');
+      await expect(client.stderr).toOutput('Never');
+      await expect(client.stderr).toOutput('Dry run');
+      expect(await exitCodePromise).toBe(0);
+      // Still a preview: nothing is written and no key is minted.
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+    });
+
+    it('prompts for the team even when one is already selected', async () => {
+      const team = useTeam();
+      useUser();
+      // A scope is already pinned, but key ownership is still an explicit choice.
+      client.config.currentTeam = team.id;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      // Pin the other options so only the team prompt remains.
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--dry-run',
+        '--agent',
+        'claude-code',
+        '--name',
+        'my-key',
+        '--refresh-period',
+        'none',
+        '--expiration',
+        'none'
+      );
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stderr).toOutput(
+        'What team should the API key be under?'
+      );
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput('Dry run');
+      expect(await exitCodePromise).toBe(0);
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+    });
+
+    it('does not require a scope in non-interactive mode', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--dry-run',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.reason).toBe('dry_run');
+    });
+  });
+
+  describe('team selection', () => {
+    it('skips the prompt with --yes and uses the current scope', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--yes',
+        '--agent',
+        'claude-code'
+      );
+
+      // No prompt is awaited: --yes accepts the current scope and the run
+      // completes without any interactive input.
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
+    });
+  });
+
+  describe('agent selection with --yes', () => {
+    it('selects the detected agents without prompting', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      client.setArgv('ai-gateway', 'coding-agents', 'connect', '--yes');
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
+      // An undetected agent is not configured.
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
+
+    it('errors when nothing is detected and no agent is named', async () => {
+      useUser();
+      // Fresh home: no agent config dirs, so nothing is detected.
+      client.setArgv('ai-gateway', 'coding-agents', 'connect', '--yes');
+
+      expect(await aiGateway(client)).toBe(1);
+      await expect(client.stderr).toOutput('No coding agents detected');
+    });
+  });
+
+  describe('key options', () => {
+    it('collects name, quota, and expiry interactively', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stderr).toOutput('use with your coding agents');
+      client.stdin.write('My Coding Key\n');
+      await expect(client.stderr).toOutput(
+        'What team should the API key be under?'
+      );
+      client.stdin.write('\n');
+      await expect(client.stderr).toOutput('Set a spend limit');
+      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('Spend limit in USD');
+      client.stdin.write('\n'); // accept default 100
+      await expect(client.stderr).toOutput('How often should the limit reset?');
+      client.stdin.write('\n'); // accept default "Never"
+      await expect(client.stderr).toOutput('Set an expiration');
+      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('Expires in');
+      client.stdin.write('\n'); // accept default preset (30 days)
+      // Planned changes are shown first, then the summary, then the apply prompt.
+      await expect(client.stderr).toOutput('Planned changes');
+      await expect(client.stderr).toOutput('Summary');
+      await expect(client.stderr).toOutput('Apply these changes?');
+      client.stdin.write('\n'); // accept default (yes)
+
+      expect(await exitCodePromise).toBe(0);
+
+      expect(lastCreateBody?.name).toBe('My Coding Key');
+      expect(lastCreateBody?.aiGatewayQuota).toMatchObject({
+        limitAmount: 100,
+      });
+      const expiresAt = lastCreateBody?.expiresAt as number;
+      expect(typeof expiresAt).toBe('number');
+      // 30-day preset lands ~30 days out.
+      const days = (expiresAt - Date.now()) / 86_400_000;
+      expect(days).toBeGreaterThan(29);
+      expect(days).toBeLessThan(31);
+    });
+
+    it('sends expiresAt from the --expiration flag', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--agent',
+        'claude-code',
+        '--expiration',
+        '7d'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const expiresAt = lastCreateBody?.expiresAt as number;
+      expect(typeof expiresAt).toBe('number');
+      const days = (expiresAt - Date.now()) / 86_400_000;
+      expect(days).toBeGreaterThan(6);
+      expect(days).toBeLessThan(8);
+    });
+
+    it('does not send expiresAt for --expiration none', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--agent',
+        'claude-code',
+        '--expiration',
+        'none'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      expect(lastCreateBody?.expiresAt).toBeUndefined();
+    });
+
+    it('rejects an invalid --expiration', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--agent',
+        'claude-code',
+        '--expiration',
+        'soon'
+      );
+
+      expect(await aiGateway(client)).toBe(1);
+      await expect(client.stderr).toOutput('Invalid expiration');
+    });
+  });
+
+  describe('custom config paths', () => {
+    it('writes an agent config to an --agent-config path', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const custom = join(home, 'work', 'claude', 'settings.json');
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        'vck_DummyKey0009',
+        '--agent',
+        'claude-code',
+        '--agent-config',
+        `claude-code=${custom}`
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      expect(existsSync(custom)).toBe(true);
+      // The default location is left untouched.
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.configured[0].file).toBe(custom);
+    });
+
+    it('honors an agent-native config dir env var (CLAUDE_CONFIG_DIR)', async () => {
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: 'vck_x',
+        home,
+        // (set per-test; restored by afterEach)
+      });
+      expect(
+        plan.changes.some(
+          c => c.path === join(home, '.claude', 'settings.json')
+        )
+      ).toBe(true);
+
+      process.env.CLAUDE_CONFIG_DIR = join(home, 'alt-claude');
+      const relocated = await buildSetupPlan([claudeCode], {
+        apiKey: 'vck_x',
+        home,
+      });
+      expect(
+        relocated.changes.some(
+          c => c.path === join(home, 'alt-claude', 'settings.json')
+        )
+      ).toBe(true);
+    });
+
+    it('rejects a malformed --agent-config', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--agent',
+        'claude-code',
+        '--agent-config',
+        'claude-code' // missing =path
+      );
+      expect(await aiGateway(client)).toBe(1);
+      await expect(client.stderr).toOutput('Invalid --agent-config');
+    });
+  });
+
+  describe('idempotency', () => {
+    it('is a no-op on the second run with the same key', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const argv = [
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        'vck_DummyKey0005',
+        '--agent',
+        'claude-code',
+      ] as const;
+
+      client.setArgv(...argv);
+      expect(await aiGateway(client)).toBe(0);
+      const first = readFileSync(claudeSettingsPath(), 'utf8');
+      const stdoutAfterFirst = client.stdout.getFullOutput().length;
+
+      client.setArgv(...argv);
+      expect(await aiGateway(client)).toBe(0);
+      const second = readFileSync(claudeSettingsPath(), 'utf8');
+
+      expect(second).toBe(first);
+      const secondJson = client.stdout.getFullOutput().slice(stdoutAfterFirst);
+      const out = JSON.parse(secondJson);
+      expect(out.configured).toHaveLength(0);
+    });
+  });
+
+  describe('safety', () => {
+    it('skips a malformed config instead of clobbering it', async () => {
+      useUser();
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(claudeSettingsPath(), '{ this is not json', 'utf8');
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        'vck_DummyKey0006',
+        '--agent',
+        'claude-code'
+      );
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      // File untouched.
+      expect(readFileSync(claudeSettingsPath(), 'utf8')).toBe(
+        '{ this is not json'
+      );
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(
+        out.skipped.some((s: any) => s.reason === 'unparseable_config')
+      ).toBe(true);
+    });
+
+    it('never prints the full key — only a masked form', async () => {
+      useUser();
+      const secret = 'vck_SuperSecretValue98765';
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        secret,
+        '--agent',
+        'claude-code',
+        '--yes'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      // Masked in the diff and the receipt; the full secret never reaches the
+      // terminal (it lives only in the config files).
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('vck_••••8765');
+      expect(stderr).not.toContain(secret);
+      expect(client.stdout.getFullOutput()).not.toContain(secret);
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects a negative budget', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--budget',
+        '-5',
+        '--agent',
+        'claude-code',
+        '--key',
+        'vck_x'
+      );
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Budget must be a positive number in dollars'
+      );
+    });
+
+    it('rejects an unknown agent', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--agent',
+        'bogus',
+        '--key',
+        'vck_x'
+      );
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain('Unknown agent');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add `vercel ai-gateway coding-agents connect` to connect local coding agents to the Vercel AI Gateway. This PR lands the **command framework** and **Claude Code**. The key is written directly into each agent's config here; optional macOS Keychain storage is added next (#16856), and Codex/OpenCode/Pi follow.

For each selected agent it configures **only the gateway base URL and authentication** — it never pins a default model.

## Key provisioning
- Reuse an existing key with `--key`, or mint a new one (`--name`, `--budget`/`--refresh-period`/`--include-byok` via the #16851 helper, `--expiration 7d|30d|60d|90d|1y|none`).
- `--scope`/`--team` selects the owning team.

## Flow
Prompts: agents (detected pre-selected) → name → team → quota → expiry, then prints planned changes + summary and asks before applying. `--yes` no prompts; `--dry-run` preview; `--non-interactive` emits JSON. Changed files backed up `.bak`; unparseable configs skipped, not clobbered. The full key is never printed — only a masked form.

## Claude Code
→ `~/.claude/settings.json`. Adding an agent is a single module under `util/ai-gateway/coding-agents/agents`.

---
**Stack — merge in order:**
1. #16851 — quota helper (base `main`)
2. #16852 — `coding-agents connect` framework + Claude Code
3. #16856 — macOS Keychain storage
4. #16853 — Codex
5. #16854 — OpenCode
6. #16855 — Pi
