### PR TITLE
Add agent run trigger filter

### DIFF
--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -32,6 +32,7 @@ export interface AgentRunsQuery {
   issueTool?: string;
   groupBy?: 'issue';
   sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
+  trigger?: 'slack' | 'http' | 'schedule' | 'manual' | 'unknown';
   runId?: string;
   trace?: boolean;
 }
@@ -77,6 +78,9 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.sessionStatus) {
     url.searchParams.set('session_status', query.sessionStatus);
+  }
+  if (query.trigger) {
+    url.searchParams.set('trigger', query.trigger);
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -81,6 +81,14 @@ export const listSubcommand = {
       description: 'Filter Agent Runs by Eve session status',
     },
     {
+      name: 'trigger',
+      shorthand: null,
+      type: String,
+      argument: 'slack|http|schedule|manual|unknown',
+      deprecated: false,
+      description: 'Filter Agent Runs by trigger source',
+    },
+    {
       name: 'page',
       shorthand: null,
       type: Number,

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -53,6 +53,7 @@ export default async function list(client: Client): Promise<number> {
     '--search': search,
     '--issue': issue,
     '--session-status': sessionStatus,
+    '--trigger': trigger,
     '--page': page,
     '--limit': limit,
     '--json': json,
@@ -66,6 +67,7 @@ export default async function list(client: Client): Promise<number> {
   telemetry.trackCliOptionSearch(search);
   telemetry.trackCliOptionIssue(issue);
   telemetry.trackCliOptionSessionStatus(sessionStatus);
+  telemetry.trackCliOptionTrigger(trigger);
   telemetry.trackCliOptionPage(page);
   telemetry.trackCliOptionLimit(limit);
   telemetry.trackCliFlagJson(json);
@@ -98,6 +100,27 @@ export default async function list(client: Client): Promise<number> {
     sessionStatus === 'waiting'
       ? sessionStatus
       : undefined;
+  if (
+    trigger &&
+    trigger !== 'slack' &&
+    trigger !== 'http' &&
+    trigger !== 'schedule' &&
+    trigger !== 'manual' &&
+    trigger !== 'unknown'
+  ) {
+    return invalidArguments(
+      client,
+      '`--trigger` supports `slack`, `http`, `schedule`, `manual`, or `unknown`.'
+    );
+  }
+  const validatedTrigger =
+    trigger === 'slack' ||
+    trigger === 'http' ||
+    trigger === 'schedule' ||
+    trigger === 'manual' ||
+    trigger === 'unknown'
+      ? trigger
+      : undefined;
 
   const scope = await resolveAgentRunsScope(client, {
     scopeFlag,
@@ -123,6 +146,7 @@ export default async function list(client: Client): Promise<number> {
       search,
       issue: issue === 'error' ? 'error' : undefined,
       sessionStatus: validatedSessionStatus,
+      trigger: validatedTrigger,
     });
   } catch (err) {
     output.stopSpinner();

--- a/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
@@ -33,6 +33,15 @@ export class AgentRunsListTelemetryClient
     }
   }
 
+  trackCliOptionTrigger(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'trigger',
+        value,
+      });
+    }
+  }
+
   trackCliOptionPage(value: number | undefined) {
     if (typeof value === 'number') {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -79,7 +79,7 @@ describe('agent-runs list', () => {
     );
   });
 
-  it('forwards search, issue, session status, pagination, environment, and time range params', async () => {
+  it('forwards search, issue, session status, trigger, pagination, environment, and time range params', async () => {
     useLinkedProject();
     let receivedQuery: Record<string, string> | undefined;
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
@@ -96,6 +96,8 @@ describe('agent-runs list', () => {
       'error',
       '--session-status',
       'failed',
+      '--trigger',
+      'slack',
       '--page',
       '2',
       '--limit',
@@ -112,6 +114,7 @@ describe('agent-runs list', () => {
       search: 'checkout',
       issue: 'error',
       session_status: 'failed',
+      trigger: 'slack',
       page: '2',
       pageSize: '50',
       environment: 'preview',
@@ -221,6 +224,16 @@ describe('agent-runs list', () => {
     );
   });
 
+  it('errors when --trigger is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'list', '--trigger', 'github');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--trigger` supports `slack`, `http`, `schedule`, `manual`, or `unknown`.'
+    );
+  });
+
   it('emits a JSON error payload in non-interactive mode for invalid arguments', async () => {
     useLinkedProject();
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -279,7 +292,9 @@ describe('agent-runs list', () => {
       '--issue',
       'error',
       '--session-status',
-      'failed'
+      'failed',
+      '--trigger',
+      'manual'
     );
     const exitCode = await agentRuns(client);
 
@@ -289,6 +304,7 @@ describe('agent-runs list', () => {
       { key: 'option:search', value: '[REDACTED]' },
       { key: 'option:issue', value: 'error' },
       { key: 'option:session-status', value: 'failed' },
+      { key: 'option:trigger', value: 'manual' },
       { key: 'flag:json', value: 'TRUE' },
     ]);
   });


### PR DESCRIPTION
- Add --trigger to vercel agent-runs list
- Forward trigger to the dashboard Agent Runs API and track CLI telemetry
- Validation: focused unit test; repo type-check still blocked by unrelated @vercel/functions ws type error