### PR TITLE
[services] Fix service framework detection when entrypoint is in a subdir of service root.

### DIFF
--- a/.changeset/mighty-forks-approve.md
+++ b/.changeset/mighty-forks-approve.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': minor
+---
+
+Fix service framework detection when entrypoint is in a subdir of service root.

--- a/packages/fs-detectors/src/services/resolve-v2.ts
+++ b/packages/fs-detectors/src/services/resolve-v2.ts
@@ -323,11 +323,10 @@ export async function resolveConfiguredServiceV2(
   let framework = config.framework;
   let detectedFramework = false;
   if (!framework) {
-    const workspace = normalizedEntrypoint
-      ? entrypointIsDirectory
+    const workspace =
+      entrypointIsDirectory && normalizedEntrypoint
         ? normalizedEntrypoint
-        : posixPath.dirname(normalizedEntrypoint) || '.'
-      : '.';
+        : '.';
     const detection = await detectFrameworkFromWorkspace({
       fs: serviceFs,
       workspace,

--- a/packages/fs-detectors/test/unit.detect-services-v2.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services-v2.test.ts
@@ -270,6 +270,37 @@ describe('detectServices (services)', () => {
     expect(api.builder.config).toMatchObject({ handlerFunction: 'app' });
   });
 
+  it('auto-detects framework using service root when entrypoint is in a subdirectory', async () => {
+    const fs = new VirtualFilesystem({
+      'vercel.json': vercelJson({
+        experimentalServicesV2: {
+          backend: {
+            root: 'backend',
+            entrypoint: 'src/main.py',
+          },
+        },
+      }),
+      'backend/pyproject.toml': '[project]\ndependencies = ["fastapi"]\n',
+      'backend/src/main.py': 'from fastapi import FastAPI\napp = FastAPI()',
+    });
+
+    const result = await detectServices({ fs });
+
+    expect(result.errors).toEqual([]);
+    const [backend] = servicesV2(result.services);
+    expect(backend).toMatchObject({
+      name: 'backend',
+      framework: 'fastapi',
+      runtime: 'python',
+      entrypoint: 'src/main.py',
+    });
+    expect(backend.builder.use).toBe('@vercel/python');
+    expect(backend.builder.config).toMatchObject({
+      framework: 'fastapi',
+      workspace: 'backend',
+    });
+  });
+
   it('resolves a service rooted at the project root (".")', async () => {
     const fs = new VirtualFilesystem({
       'vercel.json': vercelJson({


### PR DESCRIPTION
When the entrypoint was a file, the framework detection ran in the entrypoint dir, not in the service root. The framework detection would then silently fail and pass `"services"` as the framework for builders.