### PR TITLE
fix(gatsby): open gatsby runtime lmdb cache in writable directory

### DIFF
--- a/.changeset/gatsby-ssr-dsg-lmdb-writable-cache.md
+++ b/.changeset/gatsby-ssr-dsg-lmdb-writable-cache.md
@@ -1,0 +1,5 @@
+---
+'@vercel/gatsby-plugin-vercel-builder': patch
+---
+
+Fix Gatsby SSR/DSG routes crashing with `ENOENT: ... mkdir '.../.cache/caches-lmdb'` on the read-only function filesystem. Gatsby opens additional LMDB instances (the `caches-lmdb` query/resolver cache and `gatsby-core-utils` storage) lazily at request time, pathed off `global.__GATSBY.root` (Gatsby >= 5.13) or `process.cwd()`. The SSR handler now points those at the OS temp dir before the query engine is imported, mirroring the existing datastore handling.

--- a/packages/gatsby-plugin-vercel-builder/templates/ssr-handler.js
+++ b/packages/gatsby-plugin-vercel-builder/templates/ssr-handler.js
@@ -1,15 +1,28 @@
-import os from 'os';
 import etag from 'etag';
 import { join } from 'path';
 import { copySync, existsSync } from 'fs-extra';
-import { getPageName } from './utils';
+import { getPageName, redirectGatsbyCachesToWritableDir } from './utils';
 
-const TMP_DATA_PATH = join(os.tmpdir(), 'data/datastore');
+// Point Gatsby's writable cache locations at the OS temp dir BEFORE the query
+// engine is imported below (it resolves its LMDB cache path at module load).
+// See `redirectGatsbyCachesToWritableDir` in ./utils for the full rationale.
+const TMP_DIR = redirectGatsbyCachesToWritableDir();
+
+const TMP_DATA_PATH = join(TMP_DIR, 'data/datastore');
 const CUR_DATA_PATH = join(__dirname, '.cache/data/datastore');
 
 if (!existsSync(TMP_DATA_PATH)) {
   // Copies executable `data` files to the writable /tmp directory.
   copySync(CUR_DATA_PATH, TMP_DATA_PATH);
+}
+
+// Seed the writable cache dir with caches produced at build time so warm
+// resolver caches still hit at runtime (mirrors the datastore copy above).
+const TMP_CACHES_PATH = join(TMP_DIR, '.cache/caches');
+const CUR_CACHES_PATH = join(__dirname, '.cache/caches');
+
+if (!existsSync(TMP_CACHES_PATH) && existsSync(CUR_CACHES_PATH)) {
+  copySync(CUR_CACHES_PATH, TMP_CACHES_PATH);
 }
 
 async function getGraphQLEngine() {

--- a/packages/gatsby-plugin-vercel-builder/templates/utils.ts
+++ b/packages/gatsby-plugin-vercel-builder/templates/utils.ts
@@ -1,5 +1,36 @@
+import os from 'os';
 import { parse } from 'url';
 import { basename, dirname } from 'path';
+
+/**
+ * The Serverless Function's working directory (e.g. `/var/task`) is read-only at
+ * runtime; only the OS temp dir is writable. Gatsby's query engine opens several
+ * LMDB instances lazily on the first request: the datastore, the `caches-lmdb`
+ * query/resolver cache (used by e.g. the built-in `dateformat` resolver and
+ * `gatsby-plugin-mdx`), and `gatsby-core-utils` storage. The latter two derive
+ * their location from `global.__GATSBY.root` (Gatsby >= 5.13) or, as a fallback,
+ * `process.cwd()`. Without redirecting these, opening them tries to `mkdir` under
+ * the read-only deployment dir and the SSR/DSG request crashes with
+ * `ENOENT: ... mkdir '.../.cache/caches-lmdb'`.
+ *
+ * This must run before the query engine module is imported, because `caches-lmdb`
+ * resolves its path at module-load time. Returns the writable root that was
+ * applied (the OS temp dir).
+ */
+export function redirectGatsbyCachesToWritableDir(): string {
+  const tmpDir = os.tmpdir();
+  // Covers Gatsby 4.x (caches-lmdb keys off `process.cwd()`) and any other
+  // cwd-relative cache/storage write.
+  process.chdir(tmpDir);
+  // Covers Gatsby >= 5.13, where caches-lmdb and gatsby-core-utils storage read
+  // `global.__GATSBY.root`. Preserve any existing fields on the object.
+  const globalGatsby = global as typeof globalThis & {
+    __GATSBY?: { root?: string };
+  };
+  globalGatsby.__GATSBY = globalGatsby.__GATSBY || {};
+  globalGatsby.__GATSBY.root = tmpDir;
+  return tmpDir;
+}
 
 export function getPageName(url: string, pathPrefix = '') {
   let pathName = (parse(url).pathname || '/').slice(pathPrefix.length);

--- a/packages/gatsby-plugin-vercel-builder/test/unit.redirect-caches.test.ts
+++ b/packages/gatsby-plugin-vercel-builder/test/unit.redirect-caches.test.ts
@@ -1,0 +1,36 @@
+import os from 'os';
+import { realpathSync } from 'fs';
+import { redirectGatsbyCachesToWritableDir } from '../templates/utils';
+
+type GlobalWithGatsby = typeof globalThis & {
+  __GATSBY?: { root?: string; [key: string]: unknown };
+};
+
+describe('redirectGatsbyCachesToWritableDir()', () => {
+  const originalCwd = process.cwd();
+  const originalGatsby = (global as GlobalWithGatsby).__GATSBY;
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    (global as GlobalWithGatsby).__GATSBY = originalGatsby;
+  });
+
+  it('points cwd and Gatsby root at the OS temp dir', () => {
+    const applied = redirectGatsbyCachesToWritableDir();
+    const tmp = os.tmpdir();
+
+    expect(applied).toBe(tmp);
+    // realpath avoids macOS `/var` -> `/private/var` symlink differences in cwd
+    expect(realpathSync(process.cwd())).toBe(realpathSync(tmp));
+    expect((global as GlobalWithGatsby).__GATSBY?.root).toBe(tmp);
+  });
+
+  it('preserves existing fields on global.__GATSBY', () => {
+    (global as GlobalWithGatsby).__GATSBY = { foo: 'bar' };
+
+    redirectGatsbyCachesToWritableDir();
+
+    expect((global as GlobalWithGatsby).__GATSBY?.foo).toBe('bar');
+    expect((global as GlobalWithGatsby).__GATSBY?.root).toBe(os.tmpdir());
+  });
+});


