### PR TITLE
feat(cli): support vcr login <engine> command

### DIFF
--- a/.changeset/vcr-login-command.md
+++ b/.changeset/vcr-login-command.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel vcr login [engine]` to authenticate docker, podman, or buildah with the Vercel Container Registry using an OIDC token.

--- a/packages/cli/src/commands/vcr/command.ts
+++ b/packages/cli/src/commands/vcr/command.ts
@@ -120,8 +120,12 @@ export const loginSubcommand = {
       value: `${packageName} vcr login docker`,
     },
     {
-      name: 'Log in with podman or buildah',
+      name: 'Log in with Podman',
       value: `${packageName} vcr login podman`,
+    },
+    {
+      name: 'Log in with Buildah',
+      value: `${packageName} vcr login buildah`,
     },
     {
       name: 'Log in for a specific project',

--- a/packages/cli/src/commands/vcr/command.ts
+++ b/packages/cli/src/commands/vcr/command.ts
@@ -102,6 +102,34 @@ export const removeSubcommand = {
   ],
 } as const;
 
+export const loginSubcommand = {
+  name: 'login',
+  aliases: [],
+  description:
+    'Authenticate a container tool (docker, podman, or buildah) with the Vercel Container Registry',
+  arguments: [
+    {
+      name: 'engine',
+      required: true,
+    },
+  ],
+  options: [projectScopeOption, formatOption],
+  examples: [
+    {
+      name: 'Log in with Docker',
+      value: `${packageName} vcr login docker`,
+    },
+    {
+      name: 'Log in with podman or buildah',
+      value: `${packageName} vcr login podman`,
+    },
+    {
+      name: 'Log in for a specific project',
+      value: `${packageName} vcr login docker --project my-app`,
+    },
+  ],
+} as const;
+
 export const vcrCommand = {
   name: 'vcr',
   aliases: [],
@@ -113,6 +141,7 @@ export const vcrCommand = {
     inspectSubcommand,
     addSubcommand,
     removeSubcommand,
+    loginSubcommand,
     tagsAggregateCommand,
     imageAggregateCommand,
   ],

--- a/packages/cli/src/commands/vcr/index.ts
+++ b/packages/cli/src/commands/vcr/index.ts
@@ -14,6 +14,7 @@ import {
   inspectSubcommand,
   addSubcommand,
   removeSubcommand,
+  loginSubcommand,
 } from './command';
 import {
   imageAggregateCommand,
@@ -32,6 +33,7 @@ const COMMAND_CONFIG = {
   inspect: getCommandAliases(inspectSubcommand),
   add: getCommandAliases(addSubcommand),
   rm: getCommandAliases(removeSubcommand),
+  login: getCommandAliases(loginSubcommand),
   tag: getCommandAliases(tagsAggregateCommand),
   image: getCommandAliases(imageAggregateCommand),
 };
@@ -83,6 +85,10 @@ export default async function vcr(client: Client): Promise<number> {
       case 'rm':
         telemetry.trackCliFlagHelp('vcr', subcommandOriginal);
         printHelp(removeSubcommand);
+        return 2;
+      case 'login':
+        telemetry.trackCliFlagHelp('vcr', subcommandOriginal);
+        printHelp(loginSubcommand);
         return 2;
       case 'tag': {
         telemetry.trackCliFlagHelp('vcr', subcommandOriginal);
@@ -136,6 +142,9 @@ export default async function vcr(client: Client): Promise<number> {
     case 'rm':
       telemetry.trackCliSubcommandRm(subcommandOriginal);
       return (await import('./rm')).default(client, args, telemetry);
+    case 'login':
+      telemetry.trackCliSubcommandLogin(subcommandOriginal);
+      return (await import('./login')).default(client, args, telemetry);
     case 'tag':
       telemetry.trackCliSubcommandTag(subcommandOriginal);
       return (await import('./tags')).default(client, args, telemetry);

--- a/packages/cli/src/commands/vcr/login.ts
+++ b/packages/cli/src/commands/vcr/login.ts
@@ -1,0 +1,203 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import output from '../../output-manager';
+import { isAPIError } from '../../util/errors-ts';
+import { outputError } from '../../util/command-validation';
+import {
+  buildCommandWithGlobalFlags,
+  outputAgentError,
+} from '../../util/agent-output';
+import { AGENT_REASON } from '../../util/agent-output-constants';
+import type { VcrTelemetryClient } from '../../util/telemetry/commands/vcr';
+import { loginSubcommand } from './command';
+import { resolveVcrScope } from './utils/resolve-vcr-scope';
+import { validateVcrJsonOutput, validateVcrChoice } from './utils/validators';
+import { emitVcrArgParseError, handleVcrApiError } from './utils/errors';
+import {
+  VCR_ENGINES,
+  VCR_LOGIN_USERNAME,
+  engineLogin,
+  isEngineInstalled,
+  resolveRegistry,
+  type VcrEngine,
+} from './utils/engine-login';
+
+/** stderr signatures that mean the registry rejected our credentials. */
+const AUTH_FAILURE = /denied|forbidden|unauthorized|401|403/i;
+
+/** Last few lines of engine stderr, for surfacing an unexpected failure. */
+function stderrTail(stderr: string): string {
+  return stderr.trim().split('\n').slice(-5).join('\n');
+}
+
+export default async function login(
+  client: Client,
+  argv: string[],
+  telemetry: VcrTelemetryClient
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(loginSubcommand.options)
+    );
+  } catch (err) {
+    emitVcrArgParseError(
+      client,
+      err,
+      'vcr login <engine> --project <name-or-id>'
+    );
+    printError(err);
+    return 1;
+  }
+
+  const fr = validateVcrJsonOutput(client, parsedArgs.flags);
+  if (typeof fr === 'number') {
+    return fr;
+  }
+
+  const engineArg = parsedArgs.args[0] as string | undefined;
+  const project = parsedArgs.flags['--project'] as string | undefined;
+
+  telemetry.trackCliArgumentEngine(engineArg);
+  telemetry.trackCliOptionProject(project);
+  telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
+
+  // The engine must always be specified explicitly — there is no default.
+  if (!engineArg) {
+    const message = `Missing engine. Choose one of: ${VCR_ENGINES.join(', ')}.`;
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.MISSING_ARGUMENTS,
+        message,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'vcr login docker'
+            ),
+            when: 'Replace docker with the container tool you use',
+          },
+        ],
+      },
+      1
+    );
+    return outputError(client, fr.jsonOutput, 'MISSING_ARGUMENTS', message);
+  }
+
+  const choiceError = validateVcrChoice(
+    client,
+    'engine',
+    engineArg,
+    VCR_ENGINES,
+    fr.jsonOutput
+  );
+  if (typeof choiceError === 'number') {
+    return choiceError;
+  }
+  const engine = engineArg as VcrEngine;
+
+  // Fail fast on a missing binary before doing any network work.
+  if (!isEngineInstalled(engine)) {
+    const message = `\`${engine}\` is not installed or not on your PATH. Install it and try again.`;
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: 'engine_not_found',
+        message,
+      },
+      1
+    );
+    return outputError(client, fr.jsonOutput, 'ENGINE_NOT_FOUND', message);
+  }
+
+  const scope = await resolveVcrScope(client, {
+    project,
+    jsonOutput: fr.jsonOutput,
+  });
+  if (typeof scope === 'number') {
+    return scope;
+  }
+
+  const registry = resolveRegistry();
+
+  output.spinner(`Authenticating ${engine} with ${registry}...`);
+  try {
+    // Mint a fresh project OIDC token (same endpoint as `vercel project token`).
+    // The token is only ever piped to the engine over stdin — never logged,
+    // returned to the caller, or placed on the command line.
+    const { token } = await client.fetch<{ token: string }>(
+      `/projects/${scope.projectId}/token`,
+      {
+        method: 'POST',
+        accountId: scope.teamId,
+        body: JSON.stringify({ source: 'vercel-cli' }),
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const result = await engineLogin(engine, registry, token);
+    if (result.exitCode !== 0) {
+      const message = AUTH_FAILURE.test(result.stderr)
+        ? `Authentication to ${registry} as "${VCR_LOGIN_USERNAME}" was rejected. The OIDC token may be expired or lack access to this project.`
+        : `\`${engine} login\` failed (exit code ${result.exitCode}).${
+            stderrTail(result.stderr) ? `\n${stderrTail(result.stderr)}` : ''
+          }`;
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: AUTH_FAILURE.test(result.stderr)
+            ? 'not_authorized'
+            : 'command_failed',
+          message,
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(client.argv, 'whoami'),
+              when: 'See current user and team',
+            },
+          ],
+        },
+        1
+      );
+      return outputError(
+        client,
+        fr.jsonOutput,
+        AUTH_FAILURE.test(result.stderr) ? 'NOT_AUTHORIZED' : 'COMMAND_FAILED',
+        message
+      );
+    }
+
+    if (fr.jsonOutput) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            status: 'success',
+            engine,
+            registry,
+            username: VCR_LOGIN_USERNAME,
+          },
+          null,
+          2
+        )}\n`
+      );
+    } else {
+      output.success(
+        `Logged in to ${registry} as ${VCR_LOGIN_USERNAME} (${engine}).`
+      );
+    }
+    return 0;
+  } catch (err) {
+    if (isAPIError(err)) {
+      return handleVcrApiError(client, err, fr.jsonOutput);
+    }
+    throw err;
+  } finally {
+    output.stopSpinner();
+  }
+}

--- a/packages/cli/src/commands/vcr/login.ts
+++ b/packages/cli/src/commands/vcr/login.ts
@@ -27,6 +27,13 @@ import {
 /** stderr signatures that mean the registry rejected our credentials. */
 const AUTH_FAILURE = /denied|forbidden|unauthorized|401|403/i;
 
+/**
+ * The minted project OIDC token is development-scoped, which the API issues with
+ * a 12-hour TTL (see `getProjectToken` in vercel/api). The engine stores that
+ * token as a static credential, so the login is only good until it expires.
+ */
+const LOGIN_VALID_HOURS = 12;
+
 /** Last few lines of engine stderr, for surfacing an unexpected failure. */
 function stderrTail(stderr: string): string {
   return stderr.trim().split('\n').slice(-5).join('\n');
@@ -181,6 +188,7 @@ export default async function login(
             engine,
             registry,
             username: VCR_LOGIN_USERNAME,
+            validForHours: LOGIN_VALID_HOURS,
           },
           null,
           2
@@ -189,6 +197,12 @@ export default async function login(
     } else {
       output.success(
         `Logged in to ${registry} as ${VCR_LOGIN_USERNAME} (${engine}).`
+      );
+      output.log(
+        `Credentials are valid for ~${LOGIN_VALID_HOURS} hours. Re-run \`${buildCommandWithGlobalFlags(
+          client.argv,
+          `vcr login ${engine}`
+        )}\` to refresh.`
       );
     }
     return 0;

