### PR TITLE
[cli] fix self-upgrade for pnpm 11 global installs and post-upgrade prompt

### DIFF
--- a/.changeset/cli-no-update-prompt-after-upgrade.md
+++ b/.changeset/cli-no-update-prompt-after-upgrade.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Stopped showing the "Update available … Would you like to upgrade now?" prompt immediately after running `vercel upgrade`. The running process still holds the pre-upgrade version in memory, so the notifier would ask the user to upgrade again right after a successful upgrade.

--- a/.changeset/cli-upgrade-never-guess-local.md
+++ b/.changeset/cli-upgrade-never-guess-local.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vercel upgrade` no longer classifies the installation as local without positive evidence (a lockfile found above the CLI's install location). Previously, when the installation layout was not recognized, the upgrade defaulted to running `npm i vercel@latest` in the current working directory — silently adding `vercel` to whatever project (or home directory) the user happened to be standing in. Unrecognized layouts now degrade to a global npm upgrade, which runs from a temporary directory and cannot modify the current project.

--- a/.changeset/cli-upgrade-pnpm-v11-global.md
+++ b/.changeset/cli-upgrade-pnpm-v11-global.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fixed `vercel upgrade` misdetecting pnpm 11 global installs as local npm installs. pnpm 11 moved global packages to isolated directories under `PNPM_HOME/global/v11/` backed by the global virtual store, which the previous detection did not recognize — causing the upgrade to run `npm i vercel@latest` in the current working directory (creating a stray `node_modules`) while reporting success without upgrading the real installation. Detection now recognizes installs running from inside `PNPM_HOME`, and no longer crashes when the entrypoint path cannot be resolved on disk.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1387,7 +1387,10 @@ async function promptAndUpgrade(
 
 main()
   .then(async exitCode => {
-    if (cachedLatest) {
+    // Skip the update notification after `vc upgrade`: the process still has
+    // the pre-upgrade version in memory, so it would prompt the user to
+    // upgrade again right after the upgrade completed.
+    if (cachedLatest && resolvedCommandForUpdate !== 'upgrade') {
       const originalExitCode = typeof exitCode === 'number' ? exitCode : 0;
 
       // Await the fresh registry lookup to verify the exact version before

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -106,24 +106,13 @@ async function getConfigPrefix() {
 }
 
 /**
- * Detects a pnpm global install by checking whether the CLI is running from
- * inside `PNPM_HOME`. This is the most reliable signal for pnpm because it is
- * independent of pnpm's global layout, which changes across major versions:
- * pnpm ≤10 uses `{PNPM_HOME}/global/5/.pnpm/...` while pnpm 11+ uses isolated
- * installs under `{PNPM_HOME}/global/v11/{hash}/` whose realpath resolves into
- * the global virtual store at `{storeDir}/links/...`. Additionally,
- * `pnpm root -g` cannot be trusted here: on machines upgraded from pnpm ≤10 it
- * keeps answering with the stale `global/5` layout (pnpm does not migrate it,
- * see pnpm/pnpm#11528), so the query-based detection misses v11 installs.
- *
- * On clean pnpm 11 machines the query fails differently but just as fatally:
- * `pnpm root -g` answers with the parent of the isolated install dirs (e.g.
- * `{PNPM_HOME}/global/v11`), which is not a node_modules directory, so
- * `join(root, pkg)` never resolves to an existing path.
- *
- * The unresolved entrypoint (`process.argv[1]`) is checked as well as the
- * realpath'd install dir: pnpm 11 bin shims exec a target inside `PNPM_HOME`,
- * while its realpath may escape into a relocated store directory.
+ * Detects a pnpm global install: the CLI runs from inside `PNPM_HOME`.
+ * Layout-independent (pnpm has changed its global layout across majors) and
+ * more reliable than `pnpm root -g`, which returns stale or unusable paths
+ * for pnpm 11 installs (see pnpm/pnpm#11528). Checks the unresolved
+ * entrypoint as well as the realpath'd install dir because pnpm 11 shims
+ * exec a target inside `PNPM_HOME` whose realpath may escape into a
+ * relocated store directory.
  */
 async function isPnpmHomeInstall(installPath: string): Promise<boolean> {
   const pnpmHome = process.env.PNPM_HOME;
@@ -135,7 +124,7 @@ async function isPnpmHomeInstall(installPath: string): Promise<boolean> {
   try {
     candidates.push(await realpath(pnpmHome));
   } catch (_) {
-    // PNPM_HOME set but unresolvable; fall through with the raw value
+    // PNPM_HOME set but unresolvable; check the raw value only
   }
 
   const entrypoint = process.argv[1];
@@ -165,8 +154,7 @@ function isGlobalByPath(installPath: string): boolean {
     return true;
   }
 
-  // pnpm 11+ global virtual store: installs realpath into
-  // `.../pnpm/store/v{N}/links/...`
+  // pnpm 11+ global virtual store (`.../pnpm/store/v{N}/links/...`)
   if (
     installPath.includes(['', 'pnpm', 'store', ''].join(sep)) &&
     installPath.includes(sep + 'links' + sep)
@@ -231,15 +219,11 @@ async function resolveInstall() {
     // fall through to the global npm default below
   }
 
-  // A genuine local (project-dependency) install always has a lockfile above
-  // the CLI's install location. Without that positive evidence, never
-  // classify as local: a local classification makes the upgrade run
-  // `<pm> i vercel@latest` in the user's current directory, which mutates
-  // whatever project they happen to be standing in. Unknown layouts (e.g.
-  // future package manager changes) must degrade to a global upgrade, which
-  // runs from a temp dir and cannot touch the cwd.
+  // Only classify as a local install with positive evidence (a lockfile
+  // above the install). A wrong "local" runs `<pm> i vercel@latest` in the
+  // user's cwd, mutating whatever project they are standing in; unknown
+  // layouts must degrade to a global upgrade, which runs from a temp dir.
   if (!lockfileCliType) {
-    // Global installs for npm do not have a lockfile
     return { cliType: 'npm' as const, global: true };
   }
 

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -107,12 +107,8 @@ async function getConfigPrefix() {
 
 /**
  * Detects a pnpm global install: the CLI runs from inside `PNPM_HOME`.
- * Layout-independent (pnpm has changed its global layout across majors) and
- * more reliable than `pnpm root -g`, which returns stale or unusable paths
- * for pnpm 11 installs (see pnpm/pnpm#11528). Checks the unresolved
- * entrypoint as well as the realpath'd install dir because pnpm 11 shims
- * exec a target inside `PNPM_HOME` whose realpath may escape into a
- * relocated store directory.
+ * Works across pnpm's global layout changes, unlike `pnpm root -g`
+ * (see pnpm/pnpm#11528).
  */
 async function isPnpmHomeInstall(installPath: string): Promise<boolean> {
   const pnpmHome = process.env.PNPM_HOME;
@@ -124,7 +120,7 @@ async function isPnpmHomeInstall(installPath: string): Promise<boolean> {
   try {
     candidates.push(await realpath(pnpmHome));
   } catch (_) {
-    // PNPM_HOME set but unresolvable; check the raw value only
+    // unresolvable; check the raw value only
   }
 
   const entrypoint = process.argv[1];
@@ -204,8 +200,6 @@ async function resolveInstall() {
     return { cliType: globalCliType, global: true };
   }
 
-  // The entrypoint may not resolve on disk (e.g. inside a virtual filesystem
-  // snapshot); treat that the same as finding no lockfile rather than crashing.
   let lockfileCliType: string | undefined;
   try {
     const entrypoint = await realpath(process.argv[1]);
@@ -216,13 +210,11 @@ async function resolveInstall() {
       lockfileCliType = cliType;
     }
   } catch (_) {
-    // fall through to the global npm default below
+    // entrypoint may not resolve on disk (e.g. virtual filesystem snapshot)
   }
 
-  // Only classify as a local install with positive evidence (a lockfile
-  // above the install). A wrong "local" runs `<pm> i vercel@latest` in the
-  // user's cwd, mutating whatever project they are standing in; unknown
-  // layouts must degrade to a global upgrade, which runs from a temp dir.
+  // No lockfile above the install — never guess "local": a wrong local
+  // install runs in (and mutates) the user's cwd. Default to global.
   if (!lockfileCliType) {
     return { cliType: 'npm' as const, global: true };
   }

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -105,6 +105,50 @@ async function getConfigPrefix() {
   return null;
 }
 
+/**
+ * Detects a pnpm global install by checking whether the CLI is running from
+ * inside `PNPM_HOME`. This is the most reliable signal for pnpm because it is
+ * independent of pnpm's global layout, which changes across major versions:
+ * pnpm ≤10 uses `{PNPM_HOME}/global/5/.pnpm/...` while pnpm 11+ uses isolated
+ * installs under `{PNPM_HOME}/global/v11/{hash}/` whose realpath resolves into
+ * the global virtual store at `{storeDir}/links/...`. Additionally,
+ * `pnpm root -g` cannot be trusted here: on machines upgraded from pnpm ≤10 it
+ * keeps answering with the stale `global/5` layout (pnpm does not migrate it,
+ * see pnpm/pnpm#11528), so the query-based detection misses v11 installs.
+ *
+ * On clean pnpm 11 machines the query fails differently but just as fatally:
+ * `pnpm root -g` answers with the parent of the isolated install dirs (e.g.
+ * `{PNPM_HOME}/global/v11`), which is not a node_modules directory, so
+ * `join(root, pkg)` never resolves to an existing path.
+ *
+ * The unresolved entrypoint (`process.argv[1]`) is checked as well as the
+ * realpath'd install dir: pnpm 11 bin shims exec a target inside `PNPM_HOME`,
+ * while its realpath may escape into a relocated store directory.
+ */
+async function isPnpmHomeInstall(installPath: string): Promise<boolean> {
+  const pnpmHome = process.env.PNPM_HOME;
+  if (!pnpmHome) {
+    return false;
+  }
+
+  const candidates = [pnpmHome];
+  try {
+    candidates.push(await realpath(pnpmHome));
+  } catch (_) {
+    // PNPM_HOME set but unresolvable; fall through with the raw value
+  }
+
+  const entrypoint = process.argv[1];
+  for (const home of candidates) {
+    const prefix = home.endsWith(sep) ? home : home + sep;
+    if (entrypoint?.startsWith(prefix) || installPath.startsWith(prefix)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function isGlobalByPath(installPath: string): boolean {
   // This is true for e.g. nvm, node path will be equal to now path
   if (dirname(process.argv[0]) === dirname(process.argv[1])) {
@@ -118,6 +162,15 @@ function isGlobalByPath(installPath: string): boolean {
   }
 
   if (installPath.includes(['', 'pnpm', 'global', ''].join(sep))) {
+    return true;
+  }
+
+  // pnpm 11+ global virtual store: installs realpath into
+  // `.../pnpm/store/v{N}/links/...`
+  if (
+    installPath.includes(['', 'pnpm', 'store', ''].join(sep)) &&
+    installPath.includes(sep + 'links' + sep)
+  ) {
     return true;
   }
 
@@ -154,19 +207,44 @@ async function resolveInstall() {
   const pkg = isNativeBinaryInstall() ? nativePackageName : packageName;
   const installPath = await realpath(resolve(__dirname));
 
+  if (await isPnpmHomeInstall(installPath)) {
+    return { cliType: 'pnpm' as const, global: true };
+  }
+
   const globalCliType = await detectGlobalCliType(installPath, pkg);
   if (globalCliType) {
     return { cliType: globalCliType, global: true };
   }
 
-  const entrypoint = await realpath(process.argv[1]);
-  const { cliType, lockfilePath } = await scanParentDirs(
-    dirname(dirname(entrypoint))
-  );
+  // The entrypoint may not resolve on disk (e.g. inside a virtual filesystem
+  // snapshot); treat that the same as finding no lockfile rather than crashing.
+  let lockfileCliType: string | undefined;
+  try {
+    const entrypoint = await realpath(process.argv[1]);
+    const { cliType, lockfilePath } = await scanParentDirs(
+      dirname(dirname(entrypoint))
+    );
+    if (lockfilePath) {
+      lockfileCliType = cliType;
+    }
+  } catch (_) {
+    // fall through to the global npm default below
+  }
+
+  // A genuine local (project-dependency) install always has a lockfile above
+  // the CLI's install location. Without that positive evidence, never
+  // classify as local: a local classification makes the upgrade run
+  // `<pm> i vercel@latest` in the user's current directory, which mutates
+  // whatever project they happen to be standing in. Unknown layouts (e.g.
+  // future package manager changes) must degrade to a global upgrade, which
+  // runs from a temp dir and cannot touch the cwd.
+  if (!lockfileCliType) {
+    // Global installs for npm do not have a lockfile
+    return { cliType: 'npm' as const, global: true };
+  }
 
   return {
-    // Global installs for npm do not have a lockfile
-    cliType: lockfilePath ? cliType : 'npm',
+    cliType: lockfileCliType,
     global:
       isGlobalByPath(installPath) || (await isGlobalByPrefix(installPath)),
   };

--- a/packages/cli/src/util/upgrade.ts
+++ b/packages/cli/src/util/upgrade.ts
@@ -152,12 +152,19 @@ export async function executeUpgrade(targetVersion?: string): Promise<number> {
       shell: false,
     });
 
+    // Stream the installer's output to debug as it arrives. The install can
+    // hang if the package manager prompts for input (e.g. corepack download
+    // confirmations, store migration recovery) — with output piped, that
+    // prompt is otherwise invisible. Running with --debug reveals what the
+    // installer said last before any hang.
     upgradeProcess.stdout?.on('data', (data: Buffer) => {
       stdout.push(Uint8Array.from(data));
+      output.debug(`[upgrade stdout] ${data.toString().trimEnd()}`);
     });
 
     upgradeProcess.stderr?.on('data', (data: Buffer) => {
       stderr.push(Uint8Array.from(data));
+      output.debug(`[upgrade stderr] ${data.toString().trimEnd()}`);
     });
 
     upgradeProcess.on('error', (err: Error) => {

--- a/packages/cli/src/util/upgrade.ts
+++ b/packages/cli/src/util/upgrade.ts
@@ -152,11 +152,8 @@ export async function executeUpgrade(targetVersion?: string): Promise<number> {
       shell: false,
     });
 
-    // Stream the installer's output to debug as it arrives. The install can
-    // hang if the package manager prompts for input (e.g. corepack download
-    // confirmations, store migration recovery) — with output piped, that
-    // prompt is otherwise invisible. Running with --debug reveals what the
-    // installer said last before any hang.
+    // Stream to debug so --debug reveals an otherwise-invisible installer
+    // prompt (the cause of apparent hangs).
     upgradeProcess.stdout?.on('data', (data: Buffer) => {
       stdout.push(Uint8Array.from(data));
       output.debug(`[upgrade stdout] ${data.toString().trimEnd()}`);

--- a/packages/cli/test/unit/util/get-update-command.test.ts
+++ b/packages/cli/test/unit/util/get-update-command.test.ts
@@ -6,6 +6,7 @@ import getUpdateCommand, {
 
 describe('getUpdateCommand', () => {
   const originalVercelVcNative = process.env.VERCEL_VC_NATIVE;
+  const originalPnpmHome = process.env.PNPM_HOME;
 
   afterEach(() => {
     if (originalVercelVcNative === undefined) {
@@ -13,10 +14,16 @@ describe('getUpdateCommand', () => {
     } else {
       process.env.VERCEL_VC_NATIVE = originalVercelVcNative;
     }
+    if (originalPnpmHome === undefined) {
+      delete process.env.PNPM_HOME;
+    } else {
+      process.env.PNPM_HOME = originalPnpmHome;
+    }
   });
 
   it('should detect update command', async () => {
     delete process.env.VERCEL_VC_NATIVE;
+    delete process.env.PNPM_HOME;
 
     const updateCommand = await getUpdateCommand();
     if (await isGlobal()) {
@@ -33,6 +40,85 @@ describe('getUpdateCommand', () => {
 
     expect(updateCommand).toContain('@vercel/vc-native@latest');
     expect(updateCommand.split(' ')).not.toContain('vercel@latest');
+  });
+
+  describe('pnpm global installs (PNPM_HOME)', () => {
+    const originalArgv1 = process.argv[1];
+
+    afterEach(() => {
+      process.argv[1] = originalArgv1;
+    });
+
+    function setEntrypoint(value: string) {
+      process.argv[1] = value.split('/').join(sep);
+    }
+
+    function pnpmHome(value: string) {
+      process.env.PNPM_HOME = value.split('/').join(sep);
+    }
+
+    it('detects pnpm 11 isolated global installs via PNPM_HOME', async () => {
+      delete process.env.VERCEL_VC_NATIVE;
+      pnpmHome('/home/user/.local/share/pnpm');
+      // pnpm 11 bin shims exec a target inside PNPM_HOME/global/v11/{hash}/
+      setEntrypoint(
+        '/home/user/.local/share/pnpm/global/v11/150b-19f23dfe656/node_modules/vercel/dist/vc.js'
+      );
+
+      expect(await getUpdateCommand()).toEqual('pnpm i -g vercel@latest');
+      expect(await isGlobal()).toBe(true);
+    });
+
+    it('detects legacy pnpm global installs via PNPM_HOME', async () => {
+      delete process.env.VERCEL_VC_NATIVE;
+      pnpmHome('/home/user/.local/share/pnpm');
+      setEntrypoint(
+        '/home/user/.local/share/pnpm/global/5/node_modules/vercel/dist/vc.js'
+      );
+
+      expect(await getUpdateCommand()).toEqual('pnpm i -g vercel@latest');
+    });
+
+    it('matches PNPM_HOME as a path prefix, not a substring', async () => {
+      delete process.env.VERCEL_VC_NATIVE;
+      pnpmHome('/home/user/.local/share/pnpm');
+      // Sibling directory that shares the PNPM_HOME string prefix must not match
+      setEntrypoint(
+        '/home/user/.local/share/pnpm-backup/node_modules/vercel/dist/vc.js'
+      );
+
+      // Falls through to the regular detection (repo-dependent), but must not
+      // have taken the PNPM_HOME fast path with this entrypoint. The fast path
+      // always yields global pnpm; the repo fallback yields a local install.
+      const updateCommand = await getUpdateCommand();
+      const viaFastPath =
+        updateCommand === 'pnpm i -g vercel@latest' && (await isGlobal());
+      // In the dev repo the fallback resolves a local pnpm install, so the
+      // fast path result (global) would only appear if prefix matching leaked.
+      expect(viaFastPath).toBe(false);
+    });
+  });
+
+  describe('unrecognized layouts', () => {
+    const originalArgv1 = process.argv[1];
+
+    afterEach(() => {
+      process.argv[1] = originalArgv1;
+    });
+
+    it('degrades to a global npm upgrade instead of guessing local', async () => {
+      delete process.env.VERCEL_VC_NATIVE;
+      delete process.env.PNPM_HOME;
+      // Entrypoint that cannot be resolved on disk (e.g. a virtual filesystem
+      // snapshot path) and matches no global layout heuristics.
+      process.argv[1] = ['', 'nonexistent', 'snapshot', 'dist', 'vc.js'].join(
+        sep
+      );
+
+      // Must never produce a local install command, which would run in (and
+      // mutate) the user's current working directory.
+      expect(await getUpdateCommand()).toEqual('npm i -g vercel@latest');
+    });
   });
 
   describe('native install package manager detection', () => {


### PR DESCRIPTION
### What

Fixes three bugs in the CLI self-upgrade flow (`vc upgrade` and the post-command upgrade prompt):

1. **pnpm 11 global installs are misdetected as local npm installs.** The upgrade runs `npm i vercel@latest` in the user's **current working directory** — polluting whatever project (or home directory) they're standing in with a stray `node_modules`/`package.json` — and then reports success while the real installation is untouched. Reproduced on a **fully clean machine** (fresh fnm-installed Node, fresh standalone pnpm 11, single vercel install, latest CLI):

   ```
   > [debug] Executing: npm i vercel@latest (cwd: /Users/jeffsee)
   > Success! Vercel CLI has been upgraded to v54.18.7 successfully!
   $ vc -v
   54.17.3   # unchanged
   ```

2. **Unrecognized install layouts default to executing a local install in the cwd.** This is the dangerous fallback underlying bug 1: any future layout change reintroduces the same failure. Running inside a pnpm/yarn workspace also fails loudly with `EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"` because npm tries to resolve the surrounding workspace's dependency tree.

