### PR TITLE
Add agent run issues command

### DIFF
--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -28,6 +28,9 @@ export interface AgentRunsQuery {
   pageSize?: number;
   search?: string;
   issue?: 'error';
+  issueCode?: string;
+  issueTool?: string;
+  groupBy?: 'issue';
   sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
   runId?: string;
   trace?: boolean;
@@ -62,6 +65,15 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.issue) {
     url.searchParams.set('issue', query.issue);
+  }
+  if (query.issueCode) {
+    url.searchParams.set('issue_code', query.issueCode);
+  }
+  if (query.issueTool) {
+    url.searchParams.set('issue_tool', query.issueTool);
+  }
+  if (query.groupBy) {
+    url.searchParams.set('groupBy', query.groupBy);
   }
   if (query.sessionStatus) {
     url.searchParams.set('session_status', query.sessionStatus);

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -209,6 +209,30 @@ export const projectsSubcommand = {
   ],
 } as const;
 
+export const issuesSubcommand = {
+  name: 'issues',
+  aliases: [],
+  description: 'List top Agent Run issue groups for a project',
+  arguments: [],
+  options: [
+    projectOption,
+    environmentOption,
+    sinceOption,
+    untilOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'List top issue groups for the linked project',
+      value: `${packageName} agent-runs issues`,
+    },
+    {
+      name: 'Print raw issue groups as JSON',
+      value: `${packageName} agent-runs issues --json`,
+    },
+  ],
+} as const;
+
 export const agentRunsCommand = {
   name: 'agent-runs',
   aliases: [],
@@ -219,6 +243,7 @@ export const agentRunsCommand = {
     inspectSubcommand,
     traceSubcommand,
     projectsSubcommand,
+    issuesSubcommand,
   ],
   options: [],
   examples: [
@@ -229,6 +254,10 @@ export const agentRunsCommand = {
     {
       name: 'List projects with Agent Runs activity',
       value: `${packageName} agent-runs projects`,
+    },
+    {
+      name: 'List top issue groups',
+      value: `${packageName} agent-runs issues`,
     },
     {
       name: 'Inspect an Agent Run',

--- a/packages/cli/src/commands/agent-runs/index.ts
+++ b/packages/cli/src/commands/agent-runs/index.ts
@@ -2,6 +2,7 @@ import { help, type Command } from '../help';
 import {
   agentRunsCommand,
   inspectSubcommand,
+  issuesSubcommand,
   listSubcommand,
   projectsSubcommand,
   traceSubcommand,
@@ -18,12 +19,14 @@ import list from './list';
 import inspect from './inspect';
 import trace from './trace';
 import projects from './projects';
+import issues from './issues';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
   inspect: getCommandAliases(inspectSubcommand),
   trace: getCommandAliases(traceSubcommand),
   projects: getCommandAliases(projectsSubcommand),
+  issues: getCommandAliases(issuesSubcommand),
 };
 
 export default async function agentRuns(client: Client): Promise<number> {
@@ -111,6 +114,15 @@ export default async function agentRuns(client: Client): Promise<number> {
       }
       telemetry.trackCliSubcommandProjects(subcommandOriginal);
       return await projects(client);
+    }
+    case 'issues': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('agent-runs', subcommandOriginal);
+        printHelp(issuesSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandIssues(subcommandOriginal);
+      return await issues(client);
     }
     default: {
       output.error(`Unknown subcommand: ${subcommandOriginal}`);

--- a/packages/cli/src/commands/agent-runs/issues.ts
+++ b/packages/cli/src/commands/agent-runs/issues.ts
@@ -1,0 +1,148 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import cmd from '../../util/output/cmd';
+import stamp from '../../util/output/stamp';
+import table from '../../util/output/table';
+import { issuesSubcommand } from './command';
+import {
+  fetchAgentRuns,
+  handleAgentRunsApiError,
+  invalidArguments,
+  resolveAgentRunsScope,
+} from './agent-runs-api';
+import {
+  asArray,
+  formatAge,
+  formatCount,
+  readNumber,
+  readString,
+  readTimestampMs,
+  type UnknownRecord,
+} from './format';
+import { AgentIssuesTelemetryClient } from '../../util/telemetry/commands/agent-runs/issues';
+
+const ISSUE_TYPE_LABEL: Record<string, string> = {
+  action_failed: 'Action failed',
+  action_rejected: 'Action rejected',
+  step_failed: 'Step failed',
+  turn_failed: 'Turn failed',
+  session_failed: 'Session failed',
+  policy_blocked: 'Policy blocked',
+};
+
+function issueType(group: UnknownRecord): string {
+  const raw = readString(group, 'type');
+  return raw ? (ISSUE_TYPE_LABEL[raw] ?? raw) : '-';
+}
+
+function issueCode(group: UnknownRecord): string {
+  return readString(group, 'code') ?? '-';
+}
+
+function issueTool(group: UnknownRecord): string {
+  return readString(group, 'tool') ?? '-';
+}
+
+export default async function issues(client: Client): Promise<number> {
+  const telemetry = new AgentIssuesTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(issuesSubcommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const {
+    '--project': projectFlag,
+    '--environment': environment,
+    '--since': since,
+    '--until': until,
+    '--json': json,
+    '--scope': scopeFlag,
+  } = parsedArgs.flags;
+
+  telemetry.trackCliOptionProject(projectFlag);
+  telemetry.trackCliOptionEnvironment(environment);
+  telemetry.trackCliOptionSince(since);
+  telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliFlagJson(json);
+
+  if (until && !since) {
+    return invalidArguments(client, '`--until` requires `--since`.');
+  }
+
+  const scope = await resolveAgentRunsScope(client, {
+    scopeFlag,
+    projectFlag,
+    requireProject: true,
+  });
+  if (!scope.ok) {
+    return scope.exitCode;
+  }
+
+  const fetchStamp = stamp();
+  output.spinner(
+    `Fetching Agent Run issues in ${chalk.bold(scope.contextName)}…`
+  );
+  let data;
+  try {
+    data = await fetchAgentRuns(client, {
+      teamId: scope.teamId,
+      projectId: scope.projectId,
+      environment,
+      since,
+      until,
+      groupBy: 'issue',
+    });
+  } catch (err) {
+    output.stopSpinner();
+    handleAgentRunsApiError(client, err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (json) {
+    client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+    return 0;
+  }
+
+  const issueGroups = asArray(data.issueGroups);
+  if (issueGroups.length === 0) {
+    output.log('No Agent Run issues found.');
+    return 0;
+  }
+
+  output.log(
+    `Agent Run issues under ${chalk.bold(scope.contextName)} ${fetchStamp()}`
+  );
+
+  const rows = [
+    ['Type', 'Tool', 'Code', 'Turns', 'Runs', 'Last Seen', 'Sample Run'].map(
+      header => chalk.bold(chalk.cyan(header))
+    ),
+    ...issueGroups.map(group => [
+      issueType(group),
+      issueTool(group),
+      issueCode(group),
+      formatCount(readNumber(group, 'turns')),
+      formatCount(readNumber(group, 'runs')),
+      chalk.gray(formatAge(readTimestampMs(group, 'lastSeenAt'))),
+      chalk.bold(readString(group, 'sampleRunId') ?? '-'),
+    ]),
+  ];
+  client.stdout.write(`\n${table(rows, { hsep: 3 }).replace(/^/gm, '  ')}\n\n`);
+
+  output.log(
+    `Run ${cmd('vercel agent-runs list --issue error --project <name>')} to list error-bearing runs.`
+  );
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/agent-runs/index.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/index.ts
@@ -33,4 +33,11 @@ export class AgentRunsTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandIssues(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'issues',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/agent-runs/issues.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/issues.ts
@@ -1,0 +1,7 @@
+import type { TelemetryMethods } from '../../types';
+import type { issuesSubcommand } from '../../../../commands/agent-runs/command';
+import { AgentRunsQueryTelemetryClient } from './shared';
+
+export class AgentIssuesTelemetryClient
+  extends AgentRunsQueryTelemetryClient
+  implements TelemetryMethods<typeof issuesSubcommand> {}

--- a/packages/cli/test/unit/commands/agent-runs/issues.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/issues.test.ts
@@ -1,0 +1,111 @@
+import { describe, beforeEach, afterEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import agentRuns from '../../../../src/commands/agent-runs';
+import * as linkModule from '../../../../src/util/projects/link';
+
+vi.mock('../../../../src/util/projects/link', async () => {
+  const actual = await vi.importActual('../../../../src/util/projects/link');
+  return {
+    ...(actual as object),
+    getLinkedProject: vi.fn(),
+  };
+});
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+
+function useLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_test',
+      name: 'agent-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: { id: 'team_dummy', slug: 'my-team', type: 'team' },
+  } as Awaited<ReturnType<typeof linkModule.getLinkedProject>>);
+}
+
+describe('agent-runs issues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    process.env.VERCEL_AGENT_RUNS_API_URL = new URL(
+      '/api/observability/agent-runs',
+      client.apiUrl
+    ).href;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_AGENT_RUNS_API_URL;
+  });
+
+  it('lists issue groups for the linked project', async () => {
+    useLinkedProject();
+    let receivedQuery: Record<string, unknown> | undefined;
+    client.scenario.get('/api/observability/agent-runs', (req, res) => {
+      receivedQuery = req.query;
+      res.json({
+        issueGroups: [
+          {
+            type: 'action_failed',
+            code: 'ETIMEDOUT',
+            tool: 'linear.createIssue',
+            turns: 5,
+            runs: 2,
+            lastSeenAt: new Date(Date.now() - 60_000).toISOString(),
+            sampleRunId: 'run_001',
+          },
+        ],
+      });
+    });
+
+    client.setArgv('agent-runs', 'issues');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(receivedQuery).toMatchObject({
+      teamSlug: 'team_dummy',
+      project: 'prj_test',
+      environment: 'production',
+      groupBy: 'issue',
+    });
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).toContain('Action failed');
+    expect(stdout).toContain('linear.createIssue');
+    expect(stdout).toContain('ETIMEDOUT');
+    expect(stdout).toContain('run_001');
+  });
+
+  it('prints raw JSON', async () => {
+    useLinkedProject();
+    client.scenario.get('/api/observability/agent-runs', (_req, res) => {
+      res.json({ issueGroups: [] });
+    });
+
+    client.setArgv('agent-runs', 'issues', '--json');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      issueGroups: [],
+    });
+  });
+
+  it('tracks telemetry for subcommand and flags', async () => {
+    useLinkedProject();
+    client.scenario.get('/api/observability/agent-runs', (_req, res) => {
+      res.json({ issueGroups: [] });
+    });
+
+    client.setArgv('agent-runs', 'issues', '--json');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:issues', value: 'issues' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+});


### PR DESCRIPTION
- Add `vercel agent-runs issues` over the dashboard `groupBy=issue` API contract
- Render top issue groups with type/tool/code/counts/sample run; keep `--json` as raw response
- Cover URL params, table output, JSON output, and telemetry in focused unit tests