### PR TITLE
Show agent run issues in inspect

### DIFF
--- a/packages/cli/src/commands/agent-runs/inspect.ts
+++ b/packages/cli/src/commands/agent-runs/inspect.ts
@@ -43,6 +43,51 @@ function formatStartedAt(run: UnknownRecord): string {
   return `${formatAge(startedAt)} ${chalk.gray(formatTimestamp(startedAt))}`;
 }
 
+function formatIssueSummary(run: UnknownRecord): string | undefined {
+  const detailIssueSummary = readRecord(run, 'detailIssueSummary');
+  const issueSummary = readRecord(run, 'issueSummary');
+  const summary = detailIssueSummary ?? issueSummary;
+  const issueCount = readNumber(summary, 'issueCount');
+  if (!summary || !issueCount || issueCount <= 0) return undefined;
+
+  const parts: string[] = [`${formatCount(issueCount)} issues`];
+  const errorCount = readNumber(summary, 'errorCount');
+  const rejectedActionCount = readNumber(summary, 'rejectedActionCount');
+  const failedTurnCount = readNumber(summary, 'failedTurnCount');
+  if (errorCount && errorCount > 0) {
+    parts.push(`${formatCount(errorCount)} errors`);
+  }
+  if (rejectedActionCount && rejectedActionCount > 0) {
+    parts.push(`${formatCount(rejectedActionCount)} rejected`);
+  }
+  if (failedTurnCount && failedTurnCount > 0) {
+    parts.push(`${formatCount(failedTurnCount)} failed turns`);
+  }
+
+  const latestIssue =
+    readRecord(detailIssueSummary, 'latestIssue') ?? detailIssueSummary;
+  const latestCode =
+    readString(latestIssue, 'code') ??
+    readString(issueSummary, 'lastIssueCode');
+  const latestTool =
+    readString(latestIssue, 'tool') ??
+    readString(issueSummary, 'lastIssueTool');
+  const latestAt =
+    readTimestampMs(latestIssue, 'occurredAt') ??
+    readTimestampMs(issueSummary, 'lastIssueAt');
+  const latestParts = [
+    latestCode ? `code ${latestCode}` : undefined,
+    latestTool ? `tool ${latestTool}` : undefined,
+    latestAt !== undefined ? formatTimestamp(latestAt) : undefined,
+  ].filter(Boolean);
+
+  if (latestParts.length > 0) {
+    parts.push(`${chalk.gray('latest')} ${latestParts.join(' · ')}`);
+  }
+
+  return parts.join(' / ');
+}
+
 function renderDetail(run: UnknownRecord): string {
   const usage = readRecord(run, 'usage');
   const rows: string[][] = [
@@ -57,6 +102,10 @@ function renderDetail(run: UnknownRecord): string {
     [chalk.bold('Started'), formatStartedAt(run)],
     [chalk.bold('Duration'), formatDurationMs(runDurationMs(run))]
   );
+  const issueSummary = formatIssueSummary(run);
+  if (issueSummary) {
+    rows.push([chalk.bold('Issues'), issueSummary]);
+  }
   const input = readNumber(usage, 'inputTokens', 'promptTokens', 'input');
   const outputTokens = readNumber(
     usage,

--- a/packages/cli/test/unit/commands/agent-runs/inspect.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/inspect.test.ts
@@ -63,6 +63,24 @@ describe('agent-runs inspect', () => {
           createdAt: 1_718_000_000_000,
           durationMs: 4500,
           usage: { inputTokens: 100, outputTokens: 200 },
+          detailIssueSummary: {
+            issueCount: 2,
+            errorCount: 1,
+            failedActionCount: 1,
+            rejectedActionCount: 1,
+            failedTurnCount: 0,
+            failedToolCallIds: ['tool_timeout'],
+            rejectedToolCallIds: ['tool_policy'],
+            latestIssue: {
+              type: 'action_failed',
+              turnId: 'turn_1',
+              toolCallId: 'tool_timeout',
+              tool: 'linear.createIssue',
+              code: 'ETIMEDOUT',
+              message: 'Linear timed out.',
+              occurredAt: '2026-01-01T00:00:05.000Z',
+            },
+          },
           events: [{ timestamp: 1_718_000_000_000, type: 'run.started' }],
           subagents: [
             { name: 'researcher', status: 'completed', durationMs: 1200 },
@@ -84,6 +102,9 @@ describe('agent-runs inspect', () => {
     const stdout = client.stdout.getFullOutput();
     expect(stdout).toContain('run_001');
     expect(stdout).toContain('Completed');
+    expect(stdout).toContain('Issues');
+    expect(stdout).toContain('ETIMEDOUT');
+    expect(stdout).toContain('linear.createIssue');
     expect(stdout).toContain('run.started');
     expect(stdout).toContain('researcher');
     expect(client.stderr.getFullOutput()).toContain('for full run data.');


### PR DESCRIPTION
- Render `detailIssueSummary` / `issueSummary` in `vercel agent-runs inspect`
- Keep `--json` as the full raw response

Validation:
- `pnpm exec prettier --check packages/cli/src/commands/agent-runs/inspect.ts packages/cli/test/unit/commands/agent-runs/inspect.test.ts`
- `pnpm vitest run packages/cli/test/unit/commands/agent-runs/inspect.test.ts`

Note:
- `turbo -F vercel type-check` still fails in unrelated `@vercel/functions` `ws` type resolution before this CLI code is checked