### PR TITLE
[cli] Link before pulling settings in vc build, and re-anchor on first run

### DIFF
--- a/.changeset/build-first-run-link-reanchor.md
+++ b/.changeset/build-first-run-link-reanchor.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Fix `vc build` resolving the wrong work path when it establishes the project link itself (settings pulled mid-build). The link is now re-read after the pull so monorepo repo-root re-anchoring applies on the first run, not only subsequent ones.
+Fix `vc build` behavior in an unlinked directory. The link flow now runs before the "Run `vercel pull`?" prompt instead of firing as a side effect of the pull, and the freshly-established link is picked up on the same run — previously the first build computed a wrong work path (e.g. `apps/api/apps/api`) that only corrected itself on a subsequent run.

--- a/.changeset/build-first-run-link-reanchor.md
+++ b/.changeset/build-first-run-link-reanchor.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vc build` resolving the wrong work path when it establishes the project link itself (settings pulled mid-build). The link is now re-read after the pull so monorepo repo-root re-anchoring applies on the first run, not only subsequent ones.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -451,6 +451,12 @@ export default async function main(client: Client): Promise<number> {
     project = await readProjectSettings(vercelDir);
   }
 
+  // The settings pull above may have just established the link; re-read it
+  // so the re-anchoring below sees it.
+  if (!link) {
+    link = await getProjectLink(client, cwd, projectNameOrId, true);
+  }
+
   // A per-directory link (`<dir>/.vercel/project.json`) doesn't report a
   // `repoRoot` like a repo-level (`repo.json`) link does, so the build would
   // treat the linked subdirectory as the repo root. When an ancestor workspace

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -137,6 +137,7 @@ import {
   DEFAULT_VERCEL_CONFIG_FILENAME,
 } from '../../util/compile-vercel-config';
 import { help } from '../help';
+import { ensureLink } from '../../util/link/ensure-link';
 import { pullCommandLogic } from '../pull';
 import { pullEnvRecords } from '../../util/env/get-env-records';
 import { buildCommand } from './command';
@@ -413,6 +414,21 @@ export default async function main(client: Client): Promise<number> {
           )} to retrieve them. In non-interactive mode, set VERCEL_TOKEN for authentication.`
         );
         return 1;
