### PR TITLE
fix(cli): read all piped stdin before prompts in `env add` to prevent empty stored value

### DIFF
--- a/.changeset/fix-16934-piped-stdin-production.md
+++ b/.changeset/fix-16934-piped-stdin-production.md
@@ -1,0 +1,19 @@
+---
+"vercel": patch
+---
+
+fix(cli): read all piped stdin chunks before prompts in `env add`
+
+Previously `readStandardInput` resolved on the first `data` chunk and
+never waited for the stream to end.  On some systems the 500 ms timeout
+could fire before any data was delivered, leaving `stdInput` empty.
+When that happened the sensitive-type confirmation prompt was shown for
+the production target, which consumed the piped bytes; the subsequent
+value prompt then read EOF and silently stored an empty string.
+
+The function now accumulates every chunk via `stdin.on('data')` and
+resolves as soon as the stream emits `end` / `close`.  The 500 ms
+timeout is kept as a safety valve for non-TTY interactive streams where
+EOF never arrives.
+
+Fixes: #16934

--- a/packages/cli/src/util/input/read-standard-input.ts
+++ b/packages/cli/src/util/input/read-standard-input.ts
@@ -1,17 +1,64 @@
 import type { ReadableTTY } from '@vercel-internals/types';
 
+/**
+ * Reads all piped stdin before any interactive prompts run.
+ *
+ * When stdin is a TTY there is nothing to read, so we return '' immediately.
+ * Otherwise we accumulate every 'data' chunk and resolve as soon as the
+ * stream ends ('end'/'close').  A 500 ms timeout acts as a safety valve for
+ * non-TTY streams that are not actually piped (e.g. some terminal
+ * multiplexers) — in that case we return whatever we collected so far.
+ *
+ * Using stdin.once('data') was the previous approach, but it had two
+ * failure modes:
+ *   1. Only the first chunk was captured, so large piped values were
+ *      truncated.
+ *   2. If the 500 ms timeout fired before the first 'data' event the
+ *      function returned '', causing downstream prompts to consume the
+ *      piped bytes and leaving the value prompt with an empty read.
+ */
 export default async function readStandardInput(
   stdin: ReadableTTY
 ): Promise<string> {
   return new Promise<string>(resolve => {
-    setTimeout(() => resolve(''), 500);
-
     if (stdin.isTTY) {
       // found tty so we know there is nothing piped to stdin
       resolve('');
-    } else {
-      stdin.setEncoding('utf8');
-      stdin.once('data', resolve);
+      return;
     }
+
+    stdin.setEncoding('utf8');
+
+    let data = '';
+    let settled = false;
+
+    const settle = (value: string) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        stdin.removeListener('data', onData);
+        stdin.removeListener('end', onEnd);
+        stdin.removeListener('close', onEnd);
+        resolve(value);
+      }
+    };
+
+    const onData = (chunk: string) => {
+      data += chunk;
+    };
+
+    const onEnd = () => {
+      settle(data);
+    };
+
+    // Resolve with whatever we've collected if no 'end'/'close' event arrives
+    // in time.  This preserves the original behaviour for non-piped non-TTY
+    // streams while giving piped streams a chance to deliver all their data
+    // before any interactive prompts run.
+    const timer = setTimeout(() => settle(data), 500);
+
+    stdin.on('data', onData);
+    stdin.once('end', onEnd);
+    stdin.once('close', onEnd);
   });
 }

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -973,6 +973,62 @@ describe('env add', () => {
         }
       });
 
+      it('stores piped stdin value for production target when team sensitive policy is on (regression #16934)', async () => {
+        // Regression: when the team enforces sensitive env vars, the
+        // production flow previously showed a sensitive-type confirmation
+        // prompt that consumed the piped stdin bytes, leaving the value
+        // prompt to read EOF and store an empty string.
+        const teamModule = await import(
+          '../../../../src/util/teams/get-team-by-id'
+        );
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+
+        const teamSpy = vi.spyOn(teamModule, 'default').mockResolvedValue({
+          sensitiveEnvironmentVariablePolicy: 'on',
+        } as any);
+        const addSpy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        try {
+          client.stdin.isTTY = false;
+          client.setArgv('env', 'add', 'PIPED_PROD_POLICY', 'production');
+          const exitCodePromise = env(client);
+          // Emit piped value followed by EOF (stream end) to mimic
+          // `printf '%s' "my-db-url" | vercel env add KEY production`
+          setImmediate(() => {
+            client.stdin.emit('data', 'my-db-url');
+            client.stdin.emit('end');
+          });
+
+          await expect(exitCodePromise).resolves.toBe(0);
+
+          expect(addSpy).toHaveBeenCalled();
+          // addEnvRecord(client, projectId, upsert, type, key, value, targets, gitBranch)
+          const [, , , type, , envValue] = addSpy.mock.calls[0] as unknown as [
+            unknown,
+            unknown,
+            unknown,
+            string,
+            string,
+            string,
+          ];
+          // Value must not be empty – the piped bytes must reach the value
+          // parameter, not be consumed by the sensitive-type prompt.
+          expect(envValue).toBe('my-db-url');
+          expect(type).toBe('sensitive');
+          // The sensitive-type prompt must NOT have been shown
+          expect(client.stderr.getFullOutput()).not.toContain(
+            'Store as sensitive?'
+          );
+        } finally {
+          teamSpy.mockRestore();
+          addSpy.mockRestore();
+        }
+      });
+
       it('outputs action_required when name is missing', async () => {
         const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
           throw new Error('exit');


### PR DESCRIPTION
## Summary

Fixes #16934.

When running `vercel env add KEY production` with piped stdin (e.g. `printf '%s' "db-url" | vercel env add KEY production`), the CLI silently stored an **empty value** and exited 0.

### Root cause

`readStandardInput` used `stdin.once('data', resolve)` which only captured the **first chunk** and did not listen for the stream's `end`/`close` events.  In practice this created a race condition:

1. On some systems (or under load) the 500 ms timeout fired before the `'data'` event was delivered, so `stdInput` resolved to `''`.
2. With `stdInput === ''`, `skipSensitivePrompt` was `false` for the **production** target (development always skips this prompt via `isDevelopmentOnlyTarget`).
3. The sensitive-type confirmation prompt (`Store as sensitive?`) was shown.  Because stdin was not a TTY, inquirer's readline consumed the piped bytes trying to get an answer.
4. The subsequent value prompt then read **EOF** and stored an empty string — with exit 0.

This explains the asymmetry reported in the issue: the **development** target skipped the confirmation prompt (`isDevelopmentOnlyTarget = true`) so piped stdin always reached the value step correctly.

### Fix

`readStandardInput` now accumulates **all** `'data'` chunks and resolves only when the stream emits `'end'` or `'close'`.  The 500 ms timeout is kept as a safety valve for non-TTY streams where EOF never arrives (e.g. some terminal multiplexers).

```
// Before — resolves on first chunk only; 500 ms timeout may win the race
stdin.once('data', resolve);

// After — accumulates all chunks, resolves when the pipe closes
stdin.on('data', onData);
stdin.once('end', onEnd);
stdin.once('close', onEnd);
setTimeout(() => settle(data), 500); // safety valve
```

### Test plan

- [x] Added regression test: production target + team sensitive policy on + piped stdin → value stored correctly, type is sensitive, no confirmation prompt shown
- [x] All 42 existing `env add` unit tests still pass
- [x] Biome lint + format clean

```
npx vitest run packages/cli/test/unit/commands/env/add.test.ts --pool=forks --poolOptions.forks.singleFork=true
# 42 tests passed
```