### PR TITLE
fix vercel inspect --logs --format json

### DIFF
--- a/.changeset/inspect-json-build-logs.md
+++ b/.changeset/inspect-json-build-logs.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Include build logs in `vercel inspect --logs --format json` output.

--- a/packages/cli/src/commands/inspect/index.ts
+++ b/packages/cli/src/commands/inspect/index.ts
@@ -5,7 +5,11 @@ import ms from 'ms';
 import title from 'title';
 import type Client from '../../util/client';
 import { isDeploying } from '../../util/deploy/is-deploying';
-import { displayBuildLogs } from '../../util/logs';
+import {
+  type BuildLog,
+  collectBuildLogs,
+  displayBuildLogs,
+} from '../../util/logs';
 import { printError } from '../../util/error';
 import { parseArguments } from '../../util/get-args';
 import getDeployment from '../../util/get-deployment';
@@ -127,22 +131,44 @@ export default async function inspect(client: Client) {
   }
   const asJson = formatResult.jsonOutput;
   const startTimestamp = Date.now();
-  output.spinner(
-    `Fetching deployment "${deploymentIdOrHost}" in ${chalk.bold(contextName)}`
-  );
+  if (!(asJson && withLogs)) {
+    output.spinner(
+      `Fetching deployment "${deploymentIdOrHost}" in ${chalk.bold(
+        contextName
+      )}`
+    );
+  }
 
   // resolve the deployment, since we might have been given an alias
   let deployment = await getDeployment(client, contextName, deploymentIdOrHost);
 
   let abortController: AbortController | undefined;
