### PR TITLE
[cli] coding-agents connect: add OpenCode support

### DIFF
--- a/.changeset/ai-gateway-coding-agents-opencode.md
+++ b/.changeset/ai-gateway-coding-agents-opencode.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add OpenCode support to `vercel ai-gateway coding-agents connect`. It supplies the gateway API key to OpenCode's native `vercel` provider in `~/.config/opencode/opencode.json` (honoring `XDG_CONFIG_HOME`) without pinning a default model.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -1,12 +1,13 @@
 import type { CodingAgent } from '../types';
 import { claudeCode } from './claude-code';
 import { codex } from './codex';
+import { opencode } from './opencode';
 
 /**
  * Registry of supported coding agents. Add a new agent by exporting a
  * `CodingAgent` from a file in this folder and appending it here.
  */
-export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex];
+export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex, opencode];
 
 /** Default targets when the user does not pass `--agent` (excludes experimental). */
 export const DEFAULT_AGENTS = CODING_AGENTS.filter(a => !a.experimental);

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/opencode.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/opencode.ts
@@ -1,0 +1,57 @@
+import { join } from 'node:path';
+import type { CodingAgent } from '../types';
+import { mergeJson, pathExists } from '../config-files';
+
+/**
+ * OpenCode has a first-class native `vercel` provider (`@ai-sdk/gateway`). We
+ * only supply the key via `provider.vercel.options.apiKey` — we deliberately do
+ * NOT pin a default model; the user selects one (OpenCode model ids are
+ * `vercel/<creator>/<model>` since the gateway's slugs already contain a slash).
+ *
+ * Config: `~/.config/opencode/opencode.json` (honors `$XDG_CONFIG_HOME`).
+ * Docs: https://vercel.com/docs/ai-gateway/coding-agents/opencode
+ */
+function defaultConfigPath(home: string): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const base = xdg && xdg.startsWith('/') ? xdg : join(home, '.config');
+  return join(base, 'opencode', 'opencode.json');
+}
+
+export const opencode: CodingAgent = {
+  id: 'opencode',
+  displayName: 'OpenCode',
+
+  async detect(home) {
+    return pathExists(defaultConfigPath(home));
+  },
+
+  configPath(ctx) {
+    return ctx.overrides?.['opencode'] ?? defaultConfigPath(ctx.home);
+  },
+
+  buildPlan(ctx) {
+    return {
+      fileChanges: [
+        {
+          path: this.configPath(ctx),
+          label: 'OpenCode config',
+          format: 'json',
+          transform: current =>
+            mergeJson(current, {
+              provider: {
+                vercel: {
+                  options: {
+                    apiKey: ctx.apiKey,
+                  },
+                },
+              },
+            }),
+        },
+      ],
+      envExports: [],
+      notes: [
+        'OpenCode can now use the Vercel AI Gateway; pick a model like vercel/<creator>/<model>.',
+      ],
+    };
+  },
+};

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
@@ -56,6 +56,9 @@ function codexConfigPath() {
 function bashrcPath() {
   return join(home, '.bashrc');
 }
+function opencodeConfigPath() {
+  return join(home, '.config', 'opencode', 'opencode.json');
+}
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'vc-setup-agents-'));
@@ -184,6 +187,27 @@ describe('ai-gateway coding-agents connect', () => {
       expect(bashrc).toContain(
         `export AI_GATEWAY_API_KEY='vck_a$b\`c'\\''d"e'`
       );
+    });
+
+    it('configures OpenCode with the native vercel provider', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        'vck_DummyKey0003',
+        '--agent',
+        'opencode'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const cfg = JSON.parse(readFileSync(opencodeConfigPath(), 'utf8'));
+      expect(cfg.provider.vercel.options.apiKey).toBe('vck_DummyKey0003');
+      expect(cfg.model).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Add **OpenCode** support to `vercel ai-gateway coding-agents connect`.

- Supplies the gateway key to OpenCode's native `vercel` provider in `~/.config/opencode/opencode.json` (honors `XDG_CONFIG_HOME`); no default model pinned.

Adds an OpenCode test.

---
**Stack — merge in order:**
1. #16851 — quota helper (base `main`)
2. #16852 — `coding-agents connect` framework + Claude Code
3. #16856 — macOS Keychain storage
4. #16853 — Codex
5. #16854 — OpenCode
6. #16855 — Pi
