### PR TITLE
[cli] coding-agents setup: safer non-interactive defaults and failures

### DIFF
--- a/.changeset/ai-gateway-coding-agents-hardening.md
+++ b/.changeset/ai-gateway-coding-agents-hardening.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`ai-gateway coding-agents setup` now configures only the agents detected on the machine when run non-interactively without `--agent`/`--all`, exits with code 1 (without creating an API key) when no agent configuration can be written, and on Windows reports the environment variable to set instead of writing a shell file that is never loaded (unless `--shell-rc` is passed explicitly). Non-interactive re-runs with `--key` on an already-configured macOS Keychain setup now refresh the stored key instead of silently keeping the old one.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
@@ -373,6 +373,16 @@ export default async function codingAgentsSetup(
     return 0;
   }
 
+  // A shell-rc export alone doesn't count: without its agent config written,
+  // the exported key would serve nothing.
+  const agentConfigChanged = changed.filter(c => c.format !== 'shell');
+  if (agentConfigChanged.length === 0 && errored.length > 0) {
+    output.error(
+      "Couldn't write any agent configurations. Fix the files above, then re-run."
+    );
+    return 1;
+  }
+
   if (changed.length > 0 && canPrompt && !yes) {
     const confirmed = await client.input.confirm('Apply these changes?', true);
     if (!confirmed) {
@@ -456,6 +466,16 @@ export default async function codingAgentsSetup(
   }
 
   printNotes(applyPlanResult);
+  if (
+    keySource.created &&
+    !useKeychain &&
+    applyPlanResult.envExports.length > 0 &&
+    !applyPlanResult.shellRcPath
+  ) {
+    // No config file or shell rc carries the new key (e.g. Windows), so print
+    // it once — otherwise it would be unrecoverable.
+    client.stdout.write(`${keySource.key}\n`);
+  }
   return 0;
 }
 

--- a/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
@@ -32,6 +32,7 @@ export interface AgentNotes {
 export interface SetupPlan {
   changes: PlannedChange[];
   notes: AgentNotes[];
+  envExports: EnvExport[];
   shellRcPath?: string;
 }
 
@@ -146,7 +147,22 @@ export async function buildSetupPlan(
   }
 
   let shellRcPath: string | undefined;
-  if (envExports.length) {
+  if (
+    envExports.length &&
+    process.platform === 'win32' &&
+    !ctx.shellRcOverride
+  ) {
+    // There is no shell rc to manage on Windows; tell the user what to set.
+    notes.push({
+      id: 'environment',
+      displayName: 'Environment',
+      notes: [
+        `Automatic shell setup is not supported on Windows. Set ${envExports
+          .map(e => e.name)
+          .join(', ')} to your API key in your environment.`,
+      ],
+    });
+  } else if (envExports.length) {
     shellRcPath = detectShellRc(ctx.home, ctx.shellRcOverride);
     const body = envBlockBody(
       envExports,
@@ -226,7 +242,7 @@ export async function buildSetupPlan(
     });
   }
 
-  return { changes, notes, shellRcPath };
+  return { changes, notes, envExports, shellRcPath };
 }
 
 export interface ApplyResult {

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -71,13 +71,35 @@ export async function runMachine(args: {
   // Idempotent by default: if nothing needs writing and we weren't asked to
   // reconfigure, report the no-op without minting a fresh key.
   if (args.alreadyConfigured && !args.reconfigure) {
+    let message =
+      'All selected agents are already configured for the AI Gateway. Pass --reconfigure to rotate the key.';
+    // A provided key on a Keychain setup: refresh the stored secret in place,
+    // mirroring the interactive flow (the config files never carry the key).
+    if (args.useKeychain && args.keySource) {
+      if (!storeKeyInKeychain(args.keySource.key)) {
+        client.stdout.write(
+          `${JSON.stringify(
+            {
+              status: AGENT_STATUS.ERROR,
+              reason: 'keychain_error',
+              message:
+                'Failed to update the key in the macOS Keychain. Re-run with --no-keychain to write it to the config files instead.',
+            },
+            null,
+            2
+          )}\n`
+        );
+        return 1;
+      }
+      message =
+        'All selected agents are already configured; updated the macOS Keychain with the provided key.';
+    }
     client.stdout.write(
       `${JSON.stringify(
         {
           status: AGENT_STATUS.OK,
           reason: 'already_configured',
-          message:
-            'All selected agents are already configured for the AI Gateway. Pass --reconfigure to rotate the key.',
+          message,
           configured: [],
           skipped: [],
         },
@@ -86,6 +108,26 @@ export async function runMachine(args: {
       )}\n`
     );
     return 0;
+  }
+
+  const applicable = previewPlan.changes.filter(
+    c =>
+      (c.status === 'create' || c.status === 'update') && c.format !== 'shell'
+  );
+  if (applicable.length === 0 && errored.length > 0) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: 'unparseable_config',
+          message: "Couldn't write any agent configurations.",
+          skipped,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 1;
   }
 
   let key: string;

--- a/packages/cli/src/util/ai-gateway/coding-agents/resolve.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/resolve.ts
@@ -56,13 +56,9 @@ export async function resolveAgents(args: {
     return { selected: DEFAULT_AGENTS, guidance, unsupported };
   }
 
-  if (!canPrompt) {
-    return { selected: DEFAULT_AGENTS, guidance, unsupported };
-  }
-
   const detected = await Promise.all(DEFAULT_AGENTS.map(a => a.detect(home)));
 
-  if (yes) {
+  if (!canPrompt || yes) {
     const selected = DEFAULT_AGENTS.filter((_, i) => detected[i]);
     if (selected.length === 0) {
       return {

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -624,6 +624,61 @@ describe('ai-gateway coding-agents setup', () => {
     });
   });
 
+  describe('non-interactive agent selection', () => {
+    it('configures only the detected agents when none are named', async () => {
+      useUser();
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0011'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      expect(existsSync(claudeSettingsPath())).toBe(true);
+      // Undetected agents are left alone.
+      expect(existsSync(codexConfigPath())).toBe(false);
+      expect(existsSync(opencodeConfigPath())).toBe(false);
+      expect(existsSync(piAuthPath())).toBe(false);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.configured).toHaveLength(1);
+    });
+
+    it('errors when nothing is detected and no agent is named', async () => {
+      useUser();
+      client.nonInteractive = true;
+      // The mock throws to simulate process.exit terminating; assert on the
+      // spy and the emitted payload rather than the return value.
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+        _code?: number
+      ) => {
+        throw new Error('exit');
+      }) as () => never);
+      try {
+        client.setArgv(
+          'ai-gateway',
+          'coding-agents',
+          'setup',
+          '--key',
+          'vck_DummyKey0012'
+        );
+        await aiGateway(client).catch(() => {});
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        const out = JSON.parse(client.stdout.getFullOutput());
+        expect(out.status).toBe('error');
+        expect(out.message).toContain('No coding agents detected');
+        expect(existsSync(codexConfigPath())).toBe(false);
+      } finally {
+        exitSpy.mockRestore();
+      }
+    });
+  });
+
   describe('keychain', () => {
     it('is unavailable off macOS and fails closed', () => {
       if (process.platform !== 'darwin') {
@@ -1140,10 +1195,49 @@ describe('ai-gateway coding-agents setup', () => {
         'Failed to update the key in the macOS Keychain'
       );
     });
+
+    it('refreshes the Keychain on a non-interactive re-run with a new key', async () => {
+      useUser();
+      keychainState.available = true;
+      client.nonInteractive = true;
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_OldKey0031',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+      expect(keychainState.stored).toEqual(['vck_OldKey0031']);
+      const stdoutAfterFirst = client.stdout.getFullOutput().length;
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_NewKey0032',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(0);
+      expect(keychainState.stored).toEqual([
+        'vck_OldKey0031',
+        'vck_NewKey0032',
+      ]);
+      const out = JSON.parse(
+        client.stdout.getFullOutput().slice(stdoutAfterFirst)
+      );
+      expect(out.reason).toBe('already_configured');
+      expect(out.message).toContain('updated the macOS Keychain');
+    });
   });
 
   describe('safety', () => {
-    it('skips a malformed config instead of clobbering it', async () => {
+    it('skips a malformed config instead of clobbering it, and fails the run', async () => {
       useUser();
       client.nonInteractive = true;
       mkdirSync(join(home, '.claude'), { recursive: true });
@@ -1158,17 +1252,112 @@ describe('ai-gateway coding-agents setup', () => {
         '--agent',
         'claude-code'
       );
+      // Nothing could be configured, so the run reports failure.
       const exitCode = await aiGateway(client);
-      expect(exitCode).toBe(0);
+      expect(exitCode).toBe(1);
 
       // File untouched.
       expect(readFileSync(claudeSettingsPath(), 'utf8')).toBe(
         '{ this is not json'
       );
       const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.status).toBe('error');
       expect(
         out.skipped.some((s: any) => s.reason === 'unparseable_config')
       ).toBe(true);
+    });
+
+    it('does not create an API key when nothing can be written', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(claudeSettingsPath(), '{ this is not json', 'utf8');
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(1);
+      expect(lastCreateBody).toBeUndefined();
+    });
+
+    it('exits 1 when the only config cannot be written (interactive)', async () => {
+      useUser();
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(claudeSettingsPath(), '{ this is not json', 'utf8');
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--key',
+        'vck_DummyKey0013',
+        '--agent',
+        'claude-code'
+      );
+      expect(await aiGateway(client)).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        "Couldn't write any agent configurations"
+      );
+    });
+
+    it('still configures the healthy agents when one config is malformed', async () => {
+      useUser();
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(claudeSettingsPath(), '{ this is not json', 'utf8');
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0014',
+        '--agent',
+        'claude-code',
+        '--agent',
+        'codex'
+      );
+      expect(await aiGateway(client)).toBe(0);
+      expect(existsSync(codexConfigPath())).toBe(true);
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.status).toBe('ok');
+      expect(out.configured.length).toBeGreaterThan(0);
+      expect(
+        out.skipped.some((s: any) => s.reason === 'unparseable_config')
+      ).toBe(true);
+    });
+
+    it('exits 1 without minting when only the shell export would be written', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      writeFileSync(codexConfigPath(), 'not = = toml', 'utf8');
+
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'codex'
+      );
+      // The .bashrc export alone must not count as a successful configuration.
+      expect(await aiGateway(client)).toBe(1);
+      expect(lastCreateBody).toBeUndefined();
+      expect(existsSync(bashrcPath())).toBe(false);
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.status).toBe('error');
     });
 
     it('never prints the full key — only a masked form', async () => {
@@ -1622,6 +1811,77 @@ describe('ai-gateway coding-agents setup', () => {
       process.env.SHELL = '/bin/bash';
       const custom = join(home, 'custom', 'rc');
       expect(detectShellRc(home, custom)).toBe(custom);
+    });
+  });
+
+  describe('windows', () => {
+    const realPlatform = process.platform;
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', {
+        value: realPlatform,
+        configurable: true,
+      });
+    });
+
+    it('skips shell setup and reports the env var instead', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+      const plan = await buildSetupPlan([codex], {
+        apiKey: 'vck_x',
+        home,
+        useKeychain: false,
+      });
+      expect(plan.changes.find(c => c.format === 'shell')).toBeUndefined();
+      expect(plan.shellRcPath).toBeUndefined();
+      expect(
+        plan.notes.some(n =>
+          n.notes.some(l => l.includes('AI_GATEWAY_API_KEY'))
+        )
+      ).toBe(true);
+    });
+
+    it('honors an explicit --shell-rc override on Windows', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+      const rc = join(home, '.bashrc');
+      const plan = await buildSetupPlan([codex], {
+        apiKey: 'vck_x',
+        home,
+        useKeychain: false,
+        shellRcOverride: rc,
+      });
+      expect(plan.changes.find(c => c.format === 'shell')?.path).toBe(rc);
+    });
+
+    it('prints a created key once when no file can carry it', async () => {
+      const team = useTeam();
+      useUser();
+      useCreateApiKey();
+      client.config.currentTeam = team.id;
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--agent',
+        'codex'
+      );
+      expect(await aiGateway(client)).toBe(0);
+
+      // config.toml only names the env var; the key itself is only in the
+      // one-time stdout line.
+      expect(readFileSync(codexConfigPath(), 'utf8')).not.toContain(
+        CREATED_KEY
+      );
+      expect(client.stdout.getFullOutput()).toContain(CREATED_KEY);
     });
   });
 

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -187,88 +187,102 @@ describe('ai-gateway coding-agents setup', () => {
       expect(out.configured[0].action).toBe('created');
     });
 
