### PR TITLE
Add agent-runs to root CLI help

### DIFF
--- a/.changeset/agent-runs-root-help.md
+++ b/.changeset/agent-runs-root-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+List `vercel agent-runs` in the root CLI help output.

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -42,6 +42,7 @@ export const help = () => `
 
       activity                         List user activity events
       agent                [init]      Generate AGENTS.md with Vercel best practices
+      agent-runs           [cmd]       Inspect Agent Runs observability data
       alerts                           List alerts for a project or team
       alias                [cmd]       Manages your domain aliases
       api                  [endpoint]  Make authenticated HTTP requests to the Vercel API [beta]

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -37,6 +37,7 @@ exports[`base level help output > help 1`] = `
 
       activity                         List user activity events
       agent                [init]      Generate AGENTS.md with Vercel best practices
+      agent-runs           [cmd]       Inspect Agent Runs observability data
       alerts                           List alerts for a project or team
       alias                [cmd]       Manages your domain aliases
       api                  [endpoint]  Make authenticated HTTP requests to the Vercel API [beta]

--- a/packages/cli/test/unit/commands/root-help.test.ts
+++ b/packages/cli/test/unit/commands/root-help.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { help } from '../../../src/help';
+
+describe('root help output', () => {
+  it('lists the agent-runs command', () => {
+    expect(help()).toContain(
+      'agent-runs           [cmd]       Inspect Agent Runs observability data'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- List `agent-runs` in the root `vercel --help` command overview
- Add a focused regression test for root help output
- Add a patch changeset for `vercel`

## Testing
- `pnpm test test/unit/commands/root-help.test.ts`
- pre-commit hook ran Biome format/lint on staged files