### PR TITLE
[cli] Dedupe global flags already present in suggested next commands

### DIFF
--- a/.changeset/dedupe-next-command-globals.md
+++ b/.changeset/dedupe-next-command-globals.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Do not duplicate global flags (e.g. `--scope`) in agent-output `next[]` command suggestions when the command template already carries the flag

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -127,6 +127,17 @@ const GLOBAL_FLAG_NAMES = new Set([
 /** Boolean globals: the next argv token is never their value (avoids eating a subcommand like `oauth-apps`). */
 const BOOLEAN_GLOBAL_FLAG_NAMES = new Set(['--yes', '-y', '--non-interactive']);
 
+/** Shorthand → long form for global flags, so `-S` and `--scope` dedupe as the same flag. */
+const GLOBAL_FLAG_SHORTHANDS: Record<string, string> = {
+  '-y': '--yes',
+  '-S': '--scope',
+  '-T': '--team',
+};
+
+function canonicalGlobalFlagName(name: string): string {
+  return GLOBAL_FLAG_SHORTHANDS[name] ?? name;
+}
+
 /**
  * Returns global flag args from argv so suggested commands can include them (e.g. --cwd, --non-interactive).
  */
@@ -212,13 +223,24 @@ export function buildCommandWithGlobalFlags(
   options?: BuildCommandWithGlobalFlagsOptions
 ): string {
   let preserved = getGlobalFlagsFromArgv(argv);
-  if (options?.excludeFlags?.length) {
-    const exclude = new Set(options.excludeFlags);
+  // Flags the template already carries must not be appended again: a template
+  // like `deploy --scope <team-slug>` plus a preserved `--scope my-team` would
+  // suggest a command with two conflicting --scope values.
+  const exclude = new Set(
+    commandTemplate
+      .split(/\s+/)
+      .filter(token => token.startsWith('-'))
+      .map(token => canonicalGlobalFlagName(token.split('=')[0]))
+  );
+  for (const flag of options?.excludeFlags ?? []) {
+    exclude.add(canonicalGlobalFlagName(flag));
+  }
+  if (exclude.size) {
     const out: string[] = [];
     for (let i = 0; i < preserved.length; i++) {
       const arg = preserved[i];
       const name = arg.startsWith('--') ? arg.split('=')[0] : arg;
-      if (exclude.has(name)) {
+      if (exclude.has(canonicalGlobalFlagName(name))) {
         if (
           !arg.includes('=') &&
           i + 1 < preserved.length &&

--- a/packages/cli/test/unit/util/agent-output.test.ts
+++ b/packages/cli/test/unit/util/agent-output.test.ts
@@ -502,6 +502,30 @@ describe('buildCommandWithGlobalFlags', () => {
       'vercel --cwd /tmp/p --non-interactive integration resource remove r1 --disconnect-all --yes'
     );
   });
+
+  it('does not append a global flag the template already carries', () => {
+    const argv = ['node', 'vc.js', 'deploy', '--scope', 'vercel', '--yes'];
+    expect(
+      buildCommandWithGlobalFlags(
+        argv,
+        'deploy --project my-app --scope <team-slug> --yes'
+      )
+    ).toBe('vercel deploy --project my-app --scope <team-slug> --yes');
+  });
+
+  it('dedupes shorthand and long form of the same global flag', () => {
+    const argv = ['node', 'vc.js', 'deploy', '-S', 'vercel'];
+    expect(
+      buildCommandWithGlobalFlags(argv, 'deploy --scope <team-slug>')
+    ).toBe('vercel deploy --scope <team-slug>');
+  });
+
+  it('still appends globals absent from the template', () => {
+    const argv = ['node', 'vc.js', 'deploy', '--scope', 'vercel', '--yes'];
+    expect(buildCommandWithGlobalFlags(argv, 'link')).toBe(
+      'vercel link --scope vercel --yes'
+    );
+  });
 });
 
 describe('exitWithNonInteractiveError', () => {


### PR DESCRIPTION
## Summary

`buildCommandWithGlobalFlags` appends preserved global flags from argv to a suggested command template, but did not check whether the template already carries the same flag. Observed in an agent session: `vercel deploy --project x --scope vercel` hitting `project_not_found` produced the suggestion

```
vercel deploy --project deepsec-redirect --scope <team-slug> --scope vercel --yes
```

— two conflicting `--scope` values (the template's placeholder from `project-not-found-error.ts` plus the preserved argv scope), so the machine-runnable `next[]` command is broken precisely for the callers who execute it verbatim.

Fix: flag names present in the template are excluded from the appended set (merged into the existing `excludeFlags` pass), with shorthand/long forms (`-S`/`--scope`, `-y`/`--yes`, `-T`/`--team`) treated as the same flag. Templates without the flag still get argv globals appended, unchanged.

## Testing

- Three new unit tests: template-carried flag not duplicated, shorthand↔long dedupe, absent flags still appended
- `agent-output.test.ts` (49) and the caller suites — project/env/edge-config/domains/routes (686 tests, 51 files) — all pass
- Changeset included (`vercel` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)