+      }
+
+      // An unlinked directory gets the link flow first, so the pull
+      // question refers to a known project instead of linking as a side
+      // effect of the pull.
+      if (!link) {
+        const ensured = await ensureLink('build', client, cwd, {
+          projectName: projectNameOrId,
+          failIfNotFound: !!projectNameOrId,
+          pullEnv: false,
+        });
+        if (typeof ensured === 'number') {
+          return ensured;
+        }
+        link = await getProjectLink(client, cwd, projectNameOrId, true);
       }
 
       confirmed = await client.input.confirm(

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'fs-extra';
-import { join } from 'path';
+import { basename, join } from 'path';
 import {
   getWriteableDirectory,
   sanitizeConsumerName,
@@ -12,6 +12,7 @@ import { defaultProject, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 import { execSync } from 'child_process';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { vi } from 'vitest';
 import {
   detectBuilders,
@@ -508,6 +509,45 @@ describe.skipIf(flakey)('build', () => {
       { key: 'option:target', value: 'production' },
       { key: 'flag:yes', value: 'TRUE' },
     ]);
+  });
+
+  it('links before asking to pull settings in an unlinked directory', async () => {
+    const cwd = setupUnitFixture('commands/build/static-pull');
+    await fs.remove(join(cwd, '.vercel'));
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: basename(cwd),
+      name: basename(cwd),
+    });
+
+    const originalIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = true;
+    try {
+      client.cwd = cwd;
+      client.setArgv('build');
+      const exitCodePromise = build(client);
+
+      // The link flow runs before the pull question.
+      await expect(client.stderr).toOutput('Which team?');
+      client.stdin.write('\n');
+      await expect(client.stderr).toOutput('Link directory to project?');
+      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput('Linked');
+
+      await expect(client.stderr).toOutput('No Project Settings found locally');
+      client.stdin.write('y\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const projectJson = await fs.readJSON(join(cwd, '.vercel/project.json'));
+      expect(projectJson.projectId).toEqual(basename(cwd));
+    } finally {
+      process.stdin.isTTY = originalIsTTY;
+    }
   });
 
   it('should build root-level `middleware.js` and exclude from static files', async () => {

--- a/packages/cli/test/unit/commands/build/monorepo.test.ts
+++ b/packages/cli/test/unit/commands/build/monorepo.test.ts
@@ -894,6 +894,60 @@ describe('per-directory link resolution', () => {
     }
   );
 
+  // When the first build establishes the link itself (settings pulled
+  // mid-build), re-anchoring must happen on that same run — not only the next.
+  it.skipIf(process.platform === 'win32')(
+    'links and re-anchors on the very first build (link established mid-build)',
+    async () => {
+      const monorepoRoot = setupUnitFixture(
+        'commands/build/turborepo-hono-standalone'
+      );
+      const appDir = join(monorepoRoot, 'apps', 'api');
+      const output = join(appDir, '.vercel/output');
+
+      await execa('git', ['init'], { cwd: monorepoRoot });
+      await execa('pnpm', ['install', '--ignore-scripts'], {
+        cwd: monorepoRoot,
+      });
+
+      // Start unlinked so the build pulls settings and links mid-run.
+      await fs.remove(join(appDir, '.vercel'));
+
+      useUser();
+      useTeams('team_dummy');
+      // Named "api" so link auto-detection matches the directory basename.
+      useProject({
+        ...defaultProject,
+        id: 'api',
+        name: 'api',
+        framework: 'hono',
+        rootDirectory: 'apps/api',
+      });
+
+      client.cwd = appDir;
+      client.setArgv('build', '--yes');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      const projectJson = await fs.readJSON(
+        join(appDir, '.vercel', 'project.json')
+      );
+      expect(projectJson.projectId).toEqual('api');
+
+      const indexFuncDir = join(output, 'functions', 'index.func');
+      expect(await fs.pathExists(indexFuncDir)).toBe(true);
+      const vcConfig = await fs.readJSON(join(indexFuncDir, '.vc-config.json'));
+      expect(vcConfig.handler).toEqual('apps/api/src/index.js');
+
+      await expectModuleResolvesInIsolatedFunc(
+        indexFuncDir,
+        monorepoRoot,
+        'apps/api/src',
+        'hono'
+      );
+    }
+  );
+
   it.skipIf(process.platform === 'win32')(
     'recovers from a redundant rootDirectory restating the location (config #4)',
     async () => {

--- a/packages/cli/test/unit/util/get-update-command.test.ts
+++ b/packages/cli/test/unit/util/get-update-command.test.ts
@@ -67,7 +67,9 @@ describe('getUpdateCommand', () => {
         '/home/user/.local/share/pnpm/global/v11/150b-19f23dfe656/node_modules/vercel/dist/vc.js'
       );
 
-      expect(await getUpdateCommand()).toEqual('pnpm i -g vercel@latest');
+      expect(await getUpdateCommand()).toEqual(
+        'pnpm i -g vercel@latest --allow-build=esbuild'
+      );
       expect(await isGlobal()).toBe(true);
     });
 
@@ -78,7 +80,9 @@ describe('getUpdateCommand', () => {
         '/home/user/.local/share/pnpm/global/5/node_modules/vercel/dist/vc.js'
       );
 
-      expect(await getUpdateCommand()).toEqual('pnpm i -g vercel@latest');
+      expect(await getUpdateCommand()).toEqual(
+        'pnpm i -g vercel@latest --allow-build=esbuild'
+      );
     });
 
     it('matches PNPM_HOME as a path prefix, not a substring', async () => {
@@ -94,7 +98,8 @@ describe('getUpdateCommand', () => {
       // always yields global pnpm; the repo fallback yields a local install.
       const updateCommand = await getUpdateCommand();
       const viaFastPath =
-        updateCommand === 'pnpm i -g vercel@latest' && (await isGlobal());
+        updateCommand === 'pnpm i -g vercel@latest --allow-build=esbuild' &&
+        (await isGlobal());
       // In the dev repo the fallback resolves a local pnpm install, so the
       // fast path result (global) would only appear if prefix matching leaked.
       expect(viaFastPath).toBe(false);


### PR DESCRIPTION
### Problems

Two related issues when `vc build` runs in a fresh (unlinked) directory:

1. **Wrong workPath on the very first run.** The mid-build settings pull establishes the link, but the `link` variable captured before the pull stayed `null`, so the per-directory repo-root re-anchoring (#16750, enabled by default in #16913) was skipped. The build computed a nested bogus path (e.g. `apps/api/apps/api` → `spawn pnpm ENOENT`) and only corrected itself on the next run.

2. **Backwards prompt ordering.** The build asked `Run vercel pull?` before knowing the directory wasn't even linked — the link flow then fired as a side effect of the pull, sandwiched between the pull question and the env download:

   ```
   ? No Project Settings found locally. Run `vercel pull` for retrieving them? yes
   ? Which team? Vercel
   ? Link directory to project? yes
   ```

### Fixes

- Run the link flow (`ensureLink`) before the settings-pull prompt when the directory is unlinked, so linking is an explicit step and the pull question refers to a known project.
- Re-read the link after the settings-pull loop when it was previously `null`, so re-anchoring applies on the first run.

### Tests

- `links before asking to pull settings in an unlinked directory` — asserts the team/link prompts come before the pull question.
- `links and re-anchors on the very first build (link established mid-build)` — starts unlinked in a monorepo subdirectory with the common redundant `rootDirectory` setting and asserts the same run re-anchors to the repo root.

Both verified to fail without their respective changes.

Related: #16809 reworks the linking flow that leads into this path; these changes compose with it.
