### PR TITLE
Suggest closest Marketplace integration for unknown slug

### DIFF
--- a/.changeset/suggest-integration-name.md
+++ b/.changeset/suggest-integration-name.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vercel integration add` now suggests the closest Marketplace integration when a slug resolves to a non-marketplace integration (e.g. `turso` → `tursocloud`), and points to `vercel integration discover`. In non-interactive mode it emits a structured `not_found` error with suggested `next` commands instead of dead-ending.

--- a/packages/cli/src/util/integration/fetch-integration.ts
+++ b/packages/cli/src/util/integration/fetch-integration.ts
@@ -7,6 +7,14 @@ import {
   fetchMarketplaceIntegrationsList,
   type IntegrationListItem,
 } from './fetch-marketplace-integrations-list';
+import didYouMean from '../did-you-mean';
+import {
+  buildCommandWithGlobalFlags,
+  outputAgentError,
+  shouldEmitNonInteractiveCommandError,
+} from '../agent-output';
+import { AGENT_REASON } from '../agent-output-constants';
+import { packageName } from '../pkg-name';
 
 export async function fetchIntegration(client: Client, slug: string) {
   return client.fetch<Integration>(`/v2/integrations/integration/${slug}`, {
@@ -88,8 +96,14 @@ export async function resolveAndFetchIntegration(
   let directError: Error | undefined;
   try {
     const integration = await fetchIntegration(client, slug);
-    telemetry.trackCliArgumentIntegration(slug, true);
-    return integration;
+    // A marketplace integration has installable products. A slug can also resolve
+    // to a legacy, non-marketplace integration with no products (e.g. `turso`,
+    // whose Marketplace slug is `tursocloud`). Treat that like "not found" and fall
+    // through to suggest the closest marketplace match instead of dead-ending.
+    if (integration.products?.length) {
+      telemetry.trackCliArgumentIntegration(slug, true);
+      return integration;
+    }
   } catch (error) {
     directError = error as Error;
   }
@@ -121,28 +135,79 @@ export async function resolveAndFetchIntegration(
     return null;
   }
 
-  if (matches.length === 1) {
-    const match = matches[0];
-    if (client.stdin.isTTY === true) {
-      const confirmed = await client.input.confirm(
-        `Install ${chalk.bold(match.name)} (${match.slug})?`,
-        true
+  // Closest match, for "did you mean" copy and the primary suggested command.
+  const suggestion =
+    didYouMean(
+      slug,
+      matches.map(m => m.slug)
+    ) ?? matches[0].slug;
+
+  // Non-interactive (agents/CI): don't silently install a fuzzy match. Surface the
+  // suggestion and the discover command so the caller can decide the next step.
+  if (
+    client.stdin.isTTY !== true ||
+    shouldEmitNonInteractiveCommandError(client)
+  ) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.NOT_FOUND,
+        message: `"${slug}" is not a Marketplace integration.`,
+        hint: `Did you mean "${suggestion}"?`,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              `integration add ${suggestion}`,
+              packageName,
+              { prependGlobalFlags: true }
+            ),
+            when: `Install "${suggestion}" (closest match)`,
+          },
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'integration discover',
+              packageName,
+              { prependGlobalFlags: true }
+            ),
+            when: 'List available marketplace integrations and slugs',
+          },
+        ],
+      },
+      1
+    );
+    if (matches.length === 1) {
+      output.error(
+        `"${slug}" is not a Marketplace integration. Did you mean ${chalk.bold(matches[0].name)} (${chalk.bold(matches[0].slug)})?`
       );
-      if (!confirmed) {
-        telemetry.trackCliArgumentIntegration(slug, false);
-        return null;
-      }
+    } else {
+      output.error(
+        `"${slug}" is not a Marketplace integration. Did you mean one of:\n${matches.map(m => `- ${m.slug}: ${m.description}`).join('\n')}`
+      );
     }
-    slug = match.slug;
-  } else if (client.stdin.isTTY !== true) {
-    output.error(
-      `Found ${matches.length} integrations matching "${slug}". Available integrations:\n${matches.map(m => `- ${m.slug}: ${m.description}`).join('\n')}`
+    output.log(
+      `Run ${chalk.cyan('vercel integration discover')} to list all integrations.`
     );
     telemetry.trackCliArgumentIntegration(slug, false);
     return null;
+  }
+
+  if (matches.length === 1) {
+    const match = matches[0];
+    const confirmed = await client.input.confirm(
+      `Did you mean ${chalk.bold(match.name)} (${chalk.bold(match.slug)})? Install it?`,
+      true
+    );
+    if (!confirmed) {
+      telemetry.trackCliArgumentIntegration(slug, false);
+      return null;
+    }
+    slug = match.slug;
   } else {
     slug = await client.input.select({
-      message: `Found ${matches.length} integrations matching "${slug}". Pick one to install:`,
+      message: `"${slug}" is not an exact match. Did you mean one of these? Pick one to install:`,
       choices: matches.map(m => ({
         name: `${m.name} (${m.slug})${m.description ? ` - ${m.description}` : ''}`,
         value: m.slug,

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -255,6 +255,28 @@ const integrations: Record<string, Integration> = {
     name: 'Acme Integration External',
     slug: 'acme-external',
   },
+  // Legacy, non-marketplace integration (no products) whose Marketplace
+  // counterpart is `tursocloud`. Used to test "did you mean" suggestions.
+  turso: {
+    id: 'turso',
+    name: 'Turso',
+    slug: 'turso',
+  },
+  tursocloud: {
+    id: 'tursocloud',
+    name: 'Turso Cloud',
+    slug: 'tursocloud',
+    products: [
+      {
+        id: 'tursocloud-product',
+        name: 'Turso Cloud',
+        slug: 'tursocloud',
+        type: 'storage',
+        shortDescription: 'Serverless SQLite database',
+        metadataSchema: metadataSchema1,
+      },
+    ],
+  },
   'acme-no-products': {
     id: 'acme-no-products',
     name: 'Acme Integration No Products',
@@ -897,6 +919,15 @@ const discoverIntegrations = [
     isMarketplace: false,
     canInstall: true,
     products: [{ slug: 'connect', name: 'Connect' }],
+  },
+  {
+    slug: 'tursocloud',
+    name: 'Turso Cloud',
+    shortDescription: 'Serverless SQLite database',
+    tagIds: ['tag_databases'],
+    isMarketplace: true,
+    canInstall: true,
+    products: [{ slug: 'tursocloud', name: 'Turso Cloud' }],
   },
 ];
 

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -1568,13 +1568,24 @@ describe('integration add (auto-provision)', () => {
       );
     });
 
-    it('should error when integration has no products', async () => {
-      client.setArgv('integration', 'add', 'acme-no-products');
-      const exitCode = await integrationCommand(client);
-      expect(exitCode).toEqual(1);
+    it('should suggest the closest marketplace match for a non-marketplace slug', async () => {
+      // `turso` resolves to a legacy, non-marketplace integration (no products);
+      // its Marketplace counterpart is `tursocloud`.
+      useIntegrationDiscover();
+      client.setArgv('integration', 'add', 'turso');
+      const exitCodePromise = integrationCommand(client);
+
       await expect(client.stderr).toOutput(
-        'Error: Integration "acme-no-products" is not a Marketplace integration'
+        'Did you mean Turso Cloud (tursocloud)? Install it?'
       );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Turso Cloud successfully provisioned'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
     });
 
     it('should error when fetchInstallations fails', async () => {
@@ -1636,12 +1647,38 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(1);
     });
 
-    it('should error when integration is external', async () => {
+    it('emits structured JSON with a suggestion when non-interactive', async () => {
+      vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code ?? 0}`);
+      }) as () => never);
+      useIntegrationDiscover();
+      client.nonInteractive = true;
+      client.setArgv(
+        'integration',
+        'add',
+        'turso',
+        '--non-interactive',
+        '--cwd',
+        '/tmp/example'
+      );
+      await expect(integrationCommand(client)).rejects.toThrow('exit:1');
+      const payload = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'not_found',
+        hint: 'Did you mean "tursocloud"?',
+      });
+      expect(payload.next?.[0]?.command).toMatch(/integration add tursocloud$/);
+      expect(payload.next?.[1]?.command).toMatch(/integration discover$/);
+    });
+
+    it('should error when a non-marketplace slug has no close match', async () => {
+      useIntegrationDiscover();
       client.setArgv('integration', 'add', 'acme-external');
       const exitCode = await integrationCommand(client);
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput(
-        'Error: Integration "acme-external" is not a Marketplace integration'
+        'No integration found matching "acme-external"'
       );
     });
   });