-    it('configures Codex with the responses wire API and a shell export', async () => {
-      useUser();
-      client.nonInteractive = true;
-      client.setArgv(
-        'ai-gateway',
-        'coding-agents',
-        'setup',
-        '--key',
-        'vck_DummyKey0002',
-        '--agent',
-        'codex'
-      );
+    // Shell rc management is intentionally skipped on Windows.
+    it.skipIf(process.platform === 'win32')(
+      'configures Codex with the responses wire API and a shell export',
+      async () => {
+        useUser();
+        client.nonInteractive = true;
+        client.setArgv(
+          'ai-gateway',
+          'coding-agents',
+          'setup',
+          '--key',
+          'vck_DummyKey0002',
+          '--agent',
+          'codex'
+        );
 
-      const exitCode = await aiGateway(client);
-      expect(exitCode).toBe(0);
+        const exitCode = await aiGateway(client);
+        expect(exitCode).toBe(0);
 
-      const toml = tomlParse(readFileSync(codexConfigPath(), 'utf8')) as any;
-      expect(toml.model_provider).toBe('vercel');
-      // We never pin a default model — only the provider/URL/auth are set up.
-      expect(toml.model).toBeUndefined();
-      expect(toml.model_providers.vercel.base_url).toBe(
-        'https://ai-gateway.vercel.sh/v1'
-      );
-      expect(toml.model_providers.vercel.wire_api).toBe('responses');
-      expect(toml.model_providers.vercel.env_key).toBe('AI_GATEWAY_API_KEY');
+        const toml = tomlParse(readFileSync(codexConfigPath(), 'utf8')) as any;
+        expect(toml.model_provider).toBe('vercel');
+        // We never pin a default model — only the provider/URL/auth are set up.
+        expect(toml.model).toBeUndefined();
+        expect(toml.model_providers.vercel.base_url).toBe(
+          'https://ai-gateway.vercel.sh/v1'
+        );
+        expect(toml.model_providers.vercel.wire_api).toBe('responses');
+        expect(toml.model_providers.vercel.env_key).toBe('AI_GATEWAY_API_KEY');
 
-      const bashrc = readFileSync(bashrcPath(), 'utf8');
-      expect(bashrc).toContain('# >>> vercel ai-gateway >>>');
-      expect(bashrc).toContain("export AI_GATEWAY_API_KEY='vck_DummyKey0002'");
-    });
+        const bashrc = readFileSync(bashrcPath(), 'utf8');
+        expect(bashrc).toContain('# >>> vercel ai-gateway >>>');
+        expect(bashrc).toContain(
+          "export AI_GATEWAY_API_KEY='vck_DummyKey0002'"
+        );
+      }
+    );
 
