### PR TITLE
Accept marketplace integration terms with a single confirmation

### DIFF
--- a/.changeset/spotty-melons-attack.md
+++ b/.changeset/spotty-melons-attack.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Accept all marketplace integration legal documents (addendum, privacy policy, terms of service) with a single confirmation instead of one prompt each. The links are now listed together, each on its own line, before asking.

--- a/packages/cli/src/util/integration/prompt-for-terms.ts
+++ b/packages/cli/src/util/integration/prompt-for-terms.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import output from '../../output-manager';
 import type Client from '../client';
 import type { AcceptedPolicies, Integration } from './types';
@@ -47,43 +48,56 @@ export async function promptForTermAcceptance(
     return null;
   }
 
-  const addendumAccepted = await client.input.confirm(
-    `Accept Vercel Marketplace End User Addendum? (${MARKETPLACE_ADDENDUM_URL})`,
+  // Collect every legal document the user must agree to so they can be
+  // reviewed together and accepted with a single confirmation.
+  const documents: { label: string; url: string }[] = [
+    {
+      label: 'Vercel Marketplace End User Addendum',
+      url: MARKETPLACE_ADDENDUM_URL,
+    },
+  ];
+  if (integration.privacyDocUri) {
+    documents.push({
+      label: 'Privacy Policy',
+      url: integration.privacyDocUri,
+    });
+  }
+  if (integration.eulaDocUri) {
+    documents.push({
+      label: 'Terms of Service',
+      url: integration.eulaDocUri,
+    });
+  }
+
+  output.print('\n');
+  output.log(
+    `Installing ${chalk.bold(integration.name)} requires accepting the following:`
+  );
+  output.print('\n');
+  for (const { label, url } of documents) {
+    output.print(`  ${chalk.bold(label)}\n`);
+    output.print(`  ${chalk.dim(url)}\n`);
+    output.print('\n');
+  }
+
+  const accepted = await client.input.confirm(
+    'Accept all of the documents listed above?',
     false
   );
-  if (!addendumAccepted) {
-    output.error(
-      'Vercel Marketplace End User Addendum must be accepted to continue.'
-    );
+  if (!accepted) {
+    output.error('All of the listed documents must be accepted to continue.');
     return null;
   }
 
+  const acceptedAt = new Date().toISOString();
   const acceptedPolicies: AcceptedPolicies = {
-    toc: new Date().toISOString(),
+    toc: acceptedAt,
   };
-
   if (integration.privacyDocUri) {
-    const accepted = await client.input.confirm(
-      `Accept privacy policy? (${integration.privacyDocUri})`,
-      false
-    );
-    if (!accepted) {
-      output.error('Privacy policy must be accepted to continue.');
-      return null;
-    }
-    acceptedPolicies.privacy = new Date().toISOString();
+    acceptedPolicies.privacy = acceptedAt;
   }
-
   if (integration.eulaDocUri) {
-    const accepted = await client.input.confirm(
-      `Accept terms of service? (${integration.eulaDocUri})`,
-      false
-    );
-    if (!accepted) {
-      output.error('Terms of service must be accepted to continue.');
-      return null;
-    }
-    acceptedPolicies.eula = new Date().toISOString();
+    acceptedPolicies.eula = acceptedAt;
   }
 
   return acceptedPolicies;

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -346,20 +346,21 @@ describe('integration add (auto-provision)', () => {
       });
     });
 
-    it('should prompt for terms upfront and provision', async () => {
+    it('should list all documents and provision after a single acceptance', async () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // 3-term prompt sequence (upfront, before provisioning)
+      // All legal documents are listed together, each on its own line...
       await expect(client.stderr).toOutput(
-        'Accept Vercel Marketplace End User Addendum?'
+        'Vercel Marketplace End User Addendum'
       );
-      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('Privacy Policy');
+      await expect(client.stderr).toOutput('Terms of Service');
 
-      await expect(client.stderr).toOutput('Accept privacy policy?');
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput('Accept terms of service?');
+      // ...and accepted with a single confirmation.
+      await expect(client.stderr).toOutput(
+        'Accept all of the documents listed above?'
+      );
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -370,17 +371,17 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(0);
     });
 
-    it('should exit with code 1 when addendum declined', async () => {
+    it('should exit with code 1 when the documents are declined', async () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
       await expect(client.stderr).toOutput(
-        'Accept Vercel Marketplace End User Addendum?'
+        'Accept all of the documents listed above?'
       );
       client.stdin.write('n\n');
 
       await expect(client.stderr).toOutput(
-        'Vercel Marketplace End User Addendum must be accepted to continue.'
+        'All of the listed documents must be accepted to continue.'
       );
 
       const exitCode = await exitCodePromise;
@@ -398,49 +399,6 @@ describe('integration add (auto-provision)', () => {
           }),
         ])
       );
-    });
-
-    it('should exit with code 1 when privacy policy declined', async () => {
-      client.setArgv('integration', 'add', 'acme');
-      const exitCodePromise = integrationCommand(client);
-
-      await expect(client.stderr).toOutput(
-        'Accept Vercel Marketplace End User Addendum?'
-      );
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput('Accept privacy policy?');
-      client.stdin.write('n\n');
-
-      await expect(client.stderr).toOutput(
-        'Privacy policy must be accepted to continue.'
-      );
-
-      const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(1);
-    });
-
-    it('should exit with code 1 when terms of service declined', async () => {
-      client.setArgv('integration', 'add', 'acme');
-      const exitCodePromise = integrationCommand(client);
-
-      await expect(client.stderr).toOutput(
-        'Accept Vercel Marketplace End User Addendum?'
-      );
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput('Accept privacy policy?');
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput('Accept terms of service?');
-      client.stdin.write('n\n');
-
-      await expect(client.stderr).toOutput(
-        'Terms of service must be accepted to continue.'
-      );
-
-      const exitCode = await exitCodePromise;
-      expect(exitCode).toEqual(1);
     });
 
     it('should open browser for terms acceptance in non-TTY mode', async () => {
@@ -711,17 +669,20 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(1);
     });
 
