### PR TITLE
Add agent run session-status filter

### DIFF
--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -28,6 +28,7 @@ export interface AgentRunsQuery {
   pageSize?: number;
   search?: string;
   issue?: 'error';
+  sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
   runId?: string;
   trace?: boolean;
 }
@@ -61,6 +62,9 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.issue) {
     url.searchParams.set('issue', query.issue);
+  }
+  if (query.sessionStatus) {
+    url.searchParams.set('session_status', query.sessionStatus);
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -73,6 +73,14 @@ export const listSubcommand = {
       description: 'Filter Agent Runs by issue type. Currently supports: error',
     },
     {
+      name: 'session-status',
+      shorthand: null,
+      type: String,
+      argument: 'completed|failed|running|waiting',
+      deprecated: false,
+      description: 'Filter Agent Runs by Eve session status',
+    },
+    {
       name: 'page',
       shorthand: null,
       type: Number,

--- a/packages/cli/src/commands/agent-runs/format.ts
+++ b/packages/cli/src/commands/agent-runs/format.ts
@@ -86,11 +86,11 @@ export function runId(run: UnknownRecord): string {
 }
 
 export function runStatus(run: UnknownRecord): string {
-  return readString(run, 'status', 'state') ?? PLACEHOLDER;
+  return readString(run, 'sessionStatus', 'status', 'state') ?? PLACEHOLDER;
 }
 
 export function formatRunStatus(run: UnknownRecord): string {
-  const status = readString(run, 'status', 'state');
+  const status = readString(run, 'sessionStatus', 'status', 'state');
   if (!status) return PLACEHOLDER;
   const label = title(status.replace(/[_-]+/g, ' '));
   const CIRCLE = '● ';

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -52,6 +52,7 @@ export default async function list(client: Client): Promise<number> {
     '--until': until,
     '--search': search,
     '--issue': issue,
+    '--session-status': sessionStatus,
     '--page': page,
     '--limit': limit,
     '--json': json,
@@ -64,6 +65,7 @@ export default async function list(client: Client): Promise<number> {
   telemetry.trackCliOptionUntil(until);
   telemetry.trackCliOptionSearch(search);
   telemetry.trackCliOptionIssue(issue);
+  telemetry.trackCliOptionSessionStatus(sessionStatus);
   telemetry.trackCliOptionPage(page);
   telemetry.trackCliOptionLimit(limit);
   telemetry.trackCliFlagJson(json);
@@ -77,6 +79,25 @@ export default async function list(client: Client): Promise<number> {
       '`--issue` currently supports only `error`.'
     );
   }
+  if (
+    sessionStatus &&
+    sessionStatus !== 'completed' &&
+    sessionStatus !== 'failed' &&
+    sessionStatus !== 'running' &&
+    sessionStatus !== 'waiting'
+  ) {
+    return invalidArguments(
+      client,
+      '`--session-status` supports `completed`, `failed`, `running`, or `waiting`.'
+    );
+  }
+  const validatedSessionStatus =
+    sessionStatus === 'completed' ||
+    sessionStatus === 'failed' ||
+    sessionStatus === 'running' ||
+    sessionStatus === 'waiting'
+      ? sessionStatus
+      : undefined;
 
   const scope = await resolveAgentRunsScope(client, {
     scopeFlag,
@@ -101,6 +122,7 @@ export default async function list(client: Client): Promise<number> {
       pageSize: limit,
       search,
       issue: issue === 'error' ? 'error' : undefined,
+      sessionStatus: validatedSessionStatus,
     });
   } catch (err) {
     output.stopSpinner();

--- a/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
@@ -24,6 +24,15 @@ export class AgentRunsListTelemetryClient
     }
   }
 
+  trackCliOptionSessionStatus(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'session-status',
+        value,
+      });
+    }
+  }
+
   trackCliOptionPage(value: number | undefined) {
     if (typeof value === 'number') {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -30,6 +30,7 @@ function useLinkedProject() {
 const sampleRun = {
   id: 'run_001',
   status: 'completed',
+  sessionStatus: 'waiting',
   model: 'anthropic/claude-opus-4.8',
   trigger: 'api',
   createdAt: Date.now() - 60_000,
@@ -71,14 +72,14 @@ describe('agent-runs list', () => {
     expect(receivedQuery).not.toHaveProperty('view');
     const stdout = client.stdout.getFullOutput();
     expect(stdout).toContain('run_001');
-    expect(stdout).toContain('Completed');
+    expect(stdout).toContain('Waiting');
     expect(stdout).toContain('anthropic/claude-opus-4.8');
     expect(client.stderr.getFullOutput()).toContain(
       'vercel agent-runs inspect <runId>'
     );
   });
 
-  it('forwards search, issue, pagination, environment, and time range params', async () => {
+  it('forwards search, issue, session status, pagination, environment, and time range params', async () => {
     useLinkedProject();
     let receivedQuery: Record<string, string> | undefined;
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
@@ -93,6 +94,8 @@ describe('agent-runs list', () => {
       'checkout',
       '--issue',
       'error',
+      '--session-status',
+      'failed',
       '--page',
       '2',
       '--limit',
@@ -108,6 +111,7 @@ describe('agent-runs list', () => {
     expect(receivedQuery).toMatchObject({
       search: 'checkout',
       issue: 'error',
+      session_status: 'failed',
       page: '2',
       pageSize: '50',
       environment: 'preview',
@@ -207,6 +211,16 @@ describe('agent-runs list', () => {
     );
   });
 
+  it('errors when --session-status is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'list', '--session-status', 'cancelled');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--session-status` supports `completed`, `failed`, `running`, or `waiting`.'
+    );
+  });
+
   it('emits a JSON error payload in non-interactive mode for invalid arguments', async () => {
     useLinkedProject();
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -263,7 +277,9 @@ describe('agent-runs list', () => {
       '--search',
       'checkout',
       '--issue',
-      'error'
+      'error',
+      '--session-status',
+      'failed'
     );
     const exitCode = await agentRuns(client);
 
@@ -272,6 +288,7 @@ describe('agent-runs list', () => {
       { key: 'subcommand:list', value: 'list' },
       { key: 'option:search', value: '[REDACTED]' },
       { key: 'option:issue', value: 'error' },
+      { key: 'option:session-status', value: 'failed' },
       { key: 'flag:json', value: 'TRUE' },
     ]);
   });


### PR DESCRIPTION
- adds `--session-status completed|failed|running|waiting` to `vercel agent-runs list`
- sends API query param `session_status` and tracks telemetry
- prefers `sessionStatus` over workflow `status` in formatted output
- extends list tests for passthrough, validation, telemetry, and display

Stacked on https://github.com/vercel/vercel/pull/16952

Validation:
- `corepack pnpm vitest run packages/cli/test/unit/commands/agent-runs/list.test.ts packages/cli/test/unit/commands/agent-runs/projects.test.ts`
- `corepack pnpm exec prettier --check <touched files>`

Type-check note:
- `corepack pnpm turbo -F vercel type-check` still fails before CLI on unrelated `@vercel/functions` missing `ws` types.