### PR TITLE
[cli] coding-agents setup: provision an API key

### DIFF
--- a/.changeset/ai-gateway-coding-agents-create-key.md
+++ b/.changeset/ai-gateway-coding-agents-create-key.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+`ai-gateway coding-agents setup` can now **provision a key** for you: run it without `--key` and it creates an AI Gateway API key (prompting for the owning team and a name, or using `--name`/`--scope` and the current scope with `--yes`), then writes that key into the agent configs.
+
+Re-running when everything is already set up is no longer a dead end: it prompts to **rotate the key or switch team**, and `--reconfigure` does the same non-interactively (useful for a rotated or expired key, or a different org). A plain re-run stays a no-op.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
@@ -5,8 +5,15 @@ import output from '../../output-manager';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
 import { resolveAgents } from '../../util/ai-gateway/coding-agents/resolve';
+import {
+  ensureTeam,
+  createKey,
+  promptKeyName,
+  type KeySource,
+} from '../../util/ai-gateway/coding-agents/key-source';
 import {
   buildSetupPlan,
   applyPlan,
@@ -20,11 +27,12 @@ import {
   printWarning,
 } from '../../util/ai-gateway/coding-agents/render';
 import { runMachine } from '../../util/ai-gateway/coding-agents/machine';
+import { KEY_PLACEHOLDER } from '../../util/ai-gateway/coding-agents/gateway';
 import {
   outputAgentError,
   shouldEmitNonInteractiveCommandError,
 } from '../../util/agent-output';
-import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
+import { AGENT_STATUS } from '../../util/agent-output-constants';
 import { setupSubcommand } from './command';
 import { AiGatewayCodingAgentsSetupTelemetryClient } from '../../util/telemetry/commands/ai-gateway/coding-agents-setup';
 
@@ -49,25 +57,20 @@ export default async function codingAgentsSetup(
   const agentFlags = opts['--agent'] as string[] | undefined;
   const all = opts['--all'] as boolean | undefined;
   const providedKey = opts['--key'] as string | undefined;
+  const name = opts['--name'] as string | undefined;
+  const reconfigure = opts['--reconfigure'] as boolean | undefined;
   const yes = opts['--yes'] as boolean | undefined;
 
   telemetry.trackCliOptionAgent(agentFlags as [string] | undefined);
   telemetry.trackCliFlagAll(all);
   telemetry.trackCliOptionKey(providedKey);
+  telemetry.trackCliOptionName(name);
+  telemetry.trackCliFlagReconfigure(reconfigure);
   telemetry.trackCliFlagYes(yes);
 
   const machine = shouldEmitNonInteractiveCommandError(client);
   const canPrompt = Boolean(client.stdin.isTTY) && !machine;
   const home = homedir();
-
-  if (!providedKey) {
-    return failValidation(
-      client,
-      machine,
-      AGENT_REASON.INVALID_ARGUMENTS,
-      'An existing AI Gateway API key is required. Pass --key <key>.'
-    );
-  }
 
   const selection = await resolveAgents({
     client,
@@ -93,33 +96,96 @@ export default async function codingAgentsSetup(
     printWarning(note);
   }
 
+  // With no --key we create one. Resolve the owning team first — it decides
+  // where the key lives (and can fail), so it comes before any naming.
+  const willCreate = !providedKey;
+  let keyName = name;
+  if (willCreate) {
+    const teamError = await ensureTeam(client, {
+      machine,
+      canPrompt,
+      yes: Boolean(yes),
+    });
+    if (teamError) {
+      return teamError;
+    }
+    if (canPrompt && !yes && keyName === undefined) {
+      keyName = await promptKeyName(client);
+    }
+  }
+
+  const previewKey = providedKey ?? KEY_PLACEHOLDER;
+  const previewPlan = await buildSetupPlan(selected, {
+    apiKey: previewKey,
+    home,
+  });
+  const changed = previewPlan.changes.filter(
+    c => c.status === 'create' || c.status === 'update'
+  );
+  const errored = previewPlan.changes.filter(c => c.status === 'error');
+  const alreadyConfigured = changed.length === 0 && errored.length === 0;
+
   if (machine) {
     return runMachine({
       client,
       selected,
       unsupported,
-      key: providedKey,
+      keySource: providedKey ? { key: providedKey, created: false } : null,
+      createKey: () => createKey(client, { name: keyName }),
       backup: true,
       home,
+      alreadyConfigured,
+      reconfigure: Boolean(reconfigure),
     });
   }
 
-  const plan = await buildSetupPlan(selected, { apiKey: providedKey, home });
-  const changed = plan.changes.filter(
-    c => c.status === 'create' || c.status === 'update'
-  );
-  const errored = plan.changes.filter(c => c.status === 'error');
-
-  if (changed.length === 0 && errored.length === 0) {
-    printStatus(
-      'All selected agents are already configured for the AI Gateway.'
-    );
-    printKey(providedKey);
-    return 0;
+  // Already wired up: instead of a dead-end no-op, offer to rotate the key or
+  // reconfigure (e.g. a rotated/expired key, or a different team).
+  // `--reconfigure` skips the prompt.
+  if (alreadyConfigured) {
+    let doReconfigure = Boolean(reconfigure);
+    if (!doReconfigure && canPrompt && !yes) {
+      doReconfigure = await client.input.confirm(
+        'These agents are already configured for the AI Gateway. Reconfigure them?',
+        false
+      );
+    }
+    if (!doReconfigure) {
+      printStatus(
+        'All selected agents are already configured for the AI Gateway.'
+      );
+      if (providedKey) {
+        printKey(providedKey);
+      }
+      return 0;
+    }
   }
 
+  let keySource: KeySource;
+  try {
+    keySource = providedKey
+      ? { key: providedKey, created: false }
+      : { key: await createKey(client, { name: keyName }), created: true };
+  } catch (err) {
+    output.stopSpinner();
+    if (isAPIError(err)) {
+      output.error(err.message);
+      return 1;
+    }
+    throw err;
+  }
+
+  const plan = await buildSetupPlan(selected, { apiKey: keySource.key, home });
   const results = await applyPlan(plan, { backup: true });
 
+  if (results.length === 0 && keySource.created) {
+    // Rotated with a fresh key but nothing in the config files changed (e.g. the
+    // key is resolved from the environment rather than embedded).
+    output.print('\n');
+    printAlignedLabel('Rotated', 'AI Gateway API key', { gutter: '✓' });
+    printKeyRow(keySource.key);
+    output.print(chalk.dim('  No config files changed.\n'));
+  }
   if (results.length > 0) {
     // One ✓ for the completed phase; everything else is a secondary
     // receipt row behind the blank gutter.
@@ -135,7 +201,7 @@ export default async function codingAgentsSetup(
         result.path
       );
     }
-    printKeyRow(providedKey);
+    printKeyRow(keySource.key);
     if (results.some(r => r.backupPath)) {
       output.print(chalk.dim('  Previous files saved alongside as .bak\n'));
     }
@@ -148,21 +214,4 @@ export default async function codingAgentsSetup(
 
   printNotes(plan);
   return 0;
-}
-
-function failValidation(
-  client: Client,
-  machine: boolean,
-  reason: string,
-  message: string
-): number {
-  if (machine) {
-    outputAgentError(client, {
-      status: AGENT_STATUS.ERROR,
-      reason,
-      message,
-    });
-  }
-  output.error(message);
-  return 1;
 }

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -256,18 +256,38 @@ export const setupSubcommand = {
       type: String,
       argument: 'KEY',
       deprecated: false,
-      description: 'Existing AI Gateway API key to configure the agents with',
+      description: 'Use an existing AI Gateway API key instead of creating one',
+    },
+    {
+      name: 'name',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+      description: 'Name for a newly created API key',
+    },
+    {
+      name: 'reconfigure',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Re-run even if already configured, to rotate the key or switch team',
     },
     yesOption,
   ],
   examples: [
     {
-      name: 'Connect the detected coding agents with an existing key',
-      value: `${packageName} ai-gateway coding-agents setup --key <key>`,
+      name: 'Connect the detected coding agents (creates a key)',
+      value: `${packageName} ai-gateway coding-agents setup`,
     },
     {
-      name: 'Connect specific agents',
+      name: 'Connect specific agents with an existing key',
       value: `${packageName} ai-gateway coding-agents setup --key <key> --agent claude-code`,
+    },
+    {
+      name: 'Rotate the key on an already-configured setup',
+      value: `${packageName} ai-gateway coding-agents setup --reconfigure`,
     },
   ],
 } as const;

--- a/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
@@ -6,6 +6,7 @@ import {
   writeConfigFile,
   upsertManagedBlock,
 } from './config-files';
+import { KEY_PLACEHOLDER } from './gateway';
 
 export type ChangeStatus = 'create' | 'update' | 'unchanged' | 'error';
 
@@ -87,6 +88,25 @@ interface PendingChange {
   transform(current: string | null): string;
 }
 
+/**
+ * True when `current` is exactly `templated` with every KEY_PLACEHOLDER
+ * replaced by one consistent concrete secret. When the key is unknown (no
+ * --key), plans are built with the placeholder — reading the stored key as
+ * drift would make every re-run look unconfigured and mint a fresh key.
+ */
+function matchesWithStoredKey(current: string, templated: string): boolean {
+  const parts = templated.split(KEY_PLACEHOLDER);
+  if (parts.length < 2) {
+    return false;
+  }
+  const escaped = parts.map(p => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  // Keys never contain whitespace, quotes, or backslashes, so this can't
+  // swallow surrounding syntax; the backreference pins later occurrences to
+  // the first.
+  const pattern = `^${escaped[0]}([^\\s"'\\\\]+)${escaped.slice(1).join('\\1')}$`;
+  return new RegExp(pattern).test(current);
+}
+
 export async function buildSetupPlan(
   agents: CodingAgent[],
   ctx: SetupContext
@@ -162,8 +182,18 @@ export async function buildSetupPlan(
         acc = transform(acc);
       }
       next = acc;
-      status =
-        current === null ? 'create' : next === current ? 'unchanged' : 'update';
+      if (current === null) {
+        status = 'create';
+      } else if (
+        acc === current ||
+        (ctx.apiKey === KEY_PLACEHOLDER &&
+          acc !== null &&
+          matchesWithStoredKey(current, acc))
+      ) {
+        status = 'unchanged';
+      } else {
+        status = 'update';
+      }
     } catch (err) {
       status = 'error';
       error = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
@@ -1,0 +1,123 @@
+import { hostname, userInfo } from 'node:os';
+import chalk from 'chalk';
+import type Client from '../../client';
+import output from '../../../output-manager';
+import { getCommandName } from '../../pkg-name';
+import createApiKeyRequest from '../create-api-key';
+import selectOrg from '../../input/select-org';
+import { buildQuota } from '../quota';
+import { outputAgentError } from '../../agent-output';
+import { AGENT_STATUS, AGENT_REASON } from '../../agent-output-constants';
+
+export interface KeySource {
+  key: string;
+  created: boolean;
+}
+
+export interface KeyOptions {
+  name?: string;
+  budget?: number;
+  refreshPeriod?: string;
+  includeByok?: boolean;
+}
+
+export function defaultKeyName(): string {
+  let host = '';
+  let user = '';
+  try {
+    host = hostname();
+  } catch {}
+  try {
+    user = userInfo().username;
+  } catch {}
+  const device = host.split('.')[0].replace(/[-_]+/g, ' ').trim();
+  const who = user.trim();
+  if (who && device) return `[${who}'s ${device}] Coding Agents`;
+  if (device) return `[${device}] Coding Agents`;
+  if (who) return `[${who}] Coding Agents`;
+  return 'Coding Agents';
+}
+
+export async function promptKeyName(client: Client): Promise<string> {
+  const fallback = defaultKeyName();
+  const answer = await client.input.text({
+    message: `Key name? ${chalk.dim(
+      'A new AI Gateway API key will be created for your coding agents'
+    )}`,
+    default: fallback,
+  });
+  return answer.trim() || fallback;
+}
+
+function hasExplicitScopeFlag(argv: string[]): boolean {
+  const args = argv.slice(2);
+  return args.some(
+    a =>
+      a === '--scope' ||
+      a === '-S' ||
+      a === '--team' ||
+      a === '-T' ||
+      a.startsWith('--scope=') ||
+      a.startsWith('--team=')
+  );
+}
+
+export async function ensureTeam(
+  client: Client,
+  opts: { machine: boolean; canPrompt: boolean; yes: boolean }
+): Promise<number | undefined> {
+  const { machine, canPrompt, yes } = opts;
+
+  if (canPrompt && !yes && !hasExplicitScopeFlag(client.argv)) {
+    const org = await selectOrg(
+      client,
+      `Which team? ${chalk.dim('The API key is created under this team')}`
+    );
+    client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+    return undefined;
+  }
+
+  // Non-interactive, an explicit scope, or `--yes`: use the resolved scope.
+  if (hasExplicitScopeFlag(client.argv) || client.config.currentTeam) {
+    return undefined;
+  }
+
+  const message =
+    'No team selected. Pass --scope <team-slug> or run `vercel switch` first.';
+  if (machine) {
+    outputAgentError(client, {
+      status: AGENT_STATUS.ERROR,
+      reason: AGENT_REASON.MISSING_SCOPE,
+      message,
+      next: [
+        {
+          command: getCommandName(
+            'ai-gateway coding-agents setup --scope <team-slug>'
+          ),
+        },
+      ],
+    });
+  }
+  output.error(message);
+  return 1;
+}
+
+export async function createKey(
+  client: Client,
+  opts: KeyOptions
+): Promise<string> {
+  output.spinner('Creating AI Gateway API key…');
+  try {
+    const result = await createApiKeyRequest(client, {
+      name: opts.name,
+      aiGatewayQuota: buildQuota({
+        budget: opts.budget,
+        refreshPeriod: opts.refreshPeriod,
+        includeByok: opts.includeByok,
+      }),
+    });
+    return result.apiKeyString;
+  } finally {
+    output.stopSpinner();
+  }
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -1,18 +1,58 @@
 import type Client from '../../client';
-import { AGENT_STATUS } from '../../agent-output-constants';
+import { isAPIError } from '../../errors-ts';
+import { outputAgentError } from '../../agent-output';
+import { AGENT_STATUS, AGENT_REASON } from '../../agent-output-constants';
 import { UNSUPPORTED_AGENTS } from './agents';
 import { buildSetupPlan, applyPlan } from './apply';
+import type { KeySource } from './key-source';
 import type { CodingAgent } from './types';
 
 export async function runMachine(args: {
   client: Client;
   selected: CodingAgent[];
   unsupported: string[];
-  key: string;
+  keySource: KeySource | null;
+  createKey: () => Promise<string>;
   backup: boolean;
   home: string;
+  alreadyConfigured: boolean;
+  reconfigure: boolean;
 }): Promise<number> {
-  const { client, selected, key, backup, home } = args;
+  const { client, selected, backup, home } = args;
+
+  // Idempotent by default: if nothing needs writing and we weren't asked to
+  // reconfigure, report the no-op without minting a fresh key.
+  if (args.alreadyConfigured && !args.reconfigure) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: AGENT_STATUS.OK,
+          reason: 'already_configured',
+          message:
+            'All selected agents are already configured for the AI Gateway. Pass --reconfigure to rotate the key.',
+          configured: [],
+          skipped: [],
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  let key: string;
+  try {
+    key = args.keySource ? args.keySource.key : await args.createKey();
+  } catch (err) {
+    if (isAPIError(err)) {
+      outputAgentError(client, {
+        status: AGENT_STATUS.ERROR,
+        reason: err.status === 403 ? 'forbidden' : AGENT_REASON.API_ERROR,
+        message: err.message,
+      });
+    }
+    throw err;
+  }
 
   const plan = await buildSetupPlan(selected, { apiKey: key, home });
 

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
@@ -26,6 +26,18 @@ export class AiGatewayCodingAgentsSetupTelemetryClient
     }
   }
 
+  trackCliOptionName(name: string | undefined) {
+    if (name) {
+      this.trackCliOption({ option: 'name', value: this.redactedValue });
+    }
+  }
+
+  trackCliFlagReconfigure(reconfigure: boolean | undefined) {
+    if (reconfigure) {
+      this.trackCliFlag('reconfigure');
+    }
+  }
+
   trackCliFlagYes(yes: boolean | undefined) {
     if (yes) {
       this.trackCliFlag('yes');

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -10,6 +10,29 @@ import {
   mergeJson,
   upsertManagedBlock,
 } from '../../../../src/util/ai-gateway/coding-agents/config-files';
+import { useTeam } from '../../../mocks/team';
+
+const CREATED_KEY = 'vck_CreatedSecretKey1234';
+const mockApiKeyResponse = {
+  apiKeyString: CREATED_KEY,
+  apiKey: {
+    id: '5d9f2ebd38dd',
+    name: 'my-key',
+    partialKey: 'vck',
+    teamId: 'team_abc',
+    purpose: 'ai-gateway',
+    createdAt: 1700000000000,
+  },
+};
+
+let lastCreateBody: Record<string, unknown> | undefined;
+function useCreateApiKey(response = mockApiKeyResponse) {
+  lastCreateBody = undefined;
+  client.scenario.post('/v1/api-keys', (req, res) => {
+    lastCreateBody = req.body;
+    res.json(response);
+  });
+}
 
 let home: string;
 let savedEnv: Record<string, string | undefined>;
@@ -87,9 +110,41 @@ describe('ai-gateway coding-agents setup', () => {
     });
   });
 
-  describe('an existing key is required', () => {
-    it('errors when --key is omitted', async () => {
+  describe('key creation', () => {
+    it('creates a key when --key is omitted and writes it', async () => {
+      const team = useTeam();
       useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code',
+        '--name',
+        'my-coding-key'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      expect(lastCreateBody?.purpose).toBe('ai-gateway');
+      expect(lastCreateBody?.name).toBe('my-coding-key');
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.apiKey).toBe(CREATED_KEY);
+    });
+
+    it('prompts for the team and a name, then creates the key', async () => {
+      useTeam();
+      useUser();
+      useCreateApiKey();
+      mkdirSync(join(home, '.claude'), { recursive: true });
       client.setArgv(
         'ai-gateway',
         'coding-agents',
@@ -98,10 +153,37 @@ describe('ai-gateway coding-agents setup', () => {
         'claude-code'
       );
 
-      expect(await aiGateway(client)).toBe(1);
-      expect(client.stderr.getFullOutput()).toContain(
-        'existing AI Gateway API key is required'
+      const exitCodePromise = aiGateway(client);
+
+      // The owning team decides where the key lives, so it comes first.
+      await expect(client.stderr).toOutput('Which team?');
+      client.stdin.write('\n');
+      await expect(client.stderr).toOutput('Key name?');
+      client.stdin.write('My Coding Key\n');
+
+      expect(await exitCodePromise).toBe(0);
+      expect(lastCreateBody?.name).toBe('My Coding Key');
+    });
+
+    it('skips the prompts with --yes and uses the current scope', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--agent',
+        'claude-code'
       );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
     });
   });
 
@@ -132,6 +214,80 @@ describe('ai-gateway coding-agents setup', () => {
       const secondJson = client.stdout.getFullOutput().slice(stdoutAfterFirst);
       const out = JSON.parse(secondJson);
       expect(out.configured).toHaveLength(0);
+    });
+
+    it('does not mint a new key when re-run without --key', async () => {
+      const team = useTeam();
+      useUser();
+      let creates = 0;
+      client.scenario.post('/v1/api-keys', (req, res) => {
+        creates++;
+        res.json({
+          ...mockApiKeyResponse,
+          apiKeyString: `vck_Minted${creates}0000000`,
+        });
+      });
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      const argv = [
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code',
+        '--name',
+        'my-coding-key',
+      ] as const;
+
+      client.setArgv(...argv);
+      expect(await aiGateway(client)).toBe(0);
+      expect(creates).toBe(1);
+      const first = readFileSync(claudeSettingsPath(), 'utf8');
+      const stdoutAfterFirst = client.stdout.getFullOutput().length;
+
+      client.setArgv(...argv);
+      expect(await aiGateway(client)).toBe(0);
+      expect(creates).toBe(1);
+      expect(readFileSync(claudeSettingsPath(), 'utf8')).toBe(first);
+      const out = JSON.parse(
+        client.stdout.getFullOutput().slice(stdoutAfterFirst)
+      );
+      expect(out.reason).toBe('already_configured');
+      expect(out.configured).toHaveLength(0);
+    });
+
+    it('--reconfigure mints a fresh key and rewrites the configs', async () => {
+      const team = useTeam();
+      useUser();
+      let creates = 0;
+      client.scenario.post('/v1/api-keys', (req, res) => {
+        creates++;
+        res.json({
+          ...mockApiKeyResponse,
+          apiKeyString: `vck_Minted${creates}0000000`,
+        });
+      });
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      const argv = [
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code',
+        '--name',
+        'my-coding-key',
+      ] as const;
+
+      client.setArgv(...argv);
+      expect(await aiGateway(client)).toBe(0);
+      expect(creates).toBe(1);
+
+      client.setArgv(...argv, '--reconfigure');
+      expect(await aiGateway(client)).toBe(0);
+      expect(creates).toBe(2);
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('vck_Minted20000000');
     });
   });
 
@@ -463,6 +619,91 @@ describe('ai-gateway coding-agents setup', () => {
       process.env.SHELL = '/bin/bash';
       const custom = join(home, 'custom', 'rc');
       expect(detectShellRc(home, custom)).toBe(custom);
+    });
+  });
+
+  describe('reconfigure', () => {
+    it('re-running with the same key is a no-op and mints no new key', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const argv = [
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_Same0001',
+        '--agent',
+        'claude-code',
+      ] as const;
+
+      client.setArgv(...argv);
+      expect(await aiGateway(client)).toBe(0);
+      const afterFirst = client.stdout.getFullOutput().length;
+
+      // If a no-op ever mints a key, this endpoint flips the flag and fails us.
+      let minted = false;
+      client.scenario.post('/v1/api-keys', (_req, res) => {
+        minted = true;
+        res.json(mockApiKeyResponse);
+      });
+
+      client.setArgv(...argv);
+      expect(await aiGateway(client)).toBe(0);
+
+      const out = JSON.parse(client.stdout.getFullOutput().slice(afterFirst));
+      expect(out.reason).toBe('already_configured');
+      expect(out.configured).toHaveLength(0);
+      expect(minted).toBe(false);
+    });
+
+    it('--reconfigure re-runs past the already-configured short-circuit', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const base = [
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_Same0002',
+        '--agent',
+        'claude-code',
+      ] as const;
+
+      client.setArgv(...base);
+      expect(await aiGateway(client)).toBe(0);
+      const afterFirst = client.stdout.getFullOutput().length;
+
+      client.setArgv(...base, '--reconfigure');
+      expect(await aiGateway(client)).toBe(0);
+
+      const out = JSON.parse(client.stdout.getFullOutput().slice(afterFirst));
+      // Not short-circuited: it proceeded and re-applied the configuration.
+      expect(out.reason).toBe('coding_agents_configured');
+    });
+
+    it('prompts to reconfigure when already set up and proceeds on confirm', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const argv = [
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_Old0003',
+        '--agent',
+        'claude-code',
+      ] as const;
+      client.setArgv(...argv);
+      expect(await aiGateway(client)).toBe(0);
+
+      // Re-run interactively with the same key: it's already configured, so the
+      // user is asked whether to reconfigure instead of getting a silent no-op.
+      client.nonInteractive = false;
+      client.setArgv(...argv);
+      const run = aiGateway(client);
+      await expect(client.stderr).toOutput('already configured');
+      client.stdin.write('y\n');
+      expect(await run).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
Run `setup` without `--key` and it mints an AI Gateway API key — prompting for the owning team and a name, or using `--name` / the current scope with `--yes` — then writes it into the agent configs.

Re-running when everything is already configured stays a no-op even without `--key`: the plan recognizes the stored key behind the placeholder instead of reading it as drift, so nothing is rewritten and no fresh key is minted. `--reconfigure` opts back into rotating the key and rewriting the configs.

Usable: `vercel ai-gateway coding-agents setup --agent claude-code` (creates the key for you).


