### PR TITLE
[python] enable bytecode caching for lambda functions

### DIFF
--- a/.changeset/python-standard-compileall.md
+++ b/.changeset/python-standard-compileall.md
@@ -1,5 +1,5 @@
 ---
-'@vercel/python': patch
+'@vercel/python': minor
 ---
 
 Precompile Python bytecode for standard-size Lambda functions with sufficient size headroom, and allow bytecode precompilation when a custom build command is configured.

--- a/.changeset/python-standard-compileall.md
+++ b/.changeset/python-standard-compileall.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Precompile Python bytecode for standard-size Lambda functions with sufficient size headroom, and allow bytecode precompilation when a custom build command is configured.

--- a/.changeset/python-standard-compileall.md
+++ b/.changeset/python-standard-compileall.md
@@ -1,5 +1,5 @@
 ---
-'@vercel/python': minor
+'@vercel/python': patch
 ---
 
-Precompile Python bytecode for standard-size Lambda functions with sufficient size headroom, and allow bytecode precompilation when a custom build command is configured.
+Precompile Python bytecode for standard-size Lambda functions when the estimated bytecode size fits the remaining capacity, and allow bytecode precompilation when a custom build command is configured.

--- a/.changeset/python-standard-compileall.md
+++ b/.changeset/python-standard-compileall.md
@@ -1,5 +1,5 @@
 ---
-'@vercel/python': patch
+'@vercel/python': minor
 ---
 
-Precompile Python bytecode for standard-size Lambda functions when the estimated bytecode size fits the remaining capacity, and allow bytecode precompilation when a custom build command is configured.
+Precompile Python bytecode for standard-size Lambda functions when enough of the estimated bytecode fits the remaining capacity, and allow bytecode precompilation when a custom build command is configured.

--- a/packages/python/src/compileall.ts
+++ b/packages/python/src/compileall.ts
@@ -2,13 +2,6 @@ import execa from 'execa';
 import { debug, FileFsRef, type Files } from '@vercel/build-utils';
 import fs from 'fs';
 import { join, sep } from 'path';
-import { isLargeFunctionsEnabled } from './large-functions';
-
-/**
- * Minimum headroom below the size limit required to precompile a
- * standard-size function; below this, coverage would be partial at best.
- */
-export const MIN_BYTECODE_HEADROOM_BYTES = 32 * 1024 * 1024;
 
 /** Converts a hung compileall subprocess into a skipped optimization. */
 export const COMPILEALL_TIMEOUT_MS = 5 * 60 * 1000;
@@ -22,14 +15,11 @@ function isCompileAllFlagEnabled(): boolean {
 }
 
 /**
- * Compileall for large functions requires both `VERCEL_SUPPORT_LARGE_FUNCTIONS`
- * and `VERCEL_PYTHON_COMPILEALL` to be set truthy (`1`/`true`).
+ * Whether to precompile bytecode, gated by `VERCEL_PYTHON_COMPILEALL`
+ * (`1`/`true`). Callers decide the fill capacity based on which deploy path
+ * the function takes.
  */
