### PR TITLE
[cli] coding-agents setup: warn before breaking the Codex desktop app

### DIFF
--- a/.changeset/ai-gateway-coding-agents-desktop-consent.md
+++ b/.changeset/ai-gateway-coding-agents-desktop-consent.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`ai-gateway coding-agents setup` now detects the Codex desktop app and asks for consent before configuring Codex, since the desktop app cannot use custom model providers and stops working when one is set (the Codex CLI keeps working). Non-interactive and `--yes` runs configure Codex only when it is explicitly requested with `--agent`/`--all`; JSON output gains a `warnings` array and a `requires_consent` skip reason, and a run refused for lack of consent exits 1 with a self-contained `requires_consent` error payload (structured warnings, skip entries, and a runnable `next[]` command). A declined agent's configuration is left untouched.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
@@ -43,6 +43,13 @@ import {
   printStatus,
   printWarning,
 } from '../../util/ai-gateway/coding-agents/render';
+import {
+  collectAgentWarnings,
+  formatWarningMessage,
+  groupWarningsByAgent,
+  printAgentWarning,
+  promptAgentConsent,
+} from '../../util/ai-gateway/coding-agents/consent';
 import { runMachine } from '../../util/ai-gateway/coding-agents/machine';
 import { KEY_PLACEHOLDER } from '../../util/ai-gateway/coding-agents/gateway';
 import {
@@ -53,6 +60,8 @@ import {
   outputAgentError,
   shouldEmitNonInteractiveCommandError,
 } from '../../util/agent-output';
+import { packageName } from '../../util/pkg-name';
+import { stripSensitiveAuthArgs } from '../../util/redact-args';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { setupSubcommand } from './command';
 import { AiGatewayCodingAgentsSetupTelemetryClient } from '../../util/telemetry/commands/ai-gateway/coding-agents-setup';
@@ -206,6 +215,67 @@ export default async function codingAgentsSetup(
     }
   }
 
+  // Consent comes first: a user who declines must be able to bail before the
+  // key interview asks a single question or ensureTeam touches the network.
+  let agents = selected;
+  const agentWarnings = await collectAgentWarnings(selected, {
+    home,
+    overrides,
+  });
+  const machineWarnings = agentWarnings.map(e => ({
+    agent: e.agent.id,
+    code: e.warning.code,
+    message: formatWarningMessage(e.warning),
+  }));
+  const consentSkipped: Array<{
+    target: string;
+    reason: string;
+    message: string;
+  }> = [];
+  const previewKey = providedKey ?? KEY_PLACEHOLDER;
+  if (agentWarnings.length > 0) {
+    const explicit = Boolean((agentFlags && agentFlags.length > 0) || all);
+    if (canPrompt && !yes && !dryRun) {
+      const declined = await promptAgentConsent(client, agentWarnings);
+      if (declined.size > 0) {
+        agents = agents.filter(a => !declined.has(a.id));
+        for (const agent of selected) {
+          if (declined.has(agent.id)) {
+            printStatus(
+              `Skipped ${agent.displayName} — its configuration was left untouched.`
+            );
+          }
+        }
+        if (agents.length === 0) {
+          printStatus('Nothing to configure. No files were changed.');
+          return 0;
+        }
+      }
+    } else if (explicit || (canPrompt && !yes && dryRun)) {
+      for (const { warning } of agentWarnings) {
+        printAgentWarning(warning);
+      }
+      // No confirm follows here; keep the block separated from what's next.
+      output.print('\n');
+    } else {
+      for (const [agent, warnings] of groupWarningsByAgent(agentWarnings)) {
+        const message = `${warnings.map(formatWarningMessage).join(' ')} Pass --agent ${agent.id} to configure it anyway.`;
+        consentSkipped.push({
+          target: agent.id,
+          reason: AGENT_REASON.REQUIRES_CONSENT,
+          message,
+        });
+        printWarning(message);
+      }
+      agents = agents.filter(a => !consentSkipped.some(s => s.target === a.id));
+      if (agents.length === 0 && !dryRun) {
+        // Everything was consent-skipped: without explicit --agent/--all
+        // consent there is nothing this run may write.
+        return failConsent(client, machine, machineWarnings, consentSkipped);
+      }
+    }
+  }
+
   // With no --key we create one. Resolve the owning team first — it decides
   // where the key lives (and can fail) — then collect name, quota, and expiry.
   const willCreate = !providedKey;