-    it('should only prompt for addendum when integration has no privacy or EULA', async () => {
+    it('should only list the addendum when integration has no privacy or EULA', async () => {
       client.setArgv('integration', 'add', 'acme-prepayment');
       const exitCodePromise = integrationCommand(client);
 
-      // Only the addendum prompt should appear (acme-prepayment has no eulaDocUri/privacyDocUri)
+      // Only the addendum is listed (acme-prepayment has no eulaDocUri/privacyDocUri)
       await expect(client.stderr).toOutput(
-        'Accept Vercel Marketplace End User Addendum?'
+        'Vercel Marketplace End User Addendum'
+      );
+      await expect(client.stderr).toOutput(
+        'Accept all of the documents listed above?'
       );
       client.stdin.write('y\n');
 
-      // Should go straight to provisioning without privacy/EULA prompts
+      // Should go straight to provisioning
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned'
       );
@@ -897,14 +858,10 @@ describe('integration add (auto-provision)', () => {
       );
       const exitCodePromise = integrationCommand(client);
 
-      // Upfront term prompts
+      // Upfront term acceptance (single confirmation)
       await expect(client.stderr).toOutput(
-        'Accept Vercel Marketplace End User Addendum?'
+        'Accept all of the documents listed above?'
       );
-      client.stdin.write('y\n');
-      await expect(client.stderr).toOutput('Accept privacy policy?');
-      client.stdin.write('y\n');
-      await expect(client.stderr).toOutput('Accept terms of service?');
       client.stdin.write('y\n');
 
       // After provisioning attempt, falls back to browser
@@ -931,14 +888,10 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // Upfront term prompts
+      // Upfront term acceptance (single confirmation)
       await expect(client.stderr).toOutput(
-        'Accept Vercel Marketplace End User Addendum?'
+        'Accept all of the documents listed above?'
       );
-      client.stdin.write('y\n');
-      await expect(client.stderr).toOutput('Accept privacy policy?');
-      client.stdin.write('y\n');
-      await expect(client.stderr).toOutput('Accept terms of service?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -1472,14 +1425,10 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--plan', 'pro');
       const exitCodePromise = integrationCommand(client);
 
-      // Upfront term prompts
+      // Upfront term acceptance (single confirmation)
       await expect(client.stderr).toOutput(
-        'Accept Vercel Marketplace End User Addendum?'
+        'Accept all of the documents listed above?'
       );
-      client.stdin.write('y\n');
-      await expect(client.stderr).toOutput('Accept privacy policy?');
-      client.stdin.write('y\n');
-      await expect(client.stderr).toOutput('Accept terms of service?');
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(


### PR DESCRIPTION
## What

When a user installs a marketplace integration via the CLI (`vercel integration add <slug>` / `vercel integration accept-terms <slug>`), they previously had to accept each legal document in a separate yes/no prompt — one for the Vercel Marketplace End User Addendum, one for the integration's privacy policy, and one for its terms of service.

This changes the flow to **list all of the documents together** — each link on its own line — and accept them all with a **single confirmation**.

It looks like this:
<img width="1780" height="524" alt="image" src="https://github.com/user-attachments/assets/9b78c4dc-663d-4736-bdcb-4fac75eb906c" />


## Before

```
> Accept Vercel Marketplace End User Addendum? (https://vercel.com/legal/…) (y/N) y
> Accept privacy policy? (https://example.com/privacy) (y/N) y
> Accept terms of service? (https://example.com/eula) (y/N) y
```

## After

```
> Installing Acme requires accepting the following:

  Vercel Marketplace End User Addendum
  https://vercel.com/legal/integration-marketplace-end-users-addendum

  Privacy Policy
  https://example.com/privacy

  Terms of Service
  https://example.com/eula

? Accept all of the documents listed above? (y/N) y
```

Only the documents that apply are listed — integrations without a privacy policy or EULA show just the addendum. The recorded `acceptedPolicies` payload sent to the API is unchanged.

## Notes

- Non-interactive / agent / non-TTY behavior is unchanged (still errors out or falls back to the browser flow).
- Declining now returns a single "All of the listed documents must be accepted to continue." error.

## Testing

- Updated `add-auto-provision` unit tests to assert the new list + single-confirmation flow and lock out the old per-document prompts.
- `add-auto-provision.test.ts` (115) and `accept-terms.test.ts` (5) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)