### PR TITLE
[cli] detach update-check worker from the TTY to preserve raw mode

### DIFF
--- a/.changeset/heavy-donuts-refuse.md
+++ b/.changeset/heavy-donuts-refuse.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Detach the background update-check worker from the terminal so it no longer resets the parent CLI's raw mode on exit, which caused interactive prompts (e.g. the coding agents selector) to break and echo arrow keys as `^[[A`/`^[[B`

--- a/packages/cli/src/util/get-latest-version/index.ts
+++ b/packages/cli/src/util/get-latest-version/index.ts
@@ -135,7 +135,12 @@ function spawnWorker(payload: GetLatestWorkerPayload) {
     args.push('--debug');
   }
   const worker = spawn(process.execPath, args, {
-    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    // Do not inherit the parent's TTY: a Node child attached to the terminal
+    // snapshots its (cooked) termios at startup and restores it on exit,
+    // which clobbers the parent's raw mode and breaks interactive prompts
+    // (arrow keys echo as ^[[A/^[[B). Debug output is persisted to the
+    // worker's log file instead of stderr.
+    stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
     windowsHide: true,
   });
 


### PR DESCRIPTION
### What

Spawn the background update-check worker (`get-latest-worker.cjs`) with `stdio: ['ignore', 'ignore', 'ignore', 'ipc']` instead of inheriting the parent's stdio.

### Why

A Node child process attached to the terminal snapshots the terminal's (cooked) termios at startup and restores it when it exits. The worker is `unref`'d and exits at an unpredictable time, so when an update check races an open interactive prompt, the worker's exit yanks the terminal out of raw mode mid-prompt — arrow keys stop working and echo as `^[[A`/`^[[B` until the user hits `^C`.

Detaching the worker from the TTY removes its ability to reset terminal modes. Nothing else changes: the worker communicates with the parent exclusively over the IPC channel, and its debug/error output was already persisted to a log file next to the cache file.

### Testing

- `pnpm vitest-run test/unit/util/get-latest-version.test.ts test/unit/esm/worker-resolution.test.ts` — 27 passed, 1 pre-existing skip.

x-ref: https://vercel.slack.com/archives/CLDDX2Y0G/p1783385043277779 (multiple people noticed this when testing a separate change for the `ai-gateway coding-agents connect`.