### PR TITLE
Add CLI limit support to paginated lists

### DIFF
--- a/.changeset/quiet-limits-list.md
+++ b/.changeset/quiet-limits-list.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `--limit` support to additional paginated CLI list commands and preserve next-page hints when custom limits are used.

--- a/packages/cli/src/commands/alias/ls.ts
+++ b/packages/cli/src/commands/alias/ls.ts
@@ -95,7 +95,7 @@ export default async function ls(client: Client, argv: string[]) {
     output.log(`aliases found under ${chalk.bold(contextName)} ${lsStamp()}`);
     client.stdout.write(printAliasTable(aliases));
 
-    if (pagination.count === 20) {
+    if (pagination.next) {
       const flags = getCommandFlags(opts, ['_', '--next', '--format']);
       output.log(
         `To display the next page run ${getCommandName(

--- a/packages/cli/src/commands/certs/ls.ts
+++ b/packages/cli/src/commands/certs/ls.ts
@@ -71,7 +71,7 @@ async function ls(client: Client, argv: string[]): Promise<number> {
     client.stdout.write(formatCertsTable(certs));
   }
 
-  if (pagination && pagination.count === 20) {
+  if (pagination?.next) {
     const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
       `To display the next page run ${getCommandName(

--- a/packages/cli/src/commands/dns/ls.ts
+++ b/packages/cli/src/commands/dns/ls.ts
@@ -151,7 +151,7 @@ export default async function ls(client: Client, argv: string[]) {
     );
     client.stdout.write(getDNSRecordsTable([{ domainName, records }]));
 
-    if (pagination && pagination.count === 20) {
+    if (pagination?.next) {
       const flags = getCommandFlags(opts, ['_', '--next']);
       output.log(
         `To display the next page run ${getCommandName(
@@ -175,7 +175,7 @@ export default async function ls(client: Client, argv: string[]) {
     )} ${chalk.gray(lsStamp())}`
   );
   output.log(getDNSRecordsTable(dnsRecords));
-  if (pagination && pagination.count === 20) {
+  if (pagination?.next) {
     const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
       `To display the next page run ${getCommandName(

--- a/packages/cli/src/commands/domains/ls.ts
+++ b/packages/cli/src/commands/domains/ls.ts
@@ -110,7 +110,7 @@ export default async function ls(client: Client, argv: string[]) {
       output.print('\n\n');
     }
 
-    if (pagination && pagination.count === 20) {
+    if (pagination?.next) {
       const flags = getCommandFlags(opts, ['_', '--next', '--format']);
       output.log(
         `To display the next page, run ${getCommandName(

--- a/packages/cli/src/commands/list/command.ts
+++ b/packages/cli/src/commands/list/command.ts
@@ -3,6 +3,7 @@ import {
   allOption,
   confirmOption,
   formatOption,
+  limitOption,
   nextOption,
   yesOption,
 } from '../../util/arg-common';
@@ -55,6 +56,7 @@ export const listCommand = {
       deprecated: false,
     },
     nextOption,
+    limitOption,
     // this can be deprecated someday
     { name: 'prod', shorthand: null, type: Boolean, deprecated: false },
     yesOption,

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -28,6 +28,7 @@ import { ListTelemetryClient } from '../../util/telemetry/commands/list';
 import { exitWithNonInteractiveError } from '../../util/agent-output';
 import { validateLsArgs } from '../../util/validate-ls-args';
 import { validateJsonOutput } from '../../util/output-format';
+import { getPaginationOpts } from '../../util/get-pagination-opts';
 import type {
   Deployment,
   PaginationOptions,
@@ -240,21 +241,15 @@ export default async function list(client: Client) {
     }
   }
 
-  const nextTimestamp = parsedArgs.flags['--next'];
-  const limitFlag = parsedArgs.flags['--limit'];
+  let nextTimestamp;
+  let limitFlag;
+  try {
+    [nextTimestamp, limitFlag] = getPaginationOpts(parsedArgs.flags);
+  } catch (err: unknown) {
+    printError(err);
+    return 1;
+  }
   const limit = limitFlag ?? 20;
-
-  if (Number.isNaN(nextTimestamp)) {
-    error('Please provide a number for flag `--next`');
-    return 1;
-  }
-  if (
-    typeof limitFlag === 'number' &&
-    (!Number.isInteger(limitFlag) || limitFlag < 1 || limitFlag > 100)
-  ) {
-    error('Please provide an integer from 1 to 100 for option --limit');
-    return 1;
-  }
 
   const projectSlugLink = project
     ? formatProject(contextName, project.name)

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -96,6 +96,7 @@ export default async function list(client: Client) {
   telemetry.trackCliOptionEnvironment(parsedArgs.flags['--environment']);
   telemetry.trackCliOptionMeta(parsedArgs.flags['--meta']);
   telemetry.trackCliOptionNext(parsedArgs.flags['--next']);
+  telemetry.trackCliOptionLimit(parsedArgs.flags['--limit']);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
   telemetry.trackCliOptionPolicy(parsedArgs.flags['--policy']);
   telemetry.trackCliOptionStatus(parsedArgs.flags['--status']);
@@ -240,9 +241,18 @@ export default async function list(client: Client) {
   }
 
   const nextTimestamp = parsedArgs.flags['--next'];
+  const limitFlag = parsedArgs.flags['--limit'];
+  const limit = limitFlag ?? 20;
 
   if (Number.isNaN(nextTimestamp)) {
     error('Please provide a number for flag `--next`');
+    return 1;
+  }
+  if (
+    typeof limitFlag === 'number' &&
+    (!Number.isInteger(limitFlag) || limitFlag < 1 || limitFlag > 100)
+  ) {
+    error('Please provide an integer from 1 to 100 for option --limit');
     return 1;
   }
 
@@ -258,7 +268,7 @@ export default async function list(client: Client) {
 
     debug('Fetching deployments');
 
-    const query = new URLSearchParams({ limit: '20' });
+    const query = new URLSearchParams({ limit: String(limit) });
     if (project) {
       query.set('projectId', project.id);
     }
@@ -285,10 +295,11 @@ export default async function list(client: Client) {
     }>(`/v6/deployments?${query}`)) {
       deployments.push(...chunk.deployments);
       pagination = chunk.pagination;
-      if (deployments.length >= 20) {
+      if (deployments.length >= limit) {
         break;
       }
     }
+    deployments.length = Math.min(deployments.length, limit);
 
     // we don't output the table headers if we have no deployments
     if (!deployments.length) {

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -2,6 +2,7 @@ import { packageName } from '../../util/pkg-name';
 import {
   formatOption,
   jsonOption,
+  limitOption,
   nextOption,
   yesOption,
 } from '../../util/arg-common';
@@ -157,6 +158,7 @@ export const listSubcommand = {
   arguments: [],
   options: [
     nextOption,
+    limitOption,
     formatOption,
     jsonOption,
     {

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -30,7 +30,7 @@ const PAGINATION_FLAGS_TO_EXCLUDE = [
   '--json',
   '--format',
 ];
-const BASE_PROJECTS_URL = '/v9/projects?limit=20';
+const DEFAULT_PROJECTS_LIMIT = 20;
 
 export default async function list(
   client: Client,
@@ -116,11 +116,18 @@ function processFlags(
   opts: Record<string, any>,
   telemetryClient: ProjectListTelemetryClient
 ):
-  | { deprecated: boolean; next?: number; json: boolean; filter?: string }
+  | {
+      deprecated: boolean;
+      next?: number;
+      json: boolean;
+      filter?: string;
+      limit?: number;
+    }
   | { error: string } {
   const deprecated = opts['--update-required'] || false;
   const next = opts['--next'];
   const filter = opts['--filter'];
+  const limit = opts['--limit'];
   const formatResult = validateJsonOutput(opts);
   if (!formatResult.valid) {
     return { error: formatResult.error };
@@ -129,11 +136,21 @@ function processFlags(
 
   telemetryClient.trackCliFlagUpdateRequired(deprecated);
   telemetryClient.trackCliOptionNext(next);
+  telemetryClient.trackCliOptionLimit(limit);
   telemetryClient.trackCliOptionFormat(opts['--format']);
   telemetryClient.trackCliFlagJson(opts['--json']);
   telemetryClient.trackCliOptionFilter(filter);
 
-  return { deprecated, next, json, filter };
+  if (
+    typeof limit === 'number' &&
+    (!Number.isInteger(limit) || limit < 1 || limit > 100)
+  ) {
+    return {
+      error: 'Please provide an integer from 1 to 100 for option --limit',
+    };
+  }
+
+  return { deprecated, next, json, filter, limit };
 }
 
 // Helper function to build projects URL
@@ -141,20 +158,23 @@ function buildProjectsUrl(flags: {
   deprecated: boolean;
   next?: number;
   filter?: string;
+  limit?: number;
 }) {
-  let url = BASE_PROJECTS_URL;
+  const query = new URLSearchParams({
+    limit: String(flags.limit ?? DEFAULT_PROJECTS_LIMIT),
+  });
 
   if (flags.deprecated) {
-    url += `&deprecated=${flags.deprecated}`;
+    query.set('deprecated', String(flags.deprecated));
   }
   if (flags.next) {
-    url += `&until=${flags.next}`;
+    query.set('until', String(flags.next));
   }
   if (flags.filter) {
-    url += `&search=${encodeURIComponent(flags.filter)}`;
+    query.set('search', flags.filter);
   }
 
-  return url;
+  return `/v9/projects?${query}`;
 }
 
 // Helper function to create project JSON representation
@@ -242,7 +262,7 @@ function printPaginationInstructions(
   opts: Record<string, any>,
   pagination: { count: number; next: number }
 ) {
-  if (pagination && pagination.count === 20) {
+  if (pagination?.next) {
     const flags = getCommandFlags(opts, PAGINATION_FLAGS_TO_EXCLUDE);
     const nextCmd = `project ls${flags} --next ${pagination.next}`;
     output.log(`To display the next page, run ${getCommandName(nextCmd)}`);

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -11,6 +11,7 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import getScope from '../../util/get-scope';
+import { getPaginationOpts } from '../../util/get-pagination-opts';
 import type Client from '../../util/client';
 import type { Project } from '@vercel-internals/types';
 
@@ -141,13 +142,10 @@ function processFlags(
   telemetryClient.trackCliFlagJson(opts['--json']);
   telemetryClient.trackCliOptionFilter(filter);
 
-  if (
-    typeof limit === 'number' &&
-    (!Number.isInteger(limit) || limit < 1 || limit > 100)
-  ) {
-    return {
-      error: 'Please provide an integer from 1 to 100 for option --limit',
-    };
+  try {
+    getPaginationOpts(opts);
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
   }
 
   return { deprecated, next, json, filter, limit };

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { formatOption, nextOption } from '../../util/arg-common';
+import { formatOption, limitOption, nextOption } from '../../util/arg-common';
 
 export const requestSubcommand = {
   name: 'request',
@@ -67,6 +67,7 @@ export const listSubcommand = {
   arguments: [],
   options: [
     nextOption,
+    limitOption,
     formatOption,
     { name: 'since', shorthand: null, type: String, deprecated: true },
     { name: 'until', shorthand: null, type: String, deprecated: true },
@@ -147,7 +148,7 @@ export const membersSubcommand = {
   aliases: ['member'],
   description: 'List members for the currently scoped team',
   arguments: [],
-  options: [nextOption, formatOption],
+  options: [nextOption, limitOption, formatOption],
   examples: [
     {
       name: 'List team members',

--- a/packages/cli/src/commands/teams/list.ts
+++ b/packages/cli/src/commands/teams/list.ts
@@ -59,6 +59,7 @@ export default async function list(
   }
 
   const next = parsedArgs.flags['--next'];
+  const limit = parsedArgs.flags['--limit'];
   const formatResult = validateJsonOutput(parsedArgs.flags);
   if (!formatResult.valid) {
     output.error(formatResult.error);
@@ -67,6 +68,7 @@ export default async function list(
   const asJson = formatResult.jsonOutput;
 
   telemetry.trackCliOptionNext(next);
+  telemetry.trackCliOptionLimit(limit);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
   telemetry.trackCliOptionCount(parsedArgs.flags['--count']);
   telemetry.trackCliOptionUntil(parsedArgs.flags['--until']);
@@ -76,10 +78,18 @@ export default async function list(
     output.error('Please provide a number for flag `--next`');
     return 1;
   }
+  if (
+    typeof limit === 'number' &&
+    (!Number.isInteger(limit) || limit < 1 || limit > 100)
+  ) {
+    output.error('Please provide an integer from 1 to 100 for option --limit');
+    return 1;
+  }
 
   output.spinner('Fetching teams');
   const { teams, pagination } = await getTeams(client, {
     next,
+    limit,
     apiVersion: 2,
   });
   let { currentTeam } = config;
@@ -153,7 +163,7 @@ export default async function list(
     );
     client.stderr.write('\n');
 
-    if (pagination?.count === 20) {
+    if (pagination?.next) {
       const flags = getCommandFlags(parsedArgs.flags, [
         '--next',
         '-N',

--- a/packages/cli/src/commands/teams/list.ts
+++ b/packages/cli/src/commands/teams/list.ts
@@ -16,6 +16,7 @@ import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import { TeamsListTelemetryClient } from '../../util/telemetry/commands/teams/list';
 import { validateLsArgs } from '../../util/validate-ls-args';
+import { getPaginationOpts } from '../../util/get-pagination-opts';
 
 export default async function list(
   client: Client,
@@ -78,11 +79,10 @@ export default async function list(
     output.error('Please provide a number for flag `--next`');
     return 1;
   }
-  if (
-    typeof limit === 'number' &&
-    (!Number.isInteger(limit) || limit < 1 || limit > 100)
-  ) {
-    output.error('Please provide an integer from 1 to 100 for option --limit');
+  try {
+    getPaginationOpts(parsedArgs.flags);
+  } catch (error) {
+    output.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
 

--- a/packages/cli/src/commands/teams/members.ts
+++ b/packages/cli/src/commands/teams/members.ts
@@ -53,6 +53,7 @@ export default async function members(
   }
 
   const next = parsedArgs.flags['--next'];
+  const limit = parsedArgs.flags['--limit'];
   const formatResult = validateJsonOutput(parsedArgs.flags);
   if (!formatResult.valid) {
     output.error(formatResult.error);
@@ -64,6 +65,13 @@ export default async function members(
     output.error('Please provide a number for flag `--next`');
     return 1;
   }
+  if (
+    typeof limit === 'number' &&
+    (!Number.isInteger(limit) || limit < 1 || limit > 100)
+  ) {
+    output.error('Please provide an integer from 1 to 100 for option --limit');
+    return 1;
+  }
 
   const teamId = client.config.currentTeam;
   if (!teamId) {
@@ -73,7 +81,7 @@ export default async function members(
     return 1;
   }
 
-  const query = new URLSearchParams({ limit: '20' });
+  const query = new URLSearchParams({ limit: String(limit ?? 20) });
   if (next) {
     query.set('next', String(next));
   }
@@ -101,7 +109,7 @@ export default async function members(
   ];
   client.stderr.write(`${table(rows, { hsep: 3 })}\n`);
 
-  if (pagination?.count === 20) {
+  if (pagination?.next) {
     const flags = getCommandFlags(parsedArgs.flags, ['--next', '-N']);
     const nextCmd = `${packageName} teams members${flags} --next ${pagination.next}`;
     output.log(`To display the next page run ${cmd(nextCmd)}`);

--- a/packages/cli/src/commands/teams/members.ts
+++ b/packages/cli/src/commands/teams/members.ts
@@ -11,6 +11,7 @@ import { packageName } from '../../util/pkg-name';
 import getCommandFlags from '../../util/get-command-flags';
 import cmd from '../../util/output/cmd';
 import output from '../../output-manager';
+import { getPaginationOpts } from '../../util/get-pagination-opts';
 
 interface TeamMember {
   uid: string;
@@ -65,11 +66,10 @@ export default async function members(
     output.error('Please provide a number for flag `--next`');
     return 1;
   }
-  if (
-    typeof limit === 'number' &&
-    (!Number.isInteger(limit) || limit < 1 || limit > 100)
-  ) {
-    output.error('Please provide an integer from 1 to 100 for option --limit');
+  try {
+    getPaginationOpts(parsedArgs.flags);
+  } catch (error) {
+    output.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
 

--- a/packages/cli/src/util/telemetry/commands/list/index.ts
+++ b/packages/cli/src/util/telemetry/commands/list/index.ts
@@ -48,6 +48,15 @@ export class ListTelemetryClient
     }
   }
 
+  trackCliOptionLimit(limit: number | undefined) {
+    if (limit) {
+      this.trackCliOption({
+        option: 'limit',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagProd(flag: boolean | undefined) {
     if (flag) {
       this.trackCliFlag('prod');

--- a/packages/cli/src/util/telemetry/commands/project/list.ts
+++ b/packages/cli/src/util/telemetry/commands/project/list.ts
@@ -21,6 +21,15 @@ export class ProjectListTelemetryClient
     }
   }
 
+  trackCliOptionLimit(limit: number | undefined) {
+    if (limit) {
+      this.trackCliOption({
+        option: 'limit',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagJson(json: boolean | undefined) {
     if (json) {
       this.trackCliFlag('json');

--- a/packages/cli/src/util/telemetry/commands/teams/list.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/list.ts
@@ -15,6 +15,15 @@ export class TeamsListTelemetryClient
     }
   }
 
+  trackCliOptionLimit(value: number | undefined) {
+    if (value && value > 0) {
+      this.trackCliOption({
+        option: 'limit',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliOptionUntil(value: string | undefined) {
     if (value) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5151,6 +5151,13 @@ exports[`help command > list help output snapshots > list help column width 40 1
                                output     
                                format     
                                (json)     
+       --limit <NUMBER>        Number of  
+                               results to 
+                               return per 
+                               page       
+                               (default:  
+                               20, max:   
+                               100)       
   -m,  --meta <KEY=VALUE>      Filter     
                                deployments
                                by metadata
@@ -5282,6 +5289,8 @@ exports[`help command > list help output snapshots > list help column width 80 1
   -a,  --all                   List resources across all projects                 
        --environment <TARGET>                                                     
   -F,  --format <FORMAT>       Specify the output format (json)                   
+       --limit <NUMBER>        Number of results to return per page (default: 20, 
+                               max: 100)                                          
   -m,  --meta <KEY=VALUE>      Filter deployments by metadata (e.g.: \`-m          
                                KEY=value\`). Can appear many times.                
   -N,  --next <MS>             Show next page of results                          
@@ -5354,6 +5363,7 @@ exports[`help command > list help output snapshots > list help column width 120 
   -a,  --all                   List resources across all projects                                                         
        --environment <TARGET>                                                                                             
   -F,  --format <FORMAT>       Specify the output format (json)                                                           
+       --limit <NUMBER>        Number of results to return per page (default: 20, max: 100)                               
   -m,  --meta <KEY=VALUE>      Filter deployments by metadata (e.g.: \`-m KEY=value\`). Can appear many times.              
   -N,  --next <MS>             Show next page of results                                                                  
   -p,  --policy <KEY=VALUE>    See deployments with provided Deployment Retention policies (e.g.: \`-p KEY=value\`). Can    
@@ -5860,6 +5870,7 @@ exports[`help command > project help output snapshots > project list help output
 
   -f,  --filter <NAME>    Filter projects by name (substring match)                                                     
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --limit <NUMBER>   Number of results to return per page (default: 20, max: 100)                                  
   -N,  --next <MS>        Show next page of results                                                                     
        --update-required  A list of projects affected by an upcoming deprecation                                        
 
@@ -7303,6 +7314,7 @@ exports[`help command > teams help output snapshots > teams list help output sna
   Options:
 
   -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --limit <NUMBER>   Number of results to return per page (default: 20, max: 100)                                  
   -N,  --next <MS>        Show next page of results                                                                     
 
 

--- a/packages/cli/test/unit/commands/list/index.test.ts
+++ b/packages/cli/test/unit/commands/list/index.test.ts
@@ -306,12 +306,16 @@ describe('list', () => {
       useDeployment({ creator: user });
 
       client.cwd = fixture('with-team');
-      client.setArgv('list', '--next', '123456');
+      client.setArgv('list', '--next', '123456', '--limit', '5');
       await list(client);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'option:next',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:limit',
           value: '[REDACTED]',
         },
       ]);

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -71,7 +71,7 @@ describe('list', () => {
         ...defaultProject,
       });
 
-      client.setArgv('project', 'ls', '--next', '1');
+      client.setArgv('project', 'ls', '--next', '1', '--limit', '5');
       await projects(client);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -81,6 +81,10 @@ describe('list', () => {
         },
         {
           key: `option:next`,
+          value: '[REDACTED]',
+        },
+        {
+          key: `option:limit`,
           value: '[REDACTED]',
         },
       ]);

--- a/packages/cli/test/unit/commands/teams/ls.test.ts
+++ b/packages/cli/test/unit/commands/teams/ls.test.ts
@@ -63,12 +63,20 @@ describe('teams ls', () => {
     });
 
     it('--next option should be tracked', async () => {
-      client.setArgv('teams', 'list', '--next', '1584722256178');
+      client.setArgv(
+        'teams',
+        'list',
+        '--next',
+        '1584722256178',
+        '--limit',
+        '5'
+      );
       const exitCode = await teams(client);
       expect(exitCode, 'exit code for "teams"').toEqual(0);
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'subcommand:list', value: 'list' },
         { key: 'option:next', value: '[REDACTED]' },
+        { key: 'option:limit', value: '[REDACTED]' },
       ]);
     });
 

--- a/packages/cli/test/unit/commands/teams/members.test.ts
+++ b/packages/cli/test/unit/commands/teams/members.test.ts
@@ -16,6 +16,7 @@ describe('teams members', () => {
     client.config.currentTeam = 'team_123';
     client.scenario.get('/v2/teams/:teamId/members', (req, res) => {
       expect(req.params.teamId).toBe('team_123');
+      expect(req.query.limit).toBe('5');
       res.json({
         members: [
           {
@@ -27,7 +28,7 @@ describe('teams members', () => {
         ],
       });
     });
-    client.setArgv('teams', 'members');
+    client.setArgv('teams', 'members', '--limit', '5');
 
     const exitCode = await teams(client);
     expect(exitCode).toBe(0);


### PR DESCRIPTION
added to a few places where agents were tripping up - they love to add `--limit` to commands.

it makes sense they don't want to blow up context windows and want to be cautious with API payloads.

also improved the `next` page hints