### PR TITLE
[cli] coding-agents connect: add Pi support

### DIFF
--- a/.changeset/ai-gateway-coding-agents-pi.md
+++ b/.changeset/ai-gateway-coding-agents-pi.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add Pi support to `vercel ai-gateway coding-agents connect`. It writes the gateway credential to Pi's native `vercel-ai-gateway` auth entry in `~/.pi/agent/auth.json` (created `0600`, honoring `PI_CODING_AGENT_DIR`) without pinning a default model.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -2,12 +2,13 @@ import type { CodingAgent } from '../types';
 import { claudeCode } from './claude-code';
 import { codex } from './codex';
 import { opencode } from './opencode';
+import { pi } from './pi';
 
 /**
  * Registry of supported coding agents. Add a new agent by exporting a
  * `CodingAgent` from a file in this folder and appending it here.
  */
-export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex, opencode];
+export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex, opencode, pi];
 
 /** Default targets when the user does not pass `--agent` (excludes experimental). */
 export const DEFAULT_AGENTS = CODING_AGENTS.filter(a => !a.experimental);

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/pi.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/pi.ts
@@ -1,0 +1,54 @@
+import { join } from 'node:path';
+import type { CodingAgent } from '../types';
+import { mergeJson, pathExists } from '../config-files';
+
+/**
+ * Pi (the open-source terminal coding agent, `@earendil-works/pi-coding-agent`)
+ * has a first-class `vercel-ai-gateway` provider — it already knows the gateway
+ * base URL and model catalog. We only supply the credential in its auth file,
+ * `auth.json`, under the `vercel-ai-gateway` key. Pi creates that file `0600`,
+ * so we do the same. Its agent dir is `$PI_CODING_AGENT_DIR` (Pi's own override)
+ * or `~/.pi/agent`.
+ *
+ * Docs: https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md
+ */
+function piAgentDir(home: string): string {
+  const dir = process.env.PI_CODING_AGENT_DIR;
+  return dir && dir.trim() ? dir : join(home, '.pi', 'agent');
+}
+
+export const pi: CodingAgent = {
+  id: 'pi',
+  displayName: 'Pi',
+
+  async detect(home) {
+    const dir = process.env.PI_CODING_AGENT_DIR;
+    return pathExists(dir && dir.trim() ? dir : join(home, '.pi'));
+  },
+
+  configPath(ctx) {
+    return ctx.overrides?.['pi'] ?? join(piAgentDir(ctx.home), 'auth.json');
+  },
+
+  buildPlan(ctx) {
+    const path = this.configPath(ctx);
+    return {
+      fileChanges: [
+        {
+          path,
+          label: 'Pi auth',
+          format: 'json',
+          mode: 0o600,
+          transform: current =>
+            mergeJson(current, {
+              'vercel-ai-gateway': { type: 'api_key', key: ctx.apiKey },
+            }),
+        },
+      ],
+      envExports: [],
+      notes: [
+        'Pi will use the Vercel AI Gateway provider; pick a model with /model or --model.',
+      ],
+    };
+  },
+};

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
@@ -5,6 +5,7 @@ import {
   writeFileSync,
   existsSync,
   mkdirSync,
+  statSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -58,6 +59,9 @@ function bashrcPath() {
 }
 function opencodeConfigPath() {
   return join(home, '.config', 'opencode', 'opencode.json');
+}
+function piAuthPath() {
+  return join(home, '.pi', 'agent', 'auth.json');
 }
 
 beforeEach(() => {
@@ -208,6 +212,32 @@ describe('ai-gateway coding-agents connect', () => {
       const cfg = JSON.parse(readFileSync(opencodeConfigPath(), 'utf8'));
       expect(cfg.provider.vercel.options.apiKey).toBe('vck_DummyKey0003');
       expect(cfg.model).toBeUndefined();
+    });
+
+    it('configures Pi via the native vercel-ai-gateway auth entry (0600)', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'connect',
+        '--key',
+        'vck_DummyKey0007',
+        '--agent',
+        'pi'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const auth = JSON.parse(readFileSync(piAuthPath(), 'utf8'));
+      expect(auth['vercel-ai-gateway']).toEqual({
+        type: 'api_key',
+        key: 'vck_DummyKey0007',
+      });
+      if (process.platform !== 'win32') {
+        expect(statSync(piAuthPath()).mode & 0o777).toBe(0o600);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Add **Pi** support to `vercel ai-gateway coding-agents connect`, completing the four-agent set.

- Writes the gateway credential to Pi's native `vercel-ai-gateway` auth entry in `~/.pi/agent/auth.json`, created `0600` (honors `PI_CODING_AGENT_DIR`); no default model pinned.

Adds a Pi test (auth entry shape + `0600` mode).

---
**Stack — merge in order:**
1. #16851 — quota helper (base `main`)
2. #16852 — `coding-agents connect` framework + Claude Code
3. #16856 — macOS Keychain storage
4. #16853 — Codex
5. #16854 — OpenCode
6. #16855 — Pi
