### PR TITLE
[cli] coding-agents setup: add Codex support

### DIFF
--- a/.changeset/ai-gateway-coding-agents-codex.md
+++ b/.changeset/ai-gateway-coding-agents-codex.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add Codex support to `vercel ai-gateway coding-agents setup`. It writes a `vercel` model provider to `~/.codex/config.toml` (OpenAI-compatible base URL, `responses` wire API) without pinning a default model, and exports the gateway API key via your shell rc (honoring `CODEX_HOME` and fish/`ZDOTDIR`). Merging into an existing `config.toml` edits assignments in place, preserving your comments and formatting.

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -232,7 +232,8 @@ export const rulesSubcommand = {
 export const setupSubcommand = {
   name: 'setup',
   aliases: [],
-  description: 'Connect Claude Code to the AI Gateway',
+  description:
+    'Connect local coding agents (Claude Code, Codex) to the AI Gateway',
   arguments: [],
   options: [
     {
@@ -241,7 +242,7 @@ export const setupSubcommand = {
       type: [String],
       argument: 'NAME',
       deprecated: false,
-      description: 'Coding agent to configure, repeatable (claude-code)',
+      description: 'Coding agent to configure, repeatable (claude-code, codex)',
     },
     {
       name: 'all',

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
@@ -1,0 +1,65 @@
+import { join } from 'node:path';
+import type { CodingAgent } from '../types';
+import { mergeToml, pathExists } from '../config-files';
+import { GATEWAY_OPENAI_BASE_URL, GATEWAY_API_KEY_ENV } from '../gateway';
+
+/**
+ * Codex reads `~/.codex/config.toml`. We add a `vercel` model provider pointing
+ * at the gateway's OpenAI-compatible base URL and make it the default provider
+ * via the top-level `model_provider` (the top-level `profile = "..."` key is
+ * rejected by current Codex). We deliberately do NOT pin a `model` — the user
+ * keeps choosing their own. `wire_api` MUST be `responses` — Codex removed Chat
+ * Completions support, and the gateway serves the Responses API at
+ * `/v1/responses`. The key itself never lands in the TOML; `env_key` names an env
+ * var Codex reads at runtime, so we also export it via the shell rc.
+ *
+ * Docs: https://vercel.com/docs/ai-gateway/coding-agents/openai-codex
+ */
+/** Config dir: `$CODEX_HOME` (Codex's own override) or `~/.codex`. */
+function codexDir(home: string): string {
+  const dir = process.env.CODEX_HOME;
+  return dir && dir.trim() ? dir : join(home, '.codex');
+}
+
+export const codex: CodingAgent = {
+  id: 'codex',
+  displayName: 'Codex',
+
+  async detect(home) {
+    return pathExists(codexDir(home));
+  },
+
+  configPath(ctx) {
+    return ctx.overrides?.['codex'] ?? join(codexDir(ctx.home), 'config.toml');
+  },
+
+  buildPlan(ctx) {
+    const path = this.configPath(ctx);
+    return {
+      fileChanges: [
+        {
+          path,
+          label: 'Codex config',
+          format: 'toml',
+          transform: current =>
+            mergeToml(current, {
+              model_provider: 'vercel',
+              model_providers: {
+                vercel: {
+                  name: 'Vercel AI Gateway',
+                  base_url: GATEWAY_OPENAI_BASE_URL,
+                  env_key: GATEWAY_API_KEY_ENV,
+                  wire_api: 'responses',
+                },
+              },
+            }),
+        },
+      ],
+      envExports: [{ name: GATEWAY_API_KEY_ENV, value: ctx.apiKey }],
+      notes: [
+        'Codex now defaults to the Vercel AI Gateway; pick a model with --model or in config.',
+        `Open a new terminal so ${GATEWAY_API_KEY_ENV} is loaded, or run: export ${GATEWAY_API_KEY_ENV}=<key>`,
+      ],
+    };
+  },
+};

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -1,7 +1,8 @@
 import type { CodingAgent } from '../types';
 import { claudeCode } from './claude-code';
+import { codex } from './codex';
 
-export const CODING_AGENTS: CodingAgent[] = [claudeCode];
+export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex];
 
 export const DEFAULT_AGENTS = CODING_AGENTS.filter(a => !a.experimental);
 

--- a/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
@@ -122,6 +122,88 @@ export function mergeJson(current: string | null, patch: JsonObject): string {
   return `${JSON.stringify(merged, null, 2)}\n`;
 }
 
+/** True when every value the patch would set already holds (deep-merge view). */
+function patchSatisfied(existing: unknown, patch: JsonObject): boolean {
+  for (const [key, patchValue] of Object.entries(patch)) {
+    const existingValue = isPlainObject(existing)
+      ? existing[key]
+      : (undefined as unknown);
+    if (isPlainObject(patchValue) && isPlainObject(existingValue)) {
+      if (!patchSatisfied(existingValue, patchValue)) {
+        return false;
+      }
+    } else if (!isDeepStrictEqual(existingValue, patchValue)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function tomlScalar(value: unknown): string | null {
+  switch (typeof value) {
+    case 'string':
+      // A JSON string is a valid TOML basic string.
+      return JSON.stringify(value);
+    case 'number':
+      return Number.isFinite(value) ? String(value) : null;
+    case 'boolean':
+      return String(value);
+    default:
+      return null;
+  }
+}
+
+const TOML_BARE_KEY = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Flatten a patch into `section -> key -> serialized scalar`, where '' is the
+ * top-level section and nested objects become dotted table names. Returns null
+ * for shapes the line editor can't express (non-scalar leaves, keys that need
+ * quoting) — those take the legacy full-rewrite path.
+ */
+function flattenTomlPatch(
+  patch: JsonObject,
+  prefix = '',
+  out = new Map<string, Map<string, string>>()
+): Map<string, Map<string, string>> | null {
+  for (const [key, value] of Object.entries(patch)) {
+    if (!TOML_BARE_KEY.test(key)) {
+      return null;
+    }
+    if (isPlainObject(value)) {
+      const nested = flattenTomlPatch(
+        value,
+        prefix ? `${prefix}.${key}` : key,
+        out
+      );
+      if (!nested) {
+        return null;
+      }
+    } else {
+      const scalar = tomlScalar(value);
+      if (scalar === null) {
+        return null;
+      }
+      let section = out.get(prefix);
+      if (!section) {
+        section = new Map();
+        out.set(prefix, section);
+      }
+      section.set(key, scalar);
+    }
+  }
+  return out;
+}
+
+const TOML_HEADER = /^\s*\[\[?\s*([^\]]*?)\s*\]\]?\s*(?:#.*)?$/;
+
+/**
+ * The user's file is edited line by line, never re-serialized: assignments the
+ * patch sets are replaced or appended inside their table, missing tables are
+ * appended at the end, and every other line — comments, quoting, spacing —
+ * survives byte-for-byte. The result is re-parsed and checked; anything the
+ * editor mishandled (exotic layouts) falls back to a full merge-and-rewrite.
+ */
 export function mergeToml(current: string | null, patch: JsonObject): string {
   let parsed: JsonObject = {};
   if (current && current.trim()) {
@@ -133,7 +215,118 @@ export function mergeToml(current: string | null, patch: JsonObject): string {
       );
     }
   }
-  return `${tomlStringify(deepMerge(parsed, patch))}\n`;
+  const legacy = () => `${tomlStringify(deepMerge(parsed, patch))}\n`;
+  if (!current || !current.trim()) {
+    return legacy();
+  }
+  if (patchSatisfied(parsed, patch)) {
+    return current;
+  }
+  const flat = flattenTomlPatch(patch);
+  if (!flat) {
+    return legacy();
+  }
+
+  const crlf = current.includes('\r\n');
+  const lines = current.split('\n');
+  const content = (line: string) =>
+    line.endsWith('\r') ? line.slice(0, -1) : line;
+  const finish = (line: string, i: number) =>
+    i < lines.length && lines[i]?.endsWith('\r') ? `${line}\r` : line;
+
+  const headerAt = (i: number): string | null => {
+    const m = content(lines[i]).match(TOML_HEADER);
+    if (!m) {
+      return null;
+    }
+    return m[1]
+      .split('.')
+      .map(s => s.trim())
+      .join('.');
+  };
+
+  // [start, end) line range of each section's body; '' is the top level.
+  const sectionRange = (name: string): [number, number] | null => {
+    let start = name === '' ? 0 : -1;
+    for (let i = 0; i < lines.length; i++) {
+      const header = headerAt(i);
+      if (header === null) {
+        continue;
+      }
+      if (start !== -1) {
+        return [start, i];
+      }
+      if (name === '') {
+        return [0, i];
+      }
+      if (header === name) {
+        start = i + 1;
+      }
+    }
+    return start === -1 ? null : [start, lines.length];
+  };
+
+  const appendSections: string[] = [];
+  // Sections are edited independently; insertions go through a per-section
+  // splice so earlier line indices stay valid (append-only within a range).
+  for (const [name, keys] of flat) {
+    const range = sectionRange(name);
+    if (!range) {
+      appendSections.push(
+        `[${name}]`,
+        ...[...keys].map(([k, v]) => `${k} = ${v}`)
+      );
+      continue;
+    }
+    const [start, end] = range;
+    const inserts: string[] = [];
+    for (const [key, value] of keys) {
+      const assignment = new RegExp(`^(\\s*)${key}\\s*=`);
+      let replaced = false;
+      for (let i = start; i < end; i++) {
+        const m = content(lines[i]).match(assignment);
+        if (m) {
+          lines[i] = finish(`${m[1]}${key} = ${value}`, i);
+          replaced = true;
+          break;
+        }
+      }
+      if (!replaced) {
+        inserts.push(`${key} = ${value}`);
+      }
+    }
+    if (inserts.length > 0) {
+      let at = start;
+      for (let i = start; i < end; i++) {
+        if (content(lines[i]).trim() !== '') {
+          at = i + 1;
+        }
+      }
+      lines.splice(at, 0, ...inserts.map(l => finish(l, at)));
+    }
+  }
+  if (appendSections.length > 0) {
+    while (lines.length > 0 && content(lines[lines.length - 1]).trim() === '') {
+      lines.pop();
+    }
+    const eol = crlf ? '\r' : '';
+    lines.push(
+      ...['', ...appendSections, ''].map(l => (l === '' ? l : `${l}${eol}`))
+    );
+  }
+
+  const result = lines.join('\n');
+  // Full-document check, not just the patched keys: a line that happened to
+  // sit inside a multi-line string could have been rewritten, which only a
+  // comparison of every value catches.
+  try {
+    if (isDeepStrictEqual(tomlParse(result), deepMerge(parsed, patch))) {
+      return result;
+    }
+  } catch {
+    // fall through to the legacy rewrite
+  }
+  return legacy();
 }
 
 export const MANAGED_BLOCK_START = '# >>> vercel ai-gateway >>>';

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { parse as tomlParse } from 'smol-toml';
 import { client } from '../../../mocks/client';
 import aiGateway from '../../../../src/commands/ai-gateway';
 import { useUser } from '../../../mocks/user';
@@ -18,10 +19,12 @@ import {
 import { renderDiff } from '../../../../src/util/ai-gateway/coding-agents/diff';
 import {
   mergeJson,
+  mergeToml,
   upsertManagedBlock,
 } from '../../../../src/util/ai-gateway/coding-agents/config-files';
 import { useTeam } from '../../../mocks/team';
 import { claudeCode } from '../../../../src/util/ai-gateway/coding-agents/agents/claude-code';
+import { codex } from '../../../../src/util/ai-gateway/coding-agents/agents/codex';
 import {
   isKeychainAvailable,
   storeKeyInKeychain,
@@ -91,6 +94,9 @@ function claudeSettingsPath() {
 }
 function codexConfigPath() {
   return join(home, '.codex', 'config.toml');
+}
+function bashrcPath() {
+  return join(home, '.bashrc');
 }
 
 beforeEach(() => {
@@ -171,6 +177,89 @@ describe('ai-gateway coding-agents setup', () => {
       expect(out.apiKey).toBe('vck_DummyKey0001');
       expect(out.configured).toHaveLength(1);
       expect(out.configured[0].action).toBe('created');
+    });
+
+    it('configures Codex with the responses wire API and a shell export', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0002',
+        '--agent',
+        'codex'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const toml = tomlParse(readFileSync(codexConfigPath(), 'utf8')) as any;
+      expect(toml.model_provider).toBe('vercel');
+      // We never pin a default model — only the provider/URL/auth are set up.
+      expect(toml.model).toBeUndefined();
+      expect(toml.model_providers.vercel.base_url).toBe(
+        'https://ai-gateway.vercel.sh/v1'
+      );
+      expect(toml.model_providers.vercel.wire_api).toBe('responses');
+      expect(toml.model_providers.vercel.env_key).toBe('AI_GATEWAY_API_KEY');
+
+      const bashrc = readFileSync(bashrcPath(), 'utf8');
+      expect(bashrc).toContain('# >>> vercel ai-gateway >>>');
+      expect(bashrc).toContain("export AI_GATEWAY_API_KEY='vck_DummyKey0002'");
+    });
+
+    it('appends the rc block a blank line after existing user content', async () => {
+      useUser();
+      client.nonInteractive = true;
+      writeFileSync(bashrcPath(), '# my rc\nalias ll="ls -la"\n');
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0018',
+        '--agent',
+        'codex'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      // The exact bytes: the block reads as its own section, never as a tail
+      // of the user's last block.
+      expect(readFileSync(bashrcPath(), 'utf8')).toBe(
+        [
+          '# my rc',
+          'alias ll="ls -la"',
+          '',
+          '# >>> vercel ai-gateway >>>',
+          '# Managed by `vercel ai-gateway coding-agents setup` — safe to remove this block.',
+          "export AI_GATEWAY_API_KEY='vck_DummyKey0018'",
+          '# <<< vercel ai-gateway <<<',
+          '',
+        ].join('\n')
+      );
+    });
+
+    it('shell-escapes a key with special characters', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const trickyKey = 'vck_a$b`c\'d"e';
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        trickyKey,
+        '--agent',
+        'codex'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const bashrc = readFileSync(bashrcPath(), 'utf8');
+      expect(bashrc).toContain(
+        `export AI_GATEWAY_API_KEY='vck_a$b\`c'\\''d"e'`
+      );
     });
   });
 
@@ -471,6 +560,20 @@ describe('ai-gateway coding-agents setup', () => {
       const claude = plan.changes.find(c => c.label === 'Claude Code settings');
       expect(claude?.next).toContain(secret);
     });
+
+    it('reads the Codex env key from the Keychain instead of the config', async () => {
+      const secret = 'vck_KeychainSecret321';
+      const plan = await buildSetupPlan([codex], {
+        apiKey: secret,
+        home,
+        useKeychain: true,
+      });
+
+      const shell = plan.changes.find(c => c.format === 'shell');
+      expect(shell?.next).toContain('security find-generic-password');
+      expect(shell?.next).toContain('export AI_GATEWAY_API_KEY=');
+      expect(shell?.next).not.toContain(secret);
+    });
   });
 
   describe('key options', () => {
@@ -642,6 +745,20 @@ describe('ai-gateway coding-agents setup', () => {
       ).toBe(true);
     });
 
+    it('writes fish syntax to a fish rc', async () => {
+      const fishRc = join(home, '.config', 'fish', 'config.fish');
+      const plan = await buildSetupPlan([codex], {
+        apiKey: "vck_a'b",
+        home,
+        useKeychain: false,
+        shellRcOverride: fishRc,
+      });
+      const shell = plan.changes.find(c => c.format === 'shell');
+      expect(shell?.path).toBe(fishRc);
+      expect(shell?.next).toContain('set -gx AI_GATEWAY_API_KEY');
+      expect(shell?.next).not.toContain('export ');
+    });
+
     it('rejects a malformed --agent-config', async () => {
       useUser();
       client.setArgv(
@@ -655,6 +772,21 @@ describe('ai-gateway coding-agents setup', () => {
       );
       expect(await aiGateway(client)).toBe(1);
       await expect(client.stderr).toOutput('Invalid --agent-config');
+    });
+
+    it('rejects an override for an unselected agent', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code',
+        '--agent-config',
+        'codex=/tmp/x/config.toml'
+      );
+      expect(await aiGateway(client)).toBe(1);
+      await expect(client.stderr).toOutput("isn't selected");
     });
   });
 
@@ -1160,6 +1292,107 @@ describe('ai-gateway coding-agents setup', () => {
       const hostile = '{"env":"weird","env":{"B":"2"}}';
       const fixed = JSON.parse(mergeJson(hostile, { env: { TOKEN: 'vck_x' } }));
       expect(fixed.env).toEqual({ B: '2', TOKEN: 'vck_x' });
+    });
+  });
+
+  describe('mergeToml edits in place', () => {
+    const PATCH = {
+      model_provider: 'vercel',
+      model_providers: {
+        vercel: { name: 'Vercel AI Gateway', wire_api: 'responses' },
+      },
+    };
+
+    it('preserves comments, quoting, and spacing of untouched lines', async () => {
+      useUser();
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      const original = [
+        'model = "gpt-5.5"  # my pick',
+        '',
+        '[desktop.fonts]',
+        `code = '"Geist Mono", ui-monospace'`,
+        '',
+      ].join('\n');
+      writeFileSync(codexConfigPath(), original, 'utf8');
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_TomlKey0001',
+        '--agent',
+        'codex'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+
+      const next = readFileSync(codexConfigPath(), 'utf8');
+      // The user's lines survive byte-for-byte: inline comment, TOML
+      // literal-string quoting, everything.
+      expect(next).toContain('model = "gpt-5.5"  # my pick');
+      expect(next).toContain(`code = '"Geist Mono", ui-monospace'`);
+      // Only the gateway keys were added.
+      const toml = tomlParse(next) as any;
+      expect(toml.model_provider).toBe('vercel');
+      expect(toml.model_providers.vercel.wire_api).toBe('responses');
+    });
+
+    it('replaces an existing model_provider assignment in place', () => {
+      const next = mergeToml(
+        '# provider\nmodel_provider = "openai"\n\n[other]\nx = 1\n',
+        PATCH
+      );
+      expect(next).toContain('# provider');
+      expect(next).toContain('model_provider = "vercel"');
+      expect(next).not.toContain('"openai"');
+      expect(next).toContain('[other]\nx = 1');
+    });
+
+    it('keeps user keys in an existing [model_providers.vercel] table', () => {
+      const next = mergeToml(
+        '[model_providers.vercel]\nname = "Old"\nquery_params = "keep"\n',
+        PATCH
+      );
+      expect(next).toContain('query_params = "keep"');
+      expect(next).toContain('name = "Vercel AI Gateway"');
+      expect(next).not.toContain('"Old"');
+    });
+
+    it('returns the input byte-for-byte when already configured', () => {
+      const configured = mergeToml('model = "gpt-5.5"\n', PATCH);
+      expect(mergeToml(configured, PATCH)).toBe(configured);
+    });
+
+    it('falls back to a full rewrite for layouts it cannot edit in place', () => {
+      // An inline table cannot take an appended [model_providers.vercel]
+      // header, so the editor must give up rather than corrupt the file.
+      const next = mergeToml(
+        'model_providers = { vercel = { name = "x" } }\n',
+        PATCH
+      );
+      const toml = tomlParse(next) as any;
+      expect(toml.model_provider).toBe('vercel');
+      expect(toml.model_providers.vercel.wire_api).toBe('responses');
+    });
+
+    it('still rejects invalid TOML', () => {
+      expect(() => mergeToml('model = [unclosed', { a: 1 })).toThrow(
+        /existing file is not valid TOML/
+      );
+    });
+
+    it('never corrupts a multi-line string that looks like an assignment', () => {
+      // The line editor is not string-aware: a naive replace would rewrite
+      // the assignment-lookalike INSIDE the string. The full-document verify
+      // must reject that edit and fall back.
+      const banner = 'model_provider = "mine"';
+      const current = `banner = """\n${banner}\n"""\nmodel_provider = "vercel"\n`;
+      const next = mergeToml(current, PATCH);
+      const toml = tomlParse(next) as any;
+      expect(toml.banner).toContain(banner);
+      expect(toml.model_provider).toBe('vercel');
+      expect(toml.model_providers.vercel.wire_api).toBe('responses');
     });
   });
 


### PR DESCRIPTION
## Summary
Add **Codex**: writes a `vercel` model provider to `~/.codex/config.toml` (OpenAI-compatible base URL, `responses` wire API, `env_key = AI_GATEWAY_API_KEY`), no default model, and exports the key via the shell rc (honoring `CODEX_HOME`, `ZDOTDIR`, and fish).

Merging into an existing `config.toml` edits assignments in place: comments, quoting, and formatting survive byte-for-byte. The edited file is re-parsed and compared against the full merged document; any layout the line editor can't handle safely (e.g. inline tables) falls back to a full merge-and-rewrite. The previous file is kept as `config.toml.bak` either way.

## Known limitations
- Without the Keychain, the exported key lives in plaintext in the shell rc file.