-    it('appends the rc block a blank line after existing user content', async () => {
-      useUser();
-      client.nonInteractive = true;
-      writeFileSync(bashrcPath(), '# my rc\nalias ll="ls -la"\n');
-      client.setArgv(
-        'ai-gateway',
-        'coding-agents',
-        'setup',
-        '--key',
-        'vck_DummyKey0018',
-        '--agent',
-        'codex'
-      );
+    // Shell rc management is intentionally skipped on Windows.
+    it.skipIf(process.platform === 'win32')(
+      'appends the rc block a blank line after existing user content',
+      async () => {
+        useUser();
+        client.nonInteractive = true;
+        writeFileSync(bashrcPath(), '# my rc\nalias ll="ls -la"\n');
+        client.setArgv(
+          'ai-gateway',
+          'coding-agents',
+          'setup',
+          '--key',
+          'vck_DummyKey0018',
+          '--agent',
+          'codex'
+        );
 
-      expect(await aiGateway(client)).toBe(0);
-      // The exact bytes: the block reads as its own section, never as a tail
-      // of the user's last block.
-      expect(readFileSync(bashrcPath(), 'utf8')).toBe(
-        [
-          '# my rc',
-          'alias ll="ls -la"',
-          '',
-          '# >>> vercel ai-gateway >>>',
-          '# Managed by `vercel ai-gateway coding-agents setup` — safe to remove this block.',
-          "export AI_GATEWAY_API_KEY='vck_DummyKey0018'",
-          '# <<< vercel ai-gateway <<<',
-          '',
-        ].join('\n')
-      );
-    });
+        expect(await aiGateway(client)).toBe(0);
+        // The exact bytes: the block reads as its own section, never as a tail
+        // of the user's last block.
+        expect(readFileSync(bashrcPath(), 'utf8')).toBe(
+          [
+            '# my rc',
+            'alias ll="ls -la"',
+            '',
+            '# >>> vercel ai-gateway >>>',
+            '# Managed by `vercel ai-gateway coding-agents setup` — safe to remove this block.',
+            "export AI_GATEWAY_API_KEY='vck_DummyKey0018'",
+            '# <<< vercel ai-gateway <<<',
+            '',
+          ].join('\n')
+        );
+      }
+    );
 
