### PR TITLE
[cli] Preserve generated service routes

### DIFF
--- a/.changeset/preserve-generated-service-routes.md
+++ b/.changeset/preserve-generated-service-routes.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Preserve generated service routes when Build Output services are merged from framework output into a custom build output directory.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1588,12 +1588,14 @@ async function doBuild(
               if (outputConfig instanceof CantParseJSONFile) {
                 throw outputConfig;
               }
+              let shouldMergeGeneratedOutputRoutes = false;
               if (
                 hasNonEmptyObject(outputConfig?.experimentalServices) &&
                 !hasNonEmptyObject(buildOutputConfig.experimentalServices)
               ) {
                 buildOutputConfig.experimentalServices =
                   outputConfig.experimentalServices;
+                shouldMergeGeneratedOutputRoutes = true;
               }
               if (
                 hasNonEmptyObject(outputConfig?.experimentalServicesV2) &&
@@ -1601,12 +1603,23 @@ async function doBuild(
               ) {
                 buildOutputConfig.experimentalServicesV2 =
                   outputConfig.experimentalServicesV2;
+                shouldMergeGeneratedOutputRoutes = true;
               }
               if (
                 hasGeneratedServicesConfig(outputConfig) &&
                 !hasGeneratedServicesConfig(buildOutputConfig)
               ) {
                 buildOutputConfig.services = outputConfig.services;
+                shouldMergeGeneratedOutputRoutes = true;
+              }
+              if (
+                shouldMergeGeneratedOutputRoutes &&
+                Array.isArray(outputConfig?.routes)
+              ) {
+                buildOutputConfig.routes = prependMissingBuildOutputRoutes(
+                  outputConfig.routes,
+                  buildOutputConfig.routes
+                );
               }
               if (
                 hasNonEmptyObject(buildOutputConfig.experimentalServices) ||
@@ -2552,6 +2565,24 @@ function appendBuildOutputRouteTables(
   }
 
   return routes.length > 0 ? routes : undefined;
+}
+
+function prependMissingBuildOutputRoutes(
+  routesToPrepend: BuildOutputConfig['routes'],
+  existingRoutes: BuildOutputConfig['routes']
+): BuildOutputConfig['routes'] | undefined {
+  if (!Array.isArray(routesToPrepend) || routesToPrepend.length === 0) {
+    return existingRoutes;
+  }
+
+  const existingRouteKeys = new Set(
+    (existingRoutes ?? []).map(route => JSON.stringify(route))
+  );
+  const missingRoutes = routesToPrepend.filter(
+    route => !existingRouteKeys.has(JSON.stringify(route))
+  );
+
+  return appendBuildOutputRouteTables(missingRoutes, existingRoutes);
 }
 
 async function writeServiceConfigs(

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -3215,7 +3215,7 @@ writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }, nul
     ).toBe('backend output');
   });
 
-  it('should detect generated experimentalServicesV2 from default output when using --output', async () => {
+  it('should detect generated stable services routes from default output when using --output', async () => {
     const cwd = await getWriteableDirectory();
     const output = join(cwd, 'custom-output');
     await fs.ensureDir(join(cwd, '.vercel'));
@@ -3246,8 +3246,16 @@ writeFileSync(
   join(outputDir, 'config.json'),
   JSON.stringify({
     version: 3,
-    routes: [{ src: '^/api/(.*)$', service: 'backend' }],
-    experimentalServicesV2: {
+    routes: [
+      {
+        src: '^/api/(.*)$',
+        destination: {
+          type: 'service',
+          service: 'backend'
+        }
+      }
+    ],
+    services: {
       backend: {
         root: 'backend',
         entrypoint: 'package.json',
@@ -3290,7 +3298,15 @@ writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }, nul
       }),
     });
     expect(config.routes).toEqual(
-      expect.arrayContaining([{ src: '^/api/(.*)$', service: 'backend' }])
+      expect.arrayContaining([
+        {
+          src: '^/api/(.*)$',
+          destination: {
+            type: 'service',
+            service: 'backend',
+          },
+        },
+      ])
     );
     expect(await fs.readFile(join(output, 'static/index.html'), 'utf8')).toBe(
       'root output'


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/vercel/vercel/pull/16889.

PR #16889 fixed the final Build Output route assembly path so generated service routes are merged with framework/builder routes when Services V2 output is nested.

This PR fixes an earlier path where those generated routes could be dropped before the final merge:

- when a builder returns `buildOutputPath`, the CLI reads that builder-owned `config.json`
- existing logic copied generated service definitions from the main output config into that builder config
- but it did not also copy the generated `routes`
- as a result, service outputs could be built and deployed, while the root service handoff route was missing

This preserves the generated routes alongside the generated service config so routes like `/eve/v1/* -> service:eve` survive when building with a custom output directory.

x-ref: https://github.com/vercel/eve/pull/413

## Tests

```sh
corepack pnpm --filter vercel test test/unit/commands/build/index.test.ts -t "should detect generated services from build output config|should detect generated stable services routes from default output when using --output"
```