### PR TITLE
Preserve queue consumer group names that are already valid

### DIFF
--- a/.changeset/quiet-consumers-smile.md
+++ b/.changeset/quiet-consumers-smile.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Preserve queue consumer names that already contain only valid characters.

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -29,11 +29,17 @@ export type { TriggerEvent, TriggerEventInput };
  * - Other invalid chars → `_XX` (hex code)
  *
  * @example
+ * sanitizeConsumerName('my_func') // => 'my_func'
  * sanitizeConsumerName('api/test.js') // => 'api_Stest_Djs'
  * sanitizeConsumerName('api/users/handler.ts') // => 'api_Susers_Shandler_Dts'
  * sanitizeConsumerName('my_func.ts') // => 'my__func_Dts'
  */
 export function sanitizeConsumerName(functionPath: string): string {
+  if (/^[A-Za-z0-9_-]+$/.test(functionPath)) {
+    // Pass valid names as-is.
+    return functionPath;
+  }
+
   let result = '';
   for (const char of functionPath) {
     if (char === '_') {

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -612,6 +612,10 @@ describe('Lambda', () => {
       );
     });
 
+    it('should preserve already valid names', () => {
+      expect(sanitizeConsumerName('src_my-func_123')).toBe('src_my-func_123');
+    });
+
     it('should escape underscores with __', () => {
       expect(sanitizeConsumerName('src/my_func.js')).toBe('src_Smy__func_Djs');
     });


### PR DESCRIPTION
Currently, `sanitizeConsumerName` would perform sanitizing replacement
on names that are already valid and would turn every `_` into `__`.
This creates unnecessary burden on VQS integrations such as Celery where
an otherwise valid identifier would need to be translated and name
mappings maintained.

Avoid translating valid consumer group identifiers.