--- a/packages/cli/src/commands/vcr/utils/engine-login.ts
+++ b/packages/cli/src/commands/vcr/utils/engine-login.ts
@@ -1,0 +1,45 @@
+import which from 'which';
+import execa from 'execa';
+import { VCR_REGISTRY } from './format';
+
+export const VCR_ENGINES = ['docker', 'podman', 'buildah'] as const;
+export type VcrEngine = (typeof VCR_ENGINES)[number];
+
+export const VCR_LOGIN_USERNAME = 'oidc';
+
+export function resolveRegistry(): string {
+  return process.env.VERCEL_VCR_REGISTRY || VCR_REGISTRY;
+}
+
+export function isEngineInstalled(engine: VcrEngine): boolean {
+  return which.sync(engine, { nothrow: true }) !== null;
+}
+
+export interface EngineLoginResult {
+  exitCode: number;
+  stderr: string;
+}
+
+export async function engineLogin(
+  engine: VcrEngine,
+  registry: string,
+  token: string
+): Promise<EngineLoginResult> {
+  const result = await execa(
+    engine,
+    ['login', registry, '--username', VCR_LOGIN_USERNAME, '--password-stdin'],
+    { input: token, reject: false }
+  );
+
+  // With `reject: false`, a spawn failure (e.g. the binary vanished from PATH
+  // between detection and exec) resolves to an Error without a numeric exitCode
+  // rather than throwing.
+  if (result instanceof Error && typeof result.exitCode !== 'number') {
+    return { exitCode: 1, stderr: result.message };
+  }
+
+  return {
+    exitCode: typeof result.exitCode === 'number' ? result.exitCode : 1,
+    stderr: result.stderr ?? '',
+  };
+}

