### PR TITLE
[services] Make service bindings type optional.

### DIFF
--- a/.changeset/chilly-paws-battle.md
+++ b/.changeset/chilly-paws-battle.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': minor
+'vercel': minor
+---
+
+Make service bindings type optional.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -1078,8 +1078,8 @@ export type ExperimentalServices = Record<string, ExperimentalServiceConfig>;
 export type ExperimentalServiceGroups = Record<string, string[]>;
 
 export interface ServiceBinding {
-  /** Must be `"service"` for Service-to-Service HTTP bindings. */
-  type: 'service';
+  /** If present, must be `"service"` for Service-to-Service HTTP bindings. */
+  type?: 'service';
   /** Target service name from `services`. */
   service: string;
   /** Generated value shape, must be `"url"`. */

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -1049,8 +1049,8 @@ export type ExperimentalServices = Record<string, ExperimentalServiceConfig>;
 export type ExperimentalServiceGroups = Record<string, string[]>;
 
 export interface ServiceBinding {
-  /** Must be `"service"` for Service-to-Service HTTP bindings. */
-  type: 'service';
+  /** If present, must be `"service"` for Service-to-Service HTTP bindings. */
+  type?: 'service';
   /** Target service name from `services`. */
   service: string;
   /** Generated value shape, must be `"url"`. */

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -726,7 +726,10 @@ export class ServicesOrchestrator {
 
     const perServiceEnv: Record<string, string> = {};
     for (const binding of service.bindings ?? []) {
-      if (binding.type !== 'service' || binding.format !== 'url') {
+      if (
+        (binding.type !== undefined && binding.type !== 'service') ||
+        binding.format !== 'url'
+      ) {
         continue;
       }
       if (binding.env in effectiveProcessEnv) {

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -712,7 +712,10 @@ export class ServicesOrchestrator {
 
     const perServiceEnv: Record<string, string> = {};
     for (const binding of service.bindings ?? []) {
-      if (binding.type !== 'service' || binding.format !== 'url') {
+      if (
+        (binding.type !== undefined && binding.type !== 'service') ||
+        binding.format !== 'url'
+      ) {
         continue;
       }
       if (binding.env in effectiveProcessEnv) {

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -503,9 +503,13 @@ const servicesServiceNamePattern = '^[a-z]([a-z_-]*[a-z])?$';
 const servicesBindingSchema = {
   type: 'object',
   additionalProperties: false,
-  required: ['type', 'service', 'format', 'env'],
+  required: ['service', 'format', 'env'],
   properties: {
-    type: { const: 'service' },
+    type: {
+      description:
+        'Optional binding type marker. Currently the only supported type is `service`. When present this must be `service`.',
+      const: 'service',
+    },
     service: {
       type: 'string',
       minLength: 1,

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -504,9 +504,13 @@ const servicesServiceNamePattern = '^[a-z]([a-z_-]*[a-z])?$';
 const servicesBindingSchema = {
   type: 'object',
   additionalProperties: false,
-  required: ['type', 'service', 'format', 'env'],
+  required: ['service', 'format', 'env'],
   properties: {
-    type: { const: 'service' },
+    type: {
+      description:
+        'Optional binding type marker. Currently the only supported type is `service`. When present this must be `service`.',
+      const: 'service',
+    },
     service: {
       type: 'string',
       minLength: 1,

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -189,7 +189,7 @@ describe('validateConfig', () => {
 
     it('should accept a binding with `type` omitted', () => {
       const error = validateConfig({
-        experimentalServicesV2: {
+        services: {
           web: { root: '.' },
           api: {
             root: 'api/',

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -187,6 +187,19 @@ describe('validateConfig', () => {
       );
     });
 
+    it('should accept a binding with `type` omitted', () => {
+      const error = validateConfig({
+        experimentalServicesV2: {
+          web: { root: '.' },
+          api: {
+            root: 'api/',
+            bindings: [{ service: 'web', format: 'url', env: 'WEB_URL' }],
+          },
+        },
+      } as any);
+      expect(error).toBeNull();
+    });
+
     it('should reject a binding missing a required field', () => {
       const error = validateConfig({
         experimentalServicesV2: {


### PR DESCRIPTION
The type field on service bindings ("service") is now optional.

For example:
```json
{
  "services": {
    "my_frontend": {
      "root": "frontend",
      "framework": "nextjs",
      "bindings": [
        {
          "service": "my_backend",
          "format": "url",
          "env": "BACKEND_URL"
        }
      ]
    },
    "my_backend": {
      "root": "backend",
      "framework": "fastapi"
    }
  },
  "rewrites": [
    { "source": "/(.*)", "destination": { "service": "my_frontend" } }
  ]
}
```