-    it('shell-escapes a key with special characters', async () => {
-      useUser();
-      client.nonInteractive = true;
-      const trickyKey = 'vck_a$b`c\'d"e';
-      client.setArgv(
-        'ai-gateway',
-        'coding-agents',
-        'setup',
-        '--key',
-        trickyKey,
-        '--agent',
-        'codex'
-      );
+    // Shell rc management is intentionally skipped on Windows.
+    it.skipIf(process.platform === 'win32')(
+      'shell-escapes a key with special characters',
+      async () => {
+        useUser();
+        client.nonInteractive = true;
+        const trickyKey = 'vck_a$b`c\'d"e';
+        client.setArgv(
+          'ai-gateway',
+          'coding-agents',
+          'setup',
+          '--key',
+          trickyKey,
+          '--agent',
+          'codex'
+        );
 
-      expect(await aiGateway(client)).toBe(0);
-      const bashrc = readFileSync(bashrcPath(), 'utf8');
-      expect(bashrc).toContain(
-        `export AI_GATEWAY_API_KEY='vck_a$b\`c'\\''d"e'`
-      );
-    });
+        expect(await aiGateway(client)).toBe(0);
+        const bashrc = readFileSync(bashrcPath(), 'utf8');
+        expect(bashrc).toContain(
+          `export AI_GATEWAY_API_KEY='vck_a$b\`c'\\''d"e'`
+        );
+      }
+    );
 
     it('configures OpenCode with the native vercel provider', async () => {
       useUser();


### PR DESCRIPTION
## Summary
Hardens `ai-gateway coding-agents setup` for non-interactive use and failure cases:

- Non-interactive runs without `--agent`/`--all` now configure only the coding agents detected on the machine (matching the interactive `--yes` behavior) instead of writing configs for every supported agent, and error when nothing is detected.
- When no agent configuration can be written (for example every existing config is unparseable), the command no longer creates an API key, reports `status: "error"` in non-interactive mode, and exits 1. Partially successful runs still exit 0 and list the skipped files.
- On Windows there is no shell startup file to manage: instead of writing a `~/.profile` block that never loads, the command reports which environment variable to set, and prints a newly created key once so it isn't lost (for env-delivered agents it otherwise lives nowhere on disk).

## Tests
- Non-interactive selection: detected-only configuration, and the nothing-detected error payload.
- Failure semantics: exit 1 with `status: "error"` when the only config is malformed (interactive and JSON paths), no API key minted when nothing can be written, and partial success still exits 0 with the skip reported.
- Windows: no shell change planned, the env-var note is emitted, and a created key is printed once.