@@ -2737,7 +2774,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'postgres');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Pick one to install');
+      await expect(client.stderr).toOutput('Did you mean one of these?');
       client.stdin.write('\n');
 
       await expect(client.stderr).toOutput(
@@ -2752,7 +2789,9 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'Neon');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Install Neon Postgres (neon)?');
+      await expect(client.stderr).toOutput(
+        'Did you mean Neon Postgres (neon)? Install it?'
+      );
       client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
@@ -2775,14 +2814,12 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(1);
     });
 
-    it('should list matches in non-TTY mode', async () => {
+    it('should list matches (without installing) in non-TTY mode', async () => {
       (client.stdin as any).isTTY = false;
       client.setArgv('integration', 'add', 'postgres');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput(
-        'Found 2 integrations matching "postgres"'
-      );
+      await expect(client.stderr).toOutput('Did you mean one of:');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(1);
@@ -2794,7 +2831,7 @@ describe('integration add (auto-provision)', () => {
 
       // "queue" tag uniquely matches acme-two-products/acme-b (compound slug)
       await expect(client.stderr).toOutput(
-        'Install Acme Product B (acme-two-products/acme-b)?'
+        'Did you mean Acme Product B (acme-two-products/acme-b)? Install it?'
       );
       client.stdin.write('y\n');
 

--- a/packages/cli/test/unit/commands/integration/discover.test.ts
+++ b/packages/cli/test/unit/commands/integration/discover.test.ts
@@ -67,6 +67,13 @@ describe('integration', () => {
             description: 'The Acme B product',
             tags: ['Storage', 'Queue'],
           },
+          {
+            name: 'Turso Cloud',
+            slug: 'tursocloud',
+            provider: 'Turso Cloud',
+            description: 'Serverless SQLite database',
+            tags: ['Storage'],
+          },
         ],
       });
     });
@@ -136,6 +143,13 @@ describe('integration', () => {
             provider: 'Acme Integration Two Products',
             description: 'The Acme B product',
             tags: ['databases', 'Queue'],
+          },
+          {
+            name: 'Turso Cloud',
+            slug: 'tursocloud',
+            provider: 'Turso Cloud',
+            description: 'Serverless SQLite database',
+            tags: ['databases'],
           },
         ],
       });
@@ -236,7 +250,7 @@ describe('integration', () => {
         expect(exitCode, 'exit code for "integrationCommand"').toEqual(0);
 
         const output = JSON.parse(client.stdout.getFullOutput());
-        expect(output.products).toHaveLength(5);
+        expect(output.products).toHaveLength(6);
       });
     });
 


### PR DESCRIPTION
`vercel integration add <slug>` now suggests the closest Marketplace match (e.g. `turso` → `tursocloud`) and points to `vercel integration discover` instead of dead-ending when a slug resolves to a non-marketplace integration. Non-interactive runs emit a structured `not_found` error with suggested `next` commands so agents can follow up.