### PR TITLE
[cli] coding-agents connect: add Codex support

### DIFF
--- a/.changeset/ai-gateway-coding-agents-codex.md
+++ b/.changeset/ai-gateway-coding-agents-codex.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add Codex support to `vercel ai-gateway coding-agents connect`. It writes a `vercel` model provider to `~/.codex/config.toml` (OpenAI-compatible base URL, `responses` wire API) without pinning a default model, and exports the gateway API key via your shell rc (honoring `CODEX_HOME` and fish/`ZDOTDIR`).

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
@@ -1,0 +1,65 @@
+import { join } from 'node:path';
+import type { CodingAgent } from '../types';
+import { mergeToml, pathExists } from '../config-files';
+import { GATEWAY_OPENAI_BASE_URL, GATEWAY_API_KEY_ENV } from '../gateway';
+
+/**
+ * Codex reads `~/.codex/config.toml`. We add a `vercel` model provider pointing
+ * at the gateway's OpenAI-compatible base URL and make it the default provider
+ * via the top-level `model_provider` (the top-level `profile = "..."` key is
+ * rejected by current Codex). We deliberately do NOT pin a `model` — the user
+ * keeps choosing their own. `wire_api` MUST be `responses` — Codex removed Chat
+ * Completions support, and the gateway serves the Responses API at
+ * `/v1/responses`. The key itself never lands in the TOML; `env_key` names an env
+ * var Codex reads at runtime, so we also export it via the shell rc.
+ *
+ * Docs: https://vercel.com/docs/ai-gateway/coding-agents/openai-codex
+ */
+/** Config dir: `$CODEX_HOME` (Codex's own override) or `~/.codex`. */
+function codexDir(home: string): string {
+  const dir = process.env.CODEX_HOME;
+  return dir && dir.trim() ? dir : join(home, '.codex');
+}
+
+export const codex: CodingAgent = {
+  id: 'codex',
+  displayName: 'Codex',
+
+  async detect(home) {
+    return pathExists(codexDir(home));
+  },
+
+  configPath(ctx) {
+    return ctx.overrides?.['codex'] ?? join(codexDir(ctx.home), 'config.toml');
+  },
+
+  buildPlan(ctx) {
+    const path = this.configPath(ctx);
+    return {
+      fileChanges: [
+        {
+          path,
+          label: 'Codex config',
+          format: 'toml',
+          transform: current =>
+            mergeToml(current, {
+              model_provider: 'vercel',
+              model_providers: {
+                vercel: {
+                  name: 'Vercel AI Gateway',
+                  base_url: GATEWAY_OPENAI_BASE_URL,
+                  env_key: GATEWAY_API_KEY_ENV,
+                  wire_api: 'responses',
+                },
+              },
+            }),
+        },
+      ],
+      envExports: [{ name: GATEWAY_API_KEY_ENV, value: ctx.apiKey }],
+      notes: [
+        'Codex now defaults to the Vercel AI Gateway; pick a model with --model or in config.',
+        `Open a new terminal so ${GATEWAY_API_KEY_ENV} is loaded, or run: export ${GATEWAY_API_KEY_ENV}=<key>`,
+      ],
+    };
+  },
+};

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -1,11 +1,12 @@
 import type { CodingAgent } from '../types';
 import { claudeCode } from './claude-code';
+import { codex } from './codex';
 
 /**
  * Registry of supported coding agents. Add a new agent by exporting a
  * `CodingAgent` from a file in this folder and appending it here.
  */
-export const CODING_AGENTS: CodingAgent[] = [claudeCode];
+export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex];
 
 /** Default targets when the user does not pass `--agent` (excludes experimental). */
 export const DEFAULT_AGENTS = CODING_AGENTS.filter(a => !a.experimental);

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
@@ -8,12 +8,14 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { parse as tomlParse } from 'smol-toml';
 import { client } from '../../../mocks/client';
 import aiGateway from '../../../../src/commands/ai-gateway';
 import { useUser } from '../../../mocks/user';
 import { useTeam } from '../../../mocks/team';
 import { buildSetupPlan } from '../../../../src/util/ai-gateway/coding-agents/apply';
 import { claudeCode } from '../../../../src/util/ai-gateway/coding-agents/agents/claude-code';
