### PR TITLE
Merge generated output routes with build routes

### DIFF
--- a/.changeset/merge-generated-output-routes.md
+++ b/.changeset/merge-generated-output-routes.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Merge routes from generated Build Output config with builder routes when nesting Services V2 output, so framework routes and generated service or custom routes are all preserved.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -2097,14 +2097,19 @@ async function doBuild(
     routesResult.routes,
     detectedExperimentalServicesV2RootRoutes ?? existingConfig?.routes
   );
+  const mergedRoutesWithGeneratedServicesV2Routes =
+    nestExperimentalServicesV2Output
+      ? appendBuildOutputRouteTables(
+          mergedRoutes,
+          detectedExperimentalServicesV2RootRoutes ?? existingConfig?.routes
+        )
+      : mergedRoutes;
 
   // Write out the final `config.json` file based on the
   // user configuration and Builder build results
   const config: BuildOutputConfig = {
     version: 3,
-    routes: nestExperimentalServicesV2Output
-      ? explicitRootRoutes
-      : mergedRoutes,
+    routes: mergedRoutesWithGeneratedServicesV2Routes ?? explicitRootRoutes,
     images: mergedImages,
     wildcard: mergedWildcard,
     overrides: mergedOverrides,

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -2959,6 +2959,7 @@ writeFileSync(
   JSON.stringify({
     version: 3,
     routes: [
+      { src: '/generated/(.*)', dest: '/generated-output/$1' },
       { src: '/backend/(.*)', service: 'backend' },
       { src: '/ui/(.*)', service: 'ui' }
     ],
@@ -3066,6 +3067,7 @@ writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }, nul
       expect(config.routes).toEqual(
         expect.arrayContaining([
           { handle: 'filesystem' },
+          { src: '/generated/(.*)', dest: '/generated-output/$1' },
           { src: '/backend/(.*)', service: 'backend' },
           { src: '/ui/(.*)', service: 'ui' },
           expect.objectContaining({ dest: '/$1', check: true }),


### PR DESCRIPTION
## Summary
- merge generated Build Output config routes with builder routes when nesting Services V2 output
- preserve custom generated routes alongside routes emitted by framework builders
- cover already-built root output plus nested generated Services V2 routes in the CLI unit test

X-ref: https://github.com/vercel/eve/pull/413

## Tests
- pnpm --filter vercel type-check
- pnpm --filter vercel test test/unit/commands/build/index.test.ts -t "already-built generated experimentalServicesV2"