### PR TITLE
[cli] coding-agents setup: add OpenCode support

### DIFF
--- a/.changeset/ai-gateway-coding-agents-opencode.md
+++ b/.changeset/ai-gateway-coding-agents-opencode.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add OpenCode support to `vercel ai-gateway coding-agents setup`. It supplies the gateway API key to OpenCode's native `vercel` provider in `~/.config/opencode/opencode.json` (honoring `XDG_CONFIG_HOME`) without pinning a default model. With the macOS Keychain in use, the key is kept out of the config and resolved from `AI_GATEWAY_API_KEY` (exported from the shell rc) at runtime instead.

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -233,7 +233,7 @@ export const setupSubcommand = {
   name: 'setup',
   aliases: [],
   description:
-    'Connect local coding agents (Claude Code, Codex) to the AI Gateway',
+    'Connect local coding agents (Claude Code, Codex, OpenCode) to the AI Gateway',
   arguments: [],
   options: [
     {
@@ -242,7 +242,8 @@ export const setupSubcommand = {
       type: [String],
       argument: 'NAME',
       deprecated: false,
-      description: 'Coding agent to configure, repeatable (claude-code, codex)',
+      description:
+        'Coding agent to configure, repeatable (claude-code, codex, opencode)',
     },
     {
       name: 'all',

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -1,8 +1,9 @@
 import type { CodingAgent } from '../types';
 import { claudeCode } from './claude-code';
 import { codex } from './codex';
+import { opencode } from './opencode';
 
-export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex];
+export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex, opencode];
 
 export const DEFAULT_AGENTS = CODING_AGENTS.filter(a => !a.experimental);
 

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/opencode.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/opencode.ts
@@ -1,0 +1,65 @@
+import { join } from 'node:path';
+import type { CodingAgent, EnvExport } from '../types';
+import { mergeJson, pathExists } from '../config-files';
+import { GATEWAY_API_KEY_ENV } from '../gateway';
+
+/**
+ * OpenCode has a first-class native `vercel` provider (`@ai-sdk/gateway`), which
+ * reads the key from `provider.vercel.options.apiKey` or, like Codex, the
+ * `AI_GATEWAY_API_KEY` env var. We deliberately do NOT pin a default model; the
+ * user selects one (OpenCode model ids are `vercel/<creator>/<model>` since the
+ * gateway's slugs already contain a slash).
+ *
+ * With Keychain enabled we keep the key out of the config: we declare the
+ * `vercel` provider but leave the credential to `AI_GATEWAY_API_KEY`, exported
+ * from the shell rc (Keychain-resolved at runtime), so the secret never lands
+ * in `opencode.json`.
+ *
+ * Config: `~/.config/opencode/opencode.json` (honors `$XDG_CONFIG_HOME`).
+ * Docs: https://vercel.com/docs/ai-gateway/coding-agents/opencode
+ */
+function defaultConfigPath(home: string): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const base = xdg && xdg.startsWith('/') ? xdg : join(home, '.config');
+  return join(base, 'opencode', 'opencode.json');
+}
+
+export const opencode: CodingAgent = {
+  id: 'opencode',
+  displayName: 'OpenCode',
+
+  async detect(home) {
+    return pathExists(defaultConfigPath(home));
+  },
+
+  configPath(ctx) {
+    return ctx.overrides?.['opencode'] ?? defaultConfigPath(ctx.home);
+  },
+
+  buildPlan(ctx) {
+    const vercel = ctx.useKeychain ? {} : { options: { apiKey: ctx.apiKey } };
+    const envExports: EnvExport[] = ctx.useKeychain
+      ? [{ name: GATEWAY_API_KEY_ENV, value: ctx.apiKey }]
+      : [];
+    const notes = [
+      'OpenCode can now use the Vercel AI Gateway; pick a model like vercel/<creator>/<model>.',
+    ];
+    if (ctx.useKeychain) {
+      notes.push(
+        `Open a new terminal so ${GATEWAY_API_KEY_ENV} is loaded (Keychain-backed).`
+      );
+    }
+    return {
+      fileChanges: [
+        {
+          path: this.configPath(ctx),
+          label: 'OpenCode config',
+          format: 'json',
+          transform: current => mergeJson(current, { provider: { vercel } }),
+        },
+      ],
+      envExports,
+      notes,
+    };
+  },
+};

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/opencode.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/opencode.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import type { CodingAgent, EnvExport } from '../types';
 import { mergeJson, pathExists } from '../config-files';
 import { GATEWAY_API_KEY_ENV } from '../gateway';
@@ -20,7 +20,7 @@ import { GATEWAY_API_KEY_ENV } from '../gateway';
  */
 function defaultConfigPath(home: string): string {
   const xdg = process.env.XDG_CONFIG_HOME;
-  const base = xdg && xdg.startsWith('/') ? xdg : join(home, '.config');
+  const base = xdg && isAbsolute(xdg) ? xdg : join(home, '.config');
   return join(base, 'opencode', 'opencode.json');
 }
 

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -25,6 +25,7 @@ import {
 import { useTeam } from '../../../mocks/team';
 import { claudeCode } from '../../../../src/util/ai-gateway/coding-agents/agents/claude-code';
 import { codex } from '../../../../src/util/ai-gateway/coding-agents/agents/codex';
+import { opencode } from '../../../../src/util/ai-gateway/coding-agents/agents/opencode';
 import {
   isKeychainAvailable,
   storeKeyInKeychain,
@@ -97,6 +98,9 @@ function codexConfigPath() {
 }
 function bashrcPath() {
   return join(home, '.bashrc');
+}
+function opencodeConfigPath() {
+  return join(home, '.config', 'opencode', 'opencode.json');
 }
 
 beforeEach(() => {
@@ -260,6 +264,77 @@ describe('ai-gateway coding-agents setup', () => {
       expect(bashrc).toContain(
         `export AI_GATEWAY_API_KEY='vck_a$b\`c'\\''d"e'`
       );
+    });
+
+    it('configures OpenCode with the native vercel provider', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0003',
+        '--agent',
+        'opencode'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const cfg = JSON.parse(readFileSync(opencodeConfigPath(), 'utf8'));
+      expect(cfg.provider.vercel.options.apiKey).toBe('vck_DummyKey0003');
+      expect(cfg.model).toBeUndefined();
+    });
+
+    it('leaves a minified opencode.json on one line, existing entries untouched', async () => {
+      useUser();
+      client.nonInteractive = true;
+      keychainState.available = false; // deterministic: key embeds in the config
+      mkdirSync(join(home, '.config', 'opencode'), { recursive: true });
+      // Some tools write opencode.json minified; connecting must not explode
+      // it into pretty-printed form.
+      const original =
+        '{"mcp":{"devbox":{"command":["/x/devbox","mcp"],"enabled":true,"type":"local"}}}';
+      writeFileSync(opencodeConfigPath(), original, 'utf8');
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_Minified001',
+        '--agent',
+        'opencode'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+
+      const next = readFileSync(opencodeConfigPath(), 'utf8');
+      expect(next.trim()).not.toContain('\n');
+      expect(next).toContain(
+        '{"mcp":{"devbox":{"command":["/x/devbox","mcp"],"enabled":true,"type":"local"}}'
+      );
+      const cfg = JSON.parse(next);
+      expect(cfg.provider.vercel.options.apiKey).toBe('vck_Minified001');
+    });
+
+    it('keeps the OpenCode key out of the config under keychain', async () => {
+      const secret = 'vck_OpenCodeKeychain';
+      const plan = await buildSetupPlan([opencode], {
+        apiKey: secret,
+        home,
+        useKeychain: true,
+      });
+
+      // The provider is declared, but the key is not embedded…
+      const cfg = plan.changes.find(c => c.label === 'OpenCode config');
+      expect(cfg?.next).toContain('vercel');
+      expect(cfg?.next).not.toContain(secret);
+      // …it's resolved from AI_GATEWAY_API_KEY via the Keychain at runtime.
+      const shell = plan.changes.find(c => c.format === 'shell');
+      expect(shell?.next).toContain('export AI_GATEWAY_API_KEY=');
+      expect(shell?.next).toContain('security find-generic-password');
+      expect(shell?.next).not.toContain(secret);
     });
   });
 
@@ -1602,6 +1677,52 @@ describe('ai-gateway coding-agents setup', () => {
       await expect(client.stderr).toOutput('already configured');
       client.stdin.write('y\n');
       expect(await run).toBe(0);
+    });
+  });
+
+  describe('unconventional locations and multi-agent runs', () => {
+    it('places the OpenCode config under $XDG_CONFIG_HOME when set', async () => {
+      process.env.XDG_CONFIG_HOME = join(home, 'xdg');
+      const plan = await buildSetupPlan([opencode], { apiKey: 'vck_x', home });
+      expect(
+        plan.changes.some(
+          c => c.path === join(home, 'xdg', 'opencode', 'opencode.json')
+        )
+      ).toBe(true);
+    });
+
+    it('shares a single deduped env block across multiple agents', async () => {
+      const plan = await buildSetupPlan([claudeCode, codex, opencode], {
+        apiKey: 'vck_multi',
+        home,
+        useKeychain: true,
+      });
+
+      // One config file per agent.
+      expect(plan.changes.some(c => c.label === 'Claude Code settings')).toBe(
+        true
+      );
+      expect(plan.changes.some(c => c.label === 'Codex config')).toBe(true);
+      expect(plan.changes.some(c => c.label === 'OpenCode config')).toBe(true);
+
+      // A single shared shell block. Codex and OpenCode both want
+      // AI_GATEWAY_API_KEY — it's exported once (deduped) — and Claude Code
+      // contributes ANTHROPIC_AUTH_TOKEN.
+      const shells = plan.changes.filter(c => c.format === 'shell');
+      expect(shells).toHaveLength(1);
+      const gateway = shells[0].next?.match(/AI_GATEWAY_API_KEY/g) ?? [];
+      expect(gateway).toHaveLength(1);
+      expect(shells[0].next).toContain('ANTHROPIC_AUTH_TOKEN');
+    });
+
+    it('skips a malformed Codex config instead of clobbering it', async () => {
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      writeFileSync(codexConfigPath(), 'this is = = not valid toml [', 'utf8');
+
+      const plan = await buildSetupPlan([codex], { apiKey: 'vck_x', home });
+      const codexChange = plan.changes.find(c => c.format === 'toml');
+      expect(codexChange?.status).toBe('error');
+      expect(codexChange?.error).toContain('not valid TOML');
     });
   });
 });


### PR DESCRIPTION
## Summary
Add **OpenCode**: supplies the key to OpenCode's native `vercel` provider in `~/.config/opencode/opencode.json` (honoring `XDG_CONFIG_HOME`), no default model. With the macOS Keychain in use, the key is kept out of the config and resolved from `AI_GATEWAY_API_KEY` (exported from the shell rc) at runtime instead.