@@ -213,7 +283,9 @@ export default async function codingAgentsSetup(
   let keyBudget = budget;
   let keyRefresh = refreshPeriod;
   let keyExpiresAt = flagExpiresAt;
-  if (willCreate && (!dryRun || canPrompt)) {
+  // With every agent consent-skipped the run can only end as a no-op, so the
+  // key interview (and its team/scope requirement) has nothing to set up.
+  if (willCreate && agents.length > 0 && (!dryRun || canPrompt)) {
     const promptCreate = canPrompt && !yes;
 
     const teamError = await ensureTeam(client, {
@@ -246,7 +318,7 @@ export default async function codingAgentsSetup(
   }
 
   if (canPrompt && !yes) {
-    const missing = selected.filter(
+    const missing = agents.filter(
       a =>
         !overrides[a.id] &&
         !existsSync(dirname(a.configPath({ apiKey: '', home })))
@@ -274,9 +346,7 @@ export default async function codingAgentsSetup(
       }
     }
   }
-  const previewKey = providedKey ?? KEY_PLACEHOLDER;
-
-  const previewPlan = await buildSetupPlan(selected, {
+  const previewPlan = await buildSetupPlan(agents, {
     apiKey: previewKey,
     home,
     useKeychain,
@@ -293,8 +363,10 @@ export default async function codingAgentsSetup(
   if (machine) {
     return runMachine({
       client,
-      selected,
+      selected: agents,
       unsupported,
+      warnings: machineWarnings,
+      consentSkipped,
       previewPlan,
       dryRun: Boolean(dryRun),
       backup: !noBackup,
@@ -312,13 +384,25 @@ export default async function codingAgentsSetup(
       shellRcOverride,
       home,
       alreadyConfigured,
-      reconfigure: Boolean(reconfigure),
+      // With nothing consented there is nothing to rotate or reconfigure.
+      reconfigure: Boolean(reconfigure) && agents.length > 0,
     });
   }
 
   // Already wired up: instead of a dead-end no-op, offer to rotate the key or
   // reconfigure (e.g. a rotated/expired key, or a different team).
   if (alreadyConfigured) {
+    const skippedSome = agents.length < selected.length;
+    // Every selected agent was consent-skipped during a dry run: the plan is
+    // empty because nothing was inspected, not because everything is set up.
+    if (dryRun && agents.length === 0 && consentSkipped.length > 0) {
+      printStatus(
+        `All selected agents need explicit consent (see the warnings above) — a real run would fail. Pass ${consentSkipped
+          .map(s => `--agent ${s.target}`)
+          .join(' ')} (or --all) to consent. No files would be changed.`
+      );
+      return 0;
+    }
     // A provided key on a Keychain setup: refresh the stored secret in place,
     // even though the config files themselves don't change.
     if (!dryRun && useKeychain && providedKey) {
@@ -328,15 +412,18 @@ export default async function codingAgentsSetup(
         );
         return 1;
       }
-      output.log(
-        'All selected agents are already configured; updated the macOS Keychain with the provided key.'
+      printStatus(
+        agents.length === 0
+          ? 'The existing configuration already uses the AI Gateway; updated the macOS Keychain with the provided key.'
+          : `${skippedSome ? 'The remaining' : 'All selected'} agents are already configured; updated the macOS Keychain with the provided key.`
       );
       printKey(providedKey, { keychain: true });
       return 0;
     }
     // Otherwise offer to rotate/reconfigure. `--reconfigure` skips the prompt.
-    let doReconfigure = Boolean(reconfigure);
-    if (!doReconfigure && canPrompt && !yes && !dryRun) {
+    // With nothing consented there is nothing to rotate or reconfigure.
+    let doReconfigure = Boolean(reconfigure) && agents.length > 0;
+    if (!doReconfigure && agents.length > 0 && canPrompt && !yes && !dryRun) {
       doReconfigure = await client.input.confirm(
         'These agents are already configured for the AI Gateway. Reconfigure them?',
         false
@@ -344,7 +431,9 @@ export default async function codingAgentsSetup(
     }
     if (!doReconfigure) {
       printStatus(
-        'All selected agents are already configured for the AI Gateway.'
+        agents.length === 0
+          ? 'Every selected agent needs explicit consent (see the warnings above); the existing configuration already uses the AI Gateway.'
+          : `${skippedSome ? 'The remaining' : 'All selected'} agents are already configured for the AI Gateway.`
       );
       if (providedKey) {
         printKey(providedKey);
@@ -356,7 +445,7 @@ export default async function codingAgentsSetup(
 
   // Resolved state first, then the mutation preview, then the confirm.
   printResolvedState({
-    selected,
+    selected: agents,
     willCreate,
     name: keyName,
     budget: keyBudget,
@@ -421,7 +510,7 @@ export default async function codingAgentsSetup(
     useKeychain = false;
   }
 
-  const applyPlanResult = await buildSetupPlan(selected, {
+  const applyPlanResult = await buildSetupPlan(agents, {
     apiKey: keySource.key,
     home,
     useKeychain,
@@ -477,6 +566,67 @@ export default async function codingAgentsSetup(
     client.stdout.write(`${keySource.key}\n`);
   }
   return 0;
+}
+
+/**
+ * The original invocation with the consent flags appended, so following it
+ * repeats the SAME run (same key intent, budget, expiry, config paths…) plus
+ * consent — not a materially different mutation. The `--key` value is
+ * redacted: suggested commands must never carry key material.
+ */
+function buildConsentCommand(argv: string[], consentFlags: string): string {
+  const args = stripSensitiveAuthArgs(argv.slice(2));
+  const redacted: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--key') {
+      redacted.push(arg, '<key>');
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) i++;
+      continue;
+    }
+    if (arg.startsWith('--key=')) {
+      redacted.push('--key=<key>');
+      continue;
+    }
+    redacted.push(arg);
+  }
+  return `${packageName} ${redacted.join(' ')} ${consentFlags}`.trim();
+}
+
+/**
+ * Every selected agent needs consent the run doesn't have. The JSON payload
+ * must be self-contained: the human warnings went to stderr, so the structured
+ * warnings, the skip entries, and a runnable consent command travel with it.
+ * `--yes` cannot grant consent, hence a reason distinct from
+ * `confirmation_required` (which agents fix by re-running with --yes).
+ */
+function failConsent(
+  client: Client,
+  machine: boolean,
+  warnings: Array<{ agent: string; code: string; message: string }>,
+  skipped: Array<{ target: string; reason: string; message: string }>
+): number {
+  const consentFlags = skipped.map(s => `--agent ${s.target}`).join(' ');
+  const message = `All selected agents need explicit consent to configure. Pass ${consentFlags} (or --all) to consent, or run interactively without --yes.`;
+  if (machine) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.REQUIRES_CONSENT,
+          message,
+          warnings,
+          skipped,
+          next: [{ command: buildConsentCommand(client.argv, consentFlags) }],
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    output.error(message);
+  }
+  return 1;
 }
 
 function failValidation(

--- a/packages/cli/src/util/agent-output-constants.ts
+++ b/packages/cli/src/util/agent-output-constants.ts
@@ -81,6 +81,12 @@ export const AGENT_REASON = {
   INVALID_BUDGET: 'invalid_budget',
   INVALID_REFRESH_PERIOD: 'invalid_refresh_period',
   INVALID_EXPIRATION: 'invalid_expiration',
+  /**
+   * Every selected agent needs explicit `--agent`/`--all` consent (see the
+   * payload's skipped[]). `--yes` does not grant it, so this is deliberately
+   * not `confirmation_required` — re-running with --yes would loop forever.
+   */
+  REQUIRES_CONSENT: 'requires_consent',
   // Redirects
   REDIRECT_NOT_FOUND: 'redirect_not_found',
   VERSION_NOT_FOUND: 'version_not_found',

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
@@ -1,7 +1,11 @@
 import { join } from 'node:path';
-import type { CodingAgent } from '../types';
+import type { AgentWarning, CodingAgent } from '../types';
 import { mergeToml, pathExists } from '../config-files';
+import { isMacAppInstalled } from '../desktop-apps';
 import { GATEWAY_OPENAI_BASE_URL, GATEWAY_API_KEY_ENV } from '../gateway';
+
+/** The Codex desktop app shares `~/.codex/config.toml` with the CLI. */
+const CODEX_DESKTOP_APP = 'Codex.app';
 
 /**
  * Codex reads `~/.codex/config.toml`. We add a `vercel` model provider pointing
@@ -27,6 +31,24 @@ export const codex: CodingAgent = {
 
   async detect(home) {
     return pathExists(codexDir(home));
+  },
+
+  async warnings({ home, overrides }) {
+    const warnings: AgentWarning[] = [];
+    if (isMacAppInstalled(CODEX_DESKTOP_APP, home)) {
+      const configPath = this.configPath({ apiKey: '', home, overrides });
+      warnings.push({
+        code: 'desktop_app_breaks',
+        impact: 'The Codex desktop app will stop working.',
+        why: [
+          'The desktop app is installed and cannot use custom model providers, and connecting sets model_provider = "vercel" in the config.toml the app shares with the CLI.',
+          'The Codex CLI keeps working.',
+        ],
+        undo: `remove the model_provider line from ${configPath}`,
+        confirm: 'Configure Codex anyway?',
+      });
+    }
+    return warnings;
   },
 
   configPath(ctx) {

--- a/packages/cli/src/util/ai-gateway/coding-agents/consent.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/consent.ts
@@ -1,0 +1,78 @@
+import chalk from 'chalk';
+import type Client from '../../client';
+import output from '../../../output-manager';
+import { printWarning } from './render';
+import type { AgentWarning, CodingAgent, WarningContext } from './types';
+
+export interface AgentWarningEntry {
+  agent: CodingAgent;
+  warning: AgentWarning;
+}
+
+export async function collectAgentWarnings(
+  agents: CodingAgent[],
+  ctx: WarningContext
+): Promise<AgentWarningEntry[]> {
+  const entries: AgentWarningEntry[] = [];
+  for (const agent of agents) {
+    for (const warning of (await agent.warnings?.(ctx)) ?? []) {
+      entries.push({ agent, warning });
+    }
+  }
+  return entries;
+}
+
+/** One paragraph for JSON payloads and skip hints; human output uses printAgentWarning. */
+export function formatWarningMessage(warning: AgentWarning): string {
+  return `${warning.impact} ${warning.why.join(' ')} To undo, ${warning.undo}.`;
+}
+
+/** Impact on the `!` gutter row; cause lines and undo dimmed behind the gutter. */
+export function printAgentWarning(warning: AgentWarning): void {
+  output.print('\n');
+  printWarning(warning.impact);
+  for (const line of warning.why) {
+    output.print(chalk.dim(`  ${line}\n`));
+  }
+  output.print(chalk.dim(`  To undo: ${warning.undo}.\n`));
+}
+
+/** Warnings grouped per agent, preserving entry order. */
+export function groupWarningsByAgent(
+  entries: AgentWarningEntry[]
+): Map<CodingAgent, AgentWarning[]> {
+  const grouped = new Map<CodingAgent, AgentWarning[]>();
+  for (const { agent, warning } of entries) {
+    const list = grouped.get(agent) ?? [];
+    list.push(warning);
+    grouped.set(agent, list);
+  }
+  return grouped;
+}
+
+export async function promptAgentConsent(
+  client: Client,
+  entries: AgentWarningEntry[]
+): Promise<Set<string>> {
+  const declined = new Set<string>();
+  // One decision per agent: all of its warnings first, then a single
+  // confirm — never a second question that could contradict the first.
+  for (const [agent, warnings] of groupWarningsByAgent(entries)) {
+    for (const warning of warnings) {
+      printAgentWarning(warning);
+    }
+    const confirm =
+      warnings.length === 1
+        ? warnings[0].confirm
+        : `Configure ${agent.displayName} anyway?`;
+    // Indented under the warnings it answers, like other child prompts.
+    const ok = await client.input.confirm(
+      `${chalk.dim('↳')} ${confirm}`,
+      false
+    );
+    if (!ok) {
+      declined.add(agent.id);
+    }
+  }
+  return declined;
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/desktop-apps.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/desktop-apps.ts
@@ -1,0 +1,18 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Shared helper for detecting a desktop app that shares a coding agent's config
+ * files and can break when the CLI rewrites them. A missed detection only means
+ * no warning, so plain path checks of the standard install locations are enough.
+ * Which bundle to look for lives in each agent's own file.
+ */
+export function isMacAppInstalled(bundleName: string, home: string): boolean {
+  if (process.platform !== 'darwin') {
+    return false;
+  }
+  return (
+    existsSync(join('/Applications', bundleName)) ||
+    existsSync(join(home, 'Applications', bundleName))
+  );
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -12,6 +12,8 @@ export async function runMachine(args: {
   client: Client;
   selected: CodingAgent[];
   unsupported: string[];
+  warnings: Array<{ agent: string; code: string; message: string }>;
+  consentSkipped: Array<{ target: string; reason: string; message: string }>;
   previewPlan: SetupPlan;
   dryRun: boolean;
   backup: boolean;
@@ -40,6 +42,7 @@ export async function runMachine(args: {
       message: UNSUPPORTED_AGENTS[id],
     });
   }
+  skipped.push(...args.consentSkipped);
 
   if (dryRun) {
     client.stdout.write(
@@ -60,6 +63,7 @@ export async function runMachine(args: {
                   : c.status,
           })),
           skipped,
+          warnings: args.warnings,
         },
         null,
         2
@@ -71,8 +75,14 @@ export async function runMachine(args: {
   // Idempotent by default: if nothing needs writing and we weren't asked to
   // reconfigure, report the no-op without minting a fresh key.
   if (args.alreadyConfigured && !args.reconfigure) {
+    const consentSkips = args.consentSkipped.length > 0;
+    // '--reconfigure' is dead advice for a consent-skipped agent (skipped[]
+    // carries the '--agent <id>' hint), so only name the agents this run
+    // actually verified.
     let message =
-      'All selected agents are already configured for the AI Gateway. Pass --reconfigure to rotate the key.';
+      selected.length > 0
+        ? `${consentSkips ? 'The remaining' : 'All selected'} agents are already configured for the AI Gateway. Pass --reconfigure to rotate the key.`
+        : 'Every selected agent needs explicit consent (see skipped); the existing configuration already uses the AI Gateway.';
     // A provided key on a Keychain setup: refresh the stored secret in place,
     // mirroring the interactive flow (the config files never carry the key).
     if (args.useKeychain && args.keySource) {
@@ -84,6 +94,8 @@ export async function runMachine(args: {
               reason: 'keychain_error',
               message:
                 'Failed to update the key in the macOS Keychain. Re-run with --no-keychain to write it to the config files instead.',
+              skipped,
+              warnings: args.warnings,
             },
             null,
             2
@@ -92,7 +104,9 @@ export async function runMachine(args: {
         return 1;
       }
       message =
-        'All selected agents are already configured; updated the macOS Keychain with the provided key.';
+        selected.length > 0
+          ? `${consentSkips ? 'The remaining' : 'All selected'} agents are already configured; updated the macOS Keychain with the provided key.`
+          : 'The existing configuration already uses the AI Gateway; updated the macOS Keychain with the provided key.';
     }
     client.stdout.write(
       `${JSON.stringify(
@@ -101,7 +115,8 @@ export async function runMachine(args: {
           reason: 'already_configured',
           message,
           configured: [],
-          skipped: [],
+          skipped,
+          warnings: args.warnings,
         },
         null,
         2
@@ -122,6 +137,7 @@ export async function runMachine(args: {
           reason: 'unparseable_config',
           message: "Couldn't write any agent configurations.",
           skipped,
+          warnings: args.warnings,
         },
         null,
         2
@@ -173,6 +189,7 @@ export async function runMachine(args: {
           backup: r.backupPath,
         })),
         skipped,
+        warnings: args.warnings,
         notes: finalPlan.notes.flatMap(n =>
           n.notes.map(line => `${n.displayName}: ${line}`)
         ),

--- a/packages/cli/src/util/ai-gateway/coding-agents/types.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/types.ts
@@ -33,23 +33,14 @@ export interface AgentPlan {
  */
 export interface WarningContext {
   home: string;
-  /** `--agent-config` overrides, so warnings can name the exact file they mean. */
   overrides?: Record<string, string>;
 }
 
 export interface AgentWarning {
-  /** Stable machine-readable id for JSON payloads, e.g. 'desktop_app_breaks'. */
   code: string;
-  /** What the user loses by consenting — the headline, e.g. 'The Codex desktop app will stop working.' */
   impact: string;
-  /** Why connecting causes that impact: full sentences, one rendered line each. */
   why: string[];
-  /**
-   * How to revert after connecting, phrased to follow 'To undo,'. No trailing
-   * period. Name the resolved file path, matching what the receipts print.
-   */
   undo: string;
-  /** The consent question, e.g. 'Configure Codex anyway?'. */
   confirm: string;
 }
 
@@ -58,9 +49,7 @@ export interface CodingAgent {
   displayName: string;
   experimental?: boolean;
   detect(home: string): Promise<boolean>;
-  /** Resolved config-file path: override > native env var > home default. */
   configPath(ctx: SetupContext): string;
   buildPlan(ctx: SetupContext): AgentPlan;
-  /** Pre-flight warnings that need explicit consent before configuring. */
   warnings?(ctx: WarningContext): Promise<AgentWarning[]>;
 }

--- a/packages/cli/src/util/ai-gateway/coding-agents/types.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/types.ts
@@ -27,6 +27,32 @@ export interface AgentPlan {
   notes: string[];
 }
 
+/**
+ * Context available before a key exists or any setup question has been asked —
+ * warnings run first so the user can bail before the key interview.
+ */
+export interface WarningContext {
+  home: string;
+  /** `--agent-config` overrides, so warnings can name the exact file they mean. */
+  overrides?: Record<string, string>;
+}
+
+export interface AgentWarning {
+  /** Stable machine-readable id for JSON payloads, e.g. 'desktop_app_breaks'. */
+  code: string;
+  /** What the user loses by consenting — the headline, e.g. 'The Codex desktop app will stop working.' */
+  impact: string;
+  /** Why connecting causes that impact: full sentences, one rendered line each. */
+  why: string[];
+  /**
+   * How to revert after connecting, phrased to follow 'To undo,'. No trailing
+   * period. Name the resolved file path, matching what the receipts print.
+   */
+  undo: string;
+  /** The consent question, e.g. 'Configure Codex anyway?'. */
+  confirm: string;
+}
+
 export interface CodingAgent {
   id: string;
   displayName: string;
@@ -35,4 +61,6 @@ export interface CodingAgent {
   /** Resolved config-file path: override > native env var > home default. */
   configPath(ctx: SetupContext): string;
   buildPlan(ctx: SetupContext): AgentPlan;
+  /** Pre-flight warnings that need explicit consent before configuring. */
+  warnings?(ctx: WarningContext): Promise<AgentWarning[]>;
 }

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -755,19 +755,23 @@ describe('ai-gateway coding-agents setup', () => {
       expect(claude?.next).toContain(secret);
     });
 
-    it('reads the Codex env key from the Keychain instead of the config', async () => {
-      const secret = 'vck_KeychainSecret321';
-      const plan = await buildSetupPlan([codex], {
-        apiKey: secret,
-        home,
-        useKeychain: true,
-      });
+    // Keychain-backed shell exports only exist on macOS (no shell rc on Windows).
+    it.skipIf(process.platform === 'win32')(
+      'reads the Codex env key from the Keychain instead of the config',
+      async () => {
+        const secret = 'vck_KeychainSecret321';
+        const plan = await buildSetupPlan([codex], {
+          apiKey: secret,
+          home,
+          useKeychain: true,
+        });
 
-      const shell = plan.changes.find(c => c.format === 'shell');
-      expect(shell?.next).toContain('security find-generic-password');
-      expect(shell?.next).toContain('export AI_GATEWAY_API_KEY=');
-      expect(shell?.next).not.toContain(secret);
-    });
+        const shell = plan.changes.find(c => c.format === 'shell');
+        expect(shell?.next).toContain('security find-generic-password');
+        expect(shell?.next).toContain('export AI_GATEWAY_API_KEY=');
+        expect(shell?.next).not.toContain(secret);
+      }
+    );
   });
 
   describe('key options', () => {
@@ -2399,29 +2403,35 @@ describe('ai-gateway coding-agents setup', () => {
       ).toBe(true);
     });
 
-    it('shares a single deduped env block across multiple agents', async () => {
-      const plan = await buildSetupPlan([claudeCode, codex, opencode], {
-        apiKey: 'vck_multi',
-        home,
-        useKeychain: true,
-      });
+    // Shell env blocks only exist off Windows (shell rc management is disabled there).
+    it.skipIf(process.platform === 'win32')(
+      'shares a single deduped env block across multiple agents',
+      async () => {
+        const plan = await buildSetupPlan([claudeCode, codex, opencode], {
+          apiKey: 'vck_multi',
+          home,
+          useKeychain: true,
+        });
 
-      // One config file per agent.
-      expect(plan.changes.some(c => c.label === 'Claude Code settings')).toBe(
-        true
-      );
-      expect(plan.changes.some(c => c.label === 'Codex config')).toBe(true);
-      expect(plan.changes.some(c => c.label === 'OpenCode config')).toBe(true);
+        // One config file per agent.
+        expect(plan.changes.some(c => c.label === 'Claude Code settings')).toBe(
+          true
+        );
+        expect(plan.changes.some(c => c.label === 'Codex config')).toBe(true);
+        expect(plan.changes.some(c => c.label === 'OpenCode config')).toBe(
+          true
+        );
 
-      // A single shared shell block. Codex and OpenCode both want
-      // AI_GATEWAY_API_KEY — it's exported once (deduped) — and Claude Code
-      // contributes ANTHROPIC_AUTH_TOKEN.
-      const shells = plan.changes.filter(c => c.format === 'shell');
-      expect(shells).toHaveLength(1);
-      const gateway = shells[0].next?.match(/AI_GATEWAY_API_KEY/g) ?? [];
-      expect(gateway).toHaveLength(1);
-      expect(shells[0].next).toContain('ANTHROPIC_AUTH_TOKEN');
-    });
+        // A single shared shell block. Codex and OpenCode both want
+        // AI_GATEWAY_API_KEY — it's exported once (deduped) — and Claude Code
+        // contributes ANTHROPIC_AUTH_TOKEN.
+        const shells = plan.changes.filter(c => c.format === 'shell');
+        expect(shells).toHaveLength(1);
+        const gateway = shells[0].next?.match(/AI_GATEWAY_API_KEY/g) ?? [];
+        expect(gateway).toHaveLength(1);
+        expect(shells[0].next).toContain('ANTHROPIC_AUTH_TOKEN');
+      }
+    );
 
     it('skips a malformed Codex config instead of clobbering it', async () => {
       mkdirSync(join(home, '.codex'), { recursive: true });

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -66,6 +66,15 @@ vi.mock(
   }
 );
 
+// Desktop-app detection defaults to "not installed" so a developer's real
+// /Applications never leaks warnings into unrelated tests.
+const desktopState = vi.hoisted(() => ({ codex: false }));
+
+vi.mock('../../../../src/util/ai-gateway/coding-agents/desktop-apps', () => ({
+  isMacAppInstalled: (bundleName: string) =>
+    bundleName === 'Codex.app' ? desktopState.codex : false,
+}));
+
 const CREATED_KEY = 'vck_CreatedSecretKey1234';
 const mockApiKeyResponse = {
   apiKeyString: CREATED_KEY,
@@ -111,6 +120,7 @@ beforeEach(() => {
   keychainState.available = undefined;
   keychainState.stored.length = 0;
   keychainState.storeResult = true;
+  desktopState.codex = false;
   home = mkdtempSync(join(tmpdir(), 'vc-setup-agents-'));
   savedEnv = {
     HOME: process.env.HOME,
@@ -1896,6 +1906,390 @@ describe('ai-gateway coding-agents setup', () => {
         CREATED_KEY
       );
       expect(client.stdout.getFullOutput()).toContain(CREATED_KEY);
+    });
+  });
+
+  describe('desktop-app consent', () => {
+    it('asks before configuring Codex when its desktop app is installed', async () => {
+      useUser();
+      desktopState.codex = true;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0020',
+        '--agent',
+        'codex'
+      );
+
+      const exitCodePromise = aiGateway(client);
+      await expect(client.stderr).toOutput(
+        'The Codex desktop app will stop working'
+      );
+      await expect(client.stderr).toOutput('Configure Codex anyway?');
+      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('Apply these changes?');
+      client.stdin.write('\n');
+
+      expect(await exitCodePromise).toBe(0);
+      const toml = tomlParse(readFileSync(codexConfigPath(), 'utf8')) as any;
+      expect(toml.model_provider).toBe('vercel');
+    });
+
+    it('declining skips the agent and configures the rest', async () => {
+      useUser();
+      desktopState.codex = true;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0021',
+        '--agent',
+        'claude-code',
+        '--agent',
+        'codex'
+      );
+
+      const exitCodePromise = aiGateway(client);
+      await expect(client.stderr).toOutput('Configure Codex anyway?');
+      client.stdin.write('\n'); // default No
+      await expect(client.stderr).toOutput('Skipped Codex');
+      await expect(client.stderr).toOutput('Apply these changes?');
+      client.stdin.write('\n');
+
+      expect(await exitCodePromise).toBe(0);
+      expect(existsSync(claudeSettingsPath())).toBe(true);
+      // Codex was left completely untouched.
+      expect(existsSync(codexConfigPath())).toBe(false);
+      expect(existsSync(bashrcPath())).toBe(false);
+    });
+
+    it('declining the only agent ends the run before the key interview even starts', async () => {
+      useTeam();
+      useUser();
+      useCreateApiKey();
+      desktopState.codex = true;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--agent',
+        'codex'
+      );
+
+      const exitCodePromise = aiGateway(client);
+      // Consent is the FIRST question — declining costs no setup answers and
+      // no team round trip.
+      await expect(client.stderr).toOutput('Configure Codex anyway?');
+      client.stdin.write('\n'); // default No
+
+      expect(await exitCodePromise).toBe(0);
+      await expect(client.stderr).toOutput('Nothing to configure');
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).not.toContain('use with your coding agents');
+      expect(stderr).not.toContain('What team should the API key be under?');
+      expect(stderr).not.toContain('Set a spend limit');
+      expect(stderr).not.toContain('Set an expiration');
+      // No key was minted for a run that configured nothing.
+      expect(lastCreateBody).toBeUndefined();
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
+
+    it('--yes with an explicit --agent consents but still warns', async () => {
+      useUser();
+      desktopState.codex = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--key',
+        'vck_DummyKey0022',
+        '--agent',
+        'codex'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      expect(client.stderr.getFullOutput()).toContain(
+        'The Codex desktop app will stop working'
+      );
+      expect(existsSync(codexConfigPath())).toBe(true);
+    });
+
+    it('--yes without naming the agent skips it with a hint', async () => {
+      useUser();
+      desktopState.codex = true;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--key',
+        'vck_DummyKey0023'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Pass --agent codex to configure it anyway'
+      );
+      expect(existsSync(claudeSettingsPath())).toBe(true);
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
+
+    it('emits warnings in the JSON payload for an explicit agent', async () => {
+      useUser();
+      desktopState.codex = true;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0024',
+        '--agent',
+        'codex'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.status).toBe('ok');
+      expect(out.warnings).toEqual([
+        expect.objectContaining({ agent: 'codex', code: 'desktop_app_breaks' }),
+      ]);
+      expect(out.configured.length).toBeGreaterThan(0);
+    });
+
+    it('fails non-interactively with a self-contained payload when every detected agent needs consent', async () => {
+      useUser();
+      desktopState.codex = true;
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0025'
+      );
+
+      expect(await aiGateway(client)).toBe(1);
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.status).toBe('error');
+      // Not 'confirmation_required': --yes can't grant consent, so agents that
+      // auto-retry confirmation failures with --yes must not loop here.
+      expect(out.reason).toBe('requires_consent');
+      expect(out.message).toContain('--agent codex');
+      expect(out.warnings).toEqual([
+        expect.objectContaining({ agent: 'codex', code: 'desktop_app_breaks' }),
+      ]);
+      expect(out.skipped).toEqual([
+        expect.objectContaining({
+          target: 'codex',
+          reason: 'requires_consent',
+        }),
+      ]);
+      // The suggested command replays the original invocation — same key
+      // intent (redacted), same flags — with only the consent flags appended.
+      expect(out.next[0].command).toBe(
+        'vercel ai-gateway coding-agents setup --key <key> --agent codex'
+      );
+      // The suggested command must never carry key material.
+      expect(JSON.stringify(out)).not.toContain('vck_');
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
+
+    it('--all counts as explicit consent', async () => {
+      useUser();
+      desktopState.codex = true;
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--all',
+        '--key',
+        'vck_DummyKey0030'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.status).toBe('ok');
+      expect(out.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            agent: 'codex',
+            code: 'desktop_app_breaks',
+          }),
+        ])
+      );
+      expect(
+        out.skipped.filter((s: any) => s.reason === 'requires_consent')
+      ).toEqual([]);
+      expect(existsSync(codexConfigPath())).toBe(true);
+    });
+
+    it('skips a detected-but-unnamed agent in JSON mode and configures the rest', async () => {
+      useUser();
+      desktopState.codex = true;
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0026'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(
+        out.skipped.some(
+          (s: any) => s.target === 'codex' && s.reason === 'requires_consent'
+        )
+      ).toBe(true);
+      // The skipped agent's structured warning code survives on the success
+      // payload — consumers don't have to parse it out of skipped[].message.
+      expect(out.warnings).toEqual([
+        expect.objectContaining({ agent: 'codex', code: 'desktop_app_breaks' }),
+      ]);
+      expect(existsSync(claudeSettingsPath())).toBe(true);
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
+
+    it('an interactive --yes dry run predicts the failure a real run would hit', async () => {
+      useUser();
+      keychainState.available = false;
+      desktopState.codex = true;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--yes',
+        '--dry-run',
+        '--key',
+        'vck_DummyKey0034'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      // The preview states the real outcome: a refusal, not a benign skip.
+      expect(stderr).toContain('a real run would fail');
+      expect(stderr).toContain('Pass --agent codex');
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
+
+    it('carries warnings and consent skips through a JSON dry run', async () => {
+      useUser();
+      desktopState.codex = true;
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--key',
+        'vck_DummyKey0027',
+        '--agent',
+        'codex'
+      );
+      expect(await aiGateway(client)).toBe(0);
+      const explicitOut = JSON.parse(client.stdout.getFullOutput());
+      expect(explicitOut.reason).toBe('dry_run');
+      expect(explicitOut.warnings).toHaveLength(1);
+
+      const stdoutAfterFirst = client.stdout.getFullOutput().length;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--key',
+        'vck_DummyKey0027'
+      );
+      expect(await aiGateway(client)).toBe(0);
+      const implicitOut = JSON.parse(
+        client.stdout.getFullOutput().slice(stdoutAfterFirst)
+      );
+      expect(
+        implicitOut.skipped.some((s: any) => s.reason === 'requires_consent')
+      ).toBe(true);
+      // The surviving agent's changes are still previewed…
+      expect(implicitOut.changes.length).toBeGreaterThan(0);
+      // …but none of the consent-skipped agent's.
+      expect(
+        implicitOut.changes.every((c: any) => !c.file.includes('.codex'))
+      ).toBe(true);
+    });
+
+    it('warns during an interactive dry run without prompting', async () => {
+      useUser();
+      desktopState.codex = true;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--dry-run',
+        '--key',
+        'vck_DummyKey0028',
+        '--agent',
+        'codex'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const stderr = client.stderr.getFullOutput();
+      // The warning reads loss first, then the cause lines, then how to
+      // revert — each cause sentence on its own line.
+      const impactAt = stderr.indexOf(
+        'The Codex desktop app will stop working'
+      );
+      const whyAt = stderr.indexOf('cannot use custom model providers');
+      const whyLine2At = stderr.indexOf('\n  The Codex CLI keeps working.');
+      // The undo instruction names the resolved file, not a bare filename.
+      const undoAt = stderr.indexOf(
+        `To undo: remove the model_provider line from ${codexConfigPath()}`
+      );
+      expect(impactAt).toBeGreaterThanOrEqual(0);
+      expect(whyAt).toBeGreaterThan(impactAt);
+      expect(whyLine2At).toBeGreaterThan(whyAt);
+      expect(undoAt).toBeGreaterThan(whyLine2At);
+      // The old single-paragraph warning is gone.
+      expect(stderr).not.toContain('The Codex desktop app is installed');
+      expect(stderr).not.toContain('Configure Codex anyway?');
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
+
+    it('stays silent and additive when no desktop app is installed', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0029',
+        '--agent',
+        'codex'
+      );
+
+      expect(await aiGateway(client)).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.warnings).toEqual([]);
+      expect(client.stderr.getFullOutput()).not.toContain('desktop app');
     });
   });
 

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -346,24 +346,28 @@ describe('ai-gateway coding-agents setup', () => {
       expect(cfg.provider.vercel.options.apiKey).toBe('vck_Minified001');
     });
 
-    it('keeps the OpenCode key out of the config under keychain', async () => {
-      const secret = 'vck_OpenCodeKeychain';
-      const plan = await buildSetupPlan([opencode], {
-        apiKey: secret,
-        home,
-        useKeychain: true,
-      });
+    // Keychain-backed shell exports only exist on macOS (no shell rc on Windows).
+    it.skipIf(process.platform === 'win32')(
+      'keeps the OpenCode key out of the config under keychain',
+      async () => {
+        const secret = 'vck_OpenCodeKeychain';
+        const plan = await buildSetupPlan([opencode], {
+          apiKey: secret,
+          home,
+          useKeychain: true,
+        });
 
-      // The provider is declared, but the key is not embedded…
-      const cfg = plan.changes.find(c => c.label === 'OpenCode config');
-      expect(cfg?.next).toContain('vercel');
-      expect(cfg?.next).not.toContain(secret);
-      // …it's resolved from AI_GATEWAY_API_KEY via the Keychain at runtime.
-      const shell = plan.changes.find(c => c.format === 'shell');
-      expect(shell?.next).toContain('export AI_GATEWAY_API_KEY=');
-      expect(shell?.next).toContain('security find-generic-password');
-      expect(shell?.next).not.toContain(secret);
-    });
+        // The provider is declared, but the key is not embedded…
+        const cfg = plan.changes.find(c => c.label === 'OpenCode config');
+        expect(cfg?.next).toContain('vercel');
+        expect(cfg?.next).not.toContain(secret);
+        // …it's resolved from AI_GATEWAY_API_KEY via the Keychain at runtime.
+        const shell = plan.changes.find(c => c.format === 'shell');
+        expect(shell?.next).toContain('export AI_GATEWAY_API_KEY=');
+        expect(shell?.next).toContain('security find-generic-password');
+        expect(shell?.next).not.toContain(secret);
+      }
+    );
 
     it('configures Pi via the native vercel-ai-gateway auth entry (0600)', async () => {
       useUser();
@@ -712,26 +716,32 @@ describe('ai-gateway coding-agents setup', () => {
       expect(keychainLookup()).toContain('security find-generic-password');
     });
 
-    it('keeps the secret out of the configs and reads it from the shell', async () => {
-      const secret = 'vck_KeychainSecret321';
-      const plan = await buildSetupPlan([claudeCode], {
-        apiKey: secret,
-        home,
-        useKeychain: true,
-      });
+    // Keychain-backed shell exports only exist on macOS (no shell rc on Windows).
+    it.skipIf(process.platform === 'win32')(
+      'keeps the secret out of the configs and reads it from the shell',
+      async () => {
+        const secret = 'vck_KeychainSecret321';
+        const plan = await buildSetupPlan([claudeCode], {
+          apiKey: secret,
+          home,
+          useKeychain: true,
+        });
 
-      // The env-based agent resolves its var from the Keychain at runtime.
-      const shell = plan.changes.find(c => c.format === 'shell');
-      expect(shell?.next).toContain('security find-generic-password');
-      expect(shell?.next).toContain('export ANTHROPIC_AUTH_TOKEN=');
-      expect(shell?.next).not.toContain(secret);
+        // The env-based agent resolves its var from the Keychain at runtime.
+        const shell = plan.changes.find(c => c.format === 'shell');
+        expect(shell?.next).toContain('security find-generic-password');
+        expect(shell?.next).toContain('export ANTHROPIC_AUTH_TOKEN=');
+        expect(shell?.next).not.toContain(secret);
 
-      // Claude's token is no longer embedded in settings.json.
-      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
-      expect(claude?.next).toContain('ANTHROPIC_BASE_URL');
-      expect(claude?.next).not.toContain('ANTHROPIC_AUTH_TOKEN');
-      expect(claude?.next).not.toContain(secret);
-    });
+        // Claude's token is no longer embedded in settings.json.
+        const claude = plan.changes.find(
+          c => c.label === 'Claude Code settings'
+        );
+        expect(claude?.next).toContain('ANTHROPIC_BASE_URL');
+        expect(claude?.next).not.toContain('ANTHROPIC_AUTH_TOKEN');
+        expect(claude?.next).not.toContain(secret);
+      }
+    );
 
     it('embeds the key directly when keychain is off', async () => {
       const secret = 'vck_PlainSecret654';


### PR DESCRIPTION
## Summary
The Codex desktop app shares `~/.codex/config.toml` with the Codex CLI but cannot use custom model providers, so setting `model_provider = "vercel"` breaks it (its model picker/chats stop working) while the CLI keeps working. This PR makes `ai-gateway coding-agents setup` detect conflicts like this up front and get explicit consent before configuring an agent:

- **Codex desktop app** (`desktop_app_breaks`): detected via a plain path check of `/Applications` + `~/Applications`; a missed nonstandard install just means no warning.
- **Claude Code Anthropic login** (`anthropic_login_conflict`): with an Anthropic `/login` active, the gateway's `ANTHROPIC_AUTH_TOKEN` takes precedence and the login stops being used — it stays signed in but idle, and `/logout` inside Claude Code clears it. Detection keys on credential artifacts that still assert a live login (`.credentials.json` in the Claude config dir, or an `oauthAccount` record that still names an account in `~/.claude.json`), never on the mere existence of a config directory — and deliberately not on the `Claude Code-credentials` Keychain item, which stores non-login credentials and logged-out husks too, so its existence proves nothing and verifying its content would require reading the secret.
- **Codex ChatGPT/OpenAI login** (`openai_login_conflict`): an existing `auth.json` login stays but stops being used while the gateway is the default provider.

How consent works:
- **Consent comes first**: warnings and consent run right after agent selection, before the key interview (name, team, spend limit, expiry, Keychain) — declining costs zero setup answers, no team round trip, and never creates an API key.
- **Interactive**: each agent's warnings are shown together (impact first, then one dimmed line per cause sentence, then a `To undo:` line naming the resolved config-file path), followed by one question per agent (default No). Declining skips that agent and leaves it fully untouched — its config files and its existing exports in the managed shell block, which survive any later rewrite — and continues with the others.
- **`--yes` / non-interactive**: explicitly naming the agent (`--agent <id>` / `--all`) counts as consent — the run proceeds with the warnings printed to stderr. An implicitly-selected agent is skipped with one `requires_consent` entry (all of its warnings, one `Pass --agent <id> to configure it anyway.` hint).
- Consent gating never breaks no-op automation: `--dry-run` predicts the real run's outcome (skip, no-op, Keychain-only key refresh, or refusal) and exits 0; a re-run on an already-configured setup — with or without `--key` — still reports `already_configured` (exit 0, including the Keychain key refresh); and `--reconfigure` cannot tunnel past a consent skip. Only a run that would actually change a warned agent's configuration refuses, with exit 1 and reason `requires_consent` — deliberately not `confirmation_required`, because `--yes` cannot grant consent and must not send agents into a retry loop.
- The `requires_consent` failure payload is self-contained: structured `warnings`, the `skipped` entries, and a `next[]` command that replays the original invocation (`--key` redacted — suggested commands never carry key material) with the exact consent flags appended.
- **JSON output** (additive): a top-level `warnings` array (`{agent, code, message}`) on every structured payload — kept for consent-skipped agents too, so a consumer can tell a breaking desktop app from a benign login conflict without parsing prose — and a new `requires_consent` value in `skipped[].reason`.

The mechanism is reusable: any agent can implement the optional `warnings(ctx)` hook on `CodingAgent`; detection helpers live in `desktop-apps.ts` and `logins.ts`.

## Tests
Thirty-seven tests across the consent surface: the desktop-app paths (declining before the key interview even starts, `--yes` explicit vs implicit, `--all` as consent, both dry-run modes and their outcome predictions, the no-app default), the login warnings (interactive decline/accept, `requires_consent` JSON shape, detection canaries — a bare config dir is not a login, `CLAUDE_CONFIG_DIR`/`CODEX_HOME` overrides), and the automation guarantees (a no-key Keychain re-run stays `already_configured`, a skipped agent's shell export survives rewrites even across Keychain modes, `--reconfigure` cannot tunnel past a skip, the self-contained failure payload with a redacted `next[]` command, one question and one skip entry for an agent with multiple warnings). Desktop-app and Keychain detection are mocked so a developer's real machine never affects the suite.