-export function isCompileAllEnabled(): boolean {
-  return isLargeFunctionsEnabled() && isCompileAllFlagEnabled();
-}
-
-export function shouldUseCompileAll({
+export function shouldCompileAll({
   isDev,
   hasCustomCommand,
 }: {
@@ -44,28 +34,7 @@ export function shouldUseCompileAll({
   // degrades gracefully.
   if (hasCustomCommand) return false;
 
-  return isCompileAllEnabled();
-}
-
-/**
- * Whether to precompile bytecode for a function that fits the standard
- * Lambda size limit. Unlike the large-function path, this does not require
- * `VERCEL_SUPPORT_LARGE_FUNCTIONS`.
- */
-export function shouldPrecompileStandardFunction({
-  isDev,
-  hasCustomCommand,
-  headroomBytes,
-}: {
-  isDev?: boolean;
-  hasCustomCommand: boolean;
-  headroomBytes: number;
-}): boolean {
-  if (isDev) return false;
-  if (hasCustomCommand) return false;
-  if (!isCompileAllFlagEnabled()) return false;
-
-  return headroomBytes >= MIN_BYTECODE_HEADROOM_BYTES;
+  return isCompileAllFlagEnabled();
 }
 
 interface CompileAllOptions {

--- a/packages/python/src/compileall.ts
+++ b/packages/python/src/compileall.ts
@@ -5,12 +5,20 @@ import { join, sep } from 'path';
 import { isLargeFunctionsEnabled } from './large-functions';
 
 /**
- * Compileall runs only for large functions *and* when `VERCEL_PYTHON_COMPILEALL`
- * is set truthy (`1`/`true`) — an opt-in toggle, no effect otherwise.
+ * Fill target for standard-size functions when adding precompiled bytecode.
+ * Kept 5MB under LAMBDA_SIZE_THRESHOLD_BYTES so the bytecode fill
+ * can never push a function over the size limit.
  */
-export function isCompileAllEnabled(): boolean {
-  if (!isLargeFunctionsEnabled()) return false;
+export const BYTECODE_FILL_CEILING_BYTES = 220 * 1024 * 1024;
 
+/**
+ * Minimum headroom below the size limit required to precompile a
+ * standard-size function. Below this, coverage would be partial at best and
+ * the compile time is wasted.
+ */
+export const MIN_BYTECODE_HEADROOM_BYTES = 32 * 1024 * 1024;
+
+function isCompileAllFlagEnabled(): boolean {
   const val = process.env.VERCEL_PYTHON_COMPILEALL;
   if (val === undefined || val === '') return false;
 
@@ -18,22 +26,48 @@ export function isCompileAllEnabled(): boolean {
   return lower === '1' || lower === 'true';
 }
 
+/**
+ * Compileall for large functions requires both `VERCEL_SUPPORT_LARGE_FUNCTIONS`
+ * and `VERCEL_PYTHON_COMPILEALL` to be set truthy (`1`/`true`).
+ */
+export function isCompileAllEnabled(): boolean {
+  return isLargeFunctionsEnabled() && isCompileAllFlagEnabled();
+}
+
 export function shouldUseCompileAll({
   isDev,
   hasCustomCommand,
-  hasCustomBuildCommand,
 }: {
   isDev?: boolean;
   hasCustomCommand: boolean;
-  hasCustomBuildCommand: boolean;
 }): boolean {
   if (isDev) return false;
 
-  // Custom install or build commands never get compileall: they may produce
-  // their own bytecode or bypass the venv layout compileall assumes.
-  if (hasCustomCommand || hasCustomBuildCommand) return false;
+  // Custom install commands may bypass the venv layout compileall assumes.
+  if (hasCustomCommand) return false;
 
   return isCompileAllEnabled();
+}
+
+/**
+ * Whether to precompile bytecode for a function that fits the standard
+ * Lambda size limit. Unlike the large-function path, this does not require
+ * `VERCEL_SUPPORT_LARGE_FUNCTIONS`.
+ */
+export function shouldPrecompileStandardFunction({
+  isDev,
+  hasCustomCommand,
+  headroomBytes,
+}: {
+  isDev?: boolean;
+  hasCustomCommand: boolean;
+  headroomBytes: number;
+}): boolean {
+  if (isDev) return false;
+  if (hasCustomCommand) return false;
+  if (!isCompileAllFlagEnabled()) return false;
+
+  return headroomBytes >= MIN_BYTECODE_HEADROOM_BYTES;
 }
 
 interface CompileAllOptions {

--- a/packages/python/src/compileall.ts
+++ b/packages/python/src/compileall.ts
@@ -5,18 +5,13 @@ import { join, sep } from 'path';
 import { isLargeFunctionsEnabled } from './large-functions';
 
 /**
- * Fill target for standard-size functions when adding precompiled bytecode.
- * Kept 5MB under LAMBDA_SIZE_THRESHOLD_BYTES so the bytecode fill
- * can never push a function over the size limit.
- */
-export const BYTECODE_FILL_CEILING_BYTES = 220 * 1024 * 1024;
-
-/**
  * Minimum headroom below the size limit required to precompile a
- * standard-size function. Below this, coverage would be partial at best and
- * the compile time is wasted.
+ * standard-size function; below this, coverage would be partial at best.
  */
 export const MIN_BYTECODE_HEADROOM_BYTES = 32 * 1024 * 1024;
+
+/** Converts a hung compileall subprocess into a skipped optimization. */
+export const COMPILEALL_TIMEOUT_MS = 5 * 60 * 1000;
 
 function isCompileAllFlagEnabled(): boolean {
   const val = process.env.VERCEL_PYTHON_COMPILEALL;
@@ -43,7 +38,10 @@ export function shouldUseCompileAll({
 }): boolean {
   if (isDev) return false;
 
-  // Custom install commands may bypass the venv layout compileall assumes.
+  // Custom install commands replace the standard install, leaving no
+  // known-good venv layout to compile against. Custom build commands are
+  // safe: they run after the standard install, and bytecode collection
+  // degrades gracefully.
   if (hasCustomCommand) return false;
 
   return isCompileAllEnabled();
@@ -112,7 +110,10 @@ export async function runCompileAll({
   ];
 
   try {
-    await execa(pythonBin, args, { env: env || process.env });
+    await execa(pythonBin, args, {
+      env: env || process.env,
+      timeout: COMPILEALL_TIMEOUT_MS,
+    });
   } catch (err) {
     debug(`compileall error details: ${JSON.stringify(err)}`);
   }

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -1142,7 +1142,11 @@ export async function calculateBundleSize(
         statPromises.push(
           fs.promises
             .stat(fsRef.fsPath)
-            .then(stats => stats.size)
+            .then(stats => {
+              // Cache so later passes (estimate, fill recount) skip the stat.
+              fsRef.size = stats.size;
+              return stats.size;
+            })
             .catch(err => {
               console.warn(
                 `Warning: Failed to stat file ${fsRef.fsPath}, size will not be included in bundle calculation: ${err}`
@@ -1173,6 +1177,13 @@ export async function calculateBundleSize(
  * gate errs toward skipping marginal compiles.
  */
 export const PYC_TO_PY_RATIO = 1.2;
+
+/**
+ * Minimum fraction of the estimated bytecode that must fit the remaining
+ * capacity to justify running compileall. Cold-start benefit is roughly
+ * proportional to coverage, so partial fills above this floor are worth it.
+ */
+export const BYTECODE_COVERAGE_FLOOR = 0.5;
 
 /**
  * Estimate the total bytecode size compileall would produce for the .py

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -1123,11 +1123,15 @@ export async function getPackagesReachableOnPlatform(
  * to avoid redundant stat calls.  Remaining files are stat'd in
  * parallel for throughput.
  */
-export async function calculateBundleSize(files: Files): Promise<number> {
+export async function calculateBundleSize(
+  files: Files,
+  filter?: (filePath: string) => boolean
+): Promise<number> {
   let knownSize = 0;
   const statPromises: Promise<number>[] = [];
 
   for (const filePath of Object.keys(files)) {
+    if (filter && !filter(filePath)) continue;
     const file = files[filePath];
     if ('fsPath' in file && file.fsPath) {
       const fsRef = file as FileFsRef;
@@ -1161,6 +1165,23 @@ export async function calculateBundleSize(files: Files): Promise<number> {
     totalSize += s;
   }
   return totalSize;
+}
+
+/**
+ * Expected .pyc-to-.py size ratio. Measured empirically on real venvs
+ * (1.06 and 1.14 across different dependency mixes); slightly high so the
+ * gate errs toward skipping marginal compiles.
+ */
+export const PYC_TO_PY_RATIO = 1.2;
+
+/**
+ * Estimate the total bytecode size compileall would produce for the .py
+ * files in the bundle. Used only to gate whether compiling is worthwhile;
+ * the fill itself measures real .pyc sizes.
+ */
+export async function estimateBytecodeSize(files: Files): Promise<number> {
+  const pyBytes = await calculateBundleSize(files, p => p.endsWith('.py'));
+  return PYC_TO_PY_RATIO * pyBytes;
 }
 
 /**

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -65,6 +65,12 @@ function shouldStripVendorFile(filePath: string): boolean {
 // that count toward the limit but aren't part of this bundle.
 export const LAMBDA_SIZE_THRESHOLD_BYTES = 225 * 1024 * 1024;
 
+// Bytecode fill target for standard-size functions, with a margin so the
+// fill can never push a function over the size limit.
+const BYTECODE_FILL_MARGIN_BYTES = 5 * 1024 * 1024;
+export const BYTECODE_FILL_CEILING_BYTES =
+  LAMBDA_SIZE_THRESHOLD_BYTES - BYTECODE_FILL_MARGIN_BYTES;
+
 // AWS Lambda ephemeral storage (/tmp) is 512MB. Use 500MB to leave a buffer
 // for runtime overhead (.pyc generation, uv cache, metadata, etc.)
 export const LAMBDA_EPHEMERAL_STORAGE_BYTES = 500 * 1024 * 1024;

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -77,9 +77,11 @@ import {
 } from './django';
 import { containsTopLevelCallable } from '@vercel/python-analysis';
 import {
+  BYTECODE_FILL_CEILING_BYTES,
   collectAppBytecodeFiles,
   getCompileAllAppExcludeRegex,
   runCompileAll,
+  shouldPrecompileStandardFunction,
   shouldUseCompileAll,
   type BytecodeCollectionResult,
 } from './compileall';
@@ -505,11 +507,6 @@ export const build: BuildVX = async ({
   // dependency installation is disabled because custom install commands may
   // install dependencies not tracked in uv.lock.
   let hasCustomCommand = false;
-  // Track whether a custom build command/script was used. When true, compileall
-  // is disabled (a custom build may emit its own bytecode or bypass the venv
-  // layout compileall assumes). It does not affect runtime installation, since
-  // dependencies are still installed normally.
-  let hasCustomBuildCommand = false;
 
   const target = getTargetPlatform(meta.isDev ?? false);
 
@@ -826,16 +823,12 @@ export const build: BuildVX = async ({
             env: pythonEnv,
             cwd: workPath,
           });
-          hasCustomBuildCommand = true;
         } else {
-          const ranBuildScript = await runPyprojectScript(
+          await runPyprojectScript(
             workPath,
             ['vercel-build', 'now-build', 'build'],
             pythonEnv
           );
-          if (ranBuildScript) {
-            hasCustomBuildCommand = true;
-          }
         }
       });
   }
@@ -989,7 +982,6 @@ export const build: BuildVX = async ({
   const automaticCompileAllEnabled = shouldUseCompileAll({
     isDev: meta.isDev,
     hasCustomCommand,
-    hasCustomBuildCommand,
   });
 
   const predefinedExcludes = [
@@ -1096,7 +1088,7 @@ export const build: BuildVX = async ({
       // function. collectAppBytecodeFiles only collects .pyc for .py files
       // present in the bundle, so excluded source can't re-enter as .pyc.
       // Shared by the direct-bundle path and the generateBundle Hive fallback.
-      const runCompileAllAndFillBytecode = async () => {
+      const runCompileAllAndFillBytecode = async (capacityBytes: number) => {
         await builderSpan
           .child('vc.builder.python.compileall')
           .trace(async compileSpan => {
@@ -1105,7 +1097,7 @@ export const build: BuildVX = async ({
             ).filter(d => fs.existsSync(d));
             const pythonBin = getVenvPythonBin(venvPath);
 
-            console.log('Compiling Python application bytecode...');
+            console.log('Compiling Python bytecode...');
             await runCompileAll({
               pythonBin,
               filesOrDirectories: [workPath],
@@ -1113,7 +1105,6 @@ export const build: BuildVX = async ({
               excludeRegex: getCompileAllAppExcludeRegex(workPath),
             });
 
-            console.log('Compiling Python dependency bytecode...');
             await runCompileAll({
               pythonBin,
               filesOrDirectories: sitePackageDirs,
@@ -1128,10 +1119,8 @@ export const build: BuildVX = async ({
             });
           });
 
-        // Fill remaining capacity up to the large-function size limit.
         const currentSize = await calculateBundleSize(files);
-        let remainingCapacity =
-          MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE - currentSize;
+        let remainingCapacity = capacityBytes - currentSize;
 
         if (pythonVersion.major != null && pythonVersion.minor != null) {
           const appBytecodeInfo = await collectAppBytecodeFiles({
@@ -1173,28 +1162,33 @@ export const build: BuildVX = async ({
         if (fellBackToFullBundle) {
           announceLargeFunction();
           if (automaticCompileAllEnabled) {
-            await runCompileAllAndFillBytecode();
+            await runCompileAllAndFillBytecode(
+              MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
+            );
           }
         }
       } else {
         // Bundle all deps directly. Either it fits the standard size limit, or
         // large functions are enabled and the whole bundle ships.
         addFiles(files, depAnalysis.allVendorFiles);
-        if (
-          isLargeFunctionsEnabled() &&
-          depAnalysis.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES
+        if (depAnalysis.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES) {
+          if (isLargeFunctionsEnabled()) {
+            announceLargeFunction();
+          }
+          if (automaticCompileAllEnabled) {
+            await runCompileAllAndFillBytecode(
+              MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
+            );
+          }
+        } else if (
+          shouldPrecompileStandardFunction({
+            isDev: meta.isDev,
+            hasCustomCommand,
+            headroomBytes:
+              LAMBDA_SIZE_THRESHOLD_BYTES - depAnalysis.totalBundleSize,
+          })
         ) {
-          announceLargeFunction();
-        }
-        // Compileall is only for large functions. This branch also covers small
-        // bundles that fit the standard size limit, so gate on size to skip
-        // them — never precompile bytecode for a standard-size function.
-        // (automaticCompileAllEnabled already requires the large-functions flag.)
-        if (
-          automaticCompileAllEnabled &&
-          depAnalysis.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES
-        ) {
-          await runCompileAllAndFillBytecode();
+          await runCompileAllAndFillBytecode(BYTECODE_FILL_CEILING_BYTES);
         }
       }
     });

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -49,6 +49,7 @@ import {
   LAMBDA_SIZE_THRESHOLD_BYTES,
   lambdaKnapsack,
   calculateBundleSize,
+  estimateBytecodeSize,
 } from './dependency-externalizer';
 import { isLargeFunctionsEnabled } from './large-functions';
 import {
@@ -81,8 +82,7 @@ import {
   collectAppBytecodeFiles,
   getCompileAllAppExcludeRegex,
   runCompileAll,
-  shouldPrecompileStandardFunction,
-  shouldUseCompileAll,
+  shouldCompileAll,
   type BytecodeCollectionResult,
 } from './compileall';
 import {
@@ -979,7 +979,7 @@ export const build: BuildVX = async ({
     extraEnv: extraTrampolineEnv,
   });
 
-  const automaticCompileAllEnabled = shouldUseCompileAll({
+  const compileAllEnabled = shouldCompileAll({
     isDev: meta.isDev,
     hasCustomCommand,
   });
@@ -1170,7 +1170,7 @@ export const build: BuildVX = async ({
           await depExternalizer.generateBundle(files);
         if (fellBackToFullBundle) {
           announceLargeFunction();
-          if (automaticCompileAllEnabled) {
+          if (compileAllEnabled) {
             await runCompileAllAndFillBytecode(
               MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
             );
@@ -1184,20 +1184,19 @@ export const build: BuildVX = async ({
           if (isLargeFunctionsEnabled()) {
             announceLargeFunction();
           }
-          if (automaticCompileAllEnabled) {
+          if (compileAllEnabled) {
             await runCompileAllAndFillBytecode(
               MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
             );
           }
-        } else if (
-          shouldPrecompileStandardFunction({
-            isDev: meta.isDev,
-            hasCustomCommand,
-            headroomBytes:
-              LAMBDA_SIZE_THRESHOLD_BYTES - depAnalysis.totalBundleSize,
-          })
-        ) {
-          await runCompileAllAndFillBytecode(BYTECODE_FILL_CEILING_BYTES);
+        } else if (compileAllEnabled) {
+          // Compile only when the expected bytecode fits the remaining
+          // capacity; a partial fill isn't worth the compile time.
+          const capacity =
+            BYTECODE_FILL_CEILING_BYTES - depAnalysis.totalBundleSize;
+          if (capacity >= (await estimateBytecodeSize(files))) {
+            await runCompileAllAndFillBytecode(BYTECODE_FILL_CEILING_BYTES);
+          }
         }
       }
     });

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -44,6 +44,7 @@ import {
 } from './install';
 import {
   PythonDependencyExternalizer,
+  BYTECODE_FILL_CEILING_BYTES,
   MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE,
   LAMBDA_SIZE_THRESHOLD_BYTES,
   lambdaKnapsack,
@@ -77,7 +78,6 @@ import {
 } from './django';
 import { containsTopLevelCallable } from '@vercel/python-analysis';
 import {
-  BYTECODE_FILL_CEILING_BYTES,
   collectAppBytecodeFiles,
   getCompileAllAppExcludeRegex,
   runCompileAll,
@@ -1084,68 +1084,77 @@ export const build: BuildVX = async ({
         },
       });
 
-      // Precompile bytecode and fill remaining capacity for a fully bundled
-      // function. collectAppBytecodeFiles only collects .pyc for .py files
-      // present in the bundle, so excluded source can't re-enter as .pyc.
-      // Shared by the direct-bundle path and the generateBundle Hive fallback.
+      // Precompile bytecode and fill remaining capacity up to capacityBytes.
+      // Only .pyc for .py files already in the bundle are collected, so
+      // excluded source can't re-enter as .pyc. Bytecode is a pure
+      // optimization: failures are logged and the build continues.
       const runCompileAllAndFillBytecode = async (capacityBytes: number) => {
-        await builderSpan
-          .child('vc.builder.python.compileall')
-          .trace(async compileSpan => {
-            const sitePackageDirs = (
-              await getVenvSitePackagesDirs(venvPath)
-            ).filter(d => fs.existsSync(d));
-            const pythonBin = getVenvPythonBin(venvPath);
+        try {
+          await builderSpan
+            .child('vc.builder.python.compileall')
+            .trace(async compileSpan => {
+              const sitePackageDirs = (
+                await getVenvSitePackagesDirs(venvPath)
+              ).filter(d => fs.existsSync(d));
+              const pythonBin = getVenvPythonBin(venvPath);
 
-            console.log('Compiling Python bytecode...');
-            await runCompileAll({
-              pythonBin,
-              filesOrDirectories: [workPath],
-              env: pythonEnv,
-              excludeRegex: getCompileAllAppExcludeRegex(workPath),
+              console.log('Compiling Python bytecode...');
+              await runCompileAll({
+                pythonBin,
+                filesOrDirectories: [workPath],
+                env: pythonEnv,
+                excludeRegex: getCompileAllAppExcludeRegex(workPath),
+              });
+
+              await runCompileAll({
+                pythonBin,
+                filesOrDirectories: sitePackageDirs,
+                env: pythonEnv,
+              });
+
+              compileSpan.setAttributes({
+                'python.compileall.enabled': 'true',
+                'python.compileall.sitePackageDirectoryCount': String(
+                  sitePackageDirs.length
+                ),
+              });
             });
 
-            await runCompileAll({
-              pythonBin,
-              filesOrDirectories: sitePackageDirs,
-              env: pythonEnv,
+          const currentSize = await calculateBundleSize(files);
+          let remainingCapacity = capacityBytes - currentSize;
+
+          if (pythonVersion.major != null && pythonVersion.minor != null) {
+            const appBytecodeInfo = await collectAppBytecodeFiles({
+              workPath,
+              files,
+              pythonMajor: pythonVersion.major,
+              pythonMinor: pythonVersion.minor,
             });
+            remainingCapacity = addBytecodeWithinCapacity(
+              files,
+              appBytecodeInfo,
+              remainingCapacity
+            );
+          }
 
-            compileSpan.setAttributes({
-              'python.compileall.enabled': 'true',
-              'python.compileall.sitePackageDirectoryCount': String(
-                sitePackageDirs.length
-              ),
-            });
-          });
-
-        const currentSize = await calculateBundleSize(files);
-        let remainingCapacity = capacityBytes - currentSize;
-
-        if (pythonVersion.major != null && pythonVersion.minor != null) {
-          const appBytecodeInfo = await collectAppBytecodeFiles({
-            workPath,
-            files,
-            pythonMajor: pythonVersion.major,
-            pythonMinor: pythonVersion.minor,
-          });
-          remainingCapacity = addBytecodeWithinCapacity(
-            files,
-            appBytecodeInfo,
-            remainingCapacity
+          const vendorBytecodeInfo = await depExternalizer.collectBytecodeFiles(
+            {
+              vendorDirName: vendorDir,
+            }
           );
+          await addVendorBytecodeWithinCapacity({
+            files,
+            depExternalizer,
+            vendorDir,
+            bytecodeInfo: vendorBytecodeInfo,
+            capacity: remainingCapacity,
+          });
+        } catch (err) {
+          console.log(
+            'Bytecode precompilation failed; continuing without precompiled bytecode.'
+          );
+          debug(`bytecode precompilation error details: ${err}`);
         }
-
-        const vendorBytecodeInfo = await depExternalizer.collectBytecodeFiles({
-          vendorDirName: vendorDir,
-        });
-        await addVendorBytecodeWithinCapacity({
-          files,
-          depExternalizer,
-          vendorDir,
-          bytecodeInfo: vendorBytecodeInfo,
-          capacity: remainingCapacity,
-        });
       };
 
       const announceLargeFunction = () =>

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -44,6 +44,7 @@ import {
 } from './install';
 import {
   PythonDependencyExternalizer,
+  BYTECODE_COVERAGE_FLOOR,
   BYTECODE_FILL_CEILING_BYTES,
   MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE,
   LAMBDA_SIZE_THRESHOLD_BYTES,
@@ -1190,11 +1191,12 @@ export const build: BuildVX = async ({
             );
           }
         } else if (compileAllEnabled) {
-          // Compile only when the expected bytecode fits the remaining
-          // capacity; a partial fill isn't worth the compile time.
+          // Compile only when enough of the expected bytecode ships to
+          // justify the compile time.
           const capacity =
             BYTECODE_FILL_CEILING_BYTES - depAnalysis.totalBundleSize;
-          if (capacity >= (await estimateBytecodeSize(files))) {
+          const estimate = await estimateBytecodeSize(files);
+          if (capacity >= BYTECODE_COVERAGE_FLOOR * estimate) {
             await runCompileAllAndFillBytecode(BYTECODE_FILL_CEILING_BYTES);
           }
         }

--- a/packages/python/test/compileall.test.ts
+++ b/packages/python/test/compileall.test.ts
@@ -15,13 +15,17 @@ vi.mock('@vercel/build-utils', async importOriginal => ({
 import execa from 'execa';
 import { FileFsRef } from '@vercel/build-utils';
 import {
+  BYTECODE_FILL_CEILING_BYTES,
+  MIN_BYTECODE_HEADROOM_BYTES,
   collectAppBytecodeFiles,
   derivePycPath,
   getCompileAllAppExcludeRegex,
   isCompileAllEnabled,
   runCompileAll,
+  shouldPrecompileStandardFunction,
   shouldUseCompileAll,
 } from '../src/compileall';
+import { LAMBDA_SIZE_THRESHOLD_BYTES } from '../src/dependency-externalizer';
 
 const mockedExeca = vi.mocked(execa);
 const originalCompileAllEnv = process.env.VERCEL_PYTHON_COMPILEALL;
@@ -108,7 +112,6 @@ describe('shouldUseCompileAll', () => {
       shouldUseCompileAll({
         isDev: false,
         hasCustomCommand: false,
-        hasCustomBuildCommand: false,
       })
     ).toBe(true);
   });
@@ -121,20 +124,6 @@ describe('shouldUseCompileAll', () => {
       shouldUseCompileAll({
         isDev: false,
         hasCustomCommand: true,
-        hasCustomBuildCommand: false,
-      })
-    ).toBe(false);
-  });
-
-  it('does not enable compileall for custom build commands, even with large functions and the flag set', () => {
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
-    expect(
-      shouldUseCompileAll({
-        isDev: false,
-        hasCustomCommand: false,
-        hasCustomBuildCommand: true,
       })
     ).toBe(false);
   });
@@ -147,7 +136,6 @@ describe('shouldUseCompileAll', () => {
       shouldUseCompileAll({
         isDev: true,
         hasCustomCommand: false,
-        hasCustomBuildCommand: false,
       })
     ).toBe(false);
   });
@@ -160,7 +148,6 @@ describe('shouldUseCompileAll', () => {
       shouldUseCompileAll({
         isDev: false,
         hasCustomCommand: false,
-        hasCustomBuildCommand: false,
       })
     ).toBe(false);
   });
@@ -173,9 +160,108 @@ describe('shouldUseCompileAll', () => {
       shouldUseCompileAll({
         isDev: false,
         hasCustomCommand: false,
-        hasCustomBuildCommand: false,
       })
     ).toBe(false);
+  });
+});
+
+describe('shouldPrecompileStandardFunction', () => {
+  const AMPLE_HEADROOM = MIN_BYTECODE_HEADROOM_BYTES * 4;
+
+  it('enables precompilation with the flag set and ample headroom, without large functions', () => {
+    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
+    process.env.VERCEL_PYTHON_COMPILEALL = '1';
+
+    expect(
+      shouldPrecompileStandardFunction({
+        isDev: false,
+        hasCustomCommand: false,
+        headroomBytes: AMPLE_HEADROOM,
+      })
+    ).toBe(true);
+  });
+
+  it('enables precompilation at exactly the minimum headroom', () => {
+    process.env.VERCEL_PYTHON_COMPILEALL = '1';
+
+    expect(
+      shouldPrecompileStandardFunction({
+        isDev: false,
+        hasCustomCommand: false,
+        headroomBytes: MIN_BYTECODE_HEADROOM_BYTES,
+      })
+    ).toBe(true);
+  });
+
+  it('does not enable precompilation below the minimum headroom', () => {
+    process.env.VERCEL_PYTHON_COMPILEALL = '1';
+
+    expect(
+      shouldPrecompileStandardFunction({
+        isDev: false,
+        hasCustomCommand: false,
+        headroomBytes: MIN_BYTECODE_HEADROOM_BYTES - 1,
+      })
+    ).toBe(false);
+  });
+
+  it('does not enable precompilation without the flag or with a falsy flag', () => {
+    delete process.env.VERCEL_PYTHON_COMPILEALL;
+    expect(
+      shouldPrecompileStandardFunction({
+        isDev: false,
+        hasCustomCommand: false,
+        headroomBytes: AMPLE_HEADROOM,
+      })
+    ).toBe(false);
+
+    process.env.VERCEL_PYTHON_COMPILEALL = '0';
+    expect(
+      shouldPrecompileStandardFunction({
+        isDev: false,
+        hasCustomCommand: false,
+        headroomBytes: AMPLE_HEADROOM,
+      })
+    ).toBe(false);
+
+    process.env.VERCEL_PYTHON_COMPILEALL = 'false';
+    expect(
+      shouldPrecompileStandardFunction({
+        isDev: false,
+        hasCustomCommand: false,
+        headroomBytes: AMPLE_HEADROOM,
+      })
+    ).toBe(false);
+  });
+
+  it('does not enable precompilation in dev', () => {
+    process.env.VERCEL_PYTHON_COMPILEALL = '1';
+
+    expect(
+      shouldPrecompileStandardFunction({
+        isDev: true,
+        hasCustomCommand: false,
+        headroomBytes: AMPLE_HEADROOM,
+      })
+    ).toBe(false);
+  });
+
+  it('does not enable precompilation for custom install commands', () => {
+    process.env.VERCEL_PYTHON_COMPILEALL = '1';
+
+    expect(
+      shouldPrecompileStandardFunction({
+        isDev: false,
+        hasCustomCommand: true,
+        headroomBytes: AMPLE_HEADROOM,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps the fill ceiling safely below the Lambda size threshold', () => {
+    expect(BYTECODE_FILL_CEILING_BYTES).toBeLessThan(
+      LAMBDA_SIZE_THRESHOLD_BYTES
+    );
   });
 });
 

--- a/packages/python/test/compileall.test.ts
+++ b/packages/python/test/compileall.test.ts
@@ -16,14 +16,11 @@ import execa from 'execa';
 import { FileFsRef } from '@vercel/build-utils';
 import {
   COMPILEALL_TIMEOUT_MS,
-  MIN_BYTECODE_HEADROOM_BYTES,
   collectAppBytecodeFiles,
   derivePycPath,
   getCompileAllAppExcludeRegex,
-  isCompileAllEnabled,
   runCompileAll,
-  shouldPrecompileStandardFunction,
-  shouldUseCompileAll,
+  shouldCompileAll,
 } from '../src/compileall';
 import {
   BYTECODE_FILL_CEILING_BYTES,
@@ -52,213 +49,61 @@ afterEach(() => {
   }
 });
 
-describe('isCompileAllEnabled', () => {
-  it('defaults to disabled', () => {
-    delete process.env.VERCEL_PYTHON_COMPILEALL;
-    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
-    expect(isCompileAllEnabled()).toBe(false);
-  });
-
-  it('enables compileall for large functions with truthy flag values', () => {
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
+describe('shouldCompileAll', () => {
+  it('enables compileall with truthy flag values', () => {
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
-    expect(isCompileAllEnabled()).toBe(true);
+    expect(shouldCompileAll({ isDev: false, hasCustomCommand: false })).toBe(
+      true
+    );
 
     process.env.VERCEL_PYTHON_COMPILEALL = 'true';
-    expect(isCompileAllEnabled()).toBe(true);
+    expect(shouldCompileAll({ isDev: false, hasCustomCommand: false })).toBe(
+      true
+    );
 
     process.env.VERCEL_PYTHON_COMPILEALL = 'TRUE';
-    expect(isCompileAllEnabled()).toBe(true);
+    expect(shouldCompileAll({ isDev: false, hasCustomCommand: false })).toBe(
+      true
+    );
   });
 
-  it('keeps compileall disabled for large functions with non-truthy flag values', () => {
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
-    delete process.env.VERCEL_PYTHON_COMPILEALL;
-    expect(isCompileAllEnabled()).toBe(false);
-
-    process.env.VERCEL_PYTHON_COMPILEALL = '';
-    expect(isCompileAllEnabled()).toBe(false);
-
-    process.env.VERCEL_PYTHON_COMPILEALL = '0';
-    expect(isCompileAllEnabled()).toBe(false);
-
-    process.env.VERCEL_PYTHON_COMPILEALL = 'false';
-    expect(isCompileAllEnabled()).toBe(false);
-  });
-
-  it('never enables compileall without large functions, even when the flag is truthy', () => {
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
-    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-    expect(isCompileAllEnabled()).toBe(false);
-
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '0';
-    expect(isCompileAllEnabled()).toBe(false);
-
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = 'false';
-    expect(isCompileAllEnabled()).toBe(false);
-
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '';
-    expect(isCompileAllEnabled()).toBe(false);
-  });
-});
-
-describe('shouldUseCompileAll', () => {
-  it('enables compileall for large functions when the flag is set for non-custom builds', () => {
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
-    expect(
-      shouldUseCompileAll({
-        isDev: false,
-        hasCustomCommand: false,
-      })
-    ).toBe(true);
-  });
-
-  it('does not enable compileall for custom install commands, even with large functions and the flag set', () => {
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
-    expect(
-      shouldUseCompileAll({
-        isDev: false,
-        hasCustomCommand: true,
-      })
-    ).toBe(false);
-  });
-
-  it('does not enable compileall in dev even with large functions and the flag set', () => {
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
-    expect(
-      shouldUseCompileAll({
-        isDev: true,
-        hasCustomCommand: false,
-      })
-    ).toBe(false);
-  });
-
-  it('does not enable compileall without large functions even when the flag is set', () => {
+  it('does not require VERCEL_SUPPORT_LARGE_FUNCTIONS', () => {
     delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
-    expect(
-      shouldUseCompileAll({
-        isDev: false,
-        hasCustomCommand: false,
-      })
-    ).toBe(false);
+    expect(shouldCompileAll({ isDev: false, hasCustomCommand: false })).toBe(
+      true
+    );
   });
 
-  it('does not enable compileall for large functions without the flag', () => {
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
+  it('stays disabled without the flag or with non-truthy flag values', () => {
     delete process.env.VERCEL_PYTHON_COMPILEALL;
+    expect(shouldCompileAll({ isDev: false, hasCustomCommand: false })).toBe(
+      false
+    );
 
-    expect(
-      shouldUseCompileAll({
-        isDev: false,
-        hasCustomCommand: false,
-      })
-    ).toBe(false);
+    for (const val of ['', '0', 'false']) {
+      process.env.VERCEL_PYTHON_COMPILEALL = val;
+      expect(shouldCompileAll({ isDev: false, hasCustomCommand: false })).toBe(
+        false
+      );
+    }
   });
-});
 
-describe('shouldPrecompileStandardFunction', () => {
-  const AMPLE_HEADROOM = MIN_BYTECODE_HEADROOM_BYTES * 4;
-
-  it('enables precompilation with the flag set and ample headroom, without large functions', () => {
-    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
+  it('does not enable compileall in dev', () => {
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
-    expect(
-      shouldPrecompileStandardFunction({
-        isDev: false,
-        hasCustomCommand: false,
-        headroomBytes: AMPLE_HEADROOM,
-      })
-    ).toBe(true);
+    expect(shouldCompileAll({ isDev: true, hasCustomCommand: false })).toBe(
+      false
+    );
   });
 
-  it('enables precompilation at exactly the minimum headroom', () => {
+  it('does not enable compileall for custom install commands', () => {
     process.env.VERCEL_PYTHON_COMPILEALL = '1';
 
-    expect(
-      shouldPrecompileStandardFunction({
-        isDev: false,
-        hasCustomCommand: false,
-        headroomBytes: MIN_BYTECODE_HEADROOM_BYTES,
-      })
-    ).toBe(true);
-  });
-
-  it('does not enable precompilation below the minimum headroom', () => {
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
-    expect(
-      shouldPrecompileStandardFunction({
-        isDev: false,
-        hasCustomCommand: false,
-        headroomBytes: MIN_BYTECODE_HEADROOM_BYTES - 1,
-      })
-    ).toBe(false);
-  });
-
-  it('does not enable precompilation without the flag or with a falsy flag', () => {
-    delete process.env.VERCEL_PYTHON_COMPILEALL;
-    expect(
-      shouldPrecompileStandardFunction({
-        isDev: false,
-        hasCustomCommand: false,
-        headroomBytes: AMPLE_HEADROOM,
-      })
-    ).toBe(false);
-
-    process.env.VERCEL_PYTHON_COMPILEALL = '0';
-    expect(
-      shouldPrecompileStandardFunction({
-        isDev: false,
-        hasCustomCommand: false,
-        headroomBytes: AMPLE_HEADROOM,
-      })
-    ).toBe(false);
-
-    process.env.VERCEL_PYTHON_COMPILEALL = 'false';
-    expect(
-      shouldPrecompileStandardFunction({
-        isDev: false,
-        hasCustomCommand: false,
-        headroomBytes: AMPLE_HEADROOM,
-      })
-    ).toBe(false);
-  });
-
-  it('does not enable precompilation in dev', () => {
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
-    expect(
-      shouldPrecompileStandardFunction({
-        isDev: true,
-        hasCustomCommand: false,
-        headroomBytes: AMPLE_HEADROOM,
-      })
-    ).toBe(false);
-  });
-
-  it('does not enable precompilation for custom install commands', () => {
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
-    expect(
-      shouldPrecompileStandardFunction({
-        isDev: false,
-        hasCustomCommand: true,
-        headroomBytes: AMPLE_HEADROOM,
-      })
-    ).toBe(false);
+    expect(shouldCompileAll({ isDev: false, hasCustomCommand: true })).toBe(
+      false
+    );
   });
 
   it('keeps the fill ceiling safely below the Lambda size threshold', () => {

--- a/packages/python/test/compileall.test.ts
+++ b/packages/python/test/compileall.test.ts
@@ -15,7 +15,7 @@ vi.mock('@vercel/build-utils', async importOriginal => ({
 import execa from 'execa';
 import { FileFsRef } from '@vercel/build-utils';
 import {
-  BYTECODE_FILL_CEILING_BYTES,
+  COMPILEALL_TIMEOUT_MS,
   MIN_BYTECODE_HEADROOM_BYTES,
   collectAppBytecodeFiles,
   derivePycPath,
@@ -25,7 +25,10 @@ import {
   shouldPrecompileStandardFunction,
   shouldUseCompileAll,
 } from '../src/compileall';
-import { LAMBDA_SIZE_THRESHOLD_BYTES } from '../src/dependency-externalizer';
+import {
+  BYTECODE_FILL_CEILING_BYTES,
+  LAMBDA_SIZE_THRESHOLD_BYTES,
+} from '../src/dependency-externalizer';
 
 const mockedExeca = vi.mocked(execa);
 const originalCompileAllEnv = process.env.VERCEL_PYTHON_COMPILEALL;
@@ -292,8 +295,19 @@ describe('runCompileAll', () => {
         '[/\\\\]\\.vercel(?:[/\\\\]|$)',
         '/work',
       ],
-      { env }
+      { env, timeout: COMPILEALL_TIMEOUT_MS }
     );
+  });
+
+  it('resolves without throwing when compileall fails', async () => {
+    mockedExeca.mockRejectedValue(new Error('compileall crashed'));
+
+    await expect(
+      runCompileAll({
+        pythonBin: '/work/.vercel/python/.venv/bin/python',
+        filesOrDirectories: ['/work'],
+      })
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -4,7 +4,9 @@ import path from 'path';
 import { tmpdir } from 'os';
 import {
   PythonDependencyExternalizer,
+  PYC_TO_PY_RATIO,
   calculateBundleSize,
+  estimateBytecodeSize,
   getPackagesReachableOnPlatform,
   lambdaKnapsack,
   LAMBDA_SIZE_THRESHOLD_BYTES,
@@ -226,6 +228,50 @@ describe('dependency externalizer support', () => {
       } finally {
         fs.removeSync(tempDir);
       }
+    });
+
+    it('only counts files matching the filter when provided', async () => {
+      const files = {
+        'app.py': new FileFsRef({ fsPath: '/nonexistent/app.py', size: 100 }),
+        'pkg/mod.py': new FileFsRef({
+          fsPath: '/nonexistent/mod.py',
+          size: 50,
+        }),
+        'lib.so': new FileFsRef({ fsPath: '/nonexistent/lib.so', size: 999 }),
+        'data.json': new FileBlob({ data: 'x'.repeat(40) }),
+      };
+
+      const pySize = await calculateBundleSize(files, p => p.endsWith('.py'));
+      expect(pySize).toBe(150);
+
+      const allSize = await calculateBundleSize(files);
+      expect(allSize).toBe(1189);
+    });
+  });
+
+  describe('estimateBytecodeSize', () => {
+    it('estimates bytecode as PYC_TO_PY_RATIO times the .py bytes', async () => {
+      const files = {
+        'app.py': new FileFsRef({ fsPath: '/nonexistent/app.py', size: 100 }),
+        '_vendor/pkg/mod.py': new FileFsRef({
+          fsPath: '/nonexistent/mod.py',
+          size: 900,
+        }),
+        'lib.so': new FileFsRef({
+          fsPath: '/nonexistent/lib.so',
+          size: 5000,
+        }),
+      };
+
+      expect(await estimateBytecodeSize(files)).toBe(PYC_TO_PY_RATIO * 1000);
+    });
+
+    it('returns 0 when the bundle has no .py files', async () => {
+      const files = {
+        'lib.so': new FileFsRef({ fsPath: '/nonexistent/lib.so', size: 5000 }),
+      };
+
+      expect(await estimateBytecodeSize(files)).toBe(0);
     });
   });
 

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import { tmpdir } from 'os';
 import {
   PythonDependencyExternalizer,
+  BYTECODE_COVERAGE_FLOOR,
+  BYTECODE_FILL_CEILING_BYTES,
   PYC_TO_PY_RATIO,
   calculateBundleSize,
   estimateBytecodeSize,
@@ -230,6 +232,27 @@ describe('dependency externalizer support', () => {
       }
     });
 
+    it('caches stat results on the FileFsRef so later calls skip I/O', async () => {
+      const tempDir = path.join(tmpdir(), `size-cache-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      const filePath = path.join(tempDir, 'cached.txt');
+      fs.writeFileSync(filePath, 'a'.repeat(75));
+      const ref = new FileFsRef({ fsPath: filePath });
+      const files = { 'cached.txt': ref };
+
+      try {
+        expect(ref.size).toBeUndefined();
+        expect(await calculateBundleSize(files)).toBe(75);
+        expect(ref.size).toBe(75);
+      } finally {
+        fs.removeSync(tempDir);
+      }
+
+      // File is gone; a second call must use the cached size without stat.
+      expect(await calculateBundleSize(files)).toBe(75);
+    });
+
     it('only counts files matching the filter when provided', async () => {
       const files = {
         'app.py': new FileFsRef({ fsPath: '/nonexistent/app.py', size: 100 }),
@@ -272,6 +295,38 @@ describe('dependency externalizer support', () => {
       };
 
       expect(await estimateBytecodeSize(files)).toBe(0);
+    });
+  });
+
+  describe('bytecode gate math (coverage floor)', () => {
+    const MB = 1024 * 1024;
+    const gatePasses = (bundleSize: number, pyBytes: number) => {
+      const capacity = BYTECODE_FILL_CEILING_BYTES - bundleSize;
+      const estimate = PYC_TO_PY_RATIO * pyBytes;
+      return capacity >= BYTECODE_COVERAGE_FLOOR * estimate;
+    };
+
+    it('compiles a 101MB all-Python app despite a partial fill', () => {
+      expect(gatePasses(101 * MB, 101 * MB)).toBe(true);
+    });
+
+    it('compiles all-Python apps up to the guaranteed zone boundary', () => {
+      // 220 - S >= 0.5 * 1.2 * S  =>  S <= 220 / 1.6 = 137.5MB
+      expect(gatePasses(137 * MB, 137 * MB)).toBe(true);
+      expect(gatePasses(138 * MB, 138 * MB)).toBe(false);
+    });
+
+    it('skips near-limit apps with low expected coverage', () => {
+      expect(gatePasses(219 * MB, 40 * MB)).toBe(false);
+      expect(gatePasses(200 * MB, 80 * MB)).toBe(false);
+    });
+
+    it('compiles binary-heavy near-limit apps with little .py', () => {
+      expect(gatePasses(200 * MB, 10 * MB)).toBe(true);
+    });
+
+    it('skips when the bundle exceeds the fill ceiling', () => {
+      expect(gatePasses(221 * MB, 0)).toBe(false);
     });
   });
 

--- a/packages/python/test/fixtures/64-hive-compileall/build.py
+++ b/packages/python/test/fixtures/64-hive-compileall/build.py
@@ -1,7 +1,7 @@
-# Create a large, sparse file at build time so the function is large enough that
-# compileall would normally run. This proves compileall is skipped here only
-# because the fixture uses a custom build command (running this script) — not
-# because of size. The file is sparse, so it costs negligible disk, compresses
-# to almost nothing in the bundle, and is never committed to the repo.
+# Create a large, sparse file at build time so the function takes the large
+# functions path, where compileall runs. This also proves a custom build
+# command (running this script) does not disable compileall. The file is
+# sparse, so it costs negligible disk, compresses to almost nothing in the
+# bundle, and is never committed to the repo.
 with open("large_blob.bin", "wb") as f:
     f.truncate(300 * 1024 * 1024)

--- a/packages/python/test/fixtures/64-hive-compileall/build.py
+++ b/packages/python/test/fixtures/64-hive-compileall/build.py
@@ -1,7 +1,4 @@
-# Create a large, sparse file at build time so the function takes the large
-# functions path, where compileall runs. This also proves a custom build
-# command (running this script) does not disable compileall. The file is
-# sparse, so it costs negligible disk, compresses to almost nothing in the
-# bundle, and is never committed to the repo.
+# Sparse file to force the large-functions path, proving a custom build
+# command (this script) does not disable compileall.
 with open("large_blob.bin", "wb") as f:
     f.truncate(300 * 1024 * 1024)

--- a/packages/python/test/fixtures/64-hive-compileall/pyproject.toml
+++ b/packages/python/test/fixtures/64-hive-compileall/pyproject.toml
@@ -7,7 +7,8 @@ dependencies = [
   "pydantic",
 ]
 
-# A custom build command must disable compileall, even though this script's
-# blob makes the function large. probes.json asserts compileall is skipped.
+# Custom build commands do not disable compileall (only custom install
+# commands do). This script's blob makes the function large, so probes.json
+# asserts compileall runs despite the custom build command.
 [tool.vercel.scripts]
 build = "python build.py"

--- a/packages/python/test/fixtures/64-hive-compileall/pyproject.toml
+++ b/packages/python/test/fixtures/64-hive-compileall/pyproject.toml
@@ -7,8 +7,6 @@ dependencies = [
   "pydantic",
 ]
 
-# Custom build commands do not disable compileall (only custom install
-# commands do). This script's blob makes the function large, so probes.json
-# asserts compileall runs despite the custom build command.
+# probes.json asserts compileall runs despite this custom build command.
 [tool.vercel.scripts]
 build = "python build.py"

--- a/packages/python/test/fixtures/68-standard-compileall/main.py
+++ b/packages/python/test/fixtures/68-standard-compileall/main.py
@@ -1,0 +1,26 @@
+# A standard-size function (well below the Lambda size limit) with
+# VERCEL_PYTHON_COMPILEALL=1 and no VERCEL_SUPPORT_LARGE_FUNCTIONS.
+# Verifies precompiled bytecode ships in the bundle: PYTHONDONTWRITEBYTECODE
+# is set at runtime and /var/task is read-only, so any .pyc present must have
+# been produced at build time.
+from pathlib import Path
+
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+
+def has_pyc(directory: Path) -> bool:
+    pycache = directory / "__pycache__"
+    return pycache.is_dir() and any(pycache.glob("*.pyc"))
+
+
+@app.get("/")
+def index():
+    import flask
+
+    return jsonify(
+        ok=True,
+        app_pyc=has_pyc(Path(__file__).parent),
+        vendor_pyc=has_pyc(Path(flask.__file__).parent),
+    )

--- a/packages/python/test/fixtures/68-standard-compileall/main.py
+++ b/packages/python/test/fixtures/68-standard-compileall/main.py
@@ -1,8 +1,5 @@
-# A standard-size function (well below the Lambda size limit) with
-# VERCEL_PYTHON_COMPILEALL=1 and no VERCEL_SUPPORT_LARGE_FUNCTIONS.
-# Verifies precompiled bytecode ships in the bundle: PYTHONDONTWRITEBYTECODE
-# is set at runtime and /var/task is read-only, so any .pyc present must have
-# been produced at build time.
+# Standard-size function: verifies precompiled bytecode ships in the bundle.
+# The runtime never writes .pyc, so any present were produced at build time.
 from pathlib import Path
 
 from flask import Flask, jsonify

--- a/packages/python/test/fixtures/68-standard-compileall/probes.json
+++ b/packages/python/test/fixtures/68-standard-compileall/probes.json
@@ -5,6 +5,14 @@
     },
     {
       "path": "/",
+      "mustContain": "\"app_pyc\":true"
+    },
+    {
+      "path": "/",
+      "mustContain": "\"vendor_pyc\":true"
+    },
+    {
+      "path": "/",
       "mustContain": "\"ok\":true"
     }
   ]

--- a/packages/python/test/fixtures/68-standard-compileall/pyproject.toml
+++ b/packages/python/test/fixtures/68-standard-compileall/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "fixture-68-standard-compileall"
+version = "0.0.1"
+requires-python = ">=3.12"
+dependencies = [
+  "flask",
+  "pydantic",
+]

--- a/packages/python/test/fixtures/68-standard-compileall/vercel.json
+++ b/packages/python/test/fixtures/68-standard-compileall/vercel.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "env": {
+      "VERCEL_PYTHON_COMPILEALL": "1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Enable `python compileall` for functions below the 225MB threshold. Many python functions are under this threshold and we can pack their zip with bytecode up to 220MB, leaving a buffer to make sure we never push the function into failure territory.

Also added:
-  guards so a failed/hung `compileall` will not fail the build
- custom build commands run `compileall`
- e2e fixtures

## How it works

If a function is under the 225MB threshold we estimate how much bytecode it will produce by multiplying its `.py` source bytes by `1.2`. If at least 50% of the bytecode we estimate will fit in the zip we run the `compileall` command, otherwise we skip it.

**The `1.2` ratio comes from testing against a few different python projects, the highest of which was `1.15`.**