### PR TITLE
[cli] coding-agents setup: preview, confirm, and custom paths

### DIFF
--- a/.changeset/ai-gateway-coding-agents-preview.md
+++ b/.changeset/ai-gateway-coding-agents-preview.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`ai-gateway coding-agents setup` now previews before it writes. `--dry-run` and the pre-apply summary show the planned per-file changes as a masked diff, the resolved key/quota/expiry, and the `.bak` backups it would create (suppressed with `--no-backup`), then ask for confirmation before applying. For non-standard setups, `--agent-config <id>=<path>` overrides an agent's config-file location and `--shell-rc <path>` the shell rc; interactively it offers a custom path when an agent isn't found at its default location.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
@@ -1,4 +1,6 @@
 import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import chalk from 'chalk';
 import type Client from '../../util/client';
 import output from '../../output-manager';
@@ -17,6 +19,7 @@ import {
   VALID_EXPIRY_VALUES,
 } from '../../util/ai-gateway/expiry';
 import { resolveAgents } from '../../util/ai-gateway/coding-agents/resolve';
+import { getAgentById } from '../../util/ai-gateway/coding-agents/agents';
 import {
   ensureTeam,
   createKey,
@@ -30,6 +33,8 @@ import {
   applyPlan,
 } from '../../util/ai-gateway/coding-agents/apply';
 import {
+  printResolvedState,
+  printPlan,
   printNotes,
   printKey,
   printKeyRow,
@@ -74,6 +79,10 @@ export default async function codingAgentsSetup(
   const expiration = opts['--expiration'] as string | undefined;
   const name = opts['--name'] as string | undefined;
   const reconfigure = opts['--reconfigure'] as boolean | undefined;
+  const dryRun = opts['--dry-run'] as boolean | undefined;
+  const noBackup = opts['--no-backup'] as boolean | undefined;
+  const agentConfig = opts['--agent-config'] as string[] | undefined;
+  const shellRcOverride = opts['--shell-rc'] as string | undefined;
   const yes = opts['--yes'] as boolean | undefined;
 
   telemetry.trackCliOptionAgent(agentFlags as [string] | undefined);
@@ -85,6 +94,10 @@ export default async function codingAgentsSetup(
   telemetry.trackCliOptionExpiration(expiration);
   telemetry.trackCliOptionName(name);
   telemetry.trackCliFlagReconfigure(reconfigure);
+  telemetry.trackCliFlagDryRun(dryRun);
+  telemetry.trackCliFlagNoBackup(noBackup);
+  telemetry.trackCliOptionAgentConfig(agentConfig);
+  telemetry.trackCliOptionShellRc(shellRcOverride);
   telemetry.trackCliFlagYes(yes);
 
   const machine = shouldEmitNonInteractiveCommandError(client);
@@ -120,6 +133,36 @@ export default async function codingAgentsSetup(
       ? presetToExpiresAt(expiration)
       : undefined;
 
+  const overrides: Record<string, string> = {};
+  for (const pair of agentConfig ?? []) {
+    const eq = pair.indexOf('=');
+    const id = eq > 0 ? pair.slice(0, eq).trim().toLowerCase() : '';
+    const path = eq > 0 ? pair.slice(eq + 1).trim() : '';
+    if (!id || !path) {
+      return failValidation(
+        client,
+        machine,
+        AGENT_REASON.INVALID_ARGUMENTS,
+        `Invalid --agent-config "${pair}". Use <agent>=<path>, e.g. claude-code=/path/settings.json.`
+      );
+    }
+    if (!getAgentById(id)) {
+      return failValidation(
+        client,
+        machine,
+        AGENT_REASON.INVALID_ARGUMENTS,
+        `Unknown agent "${id}" in --agent-config.`
+      );
+    }
+    overrides[id] = resolve(path);
+  }
+
+  if (dryRun && !machine) {
+    printStatus(
+      `${chalk.bold('Dry run')} — previewing changes only. No files will be written and no API key will be created.`
+    );
+  }
+
   const selection = await resolveAgents({
     client,
     agentFlags,
@@ -144,6 +187,17 @@ export default async function codingAgentsSetup(
     printWarning(note);
   }
 
+  for (const id of Object.keys(overrides)) {
+    if (!selected.some(a => a.id === id)) {
+      return failValidation(
+        client,
+        machine,
+        AGENT_REASON.INVALID_ARGUMENTS,
+        `--agent-config set for "${id}", which isn't selected. Add --agent ${id} (or --all).`
+      );
+    }
+  }
+
   // With no --key we create one. Resolve the owning team first — it decides
   // where the key lives (and can fail) — then collect name, quota, and expiry.
   const willCreate = !providedKey;
@@ -151,7 +205,7 @@ export default async function codingAgentsSetup(
   let keyBudget = budget;
   let keyRefresh = refreshPeriod;
   let keyExpiresAt = flagExpiresAt;
-  if (willCreate) {
+  if (willCreate && (!dryRun || canPrompt)) {
     const promptCreate = canPrompt && !yes;
 
     const teamError = await ensureTeam(client, {
@@ -178,35 +232,69 @@ export default async function codingAgentsSetup(
       }
     }
   }
-
+  if (canPrompt && !yes) {
+    const missing = selected.filter(
+      a =>
+        !overrides[a.id] &&
+        !existsSync(dirname(a.configPath({ apiKey: '', home })))
+    );
+    if (missing.length > 0) {
+      const customize = await client.input.confirm(
+        "Some agents weren't found at their default locations. Set custom config paths?",
+        false
+      );
+      if (customize) {
+        for (const agent of missing) {
+          const resolved = agent.configPath({
+            apiKey: '',
+            home,
+          });
+          const answer = await client.input.text({
+            message: `${agent.displayName} config path?`,
+            default: resolved,
+          });
+          const picked = answer.trim();
+          if (picked && resolve(picked) !== resolved) {
+            overrides[agent.id] = resolve(picked);
+          }
+        }
+      }
+    }
+  }
   const previewKey = providedKey ?? KEY_PLACEHOLDER;
+
   const previewPlan = await buildSetupPlan(selected, {
     apiKey: previewKey,
     home,
+    overrides,
+    shellRcOverride,
   });
+
   const changed = previewPlan.changes.filter(
     c => c.status === 'create' || c.status === 'update'
   );
   const errored = previewPlan.changes.filter(c => c.status === 'error');
   const alreadyConfigured = changed.length === 0 && errored.length === 0;
 
-  const mintKey = () =>
-    createKey(client, {
-      name: keyName,
-      budget: keyBudget,
-      refreshPeriod: keyRefresh,
-      includeByok,
-      expiresAt: keyExpiresAt,
-    });
-
   if (machine) {
     return runMachine({
       client,
       selected,
       unsupported,
+      previewPlan,
+      dryRun: Boolean(dryRun),
+      backup: !noBackup,
       keySource: providedKey ? { key: providedKey, created: false } : null,
-      createKey: mintKey,
-      backup: true,
+      createKey: () =>
+        createKey(client, {
+          name: keyName,
+          budget: keyBudget,
+          refreshPeriod: keyRefresh,
+          includeByok,
+          expiresAt: keyExpiresAt,
+        }),
+      overrides,
+      shellRcOverride,
       home,
       alreadyConfigured,
       reconfigure: Boolean(reconfigure),
@@ -235,11 +323,46 @@ export default async function codingAgentsSetup(
     }
   }
 
+  // Resolved state first, then the mutation preview, then the confirm.
+  printResolvedState({
+    selected,
+    willCreate,
+    name: keyName,
+    budget: keyBudget,
+    refreshPeriod: keyRefresh,
+    expiresAt: keyExpiresAt,
+  });
+  printPlan(previewPlan, previewKey, { backup: !noBackup });
+
+  if (dryRun) {
+    printStatus(
+      `Dry run — no files written. Re-run without ${chalk.bold('--dry-run')} to apply.`
+    );
+    return 0;
+  }
+
+  if (changed.length > 0 && canPrompt && !yes) {
+    const confirmed = await client.input.confirm('Apply these changes?', true);
+    if (!confirmed) {
+      printStatus('Aborted. No files were changed.');
+      return 0;
+    }
+  }
+
   let keySource: KeySource;
   try {
     keySource = providedKey
       ? { key: providedKey, created: false }
-      : { key: await mintKey(), created: true };
+      : {
+          key: await createKey(client, {
+            name: keyName,
+            budget: keyBudget,
+            refreshPeriod: keyRefresh,
+            includeByok,
+            expiresAt: keyExpiresAt,
+          }),
+          created: true,
+        };
   } catch (err) {
     output.stopSpinner();
     if (isAPIError(err)) {
@@ -249,8 +372,14 @@ export default async function codingAgentsSetup(
     throw err;
   }
 
-  const plan = await buildSetupPlan(selected, { apiKey: keySource.key, home });
-  const results = await applyPlan(plan, { backup: true });
+  const applyPlanResult = await buildSetupPlan(selected, {
+    apiKey: keySource.key,
+    home,
+    overrides,
+    shellRcOverride,
+  });
+
+  const results = await applyPlan(applyPlanResult, { backup: !noBackup });
 
   if (results.length === 0 && keySource.created) {
     // Rotated with a fresh key but nothing in the config files changed (e.g. the
@@ -286,7 +415,7 @@ export default async function codingAgentsSetup(
     );
   }
 
-  printNotes(plan);
+  printNotes(applyPlanResult);
   return 0;
 }
 

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -308,11 +308,42 @@ export const setupSubcommand = {
       description:
         'Re-run even if already configured, to rotate the key or switch team',
     },
+    {
+      name: 'dry-run',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Show what would change without writing any files',
+    },
+    {
+      name: 'no-backup',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Do not write .bak backups of changed files',
+    },
+    {
+      name: 'agent-config',
+      shorthand: null,
+      type: [String],
+      argument: 'AGENT=PATH',
+      deprecated: false,
+      description:
+        "Override an agent's config file path, e.g. claude-code=/path/settings.json (repeatable)",
+    },
+    {
+      name: 'shell-rc',
+      shorthand: null,
+      type: String,
+      argument: 'PATH',
+      deprecated: false,
+      description: 'Shell rc file to write the env exports into',
+    },
     yesOption,
   ],
   examples: [
     {
-      name: 'Connect the detected coding agents (creates a key)',
+      name: 'Connect all detected coding agents (creates a key)',
       value: `${packageName} ai-gateway coding-agents setup`,
     },
     {
@@ -322,6 +353,10 @@ export const setupSubcommand = {
     {
       name: 'Rotate the key on an already-configured setup',
       value: `${packageName} ai-gateway coding-agents setup --reconfigure`,
+    },
+    {
+      name: 'Reuse an existing key and preview changes only',
+      value: `${packageName} ai-gateway coding-agents setup --key <key> --dry-run`,
     },
   ],
 } as const;

--- a/packages/cli/src/util/ai-gateway/coding-agents/diff.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/diff.ts
@@ -1,0 +1,129 @@
+import chalk from 'chalk';
+import { maskSecret } from './gateway';
+
+interface DiffLine {
+  type: ' ' | '-' | '+';
+  text: string;
+}
+
+function diffLines(before: string, after: string): DiffLine[] {
+  const a = before.length ? before.split('\n') : [];
+  const b = after.length ? after.split('\n') : [];
+  const m = a.length;
+  const n = b.length;
+  const lcs: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array<number>(n + 1).fill(0)
+  );
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      lcs[i][j] =
+        a[i] === b[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      out.push({ type: ' ', text: a[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ type: '-', text: a[i] });
+      i++;
+    } else {
+      out.push({ type: '+', text: b[j] });
+      j++;
+    }
+  }
+  while (i < m) out.push({ type: '-', text: a[i++] });
+  while (j < n) out.push({ type: '+', text: b[j++] });
+  return out;
+}
+
+function maskKnownSecrets(text: string, secrets: string[]): string {
+  let masked = text;
+  for (const secret of secrets) {
+    if (secret) {
+      masked = masked.split(secret).join(maskSecret(secret));
+    }
+  }
+  return masked;
+}
+
+function redactSecretFields(text: string): string {
+  return text
+    .replace(
+      /("(?:ANTHROPIC_AUTH_TOKEN|ANTHROPIC_API_KEY|apiKey|key)"\s*:\s*)"((?:[^"\\]|\\.)+)"/g,
+      (_match, prefix, value) => `${prefix}"${maskSecret(value)}"`
+    )
+    .replace(
+      /(export\s+AI_GATEWAY_API_KEY=)(["'])((?:(?!\2).)+)(\2)/g,
+      (_match, prefix, quote, value, close) =>
+        `${prefix}${quote}${maskSecret(value)}${close}`
+    )
+    .replace(
+      /(set -gx AI_GATEWAY_API_KEY )(["'])((?:(?!\2).)+)(\2)/g,
+      (_match, prefix, quote, value, close) =>
+        `${prefix}${quote}${maskSecret(value)}${close}`
+    );
+}
+
+function mask(text: string, secrets: string[]): string {
+  return redactSecretFields(maskKnownSecrets(text, secrets));
+}
+
+export interface RenderDiffOptions {
+  secrets?: string[];
+  context?: number;
+  indent?: string;
+}
+
+export function renderDiff(
+  before: string,
+  after: string,
+  options: RenderDiffOptions = {}
+): string {
+  const { secrets = [], context = 2, indent = '  ' } = options;
+  const lines = diffLines(before, after);
+  if (!lines.some(l => l.type !== ' ')) {
+    return '';
+  }
+
+  const keep = new Array<boolean>(lines.length).fill(false);
+  lines.forEach((line, idx) => {
+    if (line.type !== ' ') {
+      for (
+        let k = Math.max(0, idx - context);
+        k <= Math.min(lines.length - 1, idx + context);
+        k++
+      ) {
+        keep[k] = true;
+      }
+    }
+  });
+
+  const rendered: string[] = [];
+  let collapsed = false;
+  lines.forEach((line, idx) => {
+    if (!keep[idx]) {
+      if (!collapsed) {
+        rendered.push(chalk.dim(`${indent}  ⋯`));
+        collapsed = true;
+      }
+      return;
+    }
+    collapsed = false;
+    const text = mask(line.text, secrets);
+    if (line.type === '+') {
+      rendered.push(chalk.green(`${indent}+ ${text}`));
+    } else if (line.type === '-') {
+      rendered.push(chalk.red(`${indent}- ${text}`));
+    } else {
+      rendered.push(chalk.dim(`${indent}  ${text}`));
+    }
+  });
+  return rendered.join('\n');
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -3,7 +3,7 @@ import { isAPIError } from '../../errors-ts';
 import { outputAgentError } from '../../agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../agent-output-constants';
 import { UNSUPPORTED_AGENTS } from './agents';
-import { buildSetupPlan, applyPlan } from './apply';
+import { buildSetupPlan, applyPlan, type SetupPlan } from './apply';
 import type { KeySource } from './key-source';
 import type { CodingAgent } from './types';
 
@@ -11,14 +11,60 @@ export async function runMachine(args: {
   client: Client;
   selected: CodingAgent[];
   unsupported: string[];
+  previewPlan: SetupPlan;
+  dryRun: boolean;
+  backup: boolean;
   keySource: KeySource | null;
   createKey: () => Promise<string>;
-  backup: boolean;
+  overrides?: Record<string, string>;
+  shellRcOverride?: string;
   home: string;
   alreadyConfigured: boolean;
   reconfigure: boolean;
 }): Promise<number> {
-  const { client, selected, backup, home } = args;
+  const { client, selected, previewPlan, dryRun, backup, home } = args;
+
+  const errored = previewPlan.changes.filter(c => c.status === 'error');
+  const skipped: Array<{ target: string; reason: string; message?: string }> =
+    errored.map(c => ({
+      target: c.path,
+      reason: 'unparseable_config',
+      message: c.error,
+    }));
+  for (const id of args.unsupported) {
+    skipped.push({
+      target: id,
+      reason: 'not_automatable',
+      message: UNSUPPORTED_AGENTS[id],
+    });
+  }
+
+  if (dryRun) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: AGENT_STATUS.OK,
+          reason: 'dry_run',
+          message:
+            'Previewing AI Gateway coding-agent setup. No files written.',
+          changes: previewPlan.changes.map(c => ({
+            agent: c.owners.join(', '),
+            file: c.path,
+            action:
+              c.status === 'create'
+                ? 'would_create'
+                : c.status === 'update'
+                  ? 'would_update'
+                  : c.status,
+          })),
+          skipped,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
 
   // Idempotent by default: if nothing needs writing and we weren't asked to
   // reconfigure, report the no-op without minting a fresh key.
@@ -54,24 +100,13 @@ export async function runMachine(args: {
     throw err;
   }
 
-  const plan = await buildSetupPlan(selected, { apiKey: key, home });
-
-  const errored = plan.changes.filter(c => c.status === 'error');
-  const skipped: Array<{ target: string; reason: string; message?: string }> =
-    errored.map(c => ({
-      target: c.path,
-      reason: 'unparseable_config',
-      message: c.error,
-    }));
-  for (const id of args.unsupported) {
-    skipped.push({
-      target: id,
-      reason: 'not_automatable',
-      message: UNSUPPORTED_AGENTS[id],
-    });
-  }
-
-  const results = await applyPlan(plan, { backup });
+  const finalPlan = await buildSetupPlan(selected, {
+    apiKey: key,
+    home,
+    overrides: args.overrides,
+    shellRcOverride: args.shellRcOverride,
+  });
+  const results = await applyPlan(finalPlan, { backup });
 
   client.stdout.write(
     `${JSON.stringify(
@@ -91,7 +126,7 @@ export async function runMachine(args: {
           backup: r.backupPath,
         })),
         skipped,
-        notes: plan.notes.flatMap(n =>
+        notes: finalPlan.notes.flatMap(n =>
           n.notes.map(line => `${n.displayName}: ${line}`)
         ),
       },

--- a/packages/cli/src/util/ai-gateway/coding-agents/render.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/render.ts
@@ -4,8 +4,95 @@ import {
   ALIGNED_LABEL_WIDTH,
   printAlignedLabel,
 } from '../../output/print-aligned-label';
+import { renderDiff } from './diff';
 import { maskSecret } from './gateway';
 import type { SetupPlan } from './apply';
+import type { CodingAgent } from './types';
+
+export function printResolvedState(args: {
+  selected: CodingAgent[];
+  willCreate: boolean;
+  name?: string;
+  budget?: number;
+  refreshPeriod?: string;
+  expiresAt?: number;
+}): void {
+  const { selected, willCreate, name, budget, refreshPeriod, expiresAt } = args;
+  output.print(chalk.bold('  Summary\n'));
+  printAlignedLabel('Agents', selected.map(a => a.displayName).join(', '));
+  if (!willCreate) {
+    printAlignedLabel('API key', 'Using provided key');
+    output.print('\n');
+    return;
+  }
+  printAlignedLabel(
+    'API key',
+    name ? `Creating new key "${name}"` : 'Creating new key'
+  );
+  let spendLimit = 'Unlimited';
+  if (budget !== undefined) {
+    const period =
+      refreshPeriod && refreshPeriod !== 'none' ? refreshPeriod : '';
+    spendLimit = period ? `$${budget}/${period}` : `$${budget}`;
+  }
+  printAlignedLabel('Spend limit', spendLimit);
+  printAlignedLabel(
+    'Expires',
+    expiresAt !== undefined
+      ? new Date(expiresAt).toISOString().slice(0, 10)
+      : 'Never'
+  );
+  output.print('\n');
+}
+
+export function printPlan(
+  plan: SetupPlan,
+  previewKey: string,
+  opts: { backup?: boolean } = {}
+): void {
+  // The backup promise belongs up front — before the user decides — not only
+  // in the post-apply receipt.
+  output.print(
+    opts.backup
+      ? `${chalk.bold('  Planned changes')}  ${chalk.dim(
+          'existing files are backed up alongside as .bak first'
+        )}\n`
+      : chalk.bold('  Planned changes\n')
+  );
+  for (const change of plan.changes) {
+    if (change.status === 'unchanged') {
+      output.print(
+        `  ${chalk.dim(`= ${change.label} (unchanged)`)}  ${chalk.dim(change.path)}\n`
+      );
+      continue;
+    }
+    if (change.status === 'error') {
+      // A skipped file is a nonfatal warning: yellow gutter, dim detail.
+      output.print(
+        `${chalk.yellow('!')} ${chalk.bold(change.label)}  ${chalk.dim(change.path)}\n`
+      );
+      output.print(chalk.dim(`    cannot edit: ${change.error}\n`));
+      continue;
+    }
+    const verb = change.status === 'create' ? 'create' : 'update';
+    output.print(
+      `  ${verb === 'create' ? chalk.green('+') : '~'} ${chalk.bold(change.label)} (${verb})  ${chalk.dim(change.path)}\n`
+    );
+    // An existing file is copied to `<path>.bak` before it's overwritten;
+    // surface that side effect in the preview unless backups are disabled.
+    if (opts.backup && change.current !== null) {
+      output.print(chalk.dim(`    ↳ backs up to ${change.path}.bak\n`));
+    }
+    const diff = renderDiff(change.current ?? '', change.next ?? '', {
+      secrets: [previewKey],
+      indent: '    ',
+    });
+    if (diff) {
+      output.print(`${diff}\n`);
+    }
+  }
+  output.print('\n');
+}
 
 /** Warning gutter row (`! <message>`), not output.warn's WARNING! label. */
 export function printWarning(message: string): void {

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
@@ -65,6 +65,34 @@ export class AiGatewayCodingAgentsSetupTelemetryClient
     }
   }
 
+  trackCliFlagDryRun(dryRun: boolean | undefined) {
+    if (dryRun) {
+      this.trackCliFlag('dry-run');
+    }
+  }
+
+  trackCliFlagNoBackup(noBackup: boolean | undefined) {
+    if (noBackup) {
+      this.trackCliFlag('no-backup');
+    }
+  }
+
+  trackCliOptionAgentConfig(agentConfig: string[] | undefined) {
+    if (agentConfig && agentConfig.length) {
+      // Local paths may be sensitive; record only that the option was used.
+      this.trackCliOption({
+        option: 'agent-config',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionShellRc(shellRc: string | undefined) {
+    if (shellRc) {
+      this.trackCliOption({ option: 'shell-rc', value: this.redactedValue });
+    }
+  }
+
   trackCliFlagYes(yes: boolean | undefined) {
     if (yes) {
       this.trackCliFlag('yes');

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -1,16 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import {
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { client } from '../../../mocks/client';
 import aiGateway from '../../../../src/commands/ai-gateway';
 import { useUser } from '../../../mocks/user';
 import { detectShellRc } from '../../../../src/util/ai-gateway/coding-agents/apply';
+import { renderDiff } from '../../../../src/util/ai-gateway/coding-agents/diff';
 import {
   mergeJson,
   upsertManagedBlock,
 } from '../../../../src/util/ai-gateway/coding-agents/config-files';
 import { useTeam } from '../../../mocks/team';
+import { buildSetupPlan } from '../../../../src/util/ai-gateway/coding-agents/apply';
+import { claudeCode } from '../../../../src/util/ai-gateway/coding-agents/agents/claude-code';
 
 const CREATED_KEY = 'vck_CreatedSecretKey1234';
 const mockApiKeyResponse = {
@@ -40,6 +49,9 @@ let savedEnv: Record<string, string | undefined>;
 function claudeSettingsPath() {
   return join(home, '.claude', 'settings.json');
 }
+function codexConfigPath() {
+  return join(home, '.codex', 'config.toml');
+}
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'vc-setup-agents-'));
@@ -49,11 +61,20 @@ beforeEach(() => {
     SHELL: process.env.SHELL,
     XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
     CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+    CODEX_HOME: process.env.CODEX_HOME,
+    PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+    ZDOTDIR: process.env.ZDOTDIR,
   };
   process.env.HOME = home;
   process.env.USERPROFILE = home;
   process.env.SHELL = '/bin/bash';
-  for (const v of ['XDG_CONFIG_HOME', 'CLAUDE_CONFIG_DIR']) {
+  for (const v of [
+    'XDG_CONFIG_HOME',
+    'CLAUDE_CONFIG_DIR',
+    'CODEX_HOME',
+    'PI_CODING_AGENT_DIR',
+    'ZDOTDIR',
+  ]) {
     delete process.env[v];
   }
 });
@@ -110,90 +131,8 @@ describe('ai-gateway coding-agents setup', () => {
     });
   });
 
-  describe('key creation', () => {
-    it('creates a key when --key is omitted and writes it', async () => {
-      const team = useTeam();
-      useUser();
-      useCreateApiKey();
-      client.config.currentTeam = team.id;
-      client.nonInteractive = true;
-      client.setArgv(
-        'ai-gateway',
-        'coding-agents',
-        'setup',
-        '--agent',
-        'claude-code',
-        '--name',
-        'my-coding-key'
-      );
-
-      const exitCode = await aiGateway(client);
-      expect(exitCode).toBe(0);
-
-      expect(lastCreateBody?.purpose).toBe('ai-gateway');
-      expect(lastCreateBody?.name).toBe('my-coding-key');
-
-      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
-      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
-
-      const out = JSON.parse(client.stdout.getFullOutput());
-      expect(out.apiKey).toBe(CREATED_KEY);
-    });
-
-    it('prompts for the team and a name, then creates the key', async () => {
-      useTeam();
-      useUser();
-      useCreateApiKey();
-      mkdirSync(join(home, '.claude'), { recursive: true });
-      client.setArgv(
-        'ai-gateway',
-        'coding-agents',
-        'setup',
-        '--agent',
-        'claude-code'
-      );
-
-      const exitCodePromise = aiGateway(client);
-
-      // The owning team decides where the key lives, so it comes first.
-      await expect(client.stderr).toOutput('Which team?');
-      client.stdin.write('\n');
-      await expect(client.stderr).toOutput('Key name?');
-      client.stdin.write('My Coding Key\n');
-      // The create flow also offers a spend limit and an expiry; decline both.
-      await expect(client.stderr).toOutput('Set a spend limit');
-      client.stdin.write('\n');
-      await expect(client.stderr).toOutput('Set an expiration');
-      client.stdin.write('\n');
-
-      expect(await exitCodePromise).toBe(0);
-      expect(lastCreateBody?.name).toBe('My Coding Key');
-    });
-
-    it('skips the prompts with --yes and uses the current scope', async () => {
-      const team = useTeam();
-      useUser();
-      useCreateApiKey();
-      client.config.currentTeam = team.id;
-      client.setArgv(
-        'ai-gateway',
-        'coding-agents',
-        'setup',
-        '--yes',
-        '--agent',
-        'claude-code'
-      );
-
-      const exitCode = await aiGateway(client);
-      expect(exitCode).toBe(0);
-
-      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
-      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
-    });
-  });
-
-  describe('key limits', () => {
-    it('sends a budgeted quota from flags', async () => {
+  describe('non-interactive key creation', () => {
+    it('mints a budgeted key and writes it everywhere', async () => {
       const team = useTeam();
       useUser();
       useCreateApiKey();
@@ -211,14 +150,245 @@ describe('ai-gateway coding-agents setup', () => {
         'monthly'
       );
 
-      expect(await aiGateway(client)).toBe(0);
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      expect(lastCreateBody?.purpose).toBe('ai-gateway');
       expect(lastCreateBody?.aiGatewayQuota).toMatchObject({
         limitAmount: 500,
         refreshPeriod: 'monthly',
       });
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.apiKey).toBe(CREATED_KEY);
+    });
+  });
+
+  describe('--dry-run', () => {
+    it('writes nothing and reports the planned changes', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--key',
+        'vck_DummyKey0004',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.reason).toBe('dry_run');
+      expect(out.changes[0].action).toBe('would_create');
     });
 
-    it('collects quota and expiry interactively', async () => {
+    it('previews the .bak backup it would write for an existing config', async () => {
+      useUser();
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(claudeSettingsPath(), '{"env":{"FOO":"bar"}}', 'utf8');
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--yes',
+        '--key',
+        'vck_DummyKey0010',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+      // The preview names the backup side effect, and nothing is written.
+      await expect(client.stderr).toOutput(
+        `backs up to ${claudeSettingsPath()}.bak`
+      );
+      expect(existsSync(`${claudeSettingsPath()}.bak`)).toBe(false);
+    });
+
+    it('drops the backup note from the preview under --no-backup', async () => {
+      useUser();
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(claudeSettingsPath(), '{"env":{"FOO":"bar"}}', 'utf8');
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--yes',
+        '--no-backup',
+        '--key',
+        'vck_DummyKey0011',
+        '--agent',
+        'claude-code'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Planned changes');
+      expect(stderr).not.toContain('backed up alongside as .bak');
+      expect(stderr).not.toContain('backs up to');
+    });
+
+    it('prompts for team, name, quota, and expiry in order', async () => {
+      useUser();
+      useTeam();
+      // Found at its default location, so the custom-path prompt stays quiet.
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stderr).toOutput('previewing changes only');
+      // The owning team comes first — it decides where the key lives.
+      await expect(client.stderr).toOutput('Which team?');
+      client.stdin.write('\n'); // accept default scope
+      // Then the name.
+      await expect(client.stderr).toOutput('Key name?');
+      client.stdin.write('\n');
+      // Then quota (defaults to no).
+      await expect(client.stderr).toOutput('Set a spend limit');
+      client.stdin.write('\n');
+      // Then expiry (defaults to no).
+      await expect(client.stderr).toOutput('Set an expiration');
+      client.stdin.write('\n');
+
+      // With neither set, the summary spells out the absence of limits.
+      await expect(client.stderr).toOutput('Unlimited');
+      await expect(client.stderr).toOutput('Never');
+      await expect(client.stderr).toOutput('Dry run');
+      expect(await exitCodePromise).toBe(0);
+      // Still a preview: nothing is written and no key is minted.
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+    });
+
+    it('prompts for the team even when one is already selected', async () => {
+      const team = useTeam();
+      useUser();
+      // A scope is already pinned, but key ownership is still an explicit choice.
+      client.config.currentTeam = team.id;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      // Pin the other options so only the team prompt remains.
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--agent',
+        'claude-code',
+        '--name',
+        'my-key',
+        '--refresh-period',
+        'none',
+        '--expiration',
+        'none'
+      );
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stderr).toOutput('Which team?');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput('Dry run');
+      expect(await exitCodePromise).toBe(0);
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+    });
+
+    it('does not require a scope in non-interactive mode', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.reason).toBe('dry_run');
+    });
+  });
+
+  describe('team selection', () => {
+    it('skips the prompt with --yes and uses the current scope', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--agent',
+        'claude-code'
+      );
+
+      // No prompt is awaited: --yes accepts the current scope and the run
+      // completes without any interactive input.
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
+    });
+  });
+
+  describe('agent selection with --yes', () => {
+    it('selects the detected agents without prompting', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      client.setArgv('ai-gateway', 'coding-agents', 'setup', '--yes');
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe(CREATED_KEY);
+      // An undetected agent is not configured.
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
+
+    it('errors when nothing is detected and no agent is named', async () => {
+      useUser();
+      // Fresh home: no agent config dirs, so nothing is detected.
+      client.setArgv('ai-gateway', 'coding-agents', 'setup', '--yes');
+
+      expect(await aiGateway(client)).toBe(1);
+      await expect(client.stderr).toOutput('No coding agents detected');
+    });
+  });
+
+  describe('key options', () => {
+    it('collects name, quota, and expiry interactively', async () => {
       const team = useTeam();
       useUser();
       useCreateApiKey();
@@ -248,14 +418,25 @@ describe('ai-gateway coding-agents setup', () => {
       client.stdin.write('y\n');
       await expect(client.stderr).toOutput('Expires in');
       client.stdin.write('\n'); // accept default preset (30 days)
+      // Resolved state first, then the mutation preview, then the apply prompt.
+      await expect(client.stderr).toOutput('Summary');
+      // The backup promise rides the preview heading — up front, not only in
+      // the post-apply receipt.
+      await expect(client.stderr).toOutput(
+        'Planned changes  existing files are backed up alongside as .bak first'
+      );
+      await expect(client.stderr).toOutput('Apply these changes?');
+      client.stdin.write('\n'); // accept default (yes)
 
       expect(await exitCodePromise).toBe(0);
 
+      expect(lastCreateBody?.name).toBe('My Coding Key');
       expect(lastCreateBody?.aiGatewayQuota).toMatchObject({
         limitAmount: 100,
       });
       const expiresAt = lastCreateBody?.expiresAt as number;
       expect(typeof expiresAt).toBe('number');
+      // 30-day preset lands ~30 days out.
       const days = (expiresAt - Date.now()) / 86_400_000;
       expect(days).toBeGreaterThan(29);
       expect(days).toBeLessThan(31);
@@ -277,8 +458,11 @@ describe('ai-gateway coding-agents setup', () => {
         '7d'
       );
 
-      expect(await aiGateway(client)).toBe(0);
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
       const expiresAt = lastCreateBody?.expiresAt as number;
+      expect(typeof expiresAt).toBe('number');
       const days = (expiresAt - Date.now()) / 86_400_000;
       expect(days).toBeGreaterThan(6);
       expect(days).toBeLessThan(8);
@@ -319,22 +503,70 @@ describe('ai-gateway coding-agents setup', () => {
       expect(await aiGateway(client)).toBe(1);
       await expect(client.stderr).toOutput('Invalid expiration');
     });
+  });
 
-    it('rejects a negative budget', async () => {
+  describe('custom config paths', () => {
+    it('writes an agent config to an --agent-config path', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const custom = join(home, 'work', 'claude', 'settings.json');
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0009',
+        '--agent',
+        'claude-code',
+        '--agent-config',
+        `claude-code=${custom}`
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      expect(existsSync(custom)).toBe(true);
+      // The default location is left untouched.
+      expect(existsSync(claudeSettingsPath())).toBe(false);
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.configured[0].file).toBe(custom);
+    });
+
+    it('honors an agent-native config dir env var (CLAUDE_CONFIG_DIR)', async () => {
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: 'vck_x',
+        home,
+        // (set per-test; restored by afterEach)
+      });
+      expect(
+        plan.changes.some(
+          c => c.path === join(home, '.claude', 'settings.json')
+        )
+      ).toBe(true);
+
+      process.env.CLAUDE_CONFIG_DIR = join(home, 'alt-claude');
+      const relocated = await buildSetupPlan([claudeCode], {
+        apiKey: 'vck_x',
+        home,
+      });
+      expect(
+        relocated.changes.some(
+          c => c.path === join(home, 'alt-claude', 'settings.json')
+        )
+      ).toBe(true);
+    });
+
+    it('rejects a malformed --agent-config', async () => {
       useUser();
       client.setArgv(
         'ai-gateway',
         'coding-agents',
         'setup',
-        '--budget',
-        '-5',
         '--agent',
-        'claude-code'
+        'claude-code',
+        '--agent-config',
+        'claude-code' // missing =path
       );
       expect(await aiGateway(client)).toBe(1);
-      expect(client.stderr.getFullOutput()).toContain(
-        'Budget must be a positive number in dollars'
-      );
+      await expect(client.stderr).toOutput('Invalid --agent-config');
     });
   });
 
@@ -488,6 +720,8 @@ describe('ai-gateway coding-agents setup', () => {
       const exitCode = await aiGateway(client);
       expect(exitCode).toBe(0);
 
+      // Masked in the diff and the receipt; the full secret never reaches the
+      // terminal (it lives only in the config files).
       const stderr = client.stderr.getFullOutput();
       expect(stderr).toContain('vck_••••8765');
       expect(stderr).not.toContain(secret);
@@ -523,6 +757,26 @@ describe('ai-gateway coding-agents setup', () => {
   });
 
   describe('validation', () => {
+    it('rejects a negative budget', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--budget',
+        '-5',
+        '--agent',
+        'claude-code',
+        '--key',
+        'vck_x'
+      );
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Budget must be a positive number in dollars'
+      );
+    });
+
     it('rejects an unknown agent', async () => {
       useUser();
       client.setArgv(
@@ -733,6 +987,28 @@ describe('ai-gateway coding-agents setup', () => {
       // An empty rc starts with the block — no leading blank line.
       expect(upsertManagedBlock('', 'export X=1')).toBe(block);
       expect(upsertManagedBlock(null, 'export X=1')).toBe(block);
+    });
+  });
+
+  describe('renderDiff secret masking', () => {
+    it('masks a literal key in a POSIX export line', () => {
+      const out = renderDiff('', "export AI_GATEWAY_API_KEY='vck_LeakMe12345'");
+      expect(out).not.toContain('vck_LeakMe12345');
+      expect(out).toContain('vck_••••2345');
+    });
+
+    it('masks a literal key in a fish set -gx line', () => {
+      const out = renderDiff(
+        '',
+        "set -gx AI_GATEWAY_API_KEY 'vck_LeakMe12345'"
+      );
+      expect(out).not.toContain('vck_LeakMe12345');
+      expect(out).toContain('vck_••••2345');
+    });
+
+    it('masks JSON secret fields without a known secret list', () => {
+      const out = renderDiff('', '{\n  "apiKey": "vck_LeakMe12345"\n}');
+      expect(out).not.toContain('vck_LeakMe12345');
     });
   });
 


### PR DESCRIPTION
## Summary
Preview before writing. `--dry-run` and the pre-apply summary show a masked per-file diff, the resolved key/quota/expiry, and the `.bak` backups that would be written (suppressed by `--no-backup`), then ask to confirm. Adds `--agent-config <id>=<path>` and `--shell-rc <path>` for non-standard layouts, with an interactive custom-path prompt when an agent isn't found at its default location.

