### PR TITLE
[build-utils] add `maxDuration` as top level `vercel.json` key

### DIFF
--- a/.changeset/quiet-crabs-bet.md
+++ b/.changeset/quiet-crabs-bet.md
@@ -1,0 +1,7 @@
+---
+"@vercel/build-utils": patch
+"vercel": patch
+"@vercel/config": patch
+---
+
+[build-utils] add `maxDuration` as top level `vercel.json` key

--- a/.changeset/quiet-crabs-bet.md
+++ b/.changeset/quiet-crabs-bet.md
@@ -1,7 +1,8 @@
 ---
 "@vercel/build-utils": patch
+"@vercel/client": patch
 "vercel": patch
 "@vercel/config": patch
 ---
 
-[build-utils] add `maxDuration` as top level `vercel.json` key
+Add `maxDuration` as a top-level `vercel.json` key that sets the default for all Serverless Functions; a matching `functions` entry or in-code function config overrides it

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -122,7 +122,7 @@ export interface LambdaOptionsWithZipBuffer extends LambdaOptionsBase {
 
 interface GetLambdaOptionsFromFunctionOptions {
   sourceFile: string;
-  config?: Pick<Config, 'functions' | 'serviceName' | 'maxDuration'>;
+  config?: Pick<Config, 'functions' | 'serviceName'>;
 }
 
 function getDefaultLambdaArchitecture(
@@ -580,7 +580,7 @@ export async function getLambdaOptionsFromFunction({
         return {
           architecture: fn.architecture,
           memory: fn.memory,
-          maxDuration: fn.maxDuration ?? config?.maxDuration,
+          maxDuration: fn.maxDuration,
           regions: fn.regions,
           functionFailoverRegions: fn.functionFailoverRegions,
           experimentalTriggers,
@@ -590,7 +590,9 @@ export async function getLambdaOptionsFromFunction({
     }
   }
 
-  return config?.maxDuration !== undefined
-    ? { maxDuration: config.maxDuration }
-    : {};
+  // Intentionally NOT inherited here: the top-level `maxDuration` default is
+  // applied by consumers that can see the Lambda's own value (e.g. the CLI's
+  // write-build-result), so a project-wide default never overrides in-code
+  // per-function config, and "no pattern matched" still returns `{}`.
+  return {};
 }

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -122,7 +122,7 @@ export interface LambdaOptionsWithZipBuffer extends LambdaOptionsBase {
 
 interface GetLambdaOptionsFromFunctionOptions {
   sourceFile: string;
-  config?: Pick<Config, 'functions' | 'serviceName'>;
+  config?: Pick<Config, 'functions' | 'serviceName' | 'maxDuration'>;
 }
 
 function getDefaultLambdaArchitecture(
@@ -580,7 +580,7 @@ export async function getLambdaOptionsFromFunction({
         return {
           architecture: fn.architecture,
           memory: fn.memory,
-          maxDuration: fn.maxDuration,
+          maxDuration: fn.maxDuration ?? config?.maxDuration,
           regions: fn.regions,
           functionFailoverRegions: fn.functionFailoverRegions,
           experimentalTriggers,
@@ -590,5 +590,7 @@ export async function getLambdaOptionsFromFunction({
     }
   }
 
-  return {};
+  return config?.maxDuration !== undefined
+    ? { maxDuration: config.maxDuration }
+    : {};
 }

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -54,6 +54,8 @@ export interface Config {
   middleware?: boolean;
   /** Owning service name; scopes per-function config such as the v2beta consumer. */
   serviceName?: string;
+  /** Default maxDuration for all functions; individual functions can override via `functions`. */
+  maxDuration?: MaxDuration;
   [key: string]: unknown;
 }
 

--- a/packages/build-utils/test/unit.get-lambda-options-from-function.test.ts
+++ b/packages/build-utils/test/unit.get-lambda-options-from-function.test.ts
@@ -71,6 +71,81 @@ describe('getLambdaOptionsFromFunction', () => {
     expect(options).toEqual({});
   });
 
+  it('returns top-level maxDuration when no function pattern matches', async () => {
+    const config: Pick<Config, 'functions' | 'maxDuration'> = {
+      maxDuration: 30,
+      functions: {
+        'api/*.ts': { regions: ['sfo1'] },
+      },
+    };
+
+    const options = await getLambdaOptionsFromFunction({
+      sourceFile: 'api/user.js',
+      config,
+    });
+
+    expect(options).toEqual({ maxDuration: 30 });
+  });
+
+  it('returns top-level maxDuration when no functions config is set', async () => {
+    const config: Pick<Config, 'maxDuration'> = {
+      maxDuration: 60,
+    };
+
+    const options = await getLambdaOptionsFromFunction({
+      sourceFile: 'api/user.js',
+      config,
+    });
+
+    expect(options).toEqual({ maxDuration: 60 });
+  });
+
+  it('per-function maxDuration overrides top-level maxDuration', async () => {
+    const config: Pick<Config, 'functions' | 'maxDuration'> = {
+      maxDuration: 30,
+      functions: {
+        'api/*.js': { maxDuration: 120 },
+      },
+    };
+
+    const options = await getLambdaOptionsFromFunction({
+      sourceFile: 'api/user.js',
+      config,
+    });
+
+    expect(options.maxDuration).toBe(120);
+  });
+
+  it('falls back to top-level maxDuration when function pattern matches but omits maxDuration', async () => {
+    const config: Pick<Config, 'functions' | 'maxDuration'> = {
+      maxDuration: 45,
+      functions: {
+        'api/*.js': { memory: 512 },
+      },
+    };
+
+    const options = await getLambdaOptionsFromFunction({
+      sourceFile: 'api/user.js',
+      config,
+    });
+
+    expect(options.maxDuration).toBe(45);
+    expect(options.memory).toBe(512);
+  });
+
+  it('supports "max" as top-level maxDuration', async () => {
+    const config: Pick<Config, 'maxDuration'> = {
+      maxDuration: 'max',
+    };
+
+    const options = await getLambdaOptionsFromFunction({
+      sourceFile: 'api/user.js',
+      config,
+    });
+
+    expect(options).toEqual({ maxDuration: 'max' });
+  });
+
   it('derives the queue/v2beta consumer from the function pattern', async () => {
     const config: Pick<Config, 'functions'> = {
       functions: {

--- a/packages/build-utils/test/unit.get-lambda-options-from-function.test.ts
+++ b/packages/build-utils/test/unit.get-lambda-options-from-function.test.ts
@@ -71,7 +71,11 @@ describe('getLambdaOptionsFromFunction', () => {
     expect(options).toEqual({});
   });
 
-  it('returns top-level maxDuration when no function pattern matches', async () => {
+  // The top-level `maxDuration` default from `vercel.json` is intentionally
+  // NOT resolved here — consumers with visibility into the Lambda's own value
+  // (e.g. the CLI's write-build-result) apply it. Several builders (e.g.
+  // @vercel/python) also rely on a `{}` return to mean "no pattern matched".
+  it('ignores top-level maxDuration when no function pattern matches', async () => {
     const config: Pick<Config, 'functions' | 'maxDuration'> = {
       maxDuration: 30,
       functions: {
@@ -84,10 +88,10 @@ describe('getLambdaOptionsFromFunction', () => {
       config,
     });
 
-    expect(options).toEqual({ maxDuration: 30 });
+    expect(options).toEqual({});
   });
 
-  it('returns top-level maxDuration when no functions config is set', async () => {
+  it('ignores top-level maxDuration when no functions config is set', async () => {
     const config: Pick<Config, 'maxDuration'> = {
       maxDuration: 60,
     };
@@ -97,14 +101,14 @@ describe('getLambdaOptionsFromFunction', () => {
       config,
     });
 
-    expect(options).toEqual({ maxDuration: 60 });
+    expect(options).toEqual({});
   });
 
-  it('per-function maxDuration overrides top-level maxDuration', async () => {
+  it('ignores top-level maxDuration when a function pattern matches', async () => {
     const config: Pick<Config, 'functions' | 'maxDuration'> = {
       maxDuration: 30,
       functions: {
-        'api/*.js': { maxDuration: 120 },
+        'api/*.js': { memory: 512, maxDuration: 120 },
       },
     };
 
@@ -114,9 +118,10 @@ describe('getLambdaOptionsFromFunction', () => {
     });
 
     expect(options.maxDuration).toBe(120);
+    expect(options.memory).toBe(512);
   });
 
-  it('falls back to top-level maxDuration when function pattern matches but omits maxDuration', async () => {
+  it('does not inherit top-level maxDuration when a matching function omits it', async () => {
     const config: Pick<Config, 'functions' | 'maxDuration'> = {
       maxDuration: 45,
       functions: {
@@ -129,21 +134,8 @@ describe('getLambdaOptionsFromFunction', () => {
       config,
     });
 
-    expect(options.maxDuration).toBe(45);
+    expect(options.maxDuration).toBeUndefined();
     expect(options.memory).toBe(512);
-  });
-
-  it('supports "max" as top-level maxDuration', async () => {
-    const config: Pick<Config, 'maxDuration'> = {
-      maxDuration: 'max',
-    };
-
-    const options = await getLambdaOptionsFromFunction({
-      sourceFile: 'api/user.js',
-      config,
-    });
-
-    expect(options).toEqual({ maxDuration: 'max' });
   });
 
   it('derives the queue/v2beta consumer from the function pattern', async () => {

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -30,6 +30,7 @@ import {
   type BuildResultBuildOutput,
   getLambdaOptionsFromFunction,
   normalizePath,
+  type MaxDuration,
   type TriggerEvent,
   isBackendBuilder,
   isExperimentalBackendsEnabled,
@@ -297,7 +298,8 @@ async function writeBuildResultV2(args: {
         normalizedPath,
         undefined,
         existingFunctions,
-        standalone
+        standalone,
+        vercelConfig?.maxDuration
       );
     } else if (isPrerender(output)) {
       if (!output.lambda) {
@@ -313,7 +315,8 @@ async function writeBuildResultV2(args: {
         normalizedPath,
         undefined,
         existingFunctions,
-        standalone
+        standalone,
+        vercelConfig?.maxDuration
       );
 
       // Write the fallback file alongside the Lambda directory
@@ -546,7 +549,8 @@ async function writeBuildResultV3(args: {
       path,
       functionConfiguration,
       undefined,
-      standalone
+      standalone,
+      vercelConfig?.maxDuration
     );
   } else if (isEdgeFunction(output)) {
     await writeEdgeFunction(
@@ -759,6 +763,7 @@ async function writeEdgeFunction(
  * @param path The URL path where the `Lambda` can be accessed from
  * @param functionConfiguration (optional) Extra configuration to apply to the function's `.vc-config.json` file
  * @param existingFunctions (optional) Map of `Lambda`/`EdgeFunction` instances that have previously been written
+ * @param defaultMaxDuration (optional) Top-level `maxDuration` from `vercel.json`, applied only when neither the matched `functions` entry nor the Lambda itself sets one
  */
 async function writeLambda(
   repoRootPath: string,
@@ -767,7 +772,8 @@ async function writeLambda(
   path: string,
   functionConfiguration?: FunctionConfiguration,
   existingFunctions?: Map<Lambda | EdgeFunction, string>,
-  standalone: boolean = false
+  standalone: boolean = false,
+  defaultMaxDuration?: MaxDuration
 ) {
   const dest = join(outputDir, 'functions', `${path}.func`);
 
@@ -807,7 +813,13 @@ async function writeLambda(
   const architecture =
     functionConfiguration?.architecture ?? lambda.architecture;
   const memory = functionConfiguration?.memory ?? lambda.memory;
-  const maxDuration = functionConfiguration?.maxDuration ?? lambda.maxDuration;
+  // Precedence: `functions` entry from `vercel.json`, then the value the
+  // builder baked into the Lambda (e.g. in-code `export const config`), then
+  // the top-level `vercel.json` default.
+  const maxDuration =
+    functionConfiguration?.maxDuration ??
+    lambda.maxDuration ??
+    defaultMaxDuration;
   const regions = functionConfiguration?.regions ?? lambda.regions;
   const functionFailoverRegions =
     functionConfiguration?.functionFailoverRegions ??

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -587,6 +587,7 @@ function buildVercelConfigSchema() {
       rewrites: rewritesSchema,
       trailingSlash: trailingSlashSchema,
       functions: getFunctionsSchema(),
+      maxDuration: getMaxDurationSchema(),
       images: imagesSchema,
       crons: cronsSchema,
       bunVersion: { type: 'string' },

--- a/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/api/default.js
+++ b/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/api/default.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.json({ fn: 'default' });
+};

--- a/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/api/in-code.js
+++ b/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/api/in-code.js
@@ -1,0 +1,5 @@
+export const config = { maxDuration: 10 };
+
+export default (req, res) => {
+  res.json({ fn: 'in-code' });
+};

--- a/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/api/override.js
+++ b/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/api/override.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.json({ fn: 'override' });
+};

--- a/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "lambda-with-top-level-max-duration",
+  "private": true
+}

--- a/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/lambda-with-top-level-max-duration/vercel.json
@@ -1,0 +1,8 @@
+{
+  "maxDuration": 30,
+  "functions": {
+    "api/override.js": {
+      "maxDuration": 120
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1035,6 +1035,32 @@ describe.skipIf(flakey)('build', () => {
     });
   });
 
+  it('should apply top-level "maxDuration" from "vercel.json" as the default for Serverless Functions', async () => {
+    const cwd = fixture('lambda-with-top-level-max-duration');
+    const output = join(cwd, '.vercel/output');
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
+
+    // A function with no other configuration inherits the top-level default
+    const defaultConfig = await fs.readJSON(
+      join(output, 'functions/api/default.func/.vc-config.json')
+    );
+    expect(defaultConfig.maxDuration).toEqual(30);
+
+    // A matching `functions` entry overrides the top-level default
+    const overrideConfig = await fs.readJSON(
+      join(output, 'functions/api/override.func/.vc-config.json')
+    );
+    expect(overrideConfig.maxDuration).toEqual(120);
+
+    // In-code config (`export const config`) overrides the top-level default
+    const inCodeConfig = await fs.readJSON(
+      join(output, 'functions/api/in-code.func/.vc-config.json')
+    );
+    expect(inCodeConfig.maxDuration).toEqual(10);
+  });
+
   it('should apply project settings overrides from "vercel.json"', async () => {
     if (process.platform === 'win32') {
       // this test runs a build command with `mkdir -p` which is unsupported on Windows

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -3,6 +3,7 @@ import type {
   Builder,
   BuilderFunctions,
   Images,
+  MaxDuration,
   ProjectSettings,
   Cron,
   ExperimentalServices,
@@ -171,6 +172,11 @@ export interface VercelConfig {
   headers?: Header[];
   trailingSlash?: boolean;
   functions?: BuilderFunctions;
+  /**
+   * Default `maxDuration` for all Serverless Functions in the deployment;
+   * a matching `functions` entry or in-code function config overrides it.
+   */
+  maxDuration?: MaxDuration;
   github?: DeploymentGithubData;
   scope?: string;
   alias?: string | string[];

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -465,6 +465,10 @@ export interface VercelConfig {
    */
   env?: Record<string, string>;
   /**
+   * The default maximum duration (in seconds) for all Serverless Functions in the deployment. Individual functions can override this via the `functions` config. Accepts an integer between 1 and your plan's maximum, or `'max'` to use the plan maximum.
+   */
+  maxDuration?: number | 'max';
+  /**
    * An array of the passive regions the deployment's Serverless Functions should be deployed to that can be failed over to during a lambda outage
    */
   passiveRegions?: string[];


### PR DESCRIPTION
Adds support for `maxDuration` as a top-level `vercel.json` key

Functions inherit that config and can override it to different values