### PR TITLE
[cli] coding-agents setup: store the key in the macOS Keychain

### DIFF
--- a/.changeset/ai-gateway-coding-agents-keychain.md
+++ b/.changeset/ai-gateway-coding-agents-keychain.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Store the `coding-agents setup` API key in the macOS login Keychain instead of writing it into plaintext config files. When available it's used automatically: env-based agents resolve the key from the shell at runtime (a managed shell-rc block runs `security find-generic-password`), so the secret never lands in a config file. Pass `--no-keychain`, or run off macOS, to embed the key directly; it also falls back to embedding if the Keychain write fails.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
@@ -26,6 +26,7 @@ import {
   promptKeyName,
   promptQuota,
   promptExpiry,
+  promptKeychain,
   type KeySource,
 } from '../../util/ai-gateway/coding-agents/key-source';
 import {
@@ -44,6 +45,10 @@ import {
 } from '../../util/ai-gateway/coding-agents/render';
 import { runMachine } from '../../util/ai-gateway/coding-agents/machine';
 import { KEY_PLACEHOLDER } from '../../util/ai-gateway/coding-agents/gateway';
+import {
+  isKeychainAvailable,
+  storeKeyInKeychain,
+} from '../../util/ai-gateway/coding-agents/keychain';
 import {
   outputAgentError,
   shouldEmitNonInteractiveCommandError,
@@ -81,6 +86,7 @@ export default async function codingAgentsSetup(
   const reconfigure = opts['--reconfigure'] as boolean | undefined;
   const dryRun = opts['--dry-run'] as boolean | undefined;
   const noBackup = opts['--no-backup'] as boolean | undefined;
+  const noKeychain = opts['--no-keychain'] as boolean | undefined;
   const agentConfig = opts['--agent-config'] as string[] | undefined;
   const shellRcOverride = opts['--shell-rc'] as string | undefined;
   const yes = opts['--yes'] as boolean | undefined;
@@ -96,6 +102,7 @@ export default async function codingAgentsSetup(
   telemetry.trackCliFlagReconfigure(reconfigure);
   telemetry.trackCliFlagDryRun(dryRun);
   telemetry.trackCliFlagNoBackup(noBackup);
+  telemetry.trackCliFlagNoKeychain(noKeychain);
   telemetry.trackCliOptionAgentConfig(agentConfig);
   telemetry.trackCliOptionShellRc(shellRcOverride);
   telemetry.trackCliFlagYes(yes);
@@ -103,6 +110,7 @@ export default async function codingAgentsSetup(
   const machine = shouldEmitNonInteractiveCommandError(client);
   const canPrompt = Boolean(client.stdin.isTTY) && !machine;
   const home = homedir();
+  const wantKeychain = !noKeychain && isKeychainAvailable();
 
   if (budget !== undefined && (!Number.isFinite(budget) || budget < 1)) {
     return failValidation(
@@ -232,6 +240,11 @@ export default async function codingAgentsSetup(
       }
     }
   }
+  let useKeychain = wantKeychain;
+  if (wantKeychain && canPrompt && !yes) {
+    useKeychain = await promptKeychain(client);
+  }
+
   if (canPrompt && !yes) {
     const missing = selected.filter(
       a =>
@@ -266,6 +279,7 @@ export default async function codingAgentsSetup(
   const previewPlan = await buildSetupPlan(selected, {
     apiKey: previewKey,
     home,
+    useKeychain,
     overrides,
     shellRcOverride,
   });
@@ -293,6 +307,7 @@ export default async function codingAgentsSetup(
           includeByok,
           expiresAt: keyExpiresAt,
         }),
+      useKeychain,
       overrides,
       shellRcOverride,
       home,
@@ -303,10 +318,25 @@ export default async function codingAgentsSetup(
 
   // Already wired up: instead of a dead-end no-op, offer to rotate the key or
   // reconfigure (e.g. a rotated/expired key, or a different team).
-  // `--reconfigure` skips the prompt.
   if (alreadyConfigured) {
+    // A provided key on a Keychain setup: refresh the stored secret in place,
+    // even though the config files themselves don't change.
+    if (!dryRun && useKeychain && providedKey) {
+      if (!storeKeyInKeychain(providedKey)) {
+        output.error(
+          'Failed to update the key in the macOS Keychain. Re-run with --no-keychain to write it to the config files instead.'
+        );
+        return 1;
+      }
+      output.log(
+        'All selected agents are already configured; updated the macOS Keychain with the provided key.'
+      );
+      printKey(providedKey, { keychain: true });
+      return 0;
+    }
+    // Otherwise offer to rotate/reconfigure. `--reconfigure` skips the prompt.
     let doReconfigure = Boolean(reconfigure);
-    if (!doReconfigure && canPrompt && !yes) {
+    if (!doReconfigure && canPrompt && !yes && !dryRun) {
       doReconfigure = await client.input.confirm(
         'These agents are already configured for the AI Gateway. Reconfigure them?',
         false
@@ -321,6 +351,7 @@ export default async function codingAgentsSetup(
       }
       return 0;
     }
+    // doReconfigure: fall through to (re)create the key and apply below.
   }
 
   // Resolved state first, then the mutation preview, then the confirm.
@@ -331,6 +362,7 @@ export default async function codingAgentsSetup(
     budget: keyBudget,
     refreshPeriod: keyRefresh,
     expiresAt: keyExpiresAt,
+    keychain: wantKeychain ? useKeychain : undefined,
   });
   printPlan(previewPlan, previewKey, { backup: !noBackup });
 
@@ -372,9 +404,17 @@ export default async function codingAgentsSetup(
     throw err;
   }
 
+  if (useKeychain && !storeKeyInKeychain(keySource.key)) {
+    printWarning(
+      'Failed to store the key in the macOS Keychain; writing it to the config files instead.'
+    );
+    useKeychain = false;
+  }
+
   const applyPlanResult = await buildSetupPlan(selected, {
     apiKey: keySource.key,
     home,
+    useKeychain,
     overrides,
     shellRcOverride,
   });
@@ -386,7 +426,7 @@ export default async function codingAgentsSetup(
     // key is resolved from the environment rather than embedded).
     output.print('\n');
     printAlignedLabel('Rotated', 'AI Gateway API key', { gutter: '✓' });
-    printKeyRow(keySource.key);
+    printKeyRow(keySource.key, { keychain: useKeychain });
     output.print(chalk.dim('  No config files changed.\n'));
   }
   if (results.length > 0) {
@@ -404,7 +444,7 @@ export default async function codingAgentsSetup(
         result.path
       );
     }
-    printKeyRow(keySource.key);
+    printKeyRow(keySource.key, { keychain: useKeychain });
     if (results.some(r => r.backupPath)) {
       output.print(chalk.dim('  Previous files saved alongside as .bak\n'));
     }

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -323,6 +323,14 @@ export const setupSubcommand = {
       description: 'Do not write .bak backups of changed files',
     },
     {
+      name: 'no-keychain',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Always write the key into config files instead of the macOS Keychain',
+    },
+    {
       name: 'agent-config',
       shorthand: null,
       type: [String],

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import type { CodingAgent } from '../types';
+import type { CodingAgent, EnvExport } from '../types';
 import { mergeJson, pathExists } from '../config-files';
 import { GATEWAY_ANTHROPIC_BASE_URL } from '../gateway';
 
@@ -8,6 +8,11 @@ import { GATEWAY_ANTHROPIC_BASE_URL } from '../gateway';
  * It speaks the gateway's Anthropic-compatible endpoint, so the base URL has NO
  * `/v1` (the Anthropic SDK appends `/v1/messages`). `ANTHROPIC_API_KEY` must be
  * emptied because it takes precedence over `ANTHROPIC_AUTH_TOKEN`.
+ *
+ * With Keychain enabled we keep the token out of `settings.json` and export
+ * `ANTHROPIC_AUTH_TOKEN` from the shell rc (resolved from the Keychain) instead,
+ * so the secret never lands in the config file. Claude Code then reads the token
+ * from its inherited environment.
  *
  * Docs: https://vercel.com/docs/ai-gateway/coding-agents/claude-code
  */
@@ -37,8 +42,13 @@ export const claudeCode: CodingAgent = {
     const env: Record<string, string> = {
       ANTHROPIC_BASE_URL: GATEWAY_ANTHROPIC_BASE_URL,
       ANTHROPIC_API_KEY: '',
-      ANTHROPIC_AUTH_TOKEN: ctx.apiKey,
     };
+    const envExports: EnvExport[] = [];
+    if (ctx.useKeychain) {
+      envExports.push({ name: 'ANTHROPIC_AUTH_TOKEN', value: ctx.apiKey });
+    } else {
+      env.ANTHROPIC_AUTH_TOKEN = ctx.apiKey;
+    }
     return {
       fileChanges: [
         {
@@ -48,8 +58,13 @@ export const claudeCode: CodingAgent = {
           transform: current => mergeJson(current, { env }),
         },
       ],
-      envExports: [],
-      notes: ['Restart Claude Code to pick up the new settings.'],
+      envExports,
+      notes: ctx.useKeychain
+        ? [
+            'The Anthropic auth token is read from your shell environment (Keychain-backed).',
+            'Open a new terminal so ANTHROPIC_AUTH_TOKEN is loaded, then restart Claude Code.',
+          ]
+        : ['Restart Claude Code to pick up the new settings.'],
     };
   },
 };

--- a/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
@@ -7,6 +7,7 @@ import {
   upsertManagedBlock,
 } from './config-files';
 import { KEY_PLACEHOLDER } from './gateway';
+import { keychainLookup } from './keychain';
 
 export type ChangeStatus = 'create' | 'update' | 'unchanged' | 'error';
 
@@ -65,16 +66,26 @@ function fishQuote(value: string): string {
   return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }
 
-function envBlockBody(exports: EnvExport[], fish: boolean): string {
+function envBlockBody(
+  exports: EnvExport[],
+  useKeychain: boolean | undefined,
+  fish: boolean
+): string {
   const lines = [
     '# Managed by `vercel ai-gateway coding-agents setup` — safe to remove this block.',
   ];
   for (const e of exports) {
-    lines.push(
-      fish
-        ? `set -gx ${e.name} ${fishQuote(e.value)}`
-        : `export ${e.name}=${shellQuote(e.value)}`
-    );
+    if (fish) {
+      lines.push(
+        useKeychain
+          ? `set -gx ${e.name} ${keychainLookup({ fish: true })}`
+          : `set -gx ${e.name} ${fishQuote(e.value)}`
+      );
+    } else if (useKeychain) {
+      lines.push(`export ${e.name}="${keychainLookup()}"`);
+    } else {
+      lines.push(`export ${e.name}=${shellQuote(e.value)}`);
+    }
   }
   return lines.join('\n');
 }
@@ -137,7 +148,11 @@ export async function buildSetupPlan(
   let shellRcPath: string | undefined;
   if (envExports.length) {
     shellRcPath = detectShellRc(ctx.home, ctx.shellRcOverride);
-    const body = envBlockBody(envExports, shellRcPath.endsWith('.fish'));
+    const body = envBlockBody(
+      envExports,
+      ctx.useKeychain,
+      shellRcPath.endsWith('.fish')
+    );
     pending.push({
       path: shellRcPath,
       label: 'Shell environment',

--- a/packages/cli/src/util/ai-gateway/coding-agents/diff.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/diff.ts
@@ -60,7 +60,9 @@ function redactSecretFields(text: string): string {
       (_match, prefix, value) => `${prefix}"${maskSecret(value)}"`
     )
     .replace(
-      /(export\s+AI_GATEWAY_API_KEY=)(["'])((?:(?!\2).)+)(\2)/g,
+      // `(?!\$\()` keeps the keychain lookup readable: its value is a
+      // command substitution, not a secret.
+      /(export\s+AI_GATEWAY_API_KEY=)(["'])(?!\$\()((?:(?!\2).)+)(\2)/g,
       (_match, prefix, quote, value, close) =>
         `${prefix}${quote}${maskSecret(value)}${close}`
     )

--- a/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/key-source.ts
@@ -109,6 +109,13 @@ export async function promptExpiry(
   return presetToExpiresAt(preset);
 }
 
+export async function promptKeychain(client: Client): Promise<boolean> {
+  return client.input.confirm(
+    'Store the API key in your macOS Keychain?',
+    true
+  );
+}
+
 function hasExplicitScopeFlag(argv: string[]): boolean {
   const args = argv.slice(2);
   return args.some(

--- a/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
@@ -1,0 +1,44 @@
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Optional macOS Keychain storage for the AI Gateway key. When available we keep
+ * the secret in the login keychain and have the shell rc resolve it at runtime,
+ * so the plaintext key never lands in a config file. Everything here is a no-op
+ * (or returns `false`) off macOS, so callers fall back to writing the key
+ * directly.
+ */
+const SECURITY_BIN = '/usr/bin/security';
+const KEYCHAIN_SERVICE = 'Vercel AI Gateway';
+const KEYCHAIN_ACCOUNT = 'vercel-ai-gateway';
+
+export function isKeychainAvailable(): boolean {
+  return process.platform === 'darwin' && existsSync(SECURITY_BIN);
+}
+
+export function storeKeyInKeychain(key: string): boolean {
+  try {
+    execFileSync(
+      SECURITY_BIN,
+      [
+        'add-generic-password',
+        '-U',
+        '-s',
+        KEYCHAIN_SERVICE,
+        '-a',
+        KEYCHAIN_ACCOUNT,
+        '-w',
+        key,
+      ],
+      { stdio: 'ignore' }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function keychainLookup(opts: { fish?: boolean } = {}): string {
+  const cmd = `${SECURITY_BIN} find-generic-password -s '${KEYCHAIN_SERVICE}' -a '${KEYCHAIN_ACCOUNT}' -w 2>/dev/null`;
+  return opts.fish ? `(${cmd})` : `$(${cmd})`;
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -4,6 +4,7 @@ import { outputAgentError } from '../../agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../agent-output-constants';
 import { UNSUPPORTED_AGENTS } from './agents';
 import { buildSetupPlan, applyPlan, type SetupPlan } from './apply';
+import { storeKeyInKeychain } from './keychain';
 import type { KeySource } from './key-source';
 import type { CodingAgent } from './types';
 
@@ -16,6 +17,7 @@ export async function runMachine(args: {
   backup: boolean;
   keySource: KeySource | null;
   createKey: () => Promise<string>;
+  useKeychain: boolean;
   overrides?: Record<string, string>;
   shellRcOverride?: string;
   home: string;
@@ -100,9 +102,12 @@ export async function runMachine(args: {
     throw err;
   }
 
+  const useKeychain = args.useKeychain && storeKeyInKeychain(key);
+
   const finalPlan = await buildSetupPlan(selected, {
     apiKey: key,
     home,
+    useKeychain,
     overrides: args.overrides,
     shellRcOverride: args.shellRcOverride,
   });

--- a/packages/cli/src/util/ai-gateway/coding-agents/render.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/render.ts
@@ -16,6 +16,7 @@ export function printResolvedState(args: {
   budget?: number;
   refreshPeriod?: string;
   expiresAt?: number;
+  keychain?: boolean;
 }): void {
   const { selected, willCreate, name, budget, refreshPeriod, expiresAt } = args;
   output.print(chalk.bold('  Summary\n'));
@@ -42,6 +43,12 @@ export function printResolvedState(args: {
       ? new Date(expiresAt).toISOString().slice(0, 10)
       : 'Never'
   );
+  if (args.keychain !== undefined) {
+    printAlignedLabel(
+      'Key storage',
+      args.keychain ? 'macOS Keychain' : 'Config files'
+    );
+  }
   output.print('\n');
 }
 
@@ -111,9 +118,15 @@ export function printReceiptPath(label: string, path: string): void {
   );
 }
 
-/** Masked-key receipt row, e.g. `API Key  vck_1234••••abcd`. */
-export function printKeyRow(key: string): void {
-  printAlignedLabel('API Key', maskSecret(key));
+/** Masked-key receipt row, e.g. `API Key  vck_1234••••abcd · macOS Keychain`. */
+export function printKeyRow(
+  key: string,
+  opts: { keychain?: boolean } = {}
+): void {
+  printAlignedLabel(
+    'API Key',
+    `${maskSecret(key)} · ${opts.keychain ? 'macOS Keychain' : 'Config files'}`
+  );
 }
 
 export function printNotes(plan: SetupPlan): void {
@@ -128,7 +141,7 @@ export function printNotes(plan: SetupPlan): void {
   }
 }
 
-export function printKey(key: string): void {
+export function printKey(key: string, opts: { keychain?: boolean } = {}): void {
   output.print('\n');
-  printKeyRow(key);
+  printKeyRow(key, opts);
 }

--- a/packages/cli/src/util/ai-gateway/coding-agents/types.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/types.ts
@@ -1,6 +1,7 @@
 export interface SetupContext {
   apiKey: string;
   home: string;
+  useKeychain?: boolean;
   overrides?: Record<string, string>;
   shellRcOverride?: string;
 }

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
@@ -77,6 +77,12 @@ export class AiGatewayCodingAgentsSetupTelemetryClient
     }
   }
 
+  trackCliFlagNoKeychain(noKeychain: boolean | undefined) {
+    if (noKeychain) {
+      this.trackCliFlag('no-keychain');
+    }
+  }
+
   trackCliOptionAgentConfig(agentConfig: string[] | undefined) {
     if (agentConfig && agentConfig.length) {
       // Local paths may be sensitive; record only that the option was used.

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   mkdtempSync,
   readFileSync,
@@ -11,15 +11,55 @@ import { join } from 'node:path';
 import { client } from '../../../mocks/client';
 import aiGateway from '../../../../src/commands/ai-gateway';
 import { useUser } from '../../../mocks/user';
-import { detectShellRc } from '../../../../src/util/ai-gateway/coding-agents/apply';
+import {
+  buildSetupPlan,
+  detectShellRc,
+} from '../../../../src/util/ai-gateway/coding-agents/apply';
 import { renderDiff } from '../../../../src/util/ai-gateway/coding-agents/diff';
 import {
   mergeJson,
   upsertManagedBlock,
 } from '../../../../src/util/ai-gateway/coding-agents/config-files';
 import { useTeam } from '../../../mocks/team';
-import { buildSetupPlan } from '../../../../src/util/ai-gateway/coding-agents/apply';
 import { claudeCode } from '../../../../src/util/ai-gateway/coding-agents/agents/claude-code';
+import {
+  isKeychainAvailable,
+  storeKeyInKeychain,
+  keychainLookup,
+} from '../../../../src/util/ai-gateway/coding-agents/keychain';
+
+// A pass-through mock of the keychain module: tests that set `available` get a
+// fake in-memory keychain (usable on Linux CI); everything else hits the real
+// implementation.
+const keychainState = vi.hoisted(() => ({
+  available: undefined as boolean | undefined,
+  stored: [] as string[],
+  storeResult: true,
+}));
+
+vi.mock(
+  '../../../../src/util/ai-gateway/coding-agents/keychain',
+  async importOriginal => {
+    const actual =
+      await importOriginal<
+        typeof import('../../../../src/util/ai-gateway/coding-agents/keychain')
+      >();
+    return {
+      ...actual,
+      isKeychainAvailable: () =>
+        keychainState.available ?? actual.isKeychainAvailable(),
+      storeKeyInKeychain: (key: string) => {
+        if (keychainState.available === undefined) {
+          return actual.storeKeyInKeychain(key);
+        }
+        if (keychainState.storeResult) {
+          keychainState.stored.push(key);
+        }
+        return keychainState.storeResult;
+      },
+    };
+  }
+);
 
 const CREATED_KEY = 'vck_CreatedSecretKey1234';
 const mockApiKeyResponse = {
@@ -54,6 +94,9 @@ function codexConfigPath() {
 }
 
 beforeEach(() => {
+  keychainState.available = undefined;
+  keychainState.stored.length = 0;
+  keychainState.storeResult = true;
   home = mkdtempSync(join(tmpdir(), 'vc-setup-agents-'));
   savedEnv = {
     HOME: process.env.HOME,
@@ -387,6 +430,49 @@ describe('ai-gateway coding-agents setup', () => {
     });
   });
 
+  describe('keychain', () => {
+    it('is unavailable off macOS and fails closed', () => {
+      if (process.platform !== 'darwin') {
+        expect(isKeychainAvailable()).toBe(false);
+        expect(storeKeyInKeychain('vck_whatever')).toBe(false);
+      }
+      expect(keychainLookup()).toContain('security find-generic-password');
+    });
+
+    it('keeps the secret out of the configs and reads it from the shell', async () => {
+      const secret = 'vck_KeychainSecret321';
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: secret,
+        home,
+        useKeychain: true,
+      });
+
+      // The env-based agent resolves its var from the Keychain at runtime.
+      const shell = plan.changes.find(c => c.format === 'shell');
+      expect(shell?.next).toContain('security find-generic-password');
+      expect(shell?.next).toContain('export ANTHROPIC_AUTH_TOKEN=');
+      expect(shell?.next).not.toContain(secret);
+
+      // Claude's token is no longer embedded in settings.json.
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      expect(claude?.next).toContain('ANTHROPIC_BASE_URL');
+      expect(claude?.next).not.toContain('ANTHROPIC_AUTH_TOKEN');
+      expect(claude?.next).not.toContain(secret);
+    });
+
+    it('embeds the key directly when keychain is off', async () => {
+      const secret = 'vck_PlainSecret654';
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: secret,
+        home,
+        useKeychain: false,
+      });
+
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      expect(claude?.next).toContain(secret);
+    });
+  });
+
   describe('key options', () => {
     it('collects name, quota, and expiry interactively', async () => {
       const team = useTeam();
@@ -534,6 +620,7 @@ describe('ai-gateway coding-agents setup', () => {
       const plan = await buildSetupPlan([claudeCode], {
         apiKey: 'vck_x',
         home,
+        useKeychain: false,
         // (set per-test; restored by afterEach)
       });
       expect(
@@ -546,6 +633,7 @@ describe('ai-gateway coding-agents setup', () => {
       const relocated = await buildSetupPlan([claudeCode], {
         apiKey: 'vck_x',
         home,
+        useKeychain: false,
       });
       expect(
         relocated.changes.some(
@@ -671,6 +759,149 @@ describe('ai-gateway coding-agents setup', () => {
       expect(creates).toBe(2);
       const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
       expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('vck_Minted20000000');
+    });
+  });
+
+  describe('key rotation', () => {
+    it('updates the config when re-run with a different key', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_OldKey0001',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_NewKey0002',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('vck_NewKey0002');
+      // The pre-rotation config is kept as a backup.
+      const backup = JSON.parse(
+        readFileSync(`${claudeSettingsPath()}.bak`, 'utf8')
+      );
+      expect(backup.env.ANTHROPIC_AUTH_TOKEN).toBe('vck_OldKey0001');
+    });
+
+    it('stores a rotated key in the Keychain even when configs are unchanged', async () => {
+      useUser();
+      keychainState.available = true;
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--key',
+        'vck_OldKey0001',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+      expect(keychainState.stored).toEqual(['vck_OldKey0001']);
+      // Keychain mode: the key lives outside the config files…
+      expect(readFileSync(claudeSettingsPath(), 'utf8')).not.toContain(
+        'vck_OldKey0001'
+      );
+
+      // …so re-running with a new key writes no files but must still refresh
+      // the Keychain entry.
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--key',
+        'vck_NewKey0002',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+      expect(keychainState.stored).toEqual([
+        'vck_OldKey0001',
+        'vck_NewKey0002',
+      ]);
+      expect(client.stderr.getFullOutput()).toContain(
+        'updated the macOS Keychain'
+      );
+    });
+
+    it('does not touch the Keychain during --dry-run', async () => {
+      useUser();
+      keychainState.available = true;
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--key',
+        'vck_OldKey0001',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--yes',
+        '--key',
+        'vck_NewKey0002',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+      expect(keychainState.stored).toEqual(['vck_OldKey0001']);
+    });
+
+    it('fails when the rotated key cannot be stored in the Keychain', async () => {
+      useUser();
+      keychainState.available = true;
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--key',
+        'vck_OldKey0001',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+
+      keychainState.storeResult = false;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--key',
+        'vck_NewKey0002',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Failed to update the key in the macOS Keychain'
+      );
     });
   });
 
@@ -1009,6 +1240,13 @@ describe('ai-gateway coding-agents setup', () => {
     it('masks JSON secret fields without a known secret list', () => {
       const out = renderDiff('', '{\n  "apiKey": "vck_LeakMe12345"\n}');
       expect(out).not.toContain('vck_LeakMe12345');
+    });
+
+    it('leaves the keychain lookup command readable — it holds no secret', () => {
+      const line = `export AI_GATEWAY_API_KEY="$(/usr/bin/security find-generic-password -s 'Vercel AI Gateway' -a 'vercel-ai-gateway' -w 2>/dev/null)"`;
+      const out = renderDiff('', line);
+      expect(out).toContain('find-generic-password');
+      expect(out).not.toContain('••••');
     });
   });
 


### PR DESCRIPTION
## Summary
Optional macOS Keychain storage. When available it's used by default: env-based agents resolve the key from the shell at runtime (a managed shell-rc block runs `security find-generic-password`), keeping the secret out of plaintext config. `--no-keychain` (or a non-macOS host) embeds it directly, with automatic fallback if the Keychain write fails.

Re-running `connect --key <new-key>` refreshes the Keychain entry even when no config file changes, so an expired or rotated key can be swapped in place. For bash users on macOS the managed block goes to `~/.bash_profile` (macOS terminals start login shells); `~/.bashrc` elsewhere.

## Known limitations
- The shell rc exports the resolved key, so processes started from those shells can read it from the environment. The Keychain protects the key at rest and keeps it out of config files, not out of process environments.
- The key is passed to `security add-generic-password` as a process argument, so it is briefly visible in local `ps` output while it is stored.
- Agents launched outside an interactive shell (GUI launchers, some IDE integrations) don't inherit the exported variable — launch from a terminal, or use `--no-keychain`.
- A single Keychain item is used (service "Vercel AI Gateway"), so connecting a different team replaces the stored key.

