### PR TITLE
[cli] coding-agents setup: spend limits and expiry

### DIFF
--- a/.changeset/ai-gateway-coding-agents-key-limits.md
+++ b/.changeset/ai-gateway-coding-agents-key-limits.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`ai-gateway coding-agents setup` can now put **limits** on a key it creates: a spend cap (`--budget` with `--refresh-period` / `--include-byok`) and an expiry (`--expiration` `7d|30d|60d|90d|1y|none`). Interactively it asks whether to set each. The limits are sent only when creating a key; reusing one with `--key` is unaffected.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
@@ -7,11 +7,22 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { isAPIError } from '../../util/errors-ts';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import {
+  isValidRefreshPeriod,
+  VALID_REFRESH_PERIODS,
+} from '../../util/ai-gateway/quota';
+import {
+  isValidExpiry,
+  presetToExpiresAt,
+  VALID_EXPIRY_VALUES,
+} from '../../util/ai-gateway/expiry';
 import { resolveAgents } from '../../util/ai-gateway/coding-agents/resolve';
 import {
   ensureTeam,
   createKey,
   promptKeyName,
+  promptQuota,
+  promptExpiry,
   type KeySource,
 } from '../../util/ai-gateway/coding-agents/key-source';
 import {
@@ -32,7 +43,7 @@ import {
   outputAgentError,
   shouldEmitNonInteractiveCommandError,
 } from '../../util/agent-output';
-import { AGENT_STATUS } from '../../util/agent-output-constants';
+import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { setupSubcommand } from './command';
 import { AiGatewayCodingAgentsSetupTelemetryClient } from '../../util/telemetry/commands/ai-gateway/coding-agents-setup';
 
@@ -57,6 +68,10 @@ export default async function codingAgentsSetup(
   const agentFlags = opts['--agent'] as string[] | undefined;
   const all = opts['--all'] as boolean | undefined;
   const providedKey = opts['--key'] as string | undefined;
+  const budget = opts['--budget'] as number | undefined;
+  const refreshPeriod = opts['--refresh-period'] as string | undefined;
+  const includeByok = opts['--include-byok'] as boolean | undefined;
+  const expiration = opts['--expiration'] as string | undefined;
   const name = opts['--name'] as string | undefined;
   const reconfigure = opts['--reconfigure'] as boolean | undefined;
   const yes = opts['--yes'] as boolean | undefined;
@@ -64,6 +79,10 @@ export default async function codingAgentsSetup(
   telemetry.trackCliOptionAgent(agentFlags as [string] | undefined);
   telemetry.trackCliFlagAll(all);
   telemetry.trackCliOptionKey(providedKey);
+  telemetry.trackCliOptionBudget(budget);
+  telemetry.trackCliOptionRefreshPeriod(refreshPeriod);
+  telemetry.trackCliFlagIncludeByok(includeByok);
+  telemetry.trackCliOptionExpiration(expiration);
   telemetry.trackCliOptionName(name);
   telemetry.trackCliFlagReconfigure(reconfigure);
   telemetry.trackCliFlagYes(yes);
@@ -71,6 +90,35 @@ export default async function codingAgentsSetup(
   const machine = shouldEmitNonInteractiveCommandError(client);
   const canPrompt = Boolean(client.stdin.isTTY) && !machine;
   const home = homedir();
+
+  if (budget !== undefined && (!Number.isFinite(budget) || budget < 1)) {
+    return failValidation(
+      client,
+      machine,
+      AGENT_REASON.INVALID_BUDGET,
+      'Budget must be a positive number in dollars (minimum 1).'
+    );
+  }
+  if (refreshPeriod && !isValidRefreshPeriod(refreshPeriod)) {
+    return failValidation(
+      client,
+      machine,
+      AGENT_REASON.INVALID_REFRESH_PERIOD,
+      `Invalid refresh period "${refreshPeriod}". Must be one of: ${VALID_REFRESH_PERIODS.join(', ')}.`
+    );
+  }
+  if (expiration && !isValidExpiry(expiration)) {
+    return failValidation(
+      client,
+      machine,
+      AGENT_REASON.INVALID_EXPIRATION,
+      `Invalid expiration "${expiration}". Must be one of: ${VALID_EXPIRY_VALUES.join(', ')}.`
+    );
+  }
+  const flagExpiresAt =
+    expiration && expiration !== 'none'
+      ? presetToExpiresAt(expiration)
+      : undefined;
 
   const selection = await resolveAgents({
     client,
@@ -97,10 +145,15 @@ export default async function codingAgentsSetup(
   }
 
   // With no --key we create one. Resolve the owning team first — it decides
-  // where the key lives (and can fail), so it comes before any naming.
+  // where the key lives (and can fail) — then collect name, quota, and expiry.
   const willCreate = !providedKey;
   let keyName = name;
+  let keyBudget = budget;
+  let keyRefresh = refreshPeriod;
+  let keyExpiresAt = flagExpiresAt;
   if (willCreate) {
+    const promptCreate = canPrompt && !yes;
+
     const teamError = await ensureTeam(client, {
       machine,
       canPrompt,
@@ -109,8 +162,20 @@ export default async function codingAgentsSetup(
     if (teamError) {
       return teamError;
     }
-    if (canPrompt && !yes && keyName === undefined) {
+
+    if (promptCreate && keyName === undefined) {
       keyName = await promptKeyName(client);
+    }
+
+    if (promptCreate) {
+      if (keyBudget === undefined && keyRefresh === undefined) {
+        const quota = await promptQuota(client);
+        keyBudget = quota.budget;
+        keyRefresh = quota.refreshPeriod;
+      }
+      if (keyExpiresAt === undefined && !expiration) {
+        keyExpiresAt = await promptExpiry(client);
+      }
     }
   }
 
@@ -125,13 +190,22 @@ export default async function codingAgentsSetup(
   const errored = previewPlan.changes.filter(c => c.status === 'error');
   const alreadyConfigured = changed.length === 0 && errored.length === 0;
 
+  const mintKey = () =>
+    createKey(client, {
+      name: keyName,
+      budget: keyBudget,
+      refreshPeriod: keyRefresh,
+      includeByok,
+      expiresAt: keyExpiresAt,
+    });
+
   if (machine) {
     return runMachine({
       client,
       selected,
       unsupported,
       keySource: providedKey ? { key: providedKey, created: false } : null,
-      createKey: () => createKey(client, { name: keyName }),
+      createKey: mintKey,
       backup: true,
       home,
       alreadyConfigured,
@@ -165,7 +239,7 @@ export default async function codingAgentsSetup(
   try {
     keySource = providedKey
       ? { key: providedKey, created: false }
-      : { key: await createKey(client, { name: keyName }), created: true };
+      : { key: await mintKey(), created: true };
   } catch (err) {
     output.stopSpinner();
     if (isAPIError(err)) {
@@ -214,4 +288,21 @@ export default async function codingAgentsSetup(
 
   printNotes(plan);
   return 0;
+}
+
+function failValidation(
+  client: Client,
+  machine: boolean,
+  reason: string,
+  message: string
+): number {
+  if (machine) {
+    outputAgentError(client, {
+      status: AGENT_STATUS.ERROR,
+      reason,
+      message,
+    });
+  }
+  output.error(message);
+  return 1;
 }

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -259,6 +259,40 @@ export const setupSubcommand = {
       description: 'Use an existing AI Gateway API key instead of creating one',
     },
     {
+      name: 'budget',
+      shorthand: null,
+      type: Number,
+      argument: 'AMOUNT',
+      deprecated: false,
+      description:
+        'Quota budget in dollars for a newly created key (minimum 1)',
+    },
+    {
+      name: 'refresh-period',
+      shorthand: null,
+      type: String,
+      argument: 'PERIOD',
+      deprecated: false,
+      description:
+        'Quota refresh cadence for a new key: daily, weekly, monthly, or none',
+    },
+    {
+      name: 'include-byok',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Include BYOK usage in the new key quota',
+    },
+    {
+      name: 'expiration',
+      shorthand: null,
+      type: String,
+      argument: 'PERIOD',
+      deprecated: false,
+      description:
+        'Expiry for a new key: 7d, 30d, 60d, 90d, 1y, or none (default: none)',
+    },
+    {
       name: 'name',
       shorthand: null,
       type: String,
@@ -282,8 +316,8 @@ export const setupSubcommand = {
       value: `${packageName} ai-gateway coding-agents setup`,
     },
     {
-      name: 'Connect specific agents with an existing key',
-      value: `${packageName} ai-gateway coding-agents setup --key <key> --agent claude-code`,
+      name: 'Connect specific agents with a budgeted key',
+      value: `${packageName} ai-gateway coding-agents setup --agent claude-code --budget 500 --refresh-period monthly`,
     },
     {
       name: 'Rotate the key on an already-configured setup',

--- a/packages/cli/src/util/agent-output-constants.ts
+++ b/packages/cli/src/util/agent-output-constants.ts
@@ -80,6 +80,7 @@ export const AGENT_REASON = {
   // AI Gateway
   INVALID_BUDGET: 'invalid_budget',
   INVALID_REFRESH_PERIOD: 'invalid_refresh_period',
+  INVALID_EXPIRATION: 'invalid_expiration',
   // Redirects
   REDIRECT_NOT_FOUND: 'redirect_not_found',
   VERSION_NOT_FOUND: 'version_not_found',

--- a/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
@@ -6,6 +6,11 @@ import { getCommandName } from '../../pkg-name';
 import createApiKeyRequest from '../create-api-key';
 import selectOrg from '../../input/select-org';
 import { buildQuota } from '../quota';
+import {
+  EXPIRY_PRESETS,
+  DEFAULT_EXPIRY_PRESET,
+  presetToExpiresAt,
+} from '../expiry';
 import { outputAgentError } from '../../agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../agent-output-constants';
 
@@ -14,11 +19,14 @@ export interface KeySource {
   created: boolean;
 }
 
+const CHILD_PROMPT = chalk.dim('↳');
+
 export interface KeyOptions {
   name?: string;
   budget?: number;
   refreshPeriod?: string;
   includeByok?: boolean;
+  expiresAt?: number;
 }
 
 export function defaultKeyName(): string {
@@ -47,6 +55,58 @@ export async function promptKeyName(client: Client): Promise<string> {
     default: fallback,
   });
   return answer.trim() || fallback;
+}
+
+export async function promptQuota(client: Client): Promise<{
+  budget?: number;
+  refreshPeriod?: string;
+}> {
+  const wantsQuota = await client.input.confirm(
+    'Set a spend limit for this key?',
+    false
+  );
+  if (!wantsQuota) {
+    return {};
+  }
+  const refreshPeriod = await client.input.select<string>({
+    message: `${CHILD_PROMPT} How often should the limit reset?`,
+    choices: [
+      { name: 'Never (one-time limit)', value: 'none' },
+      { name: 'Daily', value: 'daily' },
+      { name: 'Weekly', value: 'weekly' },
+      { name: 'Monthly', value: 'monthly' },
+    ],
+    default: 'none',
+  });
+  const amount = await client.input.text({
+    message: `${CHILD_PROMPT} Spend limit in USD`,
+    default: '100',
+    validate: value => {
+      const n = Number(value);
+      return Number.isFinite(n) && n >= 1
+        ? true
+        : 'Enter a number of dollars (minimum 1).';
+    },
+  });
+  return { budget: Number(amount), refreshPeriod };
+}
+
+export async function promptExpiry(
+  client: Client
+): Promise<number | undefined> {
+  const wantsExpiry = await client.input.confirm(
+    'Set an expiration for this key?',
+    false
+  );
+  if (!wantsExpiry) {
+    return undefined;
+  }
+  const preset = await client.input.select<string>({
+    message: `${CHILD_PROMPT} Expires in`,
+    choices: EXPIRY_PRESETS.map(p => ({ name: p.label, value: p.value })),
+    default: DEFAULT_EXPIRY_PRESET,
+  });
+  return presetToExpiresAt(preset);
 }
 
 function hasExplicitScopeFlag(argv: string[]): boolean {
@@ -115,6 +175,7 @@ export async function createKey(
         refreshPeriod: opts.refreshPeriod,
         includeByok: opts.includeByok,
       }),
+      ...(opts.expiresAt !== undefined && { expiresAt: opts.expiresAt }),
     });
     return result.apiKeyString;
   } finally {

--- a/packages/cli/src/util/ai-gateway/create-api-key.ts
+++ b/packages/cli/src/util/ai-gateway/create-api-key.ts
@@ -10,6 +10,7 @@ type CreateApiKeyRequest = {
   purpose: 'ai-gateway';
   name?: string;
   aiGatewayQuota?: AiGatewayQuota;
+  expiresAt?: number;
 };
 
 type CreateApiKeyApiKey = {
@@ -28,7 +29,11 @@ export type CreateApiKeyResponse = {
 
 export default async function createApiKey(
   client: Client,
-  payload: { name?: string; aiGatewayQuota?: AiGatewayQuota }
+  payload: {
+    name?: string;
+    aiGatewayQuota?: AiGatewayQuota;
+    expiresAt?: number;
+  }
 ): Promise<CreateApiKeyResponse> {
   return await client.fetch<CreateApiKeyResponse>('/v1/api-keys', {
     method: 'POST',

--- a/packages/cli/src/util/ai-gateway/expiry.ts
+++ b/packages/cli/src/util/ai-gateway/expiry.ts
@@ -1,0 +1,45 @@
+export const EXPIRY_PRESETS = [
+  { label: '7 days', value: '7d' },
+  { label: '30 days', value: '30d' },
+  { label: '60 days', value: '60d' },
+  { label: '90 days', value: '90d' },
+  { label: '1 year', value: '1y' },
+] as const;
+
+export type ExpiryPreset = (typeof EXPIRY_PRESETS)[number]['value'];
+
+export const DEFAULT_EXPIRY_PRESET: ExpiryPreset = '30d';
+
+export const VALID_EXPIRY_VALUES = [
+  ...EXPIRY_PRESETS.map(p => p.value),
+  'none',
+] as const;
+
+export function isValidExpiry(value: string): boolean {
+  return (VALID_EXPIRY_VALUES as readonly string[]).includes(value);
+}
+
+const DAY_MS = 86_400_000;
+
+export function presetToExpiresAt(
+  value: string,
+  now: number = Date.now()
+): number | undefined {
+  switch (value) {
+    case '7d':
+      return now + 7 * DAY_MS;
+    case '30d':
+      return now + 30 * DAY_MS;
+    case '60d':
+      return now + 60 * DAY_MS;
+    case '90d':
+      return now + 90 * DAY_MS;
+    case '1y': {
+      const date = new Date(now);
+      date.setFullYear(date.getFullYear() + 1);
+      return date.getTime();
+    }
+    default:
+      return undefined;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
@@ -26,6 +26,33 @@ export class AiGatewayCodingAgentsSetupTelemetryClient
     }
   }
 
+  trackCliOptionBudget(budget: number | undefined) {
+    if (budget !== undefined) {
+      this.trackCliOption({ option: 'budget', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionRefreshPeriod(refreshPeriod: string | undefined) {
+    if (refreshPeriod) {
+      this.trackCliOption({
+        option: 'refresh-period',
+        value: refreshPeriod,
+      });
+    }
+  }
+
+  trackCliFlagIncludeByok(includeByok: boolean | undefined) {
+    if (includeByok) {
+      this.trackCliFlag('include-byok');
+    }
+  }
+
+  trackCliOptionExpiration(expiration: string | undefined) {
+    if (expiration) {
+      this.trackCliOption({ option: 'expiration', value: expiration });
+    }
+  }
+
   trackCliOptionName(name: string | undefined) {
     if (name) {
       this.trackCliOption({ option: 'name', value: this.redactedValue });

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -160,6 +160,11 @@ describe('ai-gateway coding-agents setup', () => {
       client.stdin.write('\n');
       await expect(client.stderr).toOutput('Key name?');
       client.stdin.write('My Coding Key\n');
+      // The create flow also offers a spend limit and an expiry; decline both.
+      await expect(client.stderr).toOutput('Set a spend limit');
+      client.stdin.write('\n');
+      await expect(client.stderr).toOutput('Set an expiration');
+      client.stdin.write('\n');
 
       expect(await exitCodePromise).toBe(0);
       expect(lastCreateBody?.name).toBe('My Coding Key');
@@ -184,6 +189,152 @@ describe('ai-gateway coding-agents setup', () => {
 
       const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
       expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
+    });
+  });
+
+  describe('key limits', () => {
+    it('sends a budgeted quota from flags', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code',
+        '--budget',
+        '500',
+        '--refresh-period',
+        'monthly'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      expect(lastCreateBody?.aiGatewayQuota).toMatchObject({
+        limitAmount: 500,
+        refreshPeriod: 'monthly',
+      });
+    });
+
+    it('collects quota and expiry interactively', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stderr).toOutput('Which team?');
+      client.stdin.write('\n');
+      await expect(client.stderr).toOutput('Key name?');
+      client.stdin.write('My Coding Key\n');
+      await expect(client.stderr).toOutput('Set a spend limit');
+      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('How often should the limit reset?');
+      client.stdin.write('\n'); // accept default "Never"
+      await expect(client.stderr).toOutput('Spend limit in USD');
+      client.stdin.write('\n'); // accept default 100
+      await expect(client.stderr).toOutput('Set an expiration');
+      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('Expires in');
+      client.stdin.write('\n'); // accept default preset (30 days)
+
+      expect(await exitCodePromise).toBe(0);
+
+      expect(lastCreateBody?.aiGatewayQuota).toMatchObject({
+        limitAmount: 100,
+      });
+      const expiresAt = lastCreateBody?.expiresAt as number;
+      expect(typeof expiresAt).toBe('number');
+      const days = (expiresAt - Date.now()) / 86_400_000;
+      expect(days).toBeGreaterThan(29);
+      expect(days).toBeLessThan(31);
+    });
+
+    it('sends expiresAt from the --expiration flag', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code',
+        '--expiration',
+        '7d'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const expiresAt = lastCreateBody?.expiresAt as number;
+      const days = (expiresAt - Date.now()) / 86_400_000;
+      expect(days).toBeGreaterThan(6);
+      expect(days).toBeLessThan(8);
+    });
+
+    it('does not send expiresAt for --expiration none', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code',
+        '--expiration',
+        'none'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      expect(lastCreateBody?.expiresAt).toBeUndefined();
+    });
+
+    it('rejects an invalid --expiration', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code',
+        '--expiration',
+        'soon'
+      );
+
+      expect(await aiGateway(client)).toBe(1);
+      await expect(client.stderr).toOutput('Invalid expiration');
+    });
+
+    it('rejects a negative budget', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--budget',
+        '-5',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Budget must be a positive number in dollars'
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
Put limits on a newly created key: `--budget` / `--refresh-period` / `--include-byok` (spend cap) and `--expiration` (`7d|30d|60d|90d|1y|none`), with interactive prompts and up-front validation. Limits apply only when minting a key; reusing one with `--key` is unaffected.

Usable: `… --budget 500 --refresh-period monthly --expiration 30d`.