--- a/packages/cli/src/util/telemetry/commands/vcr/index.ts
+++ b/packages/cli/src/util/telemetry/commands/vcr/index.ts
@@ -34,6 +34,24 @@ export class VcrTelemetryClient
     });
   }
 
+  trackCliSubcommandLogin(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'login',
+      value: actual,
+    });
+  }
+
+  trackCliArgumentEngine(value: string | undefined) {
+    if (value) {
+      // Engine is a bounded enum (docker|podman|buildah), so it is safe to
+      // record the actual value rather than redacting it.
+      this.trackCliArgument({
+        arg: 'engine',
+        value,
+      });
+    }
+  }
+
   trackCliSubcommandTag(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'tag',

--- a/packages/cli/test/unit/commands/vcr/login.test.ts
+++ b/packages/cli/test/unit/commands/vcr/login.test.ts
@@ -112,6 +112,7 @@ describe('vcr login', () => {
     expect(client.stderr.getFullOutput()).toContain(
       'Logged in to vcr.vercel.com'
     );
+    expect(client.stderr.getFullOutput()).toContain('valid for ~12 hours');
   });
 
   it('never leaks the token to stdout or stderr', async () => {
@@ -193,6 +194,7 @@ describe('vcr login', () => {
       engine: 'docker',
       registry: 'vcr.vercel.com',
       username: 'oidc',
+      validForHours: 12,
     });
     expect(parsed).not.toHaveProperty('token');
     expect(client.stdout.getFullOutput()).not.toContain(TOKEN);

--- a/packages/cli/test/unit/commands/vcr/login.test.ts
+++ b/packages/cli/test/unit/commands/vcr/login.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import vcr from '../../../../src/commands/vcr';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+import execa from 'execa';
+import which from 'which';
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+vi.mock('execa', () => ({ default: vi.fn() }));
+vi.mock('which', () => ({ default: { sync: vi.fn() } }));
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+const mockedExeca = vi.mocked(execa);
+const mockedWhichSync = vi.mocked(which.sync);
+
+const TOKEN = 'header.payload.signature-oidc-secret';
+
+let tmpDir: string;
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_vcr',
+      name: 'vcr-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockNotLinked() {
+  mockedGetLinkedProject.mockResolvedValue({ status: 'not_linked' } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+/** Stub the OIDC token mint endpoint (same one `vercel project token` uses). */
+function mockMint(token = TOKEN) {
+  client.scenario.post('/projects/prj_vcr/token', (_req, res) => {
+    res.json({ token });
+  });
+}
+
+/** Treat only the named engines as installed on PATH. */
+function installEngines(...names: string[]) {
+  mockedWhichSync.mockImplementation(((name: string) =>
+    names.includes(name) ? `/usr/bin/${name}` : null) as any);
+}
+
+describe('vcr login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    installEngines('docker', 'podman', 'buildah');
+    mockedExeca.mockResolvedValue({ exitCode: 0, stderr: '' } as any);
+    tmpDir = setupTmpDir('vercel-vcr-login');
+    client.cwd = tmpDir;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.VERCEL_VCR_REGISTRY;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry and exits 2', async () => {
+      client.setArgv('vcr', 'login', '--help');
+      const exitCode = await vcr(client);
+      expect(exitCode).toEqual(2);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'vcr:login',
+        },
+      ]);
+    });
+  });
+
+  it.each([
+    'docker',
+    'podman',
+    'buildah',
+  ])('logs in with the explicit %s engine', async engine => {
+    mockMint();
+    client.setArgv('vcr', 'login', engine);
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(mockedExeca).toHaveBeenCalledWith(
+      engine,
+      ['login', 'vcr.vercel.com', '--username', 'oidc', '--password-stdin'],
+      { input: TOKEN, reject: false }
+    );
+    expect(client.stderr.getFullOutput()).toContain(
+      'Logged in to vcr.vercel.com'
+    );
+  });
+
+  it('never leaks the token to stdout or stderr', async () => {
+    mockMint();
+    client.setArgv('vcr', 'login', 'docker');
+    await vcr(client);
+    expect(client.stdout.getFullOutput()).not.toContain(TOKEN);
+    expect(client.stderr.getFullOutput()).not.toContain(TOKEN);
+  });
+
+  it('errors when the engine argument is omitted (no default)', async () => {
+    client.setArgv('vcr', 'login');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Missing engine');
+    expect(client.stderr.getFullOutput()).toContain('docker, podman, buildah');
+    expect(mockedExeca).not.toHaveBeenCalled();
+  });
+
+  it('errors when the requested engine is not installed', async () => {
+    installEngines('podman'); // docker missing
+    client.setArgv('vcr', 'login', 'docker');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('docker');
+    expect(client.stderr.getFullOutput()).toContain('PATH');
+    expect(mockedExeca).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an authentication failure', async () => {
+    mockMint();
+    mockedExeca.mockResolvedValue({
+      exitCode: 1,
+      stderr: 'Error response from daemon: unauthorized: access denied',
+    } as any);
+    client.setArgv('vcr', 'login', 'docker');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('was rejected');
+  });
+
+  it('surfaces an unexpected engine failure with stderr tail', async () => {
+    mockMint();
+    mockedExeca.mockResolvedValue({
+      exitCode: 125,
+      stderr: 'Cannot connect to the Docker daemon',
+    } as any);
+    client.setArgv('vcr', 'login', 'docker');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Cannot connect');
+  });
+
+  it('errors when no project is linked and --project is omitted', async () => {
+    mockNotLinked();
+    client.setArgv('vcr', 'login', 'docker');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('No linked project');
+    expect(mockedExeca).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid engine value', async () => {
+    client.setArgv('vcr', 'login', 'nope');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('docker, podman, buildah');
+    expect(mockedExeca).not.toHaveBeenCalled();
+  });
+
+  it('emits token-free JSON with --format json', async () => {
+    mockMint();
+    client.setArgv('vcr', 'login', 'docker', '--format', 'json');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed).toMatchObject({
+      status: 'success',
+      engine: 'docker',
+      registry: 'vcr.vercel.com',
+      username: 'oidc',
+    });
+    expect(parsed).not.toHaveProperty('token');
+    expect(client.stdout.getFullOutput()).not.toContain(TOKEN);
+  });
+
+  it('honors the VERCEL_VCR_REGISTRY override', async () => {
+    process.env.VERCEL_VCR_REGISTRY = 'vcr.staging.vercel.com';
+    mockMint();
+    client.setArgv('vcr', 'login', 'docker');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(mockedExeca).toHaveBeenCalledWith(
+      'docker',
+      [
+        'login',
+        'vcr.staging.vercel.com',
+        '--username',
+        'oidc',
+        '--password-stdin',
+      ],
+      { input: TOKEN, reject: false }
+    );
+  });
+
+  it('tracks subcommand and engine telemetry', async () => {
+    mockMint();
+    client.setArgv('vcr', 'login', 'podman');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:login',
+        value: 'login',
+      },
+      {
+        key: 'argument:engine',
+        value: 'podman',
+      },
+    ]);
+  });
+
+  it('handles an API error while minting the token', async () => {
+    client.scenario.post('/projects/prj_vcr/token', (_req, res) => {
+      res.status(401).json({
+        error: { code: 'forbidden', message: 'Not allowed.' },
+      });
+    });
+    client.setArgv('vcr', 'login', 'docker');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(mockedExeca).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Support the new `vercel vcr login <engine>` command.

Examples of valid operations:

```
❯ vercel vcr login docker
Vercel CLI 54.18.7 (Node.js 20.18.0)
> Success! Logged in to vcr.vercel.com as oidc (docker).

❯ vercel vcr login podman
Vercel CLI 54.18.7 (Node.js 20.18.0)
> Success! Logged in to vcr.vercel.com as oidc (podman).
```

Examples of invalid operations:

```
❯ vercel vcr login
Vercel CLI 54.18.7 (Node.js 20.18.0)
Error: Missing engine. Choose one of: docker, podman, buildah.

❯ vercel vcr login podman
Vercel CLI 54.18.7 (Node.js 20.18.0)
Error: `podman` is not installed or not on your PATH. Install it and try again.

❯ vercel vcr login invalid
Vercel CLI 54.18.7 (Node.js 20.18.0)
Error: Invalid value for engine: "invalid". Must be one of: docker, podman, buildah.
```