3. **The update prompt re-fires immediately after a successful `vc upgrade`.** The process still holds the pre-upgrade version in memory, so it asks "Would you like to upgrade now?" right after printing the upgrade success message.

### Why detection fails on pnpm 11

pnpm 11 moved global installs to isolated directories (`{PNPM_HOME}/global/v11/{hash}/`) backed by the global virtual store, so the install's realpath lives under `{storeDir}/links/...` ([pnpm 11 release notes](https://github.com/pnpm/pnpm/releases/tag/v11.0.0)). All three detection strategies in `get-update-command.ts` miss:

- `pnpm root -g` answers with the *parent* of the isolated install dirs (not a `node_modules`), or — on machines upgraded from pnpm ≤10 — a stale `global/5` directory that pnpm does not migrate ([pnpm/pnpm#11528](https://github.com/pnpm/pnpm/issues/11528)), so `detectGlobalCliType` never matches
- no lockfile exists above the install dir inside the store, so the lockfile scan falls through to `npm`
- the store path does not contain `/pnpm/global/`, so the path heuristic misses, and the npm prefix check misses too → `global: false`

Result: `{ cliType: 'npm', global: false }` → `npm i vercel@latest` in `process.cwd()`.

### How

- **`isPnpmHomeInstall()`**: classify as pnpm + global when the unresolved entrypoint (`process.argv[1]`) or the realpath'd install dir is inside `PNPM_HOME`. This is layout-version independent — pnpm ≤10, 11, and future layouts all live under `PNPM_HOME` — and requires no shelling out. Checked before the existing query-based detection.
- **Store-links path heuristic**: `isGlobalByPath` now also recognizes the pnpm 11 global virtual store pattern (`…/pnpm/store/…/links/…`) as a safety net when `PNPM_HOME` is not in the environment.
- **Never classify as local without positive evidence**: a local (project-dependency) install always has a lockfile above the CLI's install location. Without that evidence, the upgrade now degrades to `npm i -g vercel@latest` executed from a temp dir — a potentially suboptimal suggestion, but one that cannot mutate the user's cwd.
- **Crash-proof entrypoint resolution**: `realpath(process.argv[1])` failures (e.g. virtual filesystem snapshot paths in the native binary — the class of crash fixed for natives in #16581) no longer throw out of detection; they degrade to the safe global fallback.
- **Prompt guard**: the post-command update notifier is skipped when the command was `upgrade`, mirroring the existing `canAutoUpdate` guard.

### Impact

Every pnpm 11 global install of the CLI is affected, on all released versions including current latest — and the population grows as pnpm 11 adoption spreads (each `pnpm add -g vercel` under pnpm 11 creates the broken-detection layout). #16534 fixed the pnpm ≤10 workspace case but predates pnpm 11's layout.

### Test Plan

- Unit tests covering: pnpm 11 isolated layout, legacy `global/5` layout, `PNPM_HOME` prefix anchoring (no substring false-positives), entrypoints outside `PNPM_HOME`, and the unrecognized-layout degradation (34 tests passing in `get-update-command`, `updates`, and `upgrade` suites)
- `tsc --noEmit`, biome lint, prettier: clean
- Empirical: bug reproduced pre-fix on both a long-lived dev machine and a fully reset clean machine; failure mechanism verified step-by-step against pnpm 11.7/11.9 layouts

### Follow-ups (not in this PR)

- Post-install version verification: the success message currently reports the pre-resolved target version, not what was actually installed (observed divergence when pnpm's `min-release-age` gated the newest version: "upgraded to v54.18.7" while 54.18.6 was installed)
- bun/vlt global installs are not detected (`scanParentDirs` can return them but `GlobalCliType` doesn't model them)
- Longer term: distribution-channel awareness baked in at build time (native binary self-replacing; PM-distributed builds printing rather than executing), eliminating install-method forensics entirely
