### PR TITLE
Show Eve fleet health in projects

### DIFF
--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -33,6 +33,7 @@ export interface AgentRunsQuery {
   groupBy?: 'issue';
   sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
   trigger?: 'slack' | 'http' | 'schedule' | 'manual' | 'unknown';
+  staleThreshold?: number;
   runId?: string;
   trace?: boolean;
 }
@@ -81,6 +82,12 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.trigger) {
     url.searchParams.set('trigger', query.trigger);
+  }
+  if (typeof query.staleThreshold === 'number') {
+    url.searchParams.set(
+      'stale_threshold',
+      String(Math.max(1, Math.floor(query.staleThreshold)))
+    );
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -204,7 +204,21 @@ export const projectsSubcommand = {
   aliases: [],
   description: 'List projects in the current team with Agent Runs activity',
   arguments: [],
-  options: [environmentOption, sinceOption, untilOption, jsonOption],
+  options: [
+    environmentOption,
+    sinceOption,
+    untilOption,
+    {
+      name: 'stale-threshold',
+      shorthand: null,
+      type: Number,
+      argument: 'SECONDS',
+      deprecated: false,
+      description:
+        'Seconds without session activity before in-progress runs count as stale',
+    },
+    jsonOption,
+  ],
   examples: [
     {
       name: 'List projects with Agent Runs activity',

--- a/packages/cli/src/commands/agent-runs/projects.ts
+++ b/packages/cli/src/commands/agent-runs/projects.ts
@@ -18,9 +18,11 @@ import {
   asArray,
   formatCount,
   formatDurationMs,
+  formatAge,
   formatRate,
   readNumber,
   readString,
+  readTimestampMs,
 } from './format';
 import { AgentProjectsTelemetryClient } from '../../util/telemetry/commands/agent-runs/projects';
 
@@ -44,15 +46,26 @@ export default async function projects(client: Client): Promise<number> {
     '--until': until,
     '--json': json,
     '--scope': scopeFlag,
+    '--stale-threshold': staleThreshold,
   } = parsedArgs.flags;
 
   telemetry.trackCliOptionEnvironment(environment);
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliOptionStaleThreshold(staleThreshold);
   telemetry.trackCliFlagJson(json);
 
   if (until && !since) {
     return invalidArguments(client, '`--until` requires `--since`.');
+  }
+  if (
+    typeof staleThreshold === 'number' &&
+    (!Number.isFinite(staleThreshold) || staleThreshold <= 0)
+  ) {
+    return invalidArguments(
+      client,
+      '`--stale-threshold` must be a positive number of seconds.'
+    );
   }
 
   const scope = await resolveAgentRunsScope(client, {
@@ -76,6 +89,7 @@ export default async function projects(client: Client): Promise<number> {
       environment,
       since,
       until,
+      staleThreshold,
     });
   } catch (err) {
     output.stopSpinner();
@@ -100,9 +114,17 @@ export default async function projects(client: Client): Promise<number> {
   );
 
   const rows = [
-    ['Project', 'Runs', 'Errors', 'Error Rate', 'Avg Duration'].map(header =>
-      chalk.bold(chalk.cyan(header))
-    ),
+    [
+      'Project',
+      'Runs',
+      'Errors',
+      'Error Rate',
+      'Running',
+      'Waiting',
+      'Stale',
+      'Last Issue',
+      'Avg Duration',
+    ].map(header => chalk.bold(chalk.cyan(header))),
     ...projectList.map(project => [
       chalk.bold(
         readString(
@@ -117,6 +139,10 @@ export default async function projects(client: Client): Promise<number> {
       formatCount(readNumber(project, 'runs', 'runCount', 'totalRuns')),
       formatCount(readNumber(project, 'errors')),
       formatRate(readNumber(project, 'errorRate')),
+      formatCount(readNumber(project, 'running')),
+      formatCount(readNumber(project, 'waiting')),
+      formatCount(readNumber(project, 'stale')),
+      formatAge(readTimestampMs(project, 'lastIssueAt')),
       chalk.gray(
         formatDurationMs(
           readNumber(

--- a/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
@@ -40,6 +40,15 @@ export class AgentRunsQueryTelemetryClient extends TelemetryClient {
     }
   }
 
+  trackCliOptionStaleThreshold(value: number | undefined) {
+    if (typeof value === 'number') {
+      this.trackCliOption({
+        option: 'stale-threshold',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagJson(value: boolean | undefined) {
     if (value) {
       this.trackCliFlag('json');

--- a/packages/cli/test/unit/commands/agent-runs/projects.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/projects.test.ts
@@ -50,6 +50,10 @@ describe('agent-runs projects', () => {
             runs: 5,
             errors: 1,
             errorRate: 0.2,
+            running: 2,
+            waiting: 1,
+            stale: 1,
+            lastIssueAt: new Date(Date.now() - 60_000).toISOString(),
             avgDurationMs: 1234,
           },
         ],
@@ -71,6 +75,38 @@ describe('agent-runs projects', () => {
     expect(stdout).toContain('5');
     expect(stdout).toContain('1');
     expect(stdout).toContain('20%');
+    expect(stdout).toContain('2');
+    expect(stdout).toContain('1m ago');
+  });
+
+  it('forwards --stale-threshold as seconds', async () => {
+    mockedGetLinkedProject.mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'prj_test',
+        name: 'agent-project',
+        accountId: 'team_dummy',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      },
+      org: { id: 'team_dummy', slug: 'my-team', type: 'team' },
+    } as Awaited<ReturnType<typeof linkModule.getLinkedProject>>);
+
+    let receivedQuery: Record<string, unknown> | undefined;
+    client.scenario.get('/api/observability/agent-runs', (req, res) => {
+      receivedQuery = req.query;
+      res.json({ projects: [] });
+    });
+
+    client.setArgv('agent-runs', 'projects', '--stale-threshold', '900');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(receivedQuery).toMatchObject({
+      teamSlug: 'team_dummy',
+      view: 'team',
+      stale_threshold: '900',
+    });
   });
 
   it('works with --scope and no linked project', async () => {


### PR DESCRIPTION
- Adds --stale-threshold to vercel agent-runs projects and forwards stale_threshold to the dashboard API
- Shows running, waiting, stale, and last issue columns from the team rollup response
- Adds focused unit coverage for rendering and query forwarding