### PR TITLE
Bump rust-toolchain sha to fix imposter-commit lint error.

### DIFF
--- a/.changeset/repin-rust-toolchain.md
+++ b/.changeset/repin-rust-toolchain.md
@@ -1,0 +1,4 @@
+---
+---
+
+Re-pin `dtolnay/rust-toolchain` to the current `1.96.1` commit across CI workflows. The previously pinned commit was orphaned upstream when the maintainer force-updated the version branch, causing zizmor's `impostor-commit` audit to fail.

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 24
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
         with:
           targets: wasm32-wasip2
 

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -93,7 +93,7 @@ jobs:
           package-manager-cache: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
         with:
           toolchain: stable
           targets: wasm32-wasip2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: 24
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
         with:
           targets: wasm32-wasip2
 

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
         with:
           targets: wasm32-wasip2
       - name: install pnpm@10.29.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -278,7 +278,7 @@ jobs:
 
       - name: Setup Rust toolchain
         if: ${{ matrix.needsRust == true }}
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
         with:
           targets: wasm32-wasip2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -415,7 +415,7 @@ jobs:
 
       - name: Install Ruby + Bundler
         if: ${{ matrix.packageName == 'vercel' }}
-        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: '3.3'
 

--- a/.github/workflows/validate-binary.yml
+++ b/.github/workflows/validate-binary.yml
@@ -45,7 +45,7 @@ jobs:
           package-manager-cache: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
         with:
           toolchain: stable
           targets: wasm32-wasip2


### PR DESCRIPTION
Re-pin `dtolnay/rust-toolchain` to the current `1.96.1` commit across CI workflows. The previously pinned commit was orphaned upstream when the maintainer force-updated the version branch, causing zizmor's `impostor-commit` audit to fail.