### PR TITLE
[services] Add service information to deploy-manifest.

### DIFF
--- a/.changeset/good-wombats-allow.md
+++ b/.changeset/good-wombats-allow.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': minor
+'vercel': minor
+---
+
+Add service information to deploy-manifest.

--- a/packages/build-utils/src/deploy-manifest.ts
+++ b/packages/build-utils/src/deploy-manifest.ts
@@ -1,11 +1,18 @@
 import type { PackageManifest } from './package-manifest';
+import type { ServiceBinding } from './types';
 
 export interface DeployManifestBuild extends PackageManifest {
   root: string;
   builder: string;
 }
 
+export interface DeployManifestService {
+  builds: string[];
+  bindings?: ServiceBinding[];
+}
+
 export interface DeployManifest {
   manifestVersion: '2.0';
   builds: Record<string, DeployManifestBuild>;
+  services?: Record<string, DeployManifestService>;
 }

--- a/packages/build-utils/src/deploy-manifest.ts
+++ b/packages/build-utils/src/deploy-manifest.ts
@@ -1,7 +1,7 @@
 import type { PackageManifest } from './package-manifest';
 import type { ServiceBinding } from './types';
 
-export interface DeployManifestBuild extends PackageManifest {
+export interface DeployManifestBuild extends Omit<PackageManifest, 'version'> {
   root: string;
   builder: string;
 }

--- a/packages/cli/src/commands/build/manifest.ts
+++ b/packages/cli/src/commands/build/manifest.ts
@@ -52,8 +52,10 @@ export async function writeManifests(
           ? service.routePrefix
           : undefined,
     };
+    const { version: _version, ...manifestWithoutVersion } =
+      manifest as unknown as PackageManifest;
     deployManifestBuilds[key] = {
-      ...(manifest as unknown as PackageManifest),
+      ...manifestWithoutVersion,
       root: workspace,
       builder: builderUse,
     };

--- a/packages/cli/src/commands/build/manifest.ts
+++ b/packages/cli/src/commands/build/manifest.ts
@@ -3,8 +3,10 @@ import {
   FileBlob,
   downloadFile,
   isExperimentalService,
+  isExperimentalServiceV2,
   type Config,
   type DeployManifestBuild,
+  type DeployManifestService,
   type Files,
   type PackageManifest,
   type Service,
@@ -27,6 +29,7 @@ export async function writeManifests(
 
   const projectManifest: Record<string, unknown> = {};
   const deployManifestBuilds: Record<string, DeployManifestBuild> = {};
+  const deployManifestServices: Record<string, DeployManifestService> = {};
 
   for (const {
     workspace,
@@ -54,6 +57,20 @@ export async function writeManifests(
       root: workspace,
       builder: builderUse,
     };
+
+    if (service) {
+      const existing = deployManifestServices[service.name];
+      if (existing) {
+        existing.builds.push(key);
+      } else {
+        deployManifestServices[service.name] = {
+          builds: [key],
+          bindings: isExperimentalServiceV2(service)
+            ? service.bindings
+            : undefined,
+        };
+      }
+    }
   }
 
   if (Object.keys(projectManifest).length === 0) return;
@@ -76,6 +93,7 @@ export async function writeManifests(
     data: JSON.stringify({
       manifestVersion: '2.0',
       builds: deployManifestBuilds,
+      services: deployManifestServices,
     }),
   });
   diagnostics['deploy-manifest.json'] = deployManifestBlob;


### PR DESCRIPTION
The current contents of project manifest are in `builds`, and service specific information goes in `services`.

A sample manifest would look something like:
```json
{
  "builds": {
    "@vercel/next:frontend": {
      "builder": "@vercel/next",
      "framework": "nextjs",
      "root": "frontend",
      "runtime": "node",
      "runtimeVersion": {
        "resolved": "24"
      },
      "dependencies": [...]
    },
    "@vercel/python:backend": {
      "builder": "@vercel/python",
      "framework": "fastapi",
      "root": "backend",
      "runtime": "python",
      "runtimeVersion": {
        "requested": "3.14",
        "requestedSource": "backend/.python-version",
        "resolved": "3.14"
      },
      "dependencies": [...]
    }
  },
  "manifestVersion": "2.0",
  "services": {
    "my_backend": {
      "builds": [
        "@vercel/python:backend"
      ]
    },
    "my_frontend": {
      "bindings": [
        {
          "env": "BACKEND_URL",
          "format": "url",
          "service": "my_backend",
          "type": "service"
        }
      ],
      "builds": [
        "@vercel/next:frontend"
      ]
    }
  }
}
```