### PR TITLE
[cli] Show list help for `domains ls --help`

### DIFF
--- a/.changeset/fix-domains-ls-help.md
+++ b/.changeset/fix-domains-ls-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Show list help instead of transfer-in help for `vercel domains ls --help`

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -19,6 +19,7 @@ import {
   checkSubcommand,
   domainsCommand,
   inspectSubcommand,
+  listSubcommand,
   moveSubcommand,
   priceSubcommand,
   removeSubcommand,
@@ -157,7 +158,7 @@ export default async function main(client: Client) {
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('domains', subcommandOriginal);
-        return printHelp(transferInSubcommand);
+        return printHelp(listSubcommand);
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);

--- a/packages/cli/test/unit/commands/domains/ls.test.ts
+++ b/packages/cli/test/unit/commands/domains/ls.test.ts
@@ -21,6 +21,13 @@ describe('domains ls', () => {
         },
       ]);
     });
+
+    it('prints help for the list subcommand', async () => {
+      client.setArgv('domains', 'ls', '--help');
+      const exitCodePromise = domains(client);
+      await expect(client.stderr).toOutput('Show all domains in a list');
+      await expect(exitCodePromise).resolves.toEqual(2);
+    });
   });
 
   it('should list up to 20 domains by default', async () => {


### PR DESCRIPTION
## Summary

`vercel domains ls --help` prints the **transfer-in** subcommand's help instead of the list help.

The `domains` dispatcher's `COMMAND_CONFIG` maps `ls`/`list`, but the switch has no `case 'ls'` — list requests fall through to `default:`, which dispatches execution to `ls()` correctly but printed `transferInSubcommand` help on `--help`. Anyone (human or agent) checking flags before listing domains gets documentation for a different command with different flags.

Fix: the default case now prints `listSubcommand` help, matching the execution path it dispatches to and the same pattern `dns` uses for its default subcommand.

## Testing

- New test: `domains ls --help` output contains the list synopsis (exit 2, as all help paths)
- Full `test/unit/commands/domains` suite passes (154 tests, 15 files)
- Changeset included (`vercel` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)