### PR TITLE
Apply functions config to @vercel/container

### DIFF
--- a/.changeset/container-function-config.md
+++ b/.changeset/container-function-config.md
@@ -1,0 +1,6 @@
+---
+'@vercel/container': patch
+'vercel': patch
+---
+
+Apply `functions` configuration (`memory`, `maxDuration`, `architecture`, `regions`, `functionFailoverRegions`, `experimentalTriggers`, `supportsCancellation`) to container runtime outputs. The `@vercel/container` builder now resolves matching `vercel.json` / per-service `functions` entries at build time, and the CLI writes those settings into the container `.vc-config.json`.

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -307,11 +307,9 @@ async function writeBuildResultV2(args: {
 
   const existingFunctions = new Map<Lambda | EdgeFunction, string>();
   const overrides: Record<string, PathOverride> = {};
-  const functionConfiguration = await resolveFunctionConfiguration(
-    build.src,
-    vercelConfig,
-    service
-  );
+  const functionConfiguration = build.src
+    ? await resolveFunctionConfiguration(build.src, vercelConfig, service)
+    : {};
 
   for (const [path, output] of Object.entries(buildResult.output)) {
     const normalizedPath = stripDuplicateSlashes(path);

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -209,6 +209,40 @@ function stripDuplicateSlashes(path: string): string {
   return normalize(path).replace(/(^\/|\/$)/g, '');
 }
 
+async function resolveFunctionConfiguration(
+  src: string,
+  vercelConfig: VercelConfig | null,
+  service?: Service
+): Promise<FunctionConfiguration> {
+  if (service && isExperimentalServiceV2(service) && service.functions) {
+    // `functions` keys are service-root-relative but `build.src` is
+    // project-relative; strip the root so patterns match.
+    let sourceFile = src;
+    const serviceRoot = stripDuplicateSlashes(service.root);
+    if (serviceRoot && serviceRoot !== '.') {
+      const prefix = `${serviceRoot}/`;
+      if (sourceFile.startsWith(prefix)) {
+        sourceFile = sourceFile.slice(prefix.length);
+      }
+    }
+    return getLambdaOptionsFromFunction({
+      sourceFile,
+      config: {
+        ...vercelConfig,
+        functions: service.functions,
+        serviceName: service.name,
+      },
+    });
+  }
+  if (vercelConfig) {
+    return getLambdaOptionsFromFunction({
+      sourceFile: src,
+      config: vercelConfig,
+    });
+  }
+  return {};
+}
+
 function getServiceOutputDir(outputDir: string, service: Service): string {
   return join(outputDir, 'services', service.name);
 }
@@ -273,6 +307,11 @@ async function writeBuildResultV2(args: {
 
   const existingFunctions = new Map<Lambda | EdgeFunction, string>();
   const overrides: Record<string, PathOverride> = {};
+  const functionConfiguration = await resolveFunctionConfiguration(
+    build.src,
+    vercelConfig,
+    service
+  );
 
   for (const [path, output] of Object.entries(buildResult.output)) {
     const normalizedPath = stripDuplicateSlashes(path);
@@ -282,7 +321,12 @@ async function writeBuildResultV2(args: {
         service && isExperimentalService(service) ? service : undefined,
         stripServiceRoutePrefix
       );
-      await writeContainerImage(outputDir, output, normalizedPath);
+      await writeContainerImage(
+        outputDir,
+        output,
+        normalizedPath,
+        functionConfiguration
+      );
     } else if (isLambda(output)) {
       injectServiceEnvVars(
         output,
@@ -482,34 +526,11 @@ async function writeBuildResultV3(args: {
     throw new Error(`Expected "build.src" to be a string`);
   }
 
-  let functionConfiguration: Awaited<
-    ReturnType<typeof getLambdaOptionsFromFunction>
-  > = {};
-  if (service && isExperimentalServiceV2(service) && service.functions) {
-    // `functions` keys are service-root-relative but `build.src` is
-    // project-relative; strip the root so patterns match.
-    let sourceFile = src;
-    const serviceRoot = stripDuplicateSlashes(service.root);
-    if (serviceRoot && serviceRoot !== '.') {
-      const prefix = `${serviceRoot}/`;
-      if (sourceFile.startsWith(prefix)) {
-        sourceFile = sourceFile.slice(prefix.length);
-      }
-    }
-    functionConfiguration = await getLambdaOptionsFromFunction({
-      sourceFile,
-      config: {
-        ...vercelConfig,
-        functions: service.functions,
-        serviceName: service.name,
-      },
-    });
-  } else if (vercelConfig) {
-    functionConfiguration = await getLambdaOptionsFromFunction({
-      sourceFile: src,
-      config: vercelConfig,
-    });
-  }
+  const functionConfiguration = await resolveFunctionConfiguration(
+    src,
+    vercelConfig,
+    service
+  );
 
   const ext = extname(src);
   // V2 services are already isolated under `services/<name>`, so scalar
@@ -531,7 +552,7 @@ async function writeBuildResultV3(args: {
       service && isExperimentalService(service) ? service : undefined,
       stripServiceRoutePrefix
     );
-    await writeContainerImage(outputDir, output, path);
+    await writeContainerImage(outputDir, output, path, functionConfiguration);
   } else if (isLambda(output)) {
     injectServiceEnvVars(
       output,
@@ -668,7 +689,8 @@ async function writeFunctionSymlink(
 async function writeContainerImage(
   outputDir: string,
   containerImage: ContainerImage,
-  path: string
+  path: string,
+  functionConfiguration?: FunctionConfiguration
 ) {
   const dest = join(outputDir, 'functions', `${path}.func`);
   // For `runtime: 'container'` the OCI image reference is carried in `handler`;
@@ -680,6 +702,24 @@ async function writeContainerImage(
     );
   }
 
+  const architecture =
+    functionConfiguration?.architecture ?? (containerImage as any).architecture;
+  const memory =
+    functionConfiguration?.memory ?? (containerImage as any).memory;
+  const maxDuration =
+    functionConfiguration?.maxDuration ?? (containerImage as any).maxDuration;
+  const regions =
+    functionConfiguration?.regions ?? (containerImage as any).regions;
+  const functionFailoverRegions =
+    functionConfiguration?.functionFailoverRegions ??
+    (containerImage as any).functionFailoverRegions;
+  const experimentalTriggers =
+    functionConfiguration?.experimentalTriggers ??
+    (containerImage as any).experimentalTriggers;
+  const supportsCancellation =
+    functionConfiguration?.supportsCancellation ??
+    (containerImage as any).supportsCancellation;
+
   await fs.mkdirp(dest);
   await fs.writeJSON(
     join(dest, '.vc-config.json'),
@@ -690,6 +730,15 @@ async function writeContainerImage(
       ...((containerImage as any).command
         ? { command: (containerImage as any).command }
         : {}),
+      ...(architecture !== undefined ? { architecture } : {}),
+      ...(memory !== undefined ? { memory } : {}),
+      ...(maxDuration !== undefined ? { maxDuration } : {}),
+      ...(regions !== undefined ? { regions } : {}),
+      ...(functionFailoverRegions !== undefined
+        ? { functionFailoverRegions }
+        : {}),
+      ...(experimentalTriggers !== undefined ? { experimentalTriggers } : {}),
+      ...(supportsCancellation !== undefined ? { supportsCancellation } : {}),
     },
     { spaces: 2 }
   );

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -123,7 +123,7 @@ describe('writeBuildResult()', () => {
               regions: ['iad1'],
             },
           },
-        },
+        } as unknown as import('@vercel/build-utils').BuildResultV2,
         build,
         builder: runtimeBuilder,
         builderPkg: { name: '@vercel/container' },

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -5,6 +5,7 @@ import {
   FileFsRef,
   getWriteableDirectory,
   Lambda,
+  type BuilderV2,
   type BuilderV3,
 } from '@vercel/build-utils';
 import { describe, expect, it } from 'vitest';
@@ -75,6 +76,80 @@ describe('writeBuildResult()', () => {
           )
         )
       ).toBe(false);
+    } finally {
+      await fs.remove(workPath);
+    }
+  });
+
+  it('writes container function configuration to .vc-config.json', async () => {
+    const workPath = await getWriteableDirectory();
+    const outputDir = join(workPath, '.vercel', 'output');
+    const build = {
+      src: 'Dockerfile.vercel',
+      use: '@vercel/container',
+      config: {
+        zeroConfig: true,
+        functions: {
+          'Dockerfile.vercel': {
+            memory: 2048,
+            maxDuration: 60,
+            regions: ['iad1'],
+          },
+        },
+      },
+    };
+    const runtimeBuilder: BuilderV2 = {
+      version: 2,
+      build: async () => {
+        throw new Error('not used by writeBuildResult');
+      },
+    };
+
+    try {
+      await writeBuildResult({
+        repoRootPath: workPath,
+        outputDir,
+        buildResult: {
+          routes: [{ handle: 'filesystem' }, { src: '/(.*)', dest: '/index' }],
+          output: {
+            index: {
+              type: 'Lambda',
+              files: {},
+              handler: 'docker.io/library/nginx:1.27',
+              runtime: 'container',
+              environment: {},
+              memory: 2048,
+              maxDuration: 60,
+              regions: ['iad1'],
+            },
+          },
+        },
+        build,
+        builder: runtimeBuilder,
+        builderPkg: { name: '@vercel/container' },
+        vercelConfig: {
+          functions: {
+            'Dockerfile.vercel': {
+              memory: 2048,
+              maxDuration: 60,
+              regions: ['iad1'],
+            },
+          },
+        },
+        standalone: false,
+        workPath,
+      });
+
+      const vcConfig = await fs.readJSON(
+        join(outputDir, 'functions/index.func/.vc-config.json')
+      );
+      expect(vcConfig).toMatchObject({
+        handler: 'docker.io/library/nginx:1.27',
+        runtime: 'container',
+        memory: 2048,
+        maxDuration: 60,
+        regions: ['iad1'],
+      });
     } finally {
       await fs.remove(workPath);
     }

--- a/packages/container/src/index.ts
+++ b/packages/container/src/index.ts
@@ -1,4 +1,5 @@
 import type { BuildOptions, BuildResultV2, Span } from '@vercel/build-utils';
+import { getLambdaOptionsFromFunction } from '@vercel/build-utils';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import {
@@ -32,6 +33,14 @@ export const version = 2;
 
 export { startDevServer } from './dev';
 export { prepareCache } from './prepare-cache';
+
+function resolveFunctionSourceFile(options: BuildOptions): string {
+  const entrypoint = readString(options.entrypoint) ?? '';
+  if (entrypoint === '<detect>') {
+    return findDockerfile(options.workPath) ?? entrypoint;
+  }
+  return entrypoint;
+}
 
 function normalizeCommand(command: unknown): string[] | undefined {
   if (typeof command === 'string') {
@@ -371,6 +380,11 @@ export async function build(options: BuildOptions): Promise<BuildResultV2> {
     span => resolveImageHandler(options, span)
   );
 
+  const lambdaOptions = await getLambdaOptionsFromFunction({
+    sourceFile: resolveFunctionSourceFile(options),
+    config: options.config,
+  });
+
   const command = normalizeCommand(options.config.command);
 
   // Do a normal build: the function lands at the natural `index` path and a
@@ -398,6 +412,7 @@ export async function build(options: BuildOptions): Promise<BuildResultV2> {
         runtime: 'container',
         environment: {},
         ...(command ? { command } : {}),
+        ...lambdaOptions,
       } as any,
     },
   };

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -1,4 +1,5 @@
 import type { BuildResultV2Typical } from '@vercel/build-utils';
+import { sanitizeConsumerName } from '@vercel/build-utils';
 import { EventEmitter } from 'node:events';
 import { readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
@@ -184,6 +185,60 @@ describe('@vercel/container', () => {
           environment: {},
         },
       },
+    });
+  });
+
+  it('applies matching function configuration to the build output', async () => {
+    const result = expectTypicalBuildResult(
+      await build({
+        ...createBuildOptions({
+          functions: {
+            'docker.io/library/nginx:*': {
+              memory: 2048,
+              maxDuration: 120,
+              regions: ['iad1'],
+            },
+          },
+        }),
+        entrypoint: 'docker.io/library/nginx:1.27',
+      })
+    );
+
+    expect(result.output.index).toMatchObject({
+      handler: 'docker.io/library/nginx:1.27',
+      runtime: 'container',
+      memory: 2048,
+      maxDuration: 120,
+      regions: ['iad1'],
+    });
+  });
+
+  it('applies per-service function configuration scoped by service name', async () => {
+    const result = expectTypicalBuildResult(
+      await build({
+        ...createBuildOptions({
+          functions: {
+            'docker.io/library/nginx:*': {
+              memory: 4096,
+              experimentalTriggers: [{ type: 'queue/v2beta', topic: 'jobs' }],
+            },
+          },
+          serviceName: 'api',
+        }),
+        entrypoint: 'docker.io/library/nginx:1.27',
+        service: { name: 'api' },
+      })
+    );
+
+    expect(result.output.index).toMatchObject({
+      memory: 4096,
+      experimentalTriggers: [
+        {
+          type: 'queue/v2beta',
+          topic: 'jobs',
+          consumer: sanitizeConsumerName('api~docker.io/library/nginx:*'),
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
## Summary
- `@vercel/container` now resolves matching `functions` config at build time (`memory`, `maxDuration`, `architecture`, `regions`, `functionFailoverRegions`, `experimentalTriggers`, `supportsCancellation`)
- CLI `writeContainerImage` persists those settings into `.vc-config.json`, including per-service `functions` blocks in `experimentalServicesV2`
- Function patterns match the entrypoint, or the discovered Dockerfile when the entrypoint is `<detect>`

## Why `write-build-result` needed changes

Python (and other v3 runtimes) already support `regions` and the rest of `functions` config without touching `writeContainerImage`, because they return a `Lambda` instance that is serialized by `writeLambda`. That path already merges `memory`, `regions`, `maxDuration`, etc. into `.vc-config.json`.

Container is different: it is a v2 builder whose output is detected by `runtime: 'container'` and written by a separate `writeContainerImage` helper. That helper previously only emitted a fixed subset of fields (`handler`, `runtime`, `environment`, `command`). Even if the builder had applied function config to the in-memory output, those fields would have been dropped on the way to disk.

So this PR needs both layers:
1. **Builder** — call `getLambdaOptionsFromFunction` (same shared helper Python uses) and apply the result to the build output
2. **CLI write path** — teach `writeContainerImage` to serialize those fields into `.vc-config.json`

The `resolveFunctionConfiguration` hook in the v2 write path mirrors what v3 already does for Lambdas and acts as a fallback when config is resolved at write time; for services, `service.functions` is already injected into builder config, so the builder-side change is the main path.

## Test plan
- [x] `@vercel/container` unit tests for function config matching and service-scoped queue consumers
- [x] CLI `write-build-result` unit test verifying container `.vc-config.json` output
- [ ] Deploy a container service with `functions` settings and confirm `.vc-config.json` includes `memory` / `maxDuration`