### PR TITLE
[cli] coding-agents connect: store the key in the macOS Keychain

### DIFF
--- a/.changeset/ai-gateway-coding-agents-keychain.md
+++ b/.changeset/ai-gateway-coding-agents-keychain.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Store the `coding-agents connect` API key in the macOS login Keychain instead of writing it into plaintext config files. When available it's used automatically: env-based agents resolve the key from the shell at runtime (a managed shell-rc block runs `security find-generic-password`), so the secret never lands in a config file. Pass `--no-keychain`, or run off macOS, to embed the key directly; it also falls back to embedding if the Keychain write fails.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-connect.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-connect.ts
@@ -26,6 +26,7 @@ import {
   promptKeyName,
   promptQuota,
   promptExpiry,
+  promptKeychain,
   type KeySource,
 } from '../../util/ai-gateway/coding-agents/key-source';
 import {
@@ -40,6 +41,10 @@ import {
 } from '../../util/ai-gateway/coding-agents/render';
 import { runMachine } from '../../util/ai-gateway/coding-agents/machine';
 import { KEY_PLACEHOLDER } from '../../util/ai-gateway/coding-agents/gateway';
+import {
+  isKeychainAvailable,
+  storeKeyInKeychain,
+} from '../../util/ai-gateway/coding-agents/keychain';
 import {
   outputAgentError,
   shouldEmitNonInteractiveCommandError,
@@ -76,6 +81,7 @@ export default async function codingAgentsConnect(
   const name = opts['--name'] as string | undefined;
   const dryRun = opts['--dry-run'] as boolean | undefined;
   const noBackup = opts['--no-backup'] as boolean | undefined;
+  const noKeychain = opts['--no-keychain'] as boolean | undefined;
   const agentConfig = opts['--agent-config'] as string[] | undefined;
   const shellRcOverride = opts['--shell-rc'] as string | undefined;
   const yes = opts['--yes'] as boolean | undefined;
@@ -90,6 +96,7 @@ export default async function codingAgentsConnect(
   telemetry.trackCliOptionName(name);
   telemetry.trackCliFlagDryRun(dryRun);
   telemetry.trackCliFlagNoBackup(noBackup);
+  telemetry.trackCliFlagNoKeychain(noKeychain);
   telemetry.trackCliOptionAgentConfig(agentConfig);
   telemetry.trackCliOptionShellRc(shellRcOverride);
   telemetry.trackCliFlagYes(yes);
@@ -97,6 +104,9 @@ export default async function codingAgentsConnect(
   const machine = shouldEmitNonInteractiveCommandError(client);
   const canPrompt = Boolean(client.stdin.isTTY) && !machine;
   const home = homedir();
+  // Prefer the macOS Keychain when available so the key stays out of plaintext
+  // config files; `--no-keychain` (or a non-macOS host) falls back to embedding.
+  const wantKeychain = !noKeychain && isKeychainAvailable();
 
   if (budget !== undefined && (!Number.isFinite(budget) || budget < 1)) {
     return failValidation(
@@ -228,6 +238,11 @@ export default async function codingAgentsConnect(
       }
     }
   }
+  let useKeychain = wantKeychain;
+  if (wantKeychain && canPrompt && !yes) {
+    useKeychain = await promptKeychain(client);
+  }
+
   // If a selected agent isn't at its default/native location, offer custom
   // paths (opt-in, so normal setups aren't interrupted). Flags pin paths in
   // either mode; this just surfaces the option interactively.
@@ -235,7 +250,9 @@ export default async function codingAgentsConnect(
     const missing = selected.filter(
       a =>
         !overrides[a.id] &&
-        !existsSync(dirname(a.configPath({ apiKey: '', home })))
+        !existsSync(
+          dirname(a.configPath({ apiKey: '', home, useKeychain: false }))
+        )
     );
     if (missing.length > 0) {
       const customize = await client.input.confirm(
@@ -247,6 +264,7 @@ export default async function codingAgentsConnect(
           const resolved = agent.configPath({
             apiKey: '',
             home,
+            useKeychain: false,
           });
           const answer = await client.input.text({
             message: `${agent.displayName} config path`,
@@ -265,6 +283,7 @@ export default async function codingAgentsConnect(
   const previewPlan = await buildSetupPlan(selected, {
     apiKey: previewKey,
     home,
+    useKeychain,
     overrides,
     shellRcOverride,
   });
@@ -291,6 +310,7 @@ export default async function codingAgentsConnect(
           includeByok,
           expiresAt: keyExpiresAt,
         }),
+      useKeychain,
       overrides,
       shellRcOverride,
       home,
@@ -315,6 +335,7 @@ export default async function codingAgentsConnect(
     budget: keyBudget,
     refreshPeriod: keyRefresh,
     expiresAt: keyExpiresAt,
+    keychain: wantKeychain ? useKeychain : undefined,
   });
 
   if (dryRun) {
@@ -355,9 +376,17 @@ export default async function codingAgentsConnect(
     throw err;
   }
 
+  if (useKeychain && !storeKeyInKeychain(keySource.key)) {
+    output.warn(
+      'Could not store the key in the macOS Keychain; writing it to the config instead.'
+    );
+    useKeychain = false;
+  }
+
   const applyPlanResult = await buildSetupPlan(selected, {
     apiKey: keySource.key,
     home,
+    useKeychain,
     overrides,
     shellRcOverride,
   });
@@ -383,7 +412,7 @@ export default async function codingAgentsConnect(
   }
 
   printNotes(applyPlanResult);
-  printKey(keySource.key);
+  printKey(keySource.key, { keychain: useKeychain });
   return 0;
 }
 

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -317,6 +317,14 @@ export const connectSubcommand = {
       description: 'Do not write .bak backups of changed files',
     },
     {
+      name: 'no-keychain',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Always write the key into config files instead of the macOS Keychain',
+    },
+    {
       name: 'agent-config',
       shorthand: null,
       type: [String],

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import type { CodingAgent } from '../types';
+import type { CodingAgent, EnvExport } from '../types';
 import { mergeJson, pathExists } from '../config-files';
 import { GATEWAY_ANTHROPIC_BASE_URL } from '../gateway';
 
@@ -8,6 +8,11 @@ import { GATEWAY_ANTHROPIC_BASE_URL } from '../gateway';
  * It speaks the gateway's Anthropic-compatible endpoint, so the base URL has NO
  * `/v1` (the Anthropic SDK appends `/v1/messages`). `ANTHROPIC_API_KEY` must be
  * emptied because it takes precedence over `ANTHROPIC_AUTH_TOKEN`.
+ *
+ * With Keychain enabled we keep the token out of `settings.json` and export
+ * `ANTHROPIC_AUTH_TOKEN` from the shell rc (resolved from the Keychain) instead,
+ * so the secret never lands in the config file. Claude Code then reads the token
+ * from its inherited environment.
  *
  * Docs: https://vercel.com/docs/ai-gateway/coding-agents/claude-code
  */
@@ -37,8 +42,13 @@ export const claudeCode: CodingAgent = {
     const env: Record<string, string> = {
       ANTHROPIC_BASE_URL: GATEWAY_ANTHROPIC_BASE_URL,
       ANTHROPIC_API_KEY: '',
-      ANTHROPIC_AUTH_TOKEN: ctx.apiKey,
     };
+    const envExports: EnvExport[] = [];
+    if (ctx.useKeychain) {
+      envExports.push({ name: 'ANTHROPIC_AUTH_TOKEN', value: ctx.apiKey });
+    } else {
+      env.ANTHROPIC_AUTH_TOKEN = ctx.apiKey;
+    }
     return {
       fileChanges: [
         {
@@ -48,8 +58,13 @@ export const claudeCode: CodingAgent = {
           transform: current => mergeJson(current, { env }),
         },
       ],
-      envExports: [],
-      notes: ['Restart Claude Code to pick up the new settings.'],
+      envExports,
+      notes: ctx.useKeychain
+        ? [
+            'The Anthropic auth token is read from your shell environment (Keychain-backed).',
+            'Open a new terminal so ANTHROPIC_AUTH_TOKEN is loaded, then restart Claude Code.',
+          ]
+        : ['Restart Claude Code to pick up the new settings.'],
     };
   },
 };

--- a/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
@@ -6,6 +6,7 @@ import {
   writeConfigFile,
   upsertManagedBlock,
 } from './config-files';
+import { keychainLookup } from './keychain';
 
 export type ChangeStatus = 'create' | 'update' | 'unchanged' | 'error';
 
@@ -60,16 +61,26 @@ function fishQuote(value: string): string {
   return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }
 
-function envBlockBody(exports: EnvExport[], fish: boolean): string {
+function envBlockBody(
+  exports: EnvExport[],
+  useKeychain: boolean,
+  fish: boolean
+): string {
   const lines = [
     '# Managed by `vercel ai-gateway coding-agents connect` — safe to remove this block.',
   ];
   for (const e of exports) {
-    lines.push(
-      fish
-        ? `set -gx ${e.name} ${fishQuote(e.value)}`
-        : `export ${e.name}=${shellQuote(e.value)}`
-    );
+    if (fish) {
+      lines.push(
+        useKeychain
+          ? `set -gx ${e.name} ${keychainLookup({ fish: true })}`
+          : `set -gx ${e.name} ${fishQuote(e.value)}`
+      );
+    } else if (useKeychain) {
+      lines.push(`export ${e.name}="${keychainLookup()}"`);
+    } else {
+      lines.push(`export ${e.name}=${shellQuote(e.value)}`);
+    }
   }
   return lines.join('\n');
 }
@@ -113,7 +124,11 @@ export async function buildSetupPlan(
   let shellRcPath: string | undefined;
   if (envExports.length) {
     shellRcPath = detectShellRc(ctx.home, ctx.shellRcOverride);
-    const body = envBlockBody(envExports, shellRcPath.endsWith('.fish'));
+    const body = envBlockBody(
+      envExports,
+      ctx.useKeychain,
+      shellRcPath.endsWith('.fish')
+    );
     pending.push({
       path: shellRcPath,
       label: 'Shell environment',

--- a/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
@@ -108,6 +108,13 @@ export async function promptExpiry(
   return presetToExpiresAt(preset);
 }
 
+export async function promptKeychain(client: Client): Promise<boolean> {
+  return client.input.confirm(
+    'Store the API key in your macOS Keychain?',
+    true
+  );
+}
+
 function hasExplicitScopeFlag(argv: string[]): boolean {
   const args = argv.slice(2);
   return args.some(

--- a/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Optional macOS Keychain storage for the AI Gateway key. When available we keep
+ * the secret in the login keychain and have the shell rc resolve it at runtime,
+ * so the plaintext key never lands in a config file. Everything here is a no-op
+ * (or returns `false`) off macOS, so callers fall back to writing the key
+ * directly.
+ */
+const SECURITY_BIN = '/usr/bin/security';
+const KEYCHAIN_SERVICE = 'Vercel AI Gateway';
+const KEYCHAIN_ACCOUNT = 'vercel-ai-gateway';
+
+export function isKeychainAvailable(): boolean {
+  return process.platform === 'darwin' && existsSync(SECURITY_BIN);
+}
+
+export function storeKeyInKeychain(key: string): boolean {
+  try {
+    execFileSync(
+      SECURITY_BIN,
+      [
+        'add-generic-password',
+        '-U', // update the existing item instead of erroring
+        '-s',
+        KEYCHAIN_SERVICE,
+        '-a',
+        KEYCHAIN_ACCOUNT,
+        '-w',
+        key,
+      ],
+      { stdio: 'ignore' }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function keychainLookup(opts: { fish?: boolean } = {}): string {
+  const cmd = `${SECURITY_BIN} find-generic-password -s '${KEYCHAIN_SERVICE}' -a '${KEYCHAIN_ACCOUNT}' -w 2>/dev/null`;
+  // POSIX shells use `$(…)`; fish uses `(…)`.
+  return opts.fish ? `(${cmd})` : `$(${cmd})`;
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -4,6 +4,7 @@ import { outputAgentError } from '../../agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../agent-output-constants';
 import { UNSUPPORTED_AGENTS } from './agents';
 import { buildSetupPlan, applyPlan, type SetupPlan } from './apply';
+import { storeKeyInKeychain } from './keychain';
 import type { KeySource } from './key-source';
 import type { CodingAgent } from './types';
 
@@ -16,6 +17,7 @@ export async function runMachine(args: {
   backup: boolean;
   keySource: KeySource | null;
   createKey: () => Promise<string>;
+  useKeychain: boolean;
   overrides?: Record<string, string>;
   shellRcOverride?: string;
   home: string;
@@ -78,9 +80,12 @@ export async function runMachine(args: {
     throw err;
   }
 
+  const useKeychain = args.useKeychain && storeKeyInKeychain(key);
+
   const finalPlan = await buildSetupPlan(selected, {
     apiKey: key,
     home,
+    useKeychain,
     overrides: args.overrides,
     shellRcOverride: args.shellRcOverride,
   });

--- a/packages/cli/src/util/ai-gateway/coding-agents/render.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/render.ts
@@ -13,6 +13,7 @@ export function printResolvedState(args: {
   budget?: number;
   refreshPeriod?: string;
   expiresAt?: number;
+  keychain?: boolean;
 }): void {
   const { selected, willCreate, name, budget, refreshPeriod, expiresAt } = args;
   output.print(chalk.bold('Summary\n'));
@@ -39,6 +40,12 @@ export function printResolvedState(args: {
       ? new Date(expiresAt).toISOString().slice(0, 10)
       : 'Never'
   );
+  if (args.keychain !== undefined) {
+    printAlignedLabel(
+      'Key storage',
+      args.keychain ? 'macOS Keychain' : 'Config files'
+    );
+  }
   output.print('\n');
 }
 
@@ -84,11 +91,14 @@ export function printNotes(plan: SetupPlan): void {
   }
 }
 
-export function printKey(key: string): void {
+export function printKey(key: string, opts: { keychain?: boolean } = {}): void {
+  const where = opts.keychain
+    ? 'stored in your macOS Keychain'
+    : 'written to the configs above';
   output.print('\n');
   output.log(
     chalk.dim(
-      `AI Gateway API key ${maskSecret(key)} written to the configs above — keep it secret.`
+      `AI Gateway API key ${maskSecret(key)} ${where} — keep it secret.`
     )
   );
 }

--- a/packages/cli/src/util/ai-gateway/coding-agents/types.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/types.ts
@@ -1,6 +1,7 @@
 export interface SetupContext {
   apiKey: string;
   home: string;
+  useKeychain: boolean;
   /** Per-agent config-file path overrides, keyed by agent id. */
   overrides?: Record<string, string>;
   /** Override for the shell rc file env exports are written into. */

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-connect.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-connect.ts
@@ -71,6 +71,12 @@ export class AiGatewayCodingAgentsConnectTelemetryClient
     }
   }
 
+  trackCliFlagNoKeychain(noKeychain: boolean | undefined) {
+    if (noKeychain) {
+      this.trackCliFlag('no-keychain');
+    }
+  }
+
   trackCliOptionAgentConfig(agentConfig: string[] | undefined) {
     if (agentConfig && agentConfig.length) {
       // Local paths may be sensitive; record only that the option was used.

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-connect.test.ts
@@ -14,6 +14,11 @@ import { useUser } from '../../../mocks/user';
 import { useTeam } from '../../../mocks/team';
 import { buildSetupPlan } from '../../../../src/util/ai-gateway/coding-agents/apply';
 import { claudeCode } from '../../../../src/util/ai-gateway/coding-agents/agents/claude-code';
+import {
+  isKeychainAvailable,
+  storeKeyInKeychain,
+  keychainLookup,
+} from '../../../../src/util/ai-gateway/coding-agents/keychain';
 
 const CREATED_KEY = 'vck_CreatedSecretKey1234';
 const mockApiKeyResponse = {
@@ -333,6 +338,49 @@ describe('ai-gateway coding-agents connect', () => {
     });
   });
 
+  describe('keychain', () => {
+    it('is unavailable off macOS and fails closed', () => {
+      if (process.platform !== 'darwin') {
+        expect(isKeychainAvailable()).toBe(false);
+        expect(storeKeyInKeychain('vck_whatever')).toBe(false);
+      }
+      expect(keychainLookup()).toContain('security find-generic-password');
+    });
+
+    it('keeps the secret out of the configs and reads it from the shell', async () => {
+      const secret = 'vck_KeychainSecret321';
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: secret,
+        home,
+        useKeychain: true,
+      });
+
+      // The env-based agent resolves its var from the Keychain at runtime.
+      const shell = plan.changes.find(c => c.format === 'shell');
+      expect(shell?.next).toContain('security find-generic-password');
+      expect(shell?.next).toContain('export ANTHROPIC_AUTH_TOKEN=');
+      expect(shell?.next).not.toContain(secret);
+
+      // Claude's token is no longer embedded in settings.json.
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      expect(claude?.next).toContain('ANTHROPIC_BASE_URL');
+      expect(claude?.next).not.toContain('ANTHROPIC_AUTH_TOKEN');
+      expect(claude?.next).not.toContain(secret);
+    });
+
+    it('embeds the key directly when keychain is off', async () => {
+      const secret = 'vck_PlainSecret654';
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: secret,
+        home,
+        useKeychain: false,
+      });
+
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      expect(claude?.next).toContain(secret);
+    });
+  });
+
   describe('key options', () => {
     it('collects name, quota, and expiry interactively', async () => {
       const team = useTeam();
@@ -478,6 +526,7 @@ describe('ai-gateway coding-agents connect', () => {
       const plan = await buildSetupPlan([claudeCode], {
         apiKey: 'vck_x',
         home,
+        useKeychain: false,
         // (set per-test; restored by afterEach)
       });
       expect(
@@ -490,6 +539,7 @@ describe('ai-gateway coding-agents connect', () => {
       const relocated = await buildSetupPlan([claudeCode], {
         apiKey: 'vck_x',
         home,
+        useKeychain: false,
       });
       expect(
         relocated.changes.some(


### PR DESCRIPTION
## Summary

Extract macOS **Keychain** storage for the `coding-agents connect` key into its own layer on top of the framework (#16852), so the `security`-CLI integration, shell-resolution, and fallback are reviewable in isolation.

Without this, the framework writes the key directly into each agent's config. With it (on macOS, auto-detected):

- The key is stored in the login Keychain (`security add-generic-password`).
- Env-based agents resolve it at runtime: the managed shell-rc block runs `security find-generic-password` instead of embedding the plaintext value, so the secret never lands in a config file.
- `--no-keychain` (or a non-macOS host) embeds the key directly; it also falls back to embedding if the Keychain write fails.

Adds `keychain.ts`, threads `useKeychain` through the plan/apply/render path and the command, the `--no-keychain` flag, and the keychain unit tests.

---
**Stack — merge in order:**
1. #16851 — quota helper (base `main`)
2. #16852 — `coding-agents connect` framework + Claude Code
3. #16856 — macOS Keychain storage
4. #16853 — Codex
5. #16854 — OpenCode
6. #16855 — Pi