+import { codex } from '../../../../src/util/ai-gateway/coding-agents/agents/codex';
 import {
   isKeychainAvailable,
   storeKeyInKeychain,
@@ -50,6 +52,9 @@ function claudeSettingsPath() {
 }
 function codexConfigPath() {
   return join(home, '.codex', 'config.toml');
+}
+function bashrcPath() {
+  return join(home, '.bashrc');
 }
 
 beforeEach(() => {
@@ -127,6 +132,58 @@ describe('ai-gateway coding-agents connect', () => {
       expect(out.apiKey).toBe('vck_DummyKey0001');
       expect(out.configured).toHaveLength(1);
       expect(out.configured[0].action).toBe('created');
+    });
+
+    it('configures Codex with the responses wire API and a shell export', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        'vck_DummyKey0002',
+        '--agent',
+        'codex'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const toml = tomlParse(readFileSync(codexConfigPath(), 'utf8')) as any;
+      expect(toml.model_provider).toBe('vercel');
+      // We never pin a default model — only the provider/URL/auth are set up.
+      expect(toml.model).toBeUndefined();
+      expect(toml.model_providers.vercel.base_url).toBe(
+        'https://ai-gateway.vercel.sh/v1'
+      );
+      expect(toml.model_providers.vercel.wire_api).toBe('responses');
+      expect(toml.model_providers.vercel.env_key).toBe('AI_GATEWAY_API_KEY');
+
+      const bashrc = readFileSync(bashrcPath(), 'utf8');
+      expect(bashrc).toContain('# >>> vercel ai-gateway >>>');
+      expect(bashrc).toContain("export AI_GATEWAY_API_KEY='vck_DummyKey0002'");
+    });
+
+    it('shell-escapes a key with special characters', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const trickyKey = 'vck_a$b`c\'d"e';
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        trickyKey,
+        '--agent',
+        'codex'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const bashrc = readFileSync(bashrcPath(), 'utf8');
+      expect(bashrc).toContain(
+        `export AI_GATEWAY_API_KEY='vck_a$b\`c'\\''d"e'`
+      );
     });
   });
 
@@ -379,6 +436,20 @@ describe('ai-gateway coding-agents connect', () => {
       const claude = plan.changes.find(c => c.label === 'Claude Code settings');
       expect(claude?.next).toContain(secret);
     });
+
+    it('reads the Codex env key from the Keychain instead of the config', async () => {
+      const secret = 'vck_KeychainSecret321';
+      const plan = await buildSetupPlan([codex], {
+        apiKey: secret,
+        home,
+        useKeychain: true,
+      });
+
+      const shell = plan.changes.find(c => c.format === 'shell');
+      expect(shell?.next).toContain('security find-generic-password');
+      expect(shell?.next).toContain('export AI_GATEWAY_API_KEY=');
+      expect(shell?.next).not.toContain(secret);
+    });
   });
 
   describe('key options', () => {
@@ -548,6 +619,20 @@ describe('ai-gateway coding-agents connect', () => {
       ).toBe(true);
     });
 
+    it('writes fish syntax to a fish rc', async () => {
+      const fishRc = join(home, '.config', 'fish', 'config.fish');
+      const plan = await buildSetupPlan([codex], {
+        apiKey: "vck_a'b",
+        home,
+        useKeychain: false,
+        shellRcOverride: fishRc,
+      });
+      const shell = plan.changes.find(c => c.format === 'shell');
+      expect(shell?.path).toBe(fishRc);
+      expect(shell?.next).toContain('set -gx AI_GATEWAY_API_KEY');
+      expect(shell?.next).not.toContain('export ');
+    });
+
     it('rejects a malformed --agent-config', async () => {
       useUser();
       client.setArgv(
@@ -561,6 +646,21 @@ describe('ai-gateway coding-agents connect', () => {
       );
       expect(await aiGateway(client)).toBe(1);
       await expect(client.stderr).toOutput('Invalid --agent-config');
+    });
+
+    it('rejects an override for an unselected agent', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--agent',
+        'claude-code',
+        '--agent-config',
+        'codex=/tmp/x/config.toml'
+      );
+      expect(await aiGateway(client)).toBe(1);
+      await expect(client.stderr).toOutput("isn't selected");
     });
   });
 


### PR DESCRIPTION
## Summary

Add **Codex** support to `vercel ai-gateway coding-agents connect`.

- Writes a `vercel` model provider to `~/.codex/config.toml` (OpenAI-compatible base URL, `wire_api = "responses"`, `env_key = AI_GATEWAY_API_KEY`); no default model pinned.
- Exports the gateway key via a managed block in your shell rc (honors `CODEX_HOME`, `ZDOTDIR`, fish). With Keychain on (#16856), the export resolves the key at runtime.

Adds Codex tests: config shape, shell export + special-char escaping, fish rc, Keychain-backed env, and the cross-agent `--agent-config` "not selected" guard.

---
**Stack — merge in order:**
1. #16851 — quota helper (base `main`)
2. #16852 — `coding-agents connect` framework + Claude Code
3. #16856 — macOS Keychain storage
4. #16853 — Codex
5. #16854 — OpenCode
6. #16855 — Pi