### PR DESCRIPTION
## Problem

Gatsby SSR and DSG routes 500 at runtime with:

Error: ENOENT: no such file or directory, mkdir '/var/task/.cache/caches-lmdb'
    at GatsbyCacheLmdb.getStore (.cache/query-engine/index.js)

When a deferred (DSG) or SSR page renders, Gatsby's query engine runs inside the Serverless Function and opens several LMDB instances. We already redirect the LMDB **datastore** to `os.tmpdir()` in `ssr-handler.js`, but Gatsby *also* opens its `caches-lmdb` query/resolver cache and `gatsby-core-utils` storage lazily on the first request. Those derive their path from `global.__GATSBY.root` (Gatsby ≥ 5.13) or, as a fallback, `process.cwd()` — which is the read-only deployment dir (`/var/task`) at runtime. The resulting `mkdir` throws and the request crashes.

Any DSG/SSR page that hits a cache-writing resolver is affected — the built-in `dateformat` resolver (i.e. any `date(formatString: …)` query), `gatsby-plugin-mdx`, `gatsby-source-contentful`, etc. — in practice this is most content-driven Gatsby sites.

## Fix

Before the query engine is imported (its cache path resolves at module load), point Gatsby's writable locations at the OS temp dir:

- `process.chdir(os.tmpdir())` — covers Gatsby 4.x, where `caches-lmdb` keys off `process.cwd()`.
- `global.__GATSBY.root = os.tmpdir()` — covers Gatsby >= 5.13, which read this seam (added in gatsbyjs/gatsby#38631).

This is extracted into a unit-tested helper (`redirectGatsbyCachesToWritableDir`) in `templates/utils.ts`. The handler also seeds the writable dir with the build-time `.cache/caches` so warm resolver caches still hit, mirroring the existing datastore copy.

This generalizes the datastore handling we already do and matches how the Netlify adapter handles the same constraint.

### Testing

- `pnpm test-unit` — 16 passed (2 new in `test/unit.redirect-caches.test.ts`).
- `pnpm type-check`, Biome lint + format — clean.
- Bundled `ssr-handler.js` with the exact esbuild config `writeHandler` uses to confirm the new `./utils` import resolves in the generated function.

### Refs

- Same crash reported on Vercel + Gatsby 5.13.4 (still open): [gatsbyjs/gatsby#38972](https://github.com/gatsbyjs/gatsby/issues/38972)
- Upstream seam this adopts: [gatsbyjs/gatsby#38631](https://github.com/gatsbyjs/gatsby/pull/38631)