### PR TITLE
fix(cli): point rolling-release start at dedicated start endpoint

### DIFF
--- a/.changeset/bright-tomatoes-happen.md
+++ b/.changeset/bright-tomatoes-happen.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Point rolling release start at the dedicated rolling-release start API endpoint.

--- a/packages/cli/src/commands/rolling-release/start-rolling-release.ts
+++ b/packages/cli/src/commands/rolling-release/start-rolling-release.ts
@@ -74,12 +74,12 @@ export default async function startRollingRelease({
     );
     return 0;
   }
-  // request the promotion
+  // request the rolling release start
   await client.fetch(
-    `/v10/projects/${projectId}/promote/${deployment.id}?teamId=${teamId}`,
+    `/v1/projects/${projectId}/rolling-release/start?teamId=${teamId}`,
     {
-      body: {}, // required
-      json: false,
+      body: { canaryDeploymentId: deployment.id }, // required
+      json: true,
       method: 'POST',
     }
   );

--- a/packages/cli/test/unit/commands/rolling-release/start.test.ts
+++ b/packages/cli/test/unit/commands/rolling-release/start.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import startRollingRelease from '../../../../src/commands/rolling-release/start-rolling-release';
+import getProjectByDeployment from '../../../../src/util/projects/get-project-by-deployment';
+
+vi.mock('../../../../src/util/projects/get-project-by-deployment');
+
+const mockedGetProjectByDeployment = vi.mocked(getProjectByDeployment);
+
+describe('rolling-release start', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the dedicated rolling-release start endpoint', async () => {
+    const fetch = vi.fn().mockResolvedValue({});
+
+    mockedGetProjectByDeployment.mockResolvedValue({
+      contextName: 'my-team',
+      deployment: {
+        id: 'dpl_canary',
+        target: 'production',
+        ownerId: 'team_123',
+      } as any,
+      project: {
+        id: 'prj_123',
+      } as any,
+    });
+
+    const exitCode = await startRollingRelease({
+      client: {
+        fetch,
+        nonInteractive: false,
+        input: { confirm: vi.fn() },
+      } as any,
+      dpl: 'dpl_canary',
+      projectId: 'prj_123',
+      teamId: 'team_123',
+      yes: false,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fetch).toHaveBeenCalledWith(
+      '/v1/projects/prj_123/rolling-release/start?teamId=team_123',
+      {
+        body: { canaryDeploymentId: 'dpl_canary' },
+        json: true,
+        method: 'POST',
+      }
+    );
+    expect(fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/promote/'),
+      expect.anything()
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Updates `vercel rolling-release start` to call `POST /v1/projects/:idOrName/rolling-release/start` with `{ canaryDeploymentId }` instead of the promote API
- Fixes **PIPE-6827**: when auto-assign starts a rolling release on deploy ready, a subsequent `vercel rolling-release start` no longer completes the rollout via promote
- Adds a focused unit test asserting the new endpoint path and request body

Companion API change: https://github.com/vercel/api/pull/78174

The start endpoint is idempotent (re-starting the active canary returns `200`), while promote semantics remain unchanged for dashboard compatibility. `rolling-release complete` already uses its dedicated endpoint.

## Test plan

- [x] `pnpm -C packages/cli test test/unit/commands/rolling-release/start.test.ts`