-  if (withLogs && !asJson) {
-    let promise: Promise<void>;
-    ({ abortController, promise } = displayBuildLogs(client, deployment, wait));
-    if (wait) {
-      // when waiting for the deployment's end, we don't wait for the logs to finish
-      promise.catch(error => warn(`Failed to read build logs: ${error}`));
+  let buildLogsPromise: Promise<BuildLog[]> | undefined;
+  if (withLogs) {
+    if (asJson) {
+      let promise: Promise<BuildLog[]>;
+      ({ abortController, promise } = collectBuildLogs(
+        client,
+        deployment,
+        wait
+      ));
+      buildLogsPromise = promise.catch(error => {
+        warn(`Failed to read build logs: ${error}`);
+        return [];
+      });
     } else {
-      await promise;
+      let promise: Promise<void>;
+      ({ abortController, promise } = displayBuildLogs(
+        client,
+        deployment,
+        wait
+      ));
+      if (wait) {
+        // when waiting for the deployment's end, we don't wait for the logs to finish
+        promise.catch(error => warn(`Failed to read build logs: ${error}`));
+      } else {
+        await promise;
+      }
     }
   }
   while (wait) {
@@ -162,7 +188,11 @@ export default async function inspect(client: Client) {
 
   if (asJson) {
     output.stopSpinner();
-    await printJson({ deployment, contextName, client });
+    if (withLogs) {
+      printLogsJson(client, (await buildLogsPromise) ?? []);
+    } else {
+      await printJson({ deployment, contextName, client });
+    }
   } else if (withLogs) {
     print(`${chalk.cyan('status')}\t${stateString(deployment.readyState)}\n`);
   } else {
@@ -327,6 +357,10 @@ async function printJson({
   };
 
   client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+}
+
+function printLogsJson(client: Client, logs: BuildLog[]): void {
+  client.stdout.write(`${JSON.stringify(logs, null, 2)}\n`);
 }
 
 function exitCode(state: Deployment['readyState']) {

--- a/packages/cli/src/util/logs.ts
+++ b/packages/cli/src/util/logs.ts
@@ -37,6 +37,34 @@ export function displayBuildLogs(
   return { promise, abortController };
 }
 
+export function collectBuildLogs(
+  client: Client,
+  deployment: Deployment,
+  follow: boolean = true
+): {
+  promise: Promise<BuildLog[]>;
+  abortController: AbortController;
+} {
+  const logs: BuildLog[] = [];
+  const abortController = new AbortController();
+  const promise = printEvents(
+    client,
+    deployment.id,
+    {
+      mode: 'logs',
+      onEvent: (event: BuildLog) => {
+        if (event.created) {
+          logs.push(event);
+        }
+      },
+      quiet: true,
+      findOpts: { direction: 'forward', follow },
+    },
+    abortController
+  ).then(() => logs);
+  return { promise, abortController };
+}
+
 export async function displayBuildLogsUntilFinalError(
   client: Client,
   deployment: Deployment,

--- a/packages/cli/test/unit/commands/inspect/index.test.ts
+++ b/packages/cli/test/unit/commands/inspect/index.test.ts
@@ -240,6 +240,78 @@ describe('inspect', () => {
         expect(jsonOutput).toHaveProperty('url');
         expect(jsonOutput).toHaveProperty('readyState');
       });
+
+      it('outputs build logs as a top-level JSON array without printing logs to stderr', async () => {
+        const user = useUser();
+        const deployment = useDeployment({ creator: user });
+        useBuildLogs({
+          deployment,
+          logProducer: async function* () {
+            yield {
+              created: 1717426870339,
+              date: 1717426870339,
+              deploymentId: deployment.id,
+              id: 'evt_1',
+              info: { type: 'build', name: 'install', step: 'install' },
+              serial: '1',
+              text: '\u001b[31mHello, world!\u001b[39m',
+              type: 'stdout',
+            };
+            yield {
+              created: 1717426870340,
+              date: 1717426870340,
+              deploymentId: deployment.id,
+              id: 'evt_2',
+              info: { type: 'build', name: 'build', step: 'build' },
+              level: 'warning',
+              serial: '2',
+              text: 'Line 1\nLine 2\n',
+              type: 'stderr',
+            };
+          },
+        });
+
+        client.setArgv('inspect', deployment.url, '--logs', '--format', 'json');
+        const exitCode = await inspect(client);
+        expect(exitCode).toEqual(0);
+
+        const stdout = client.stdout.getFullOutput();
+        const logsOutput = JSON.parse(stdout);
+
+        expect(Array.isArray(logsOutput)).toBe(true);
+        expect(logsOutput).toHaveLength(2);
+        expect(logsOutput).not.toHaveProperty('id');
+        expect(logsOutput[0]).toMatchObject({
+          created: 1717426870339,
+          date: 1717426870339,
+          type: 'stdout',
+          text: '\u001b[31mHello, world!\u001b[39m',
+          id: 'evt_1',
+          serial: '1',
+          deploymentId: deployment.id,
+          info: { type: 'build', name: 'install', step: 'install' },
+        });
+        expect(logsOutput[0]).not.toHaveProperty('level');
+        expect(logsOutput[0]).not.toHaveProperty('step');
+        expect(logsOutput[0].text).toContain('\u001b');
+        expect(logsOutput[1]).toMatchObject({
+          created: 1717426870340,
+          date: 1717426870340,
+          level: 'warning',
+          type: 'stderr',
+          text: 'Line 1\nLine 2\n',
+          id: 'evt_2',
+          serial: '2',
+          deploymentId: deployment.id,
+          info: { type: 'build', name: 'build', step: 'build' },
+        });
+        expect(logsOutput[1]).not.toHaveProperty('step');
+
+        const stderr = client.stderr.getFullOutput();
+        expect(stderr).not.toContain('Hello, world!');
+        expect(stderr).not.toContain('Line 1');
+        expect(stderr).not.toContain('Line 2');
+      });
     });
 
     it('tracks deplomymentUrl as telemetry', async () => {


### PR DESCRIPTION
## Summary

Before this change, `vercel inspect <url> --logs --format json` accepted both flags but did not return build logs. The JSON output path bypassed the `--logs` handling and returned the normal `deployment` JSON instead.

Now, when `--logs` is combined with `--format json`, the command returns the raw build log events as a top-level JSON array on stdout. Regular `vercel inspect <url> --format json` continues to return deployment metadata.


Verified with a random vercel deployment: `npx https://vercel-b6laf184m.vercel.sh/tarballs/vercel.tgz inspect examples-svelte-hn2v5mjm7.vercel.sh --logs --format json --scope vercel`

```
...(only showing last 2 for this PR)
  {
    "created": 1783471638756,
    "date": 1783471638756,
    "deploymentId": "dpl_2A1YdwhTadMp5nphik5kEwFBwnxR",
    "id": "1783471638756857881582900003",
    "text": "Uploading build cache [80.83 MB]",
    "type": "stdout",
    "serial": "1783471638756857881582900003",
    "info": {
      "type": "build",
      "name": "bld_5gndb9d0q",
      "entrypoint": "."
    }
  },
  {
    "created": 1783471642720,
    "date": 1783471642720,
    "deploymentId": "dpl_2A1YdwhTadMp5nphik5kEwFBwnxR",
    "id": "1783471642720857881582900000",
    "text": "Build cache uploaded: 3.964s",
    "type": "stdout",
    "serial": "1783471642720857881582900000",
    "info": {
      "type": "build",
      "name": "bld_5gndb9d0q",
      "entrypoint": "."
    }
  }
]
```