### PR TITLE
[cli] Emit agent-output JSON when `vercel list <project>` does not resolve

### DIFF
--- a/.changeset/list-non-interactive-project-not-found.md
+++ b/.changeset/list-non-interactive-project-not-found.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Emit structured agent-output JSON (`project_not_found` with runnable `next` suggestions) when `vercel list <project>` does not resolve in non-interactive mode

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -199,7 +199,10 @@ export default async function list(client: Client) {
     }
     const p = await getProjectByNameOrId(client, app);
     if (p instanceof ProjectNotFound) {
-      exitWithNonInteractiveError(client, p, 1, { variant: 'list' });
+      exitWithNonInteractiveError(client, p, 1, {
+        variant: 'list',
+        projectName: app,
+      });
       error(`The provided argument "${app}" is not a valid project name`);
       return 1;
     }

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -25,6 +25,7 @@ import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name'
 import { formatProject } from '../../util/projects/format-project';
 import { formatEnvironment } from '../../util/target/format-environment';
 import { ListTelemetryClient } from '../../util/telemetry/commands/list';
+import { exitWithNonInteractiveError } from '../../util/agent-output';
 import { validateLsArgs } from '../../util/validate-ls-args';
 import { validateJsonOutput } from '../../util/output-format';
 import type {
@@ -198,6 +199,7 @@ export default async function list(client: Client) {
     }
     const p = await getProjectByNameOrId(client, app);
     if (p instanceof ProjectNotFound) {
+      exitWithNonInteractiveError(client, p, 1, { variant: 'list' });
       error(`The provided argument "${app}" is not a valid project name`);
       return 1;
     }

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -564,12 +564,44 @@ export type ExitWithNonInteractiveErrorVariant =
   | 'speed-insights'
   | 'web-analytics'
   | 'checks'
-  | 'edge-config';
+  | 'edge-config'
+  | 'list';
 
 type ProjectExitWithNonInteractiveVariant = Exclude<
   ExitWithNonInteractiveErrorVariant,
-  'edge-config'
+  'edge-config' | 'list'
 >;
+
+const LIST_ERROR_HINT =
+  'Project names are team-scoped. Use --scope when the project belongs to another team, or `list --all` to list deployments across all projects.';
+
+/**
+ * Suggested follow-ups for `vercel list` failures (only caller of
+ * exitWithNonInteractiveError). `project ls --filter` beats bare `project ls`
+ * here: both return a single page of 20, so on large teams only a name search
+ * reliably surfaces the intended project.
+ */
+function buildNextStepsForList(
+  client: Client
+): NonNullable<AgentErrorPayload['next']> {
+  return [
+    {
+      command: buildCommandWithGlobalFlags(
+        client.argv,
+        'project ls --filter <name>'
+      ),
+      when: 'Search projects by name substring to find the right one (replace <name>)',
+    },
+    {
+      command: buildCommandWithGlobalFlags(client.argv, 'list --all'),
+      when: 'List deployments across all projects in the current scope',
+    },
+    {
+      command: buildCommandWithGlobalFlags(client.argv, 'link'),
+      when: 'Re-link this directory to the correct Vercel project',
+    },
+  ];
+}
 
 /** Suggested follow-ups for project subcommands that use `exitWithNonInteractiveError`. */
 function buildNextStepsForProjectSubcommands(
@@ -638,6 +670,12 @@ function resolveNonInteractiveDefaults(
     return {
       next: buildNextStepsForEdgeConfig(client),
       hint: EDGE_CONFIG_NON_INTERACTIVE_HINT,
+    };
+  }
+  if (variant === 'list') {
+    return {
+      next: buildNextStepsForList(client),
+      hint: LIST_ERROR_HINT,
     };
   }
   return {

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -579,19 +579,29 @@ const LIST_ERROR_HINT =
  * Suggested follow-ups for `vercel list` failures (only caller of
  * exitWithNonInteractiveError). `project ls --filter` beats bare `project ls`
  * here: both return a single page of 20, so on large teams only a name search
- * reliably surfaces the intended project.
+ * reliably surfaces the intended project. When the attempted project name is
+ * known, the filter suggestion is emitted fully runnable.
  */
 function buildNextStepsForList(
-  client: Client
+  client: Client,
+  projectName?: string
 ): NonNullable<AgentErrorPayload['next']> {
   return [
-    {
-      command: buildCommandWithGlobalFlags(
-        client.argv,
-        'project ls --filter <name>'
-      ),
-      when: 'Search projects by name substring to find the right one (replace <name>)',
-    },
+    projectName
+      ? {
+          command: buildCommandWithGlobalFlags(
+            client.argv,
+            `project ls --filter ${projectName}`
+          ),
+          when: 'Search projects matching the attempted name to find the right one',
+        }
+      : {
+          command: buildCommandWithGlobalFlags(
+            client.argv,
+            'project ls --filter <name>'
+          ),
+          when: 'Search projects by name substring to find the right one (replace <name>)',
+        },
     {
       command: buildCommandWithGlobalFlags(client.argv, 'list --all'),
       when: 'List deployments across all projects in the current scope',
@@ -736,7 +746,11 @@ export function exitWithNonInteractiveError(
   client: Client,
   err: unknown,
   exitCode: number = 1,
-  options: { variant: ExitWithNonInteractiveErrorVariant } = {
+  options: {
+    variant: ExitWithNonInteractiveErrorVariant;
+    /** Attempted project name; makes `list` next[] suggestions fully runnable. */
+    projectName?: string;
+  } = {
     variant: 'members',
   }
 ): void {
@@ -779,6 +793,9 @@ export function exitWithNonInteractiveError(
         status: 'error',
         reason: 'project_not_found',
         message: err instanceof Error ? err.message : String(err),
+        ...(variant === 'list' && options.projectName
+          ? { next: buildNextStepsForList(client, options.projectName) }
+          : {}),
       },
       exitCode,
       variant

--- a/packages/cli/test/unit/commands/list/index.test.ts
+++ b/packages/cli/test/unit/commands/list/index.test.ts
@@ -70,7 +70,7 @@ describe('list', () => {
         });
         expect(
           payload.next?.some((n: { command: string }) =>
-            /project ls --filter/.test(n.command)
+            /project ls --filter does-not-exist/.test(n.command)
           )
         ).toBe(true);
       } finally {

--- a/packages/cli/test/unit/commands/list/index.test.ts
+++ b/packages/cli/test/unit/commands/list/index.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import createLineIterator from 'line-async-iterator';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
@@ -10,7 +10,11 @@ import list, {
 import { join } from 'path';
 import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 import { useTeams, createTeam } from '../../../mocks/team';
-import { defaultProject, useProject } from '../../../mocks/project';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
 import { useDeployment } from '../../../mocks/deployment';
 import {
   parseSpacedTableRow,
@@ -37,6 +41,42 @@ describe('list', () => {
       expect(exitCode).toEqual(0);
 
       (client as { nonInteractive: boolean }).nonInteractive = false;
+    });
+
+    it('outputs project_not_found JSON when the project argument does not resolve', async () => {
+      const cwd = setupTmpDir();
+      useUser({ version: 'northstar' });
+      useTeams('team_dummy');
+      useUnknownProject();
+      client.cwd = cwd;
+
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+        code?: number
+      ) => {
+        throw new Error(`exit:${code ?? 0}`);
+      }) as () => never);
+
+      client.setArgv('list', 'does-not-exist', '--non-interactive');
+      (client as { nonInteractive: boolean }).nonInteractive = true;
+
+      try {
+        await expect(list(client)).rejects.toThrow('exit:1');
+
+        const payload = JSON.parse(client.stdout.getFullOutput().trim());
+        expect(payload).toMatchObject({
+          status: 'error',
+          reason: 'project_not_found',
+          message: 'There is no project for "does-not-exist"',
+        });
+        expect(
+          payload.next?.some((n: { command: string }) =>
+            /project ls --filter/.test(n.command)
+          )
+        ).toBe(true);
+      } finally {
+        exitSpy.mockRestore();
+        (client as { nonInteractive: boolean }).nonInteractive = false;
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

When `vercel list <project>` is given a project name that doesn't resolve, non-interactive/agent runs currently get only human-formatted stderr text (`The provided argument "x" is not a valid project name`) and exit 1 — no machine-readable `reason` to branch on and no recovery suggestions. In agent telemetry this is one of the most common `list` failure modes (wrong scope, or a guessed project name).

This wires the existing `exitWithNonInteractiveError` helper into that path with a new `list` variant:

```json
{
  "status": "error",
  "reason": "project_not_found",
  "message": "There is no project for \"my-app\"",
  "hint": "Project names are team-scoped. Use --scope when the project belongs to another team, or `list --all` to list deployments across all projects.",
  "next": [
    { "command": "vercel project ls --filter my-app", "when": "Search projects matching the attempted name to find the right one" },
    { "command": "vercel list --all", "when": "List deployments across all projects in the current scope" },
    { "command": "vercel link", "when": "Re-link this directory to the correct Vercel project" }
  ]
}
```

Interactive behavior is unchanged — the helper no-ops unless `--non-interactive`/agent mode is active, and the existing human error path still runs otherwise.

Scoped deliberately to the one failure that classifies cleanly with existing machinery. Candidate follow-ups (not in this PR, happy to do them if the pattern looks right to you): the `getScope` `NOT_AUTHORIZED`/`TEAM_DELETED` path (needs an errno→reason mapping in the shared classifier), and invalid `--status`/argument-shape errors (needs a `missing_requirements` payload decision).

Both suggested listing commands are internally bounded to a single page of 20 (`/v9/projects?limit=20`; `list` breaks at 20 accumulated deployments), so `next[]` can't flood an agent on large teams; `--filter` is suggested because on large teams a name search beats paging.

Update: the `next[]` filter suggestion is now emitted **fully runnable** with the attempted project name (placeholder form remains for callers without a name).

## Testing

- New unit test asserting the `project_not_found` payload shape and `next[]` content (`packages/cli/test/unit/commands/list/index.test.ts`), following the pattern in `project/access-groups.test.ts`
- `pnpm vitest run test/unit/commands/list/index.test.ts`: 26 passed
- `pnpm vitest run test/unit/util/agent-output.test.ts`: 46 passed
- `tsc --noEmit` error count identical to main (pre-existing errors only, none in touched files)
- Prettier clean on touched files; changeset included (`vercel` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

