### PR TITLE
Add agent run error filters to CLI

### DIFF
--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -27,6 +27,7 @@ export interface AgentRunsQuery {
   page?: number;
   pageSize?: number;
   search?: string;
+  issue?: 'error';
   runId?: string;
   trace?: boolean;
 }
@@ -57,6 +58,9 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.search) {
     url.searchParams.set('search', query.search);
+  }
+  if (query.issue) {
+    url.searchParams.set('issue', query.issue);
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -65,6 +65,14 @@ export const listSubcommand = {
       description: 'Search Agent Runs by title',
     },
     {
+      name: 'issue',
+      shorthand: null,
+      type: String,
+      argument: 'error',
+      deprecated: false,
+      description: 'Filter Agent Runs by issue type. Currently supports: error',
+    },
+    {
       name: 'page',
       shorthand: null,
       type: Number,

--- a/packages/cli/src/commands/agent-runs/format.ts
+++ b/packages/cli/src/commands/agent-runs/format.ts
@@ -194,3 +194,12 @@ export function formatCount(value: number | undefined): string {
   if (value < 1_000_000) return `${(value / 1000).toFixed(1)}k`;
   return `${(value / 1_000_000).toFixed(1)}m`;
 }
+
+export function formatRate(value: number | undefined): string {
+  if (value === undefined) return PLACEHOLDER;
+  const percent = value * 100;
+  if (percent === 0) return '0%';
+  if (percent < 0.1) return '<0.1%';
+  if (percent < 10) return `${percent.toFixed(1)}%`;
+  return `${Math.round(percent)}%`;
+}

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -51,6 +51,7 @@ export default async function list(client: Client): Promise<number> {
     '--since': since,
     '--until': until,
     '--search': search,
+    '--issue': issue,
     '--page': page,
     '--limit': limit,
     '--json': json,
@@ -62,12 +63,19 @@ export default async function list(client: Client): Promise<number> {
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
   telemetry.trackCliOptionSearch(search);
+  telemetry.trackCliOptionIssue(issue);
   telemetry.trackCliOptionPage(page);
   telemetry.trackCliOptionLimit(limit);
   telemetry.trackCliFlagJson(json);
 
   if (until && !since) {
     return invalidArguments(client, '`--until` requires `--since`.');
+  }
+  if (issue && issue !== 'error') {
+    return invalidArguments(
+      client,
+      '`--issue` currently supports only `error`.'
+    );
   }
 
   const scope = await resolveAgentRunsScope(client, {
@@ -92,6 +100,7 @@ export default async function list(client: Client): Promise<number> {
       page,
       pageSize: limit,
       search,
+      issue: issue === 'error' ? 'error' : undefined,
     });
   } catch (err) {
     output.stopSpinner();

--- a/packages/cli/src/commands/agent-runs/projects.ts
+++ b/packages/cli/src/commands/agent-runs/projects.ts
@@ -18,6 +18,7 @@ import {
   asArray,
   formatCount,
   formatDurationMs,
+  formatRate,
   readNumber,
   readString,
 } from './format';
@@ -99,7 +100,7 @@ export default async function projects(client: Client): Promise<number> {
   );
 
   const rows = [
-    ['Project', 'Runs', 'Avg Duration'].map(header =>
+    ['Project', 'Runs', 'Errors', 'Error Rate', 'Avg Duration'].map(header =>
       chalk.bold(chalk.cyan(header))
     ),
     ...projectList.map(project => [
@@ -114,6 +115,8 @@ export default async function projects(client: Client): Promise<number> {
         ) ?? '-'
       ),
       formatCount(readNumber(project, 'runs', 'runCount', 'totalRuns')),
+      formatCount(readNumber(project, 'errors')),
+      formatRate(readNumber(project, 'errorRate')),
       chalk.gray(
         formatDurationMs(
           readNumber(

--- a/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
@@ -15,6 +15,15 @@ export class AgentRunsListTelemetryClient
     }
   }
 
+  trackCliOptionIssue(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'issue',
+        value,
+      });
+    }
+  }
+
   trackCliOptionPage(value: number | undefined) {
     if (typeof value === 'number') {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -78,7 +78,7 @@ describe('agent-runs list', () => {
     );
   });
 
-  it('forwards search, pagination, environment, and time range params', async () => {
+  it('forwards search, issue, pagination, environment, and time range params', async () => {
     useLinkedProject();
     let receivedQuery: Record<string, string> | undefined;
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
@@ -91,6 +91,8 @@ describe('agent-runs list', () => {
       'list',
       '--search',
       'checkout',
+      '--issue',
+      'error',
       '--page',
       '2',
       '--limit',
@@ -105,6 +107,7 @@ describe('agent-runs list', () => {
     expect(exitCode).toBe(0);
     expect(receivedQuery).toMatchObject({
       search: 'checkout',
+      issue: 'error',
       page: '2',
       pageSize: '50',
       environment: 'preview',
@@ -194,6 +197,16 @@ describe('agent-runs list', () => {
     );
   });
 
+  it('errors when --issue is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'list', '--issue', 'policy_blocked');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--issue` currently supports only `error`.'
+    );
+  });
+
   it('emits a JSON error payload in non-interactive mode for invalid arguments', async () => {
     useLinkedProject();
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -243,13 +256,22 @@ describe('agent-runs list', () => {
       res.json({ runs: [] });
     });
 
-    client.setArgv('agent-runs', 'list', '--json', '--search', 'checkout');
+    client.setArgv(
+      'agent-runs',
+      'list',
+      '--json',
+      '--search',
+      'checkout',
+      '--issue',
+      'error'
+    );
     const exitCode = await agentRuns(client);
 
     expect(exitCode).toBe(0);
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'subcommand:list', value: 'list' },
       { key: 'option:search', value: '[REDACTED]' },
+      { key: 'option:issue', value: 'error' },
       { key: 'flag:json', value: 'TRUE' },
     ]);
   });

--- a/packages/cli/test/unit/commands/agent-runs/projects.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/projects.test.ts
@@ -44,7 +44,15 @@ describe('agent-runs projects', () => {
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
       receivedQuery = req.query;
       res.json({
-        projects: [{ projectName: 'my-app', runs: 5, avgDurationMs: 1234 }],
+        projects: [
+          {
+            projectName: 'my-app',
+            runs: 5,
+            errors: 1,
+            errorRate: 0.2,
+            avgDurationMs: 1234,
+          },
+        ],
       });
     });
 
@@ -61,6 +69,8 @@ describe('agent-runs projects', () => {
     const stdout = client.stdout.getFullOutput();
     expect(stdout).toContain('my-app');
     expect(stdout).toContain('5');
+    expect(stdout).toContain('1');
+    expect(stdout).toContain('20%');
   });
 
   it('works with --scope and no linked project', async () => {


### PR DESCRIPTION
- Add `--issue error` to `vercel agent-runs list` and pass it to the dashboard API
- Show `Errors` and `Error Rate` in `vercel agent-runs projects` formatted output
- Depends on https://github.com/vercel/front/pull/76346 for API fields/filter support
- Tests: corepack pnpm vitest run packages/cli/test/unit/commands/agent-runs/list.test.ts packages/cli/test/unit/commands/agent-runs/projects.test.ts
- Type-check note: `corepack pnpm turbo -F vercel type-check` is blocked by existing `@vercel/functions` missing `ws` types before this package type-checks