### PR TITLE
[cli] Expose pprState in `vc logs` output

### DIFF
--- a/.changeset/ppr-state-logs.md
+++ b/.changeset/ppr-state-logs.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Expose `pprState` in `vc logs` output, alongside the existing cache status and reason, so users can see how a PPR page was served (`fully_static` / `partially_dynamic` / `fully_dynamic`).

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -23,6 +23,7 @@ export interface RequestLogEntry {
   branch?: string;
   cache?: string;
   cacheReason?: string;
+  pprState?: string;
   traceId?: string;
   messageTruncated?: boolean;
   logs: RequestLogMessage[];
@@ -189,6 +190,7 @@ export async function fetchRequestLogs(
     branch?: string;
     cache?: string;
     cacheReason?: string;
+    pprState?: string;
     traceId?: string;
     logs?: Array<{
       level?: string;
@@ -230,6 +232,7 @@ export async function fetchRequestLogs(
       branch: row.branch,
       cache: row.cache,
       cacheReason: row.cacheReason,
+      pprState: row.pprState,
       traceId: row.traceId,
       logs: requestLogs,
     };

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -19,6 +19,7 @@ interface ApiLogEntry {
   domain?: string;
   cache?: string;
   cacheReason?: string;
+  pprState?: string;
   logs?: Array<{
     level?: string;
     message?: string;
@@ -66,9 +67,13 @@ describe('logs-v2 utility', () => {
       expect(result.logs[0].id).toEqual('log_123');
     });
 
-    it('should pass through cache status and cacheReason', async () => {
+    it('should pass through cache status, cacheReason, and pprState', async () => {
       const mockLogs = [
-        createMockApiLog({ cache: 'BYPASS', cacheReason: 'draft_mode' }),
+        createMockApiLog({
+          cache: 'BYPASS',
+          cacheReason: 'draft_mode',
+          pprState: 'partially_dynamic',
+        }),
       ];
       client.scenario.get('/api/logs/request-logs', (req, res) => {
         res.json({ rows: mockLogs, hasMoreRows: false });
@@ -82,6 +87,7 @@ describe('logs-v2 utility', () => {
       expect(result.logs).toHaveLength(1);
       expect(result.logs[0].cache).toEqual('BYPASS');
       expect(result.logs[0].cacheReason).toEqual('draft_mode');
+      expect(result.logs[0].pprState).toEqual('partially_dynamic');
     });
 
     it('should include deploymentId in query when provided', async () => {


### PR DESCRIPTION
### Why

proxy now emits a `ppr_state` field per request — `fully_static` / `partially_dynamic` / `fully_dynamic` — describing how a Partial Prerendering page was served (vercel/proxy#23270). This threads it through `vc logs` so it appears next to `cache` / `cacheReason` in the `--json` output

Relevant PRs:
https://github.com/vercel/proxy/pull/23270
https://github.com/vercel/infra/pull/29426
https://github.com/vercel/api/pull/78014

### What

- Add `pprState` to the `RequestLogEntry` and API-response entry types in `logs-v2.ts`
- Map it in the row→entry transform, so `vc logs --json` emits it alongside `cache` and `cacheReason`

### Backend dependency

- `vc logs` hits `vercel.com/api/logs/request-logs` served by **front** so the field appears once the companion **vercel/front** PR ships (the request-logs route there)
- data already lands in ClickHouse (`proxyPprState`, mapped from `data.pprState`)

### Testing

- Extended the passthrough unit test to assert `cache` + `cacheReason` + `pprState` flow through `fetchRequestLogs`: `16 passed`
- Will conduct further tests on prod traffic once https://github.com/vercel/proxy/pull/23270 is approved and ppr_state is flowing through o11y

```
shinapatel@Shinas-MacBook-Pro ~ % node ~/Desktop/repos/vercel/packages/cli/dist/index.js logs dpl_7WqBudXwthZysHx9f1LH1sBNHDhd \
  --json --scope vercel \
  | jq -c 'select((.pprState // "") != "") | {path: .requestPath, cache, pprState}'
Vercel CLI 54.18.6 (Node.js 24.14.0)
{"path":"/signup","cache":"HIT","pprState":"blocking"}
shinapatel@Shinas-MacBook-Pro ~ % 
```