### PR TITLE
Expose Agent Runs triage filters in CLI

### DIFF
--- a/.changeset/agent-runs-triage-cli.md
+++ b/.changeset/agent-runs-triage-cli.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add Agent Runs triage filters, issue-group output, detail issue summaries, and fleet-health project columns to the CLI.

--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -32,6 +32,7 @@ export interface AgentRunsQuery {
   issueTool?: string;
   groupBy?: 'issue';
   sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
+  trigger?: 'slack' | 'http' | 'schedule' | 'manual' | 'unknown';
   runId?: string;
   trace?: boolean;
 }
@@ -77,6 +78,9 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.sessionStatus) {
     url.searchParams.set('session_status', query.sessionStatus);
+  }
+  if (query.trigger) {
+    url.searchParams.set('trigger', query.trigger);
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -28,6 +28,7 @@ export interface AgentRunsQuery {
   pageSize?: number;
   search?: string;
   issue?: 'error';
+  sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
   runId?: string;
   trace?: boolean;
 }
@@ -61,6 +62,9 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.issue) {
     url.searchParams.set('issue', query.issue);
+  }
+  if (query.sessionStatus) {
+    url.searchParams.set('session_status', query.sessionStatus);
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -28,6 +28,9 @@ export interface AgentRunsQuery {
   pageSize?: number;
   search?: string;
   issue?: 'error';
+  issueCode?: string;
+  issueTool?: string;
+  groupBy?: 'issue';
   sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
   runId?: string;
   trace?: boolean;
@@ -62,6 +65,15 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.issue) {
     url.searchParams.set('issue', query.issue);
+  }
+  if (query.issueCode) {
+    url.searchParams.set('issue_code', query.issueCode);
+  }
+  if (query.issueTool) {
+    url.searchParams.set('issue_tool', query.issueTool);
+  }
+  if (query.groupBy) {
+    url.searchParams.set('groupBy', query.groupBy);
   }
   if (query.sessionStatus) {
     url.searchParams.set('session_status', query.sessionStatus);

--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -29,11 +29,17 @@ export interface AgentRunsQuery {
   search?: string;
   issue?: 'error';
   issueCode?: string;
+  issueType?:
+    | 'action_failed'
+    | 'action_rejected'
+    | 'step_failed'
+    | 'turn_failed'
+    | 'session_failed'
+    | 'policy_blocked';
+  issueSource?: 'skill' | 'subagent' | 'tool' | 'workflow';
   issueTool?: string;
   groupBy?: 'issue';
-  sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
   trigger?: 'slack' | 'http' | 'schedule' | 'manual' | 'unknown';
-  staleThreshold?: number;
   runId?: string;
   trace?: boolean;
 }
@@ -71,23 +77,20 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   if (query.issueCode) {
     url.searchParams.set('issue_code', query.issueCode);
   }
+  if (query.issueType) {
+    url.searchParams.set('issue_type', query.issueType);
+  }
+  if (query.issueSource) {
+    url.searchParams.set('issue_source', query.issueSource);
+  }
   if (query.issueTool) {
     url.searchParams.set('issue_tool', query.issueTool);
   }
   if (query.groupBy) {
     url.searchParams.set('groupBy', query.groupBy);
   }
-  if (query.sessionStatus) {
-    url.searchParams.set('session_status', query.sessionStatus);
-  }
   if (query.trigger) {
     url.searchParams.set('trigger', query.trigger);
-  }
-  if (typeof query.staleThreshold === 'number') {
-    url.searchParams.set(
-      'stale_threshold',
-      String(Math.max(1, Math.floor(query.staleThreshold)))
-    );
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -27,6 +27,7 @@ export interface AgentRunsQuery {
   page?: number;
   pageSize?: number;
   search?: string;
+  issue?: 'error';
   runId?: string;
   trace?: boolean;
 }
@@ -57,6 +58,9 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.search) {
     url.searchParams.set('search', query.search);
+  }
+  if (query.issue) {
+    url.searchParams.set('issue', query.issue);
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -34,8 +34,7 @@ export interface AgentRunsQuery {
     | 'action_rejected'
     | 'step_failed'
     | 'turn_failed'
-    | 'session_failed'
-    | 'policy_blocked';
+    | 'session_failed';
   issueSource?: 'remote_subagent' | 'skill' | 'subagent' | 'tool' | 'workflow';
   issueTool?: string;
   groupBy?: 'issue';

--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -36,7 +36,7 @@ export interface AgentRunsQuery {
     | 'turn_failed'
     | 'session_failed'
     | 'policy_blocked';
-  issueSource?: 'skill' | 'subagent' | 'tool' | 'workflow';
+  issueSource?: 'remote_subagent' | 'skill' | 'subagent' | 'tool' | 'workflow';
   issueTool?: string;
   groupBy?: 'issue';
   trigger?: 'slack' | 'http' | 'schedule' | 'manual' | 'unknown';

--- a/packages/cli/src/commands/agent-runs/agent-runs-api.ts
+++ b/packages/cli/src/commands/agent-runs/agent-runs-api.ts
@@ -33,6 +33,7 @@ export interface AgentRunsQuery {
   groupBy?: 'issue';
   sessionStatus?: 'completed' | 'failed' | 'running' | 'waiting';
   trigger?: 'slack' | 'http' | 'schedule' | 'manual' | 'unknown';
+  staleThreshold?: number;
   runId?: string;
   trace?: boolean;
 }
@@ -81,6 +82,12 @@ export function buildAgentRunsUrl(query: AgentRunsQuery): string {
   }
   if (query.trigger) {
     url.searchParams.set('trigger', query.trigger);
+  }
+  if (typeof query.staleThreshold === 'number') {
+    url.searchParams.set(
+      'stale_threshold',
+      String(Math.max(1, Math.floor(query.staleThreshold)))
+    );
   }
   if (query.runId) {
     url.searchParams.set('runId', query.runId);

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -209,6 +209,30 @@ export const projectsSubcommand = {
   ],
 } as const;
 
+export const issuesSubcommand = {
+  name: 'issues',
+  aliases: [],
+  description: 'List top Agent Run issue groups for a project',
+  arguments: [],
+  options: [
+    projectOption,
+    environmentOption,
+    sinceOption,
+    untilOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'List top issue groups for the linked project',
+      value: `${packageName} agent-runs issues`,
+    },
+    {
+      name: 'Print raw issue groups as JSON',
+      value: `${packageName} agent-runs issues --json`,
+    },
+  ],
+} as const;
+
 export const agentRunsCommand = {
   name: 'agent-runs',
   aliases: [],
@@ -219,6 +243,7 @@ export const agentRunsCommand = {
     inspectSubcommand,
     traceSubcommand,
     projectsSubcommand,
+    issuesSubcommand,
   ],
   options: [],
   examples: [
@@ -229,6 +254,10 @@ export const agentRunsCommand = {
     {
       name: 'List projects with Agent Runs activity',
       value: `${packageName} agent-runs projects`,
+    },
+    {
+      name: 'List top issue groups',
+      value: `${packageName} agent-runs issues`,
     },
     {
       name: 'Inspect an Agent Run',

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -60,7 +60,7 @@ const issueTypeOption = {
   shorthand: null,
   type: String,
   argument:
-    'action_failed|action_rejected|step_failed|turn_failed|session_failed|policy_blocked',
+    'action_failed|action_rejected|step_failed|turn_failed|session_failed',
   deprecated: false,
   description: 'Filter Agent Runs by issue fingerprint type',
 } as const;
@@ -264,6 +264,14 @@ export const issuesSubcommand = {
     issueTypeOption,
     issueSourceOption,
     issueToolOption,
+    {
+      name: 'trigger',
+      shorthand: null,
+      type: String,
+      argument: 'slack|http|schedule|manual|unknown',
+      deprecated: false,
+      description: 'Filter Agent Runs by trigger source',
+    },
     jsonOption,
   ],
   examples: [

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -62,7 +62,7 @@ const issueTypeOption = {
   argument:
     'action_failed|action_rejected|step_failed|turn_failed|session_failed',
   deprecated: false,
-  description: 'Filter Agent Runs by issue fingerprint type',
+  description: 'Filter Agent Runs by platform-derived issue type',
 } as const;
 
 const issueSourceOption = {

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -46,6 +46,24 @@ const jsonOption = {
   description: 'Print the raw API response as JSON to stdout',
 } as const;
 
+const issueCodeOption = {
+  name: 'issue-code',
+  shorthand: null,
+  type: String,
+  argument: 'CODE',
+  deprecated: false,
+  description: 'Filter Agent Runs by issue code',
+} as const;
+
+const issueToolOption = {
+  name: 'issue-tool',
+  shorthand: null,
+  type: String,
+  argument: 'TOOL',
+  deprecated: false,
+  description: 'Filter Agent Runs by issue tool name',
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -72,6 +90,8 @@ export const listSubcommand = {
       deprecated: false,
       description: 'Filter Agent Runs by issue type. Currently supports: error',
     },
+    issueCodeOption,
+    issueToolOption,
     {
       name: 'session-status',
       shorthand: null,
@@ -241,6 +261,8 @@ export const issuesSubcommand = {
     environmentOption,
     sinceOption,
     untilOption,
+    issueCodeOption,
+    issueToolOption,
     jsonOption,
   ],
   examples: [

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -204,7 +204,21 @@ export const projectsSubcommand = {
   aliases: [],
   description: 'List projects in the current team with Agent Runs activity',
   arguments: [],
-  options: [environmentOption, sinceOption, untilOption, jsonOption],
+  options: [
+    environmentOption,
+    sinceOption,
+    untilOption,
+    {
+      name: 'stale-threshold',
+      shorthand: null,
+      type: Number,
+      argument: 'SECONDS',
+      deprecated: false,
+      description:
+        'Seconds without session activity before in-progress runs count as stale',
+    },
+    jsonOption,
+  ],
   examples: [
     {
       name: 'List projects with Agent Runs activity',

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -55,6 +55,25 @@ const issueCodeOption = {
   description: 'Filter Agent Runs by issue code',
 } as const;
 
+const issueTypeOption = {
+  name: 'issue-type',
+  shorthand: null,
+  type: String,
+  argument:
+    'action_failed|action_rejected|step_failed|turn_failed|session_failed|policy_blocked',
+  deprecated: false,
+  description: 'Filter Agent Runs by issue fingerprint type',
+} as const;
+
+const issueSourceOption = {
+  name: 'issue-source',
+  shorthand: null,
+  type: String,
+  argument: 'skill|subagent|tool|workflow',
+  deprecated: false,
+  description: 'Filter Agent Runs by where the issue occurred',
+} as const;
+
 const issueToolOption = {
   name: 'issue-tool',
   shorthand: null,
@@ -91,15 +110,9 @@ export const listSubcommand = {
       description: 'Filter Agent Runs by issue type. Currently supports: error',
     },
     issueCodeOption,
+    issueTypeOption,
+    issueSourceOption,
     issueToolOption,
-    {
-      name: 'session-status',
-      shorthand: null,
-      type: String,
-      argument: 'completed|failed|running|waiting',
-      deprecated: false,
-      description: 'Filter Agent Runs by Eve session status',
-    },
     {
       name: 'trigger',
       shorthand: null,
@@ -224,21 +237,7 @@ export const projectsSubcommand = {
   aliases: [],
   description: 'List projects in the current team with Agent Runs activity',
   arguments: [],
-  options: [
-    environmentOption,
-    sinceOption,
-    untilOption,
-    {
-      name: 'stale-threshold',
-      shorthand: null,
-      type: Number,
-      argument: 'SECONDS',
-      deprecated: false,
-      description:
-        'Seconds without session activity before in-progress runs count as stale',
-    },
-    jsonOption,
-  ],
+  options: [environmentOption, sinceOption, untilOption, jsonOption],
   examples: [
     {
       name: 'List projects with Agent Runs activity',
@@ -262,6 +261,8 @@ export const issuesSubcommand = {
     sinceOption,
     untilOption,
     issueCodeOption,
+    issueTypeOption,
+    issueSourceOption,
     issueToolOption,
     jsonOption,
   ],

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -73,6 +73,14 @@ export const listSubcommand = {
       description: 'Filter Agent Runs by issue type. Currently supports: error',
     },
     {
+      name: 'session-status',
+      shorthand: null,
+      type: String,
+      argument: 'completed|failed|running|waiting',
+      deprecated: false,
+      description: 'Filter Agent Runs by Eve session status',
+    },
+    {
       name: 'page',
       shorthand: null,
       type: Number,

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -69,7 +69,7 @@ const issueSourceOption = {
   name: 'issue-source',
   shorthand: null,
   type: String,
-  argument: 'skill|subagent|tool|workflow',
+  argument: 'remote_subagent|skill|subagent|tool|workflow',
   deprecated: false,
   description: 'Filter Agent Runs by where the issue occurred',
 } as const;

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -65,6 +65,14 @@ export const listSubcommand = {
       description: 'Search Agent Runs by title',
     },
     {
+      name: 'issue',
+      shorthand: null,
+      type: String,
+      argument: 'error',
+      deprecated: false,
+      description: 'Filter Agent Runs by issue type. Currently supports: error',
+    },
+    {
       name: 'page',
       shorthand: null,
       type: Number,

--- a/packages/cli/src/commands/agent-runs/command.ts
+++ b/packages/cli/src/commands/agent-runs/command.ts
@@ -81,6 +81,14 @@ export const listSubcommand = {
       description: 'Filter Agent Runs by Eve session status',
     },
     {
+      name: 'trigger',
+      shorthand: null,
+      type: String,
+      argument: 'slack|http|schedule|manual|unknown',
+      deprecated: false,
+      description: 'Filter Agent Runs by trigger source',
+    },
+    {
       name: 'page',
       shorthand: null,
       type: Number,

--- a/packages/cli/src/commands/agent-runs/format.ts
+++ b/packages/cli/src/commands/agent-runs/format.ts
@@ -194,3 +194,12 @@ export function formatCount(value: number | undefined): string {
   if (value < 1_000_000) return `${(value / 1000).toFixed(1)}k`;
   return `${(value / 1_000_000).toFixed(1)}m`;
 }
+
+export function formatRate(value: number | undefined): string {
+  if (value === undefined) return PLACEHOLDER;
+  const percent = value * 100;
+  if (percent === 0) return '0%';
+  if (percent < 0.1) return '<0.1%';
+  if (percent < 10) return `${percent.toFixed(1)}%`;
+  return `${Math.round(percent)}%`;
+}

--- a/packages/cli/src/commands/agent-runs/format.ts
+++ b/packages/cli/src/commands/agent-runs/format.ts
@@ -86,11 +86,11 @@ export function runId(run: UnknownRecord): string {
 }
 
 export function runStatus(run: UnknownRecord): string {
-  return readString(run, 'sessionStatus', 'status', 'state') ?? PLACEHOLDER;
+  return readString(run, 'status', 'state', 'sessionStatus') ?? PLACEHOLDER;
 }
 
 export function formatRunStatus(run: UnknownRecord): string {
-  const status = readString(run, 'sessionStatus', 'status', 'state');
+  const status = readString(run, 'status', 'state', 'sessionStatus');
   if (!status) return PLACEHOLDER;
   const label = title(status.replace(/[_-]+/g, ' '));
   const CIRCLE = '● ';

--- a/packages/cli/src/commands/agent-runs/format.ts
+++ b/packages/cli/src/commands/agent-runs/format.ts
@@ -86,11 +86,11 @@ export function runId(run: UnknownRecord): string {
 }
 
 export function runStatus(run: UnknownRecord): string {
-  return readString(run, 'status', 'state') ?? PLACEHOLDER;
+  return readString(run, 'sessionStatus', 'status', 'state') ?? PLACEHOLDER;
 }
 
 export function formatRunStatus(run: UnknownRecord): string {
-  const status = readString(run, 'status', 'state');
+  const status = readString(run, 'sessionStatus', 'status', 'state');
   if (!status) return PLACEHOLDER;
   const label = title(status.replace(/[_-]+/g, ' '));
   const CIRCLE = '● ';

--- a/packages/cli/src/commands/agent-runs/index.ts
+++ b/packages/cli/src/commands/agent-runs/index.ts
@@ -2,6 +2,7 @@ import { help, type Command } from '../help';
 import {
   agentRunsCommand,
   inspectSubcommand,
+  issuesSubcommand,
   listSubcommand,
   projectsSubcommand,
   traceSubcommand,
@@ -18,12 +19,14 @@ import list from './list';
 import inspect from './inspect';
 import trace from './trace';
 import projects from './projects';
+import issues from './issues';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
   inspect: getCommandAliases(inspectSubcommand),
   trace: getCommandAliases(traceSubcommand),
   projects: getCommandAliases(projectsSubcommand),
+  issues: getCommandAliases(issuesSubcommand),
 };
 
 export default async function agentRuns(client: Client): Promise<number> {
@@ -111,6 +114,15 @@ export default async function agentRuns(client: Client): Promise<number> {
       }
       telemetry.trackCliSubcommandProjects(subcommandOriginal);
       return await projects(client);
+    }
+    case 'issues': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('agent-runs', subcommandOriginal);
+        printHelp(issuesSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandIssues(subcommandOriginal);
+      return await issues(client);
     }
     default: {
       output.error(`Unknown subcommand: ${subcommandOriginal}`);

--- a/packages/cli/src/commands/agent-runs/inspect.ts
+++ b/packages/cli/src/commands/agent-runs/inspect.ts
@@ -99,6 +99,7 @@ function renderDetail(run: UnknownRecord): string {
   rows.push(
     [chalk.bold('Trigger'), runTrigger(run)],
     [chalk.bold('Model'), runModel(run)],
+    [chalk.bold('Eve Version'), readString(run, 'eveVersion') ?? '-'],
     [chalk.bold('Started'), formatStartedAt(run)],
     [chalk.bold('Duration'), formatDurationMs(runDurationMs(run))]
   );

--- a/packages/cli/src/commands/agent-runs/inspect.ts
+++ b/packages/cli/src/commands/agent-runs/inspect.ts
@@ -50,18 +50,18 @@ function formatIssueSummary(run: UnknownRecord): string | undefined {
   const issueCount = readNumber(summary, 'issueCount');
   if (!summary || !issueCount || issueCount <= 0) return undefined;
 
-  const parts: string[] = [`${formatCount(issueCount)} issues`];
+  const parts: string[] = [formatCountNoun(issueCount, 'issue')];
   const errorCount = readNumber(summary, 'errorCount');
   const rejectedActionCount = readNumber(summary, 'rejectedActionCount');
   const failedTurnCount = readNumber(summary, 'failedTurnCount');
   if (errorCount && errorCount > 0) {
-    parts.push(`${formatCount(errorCount)} errors`);
+    parts.push(formatCountNoun(errorCount, 'error'));
   }
   if (rejectedActionCount && rejectedActionCount > 0) {
-    parts.push(`${formatCount(rejectedActionCount)} rejected`);
+    parts.push(formatCountNoun(rejectedActionCount, 'rejection'));
   }
   if (failedTurnCount && failedTurnCount > 0) {
-    parts.push(`${formatCount(failedTurnCount)} failed turns`);
+    parts.push(formatCountNoun(failedTurnCount, 'failed turn'));
   }
 
   const latestIssue =
@@ -86,6 +86,10 @@ function formatIssueSummary(run: UnknownRecord): string | undefined {
   }
 
   return parts.join(' / ');
+}
+
+function formatCountNoun(count: number, noun: string): string {
+  return `${formatCount(count)} ${count === 1 ? noun : `${noun}s`}`;
 }
 
 function renderDetail(run: UnknownRecord): string {
@@ -154,7 +158,7 @@ function renderDetail(run: UnknownRecord): string {
     sections.push(`${chalk.bold('Events')}\n${table(eventRows, { hsep: 3 })}`);
   }
 
-  const subagents = asArray(run.subagents ?? run.subAgents);
+  const subagents = asArray(run.subagentRuns ?? run.subagents ?? run.subAgents);
   if (subagents.length > 0) {
     const subagentRows = [
       ['Subagent', 'Status', 'Model', 'Tokens', 'Duration'].map(header =>

--- a/packages/cli/src/commands/agent-runs/inspect.ts
+++ b/packages/cli/src/commands/agent-runs/inspect.ts
@@ -43,6 +43,51 @@ function formatStartedAt(run: UnknownRecord): string {
   return `${formatAge(startedAt)} ${chalk.gray(formatTimestamp(startedAt))}`;
 }
 
+function formatIssueSummary(run: UnknownRecord): string | undefined {
+  const detailIssueSummary = readRecord(run, 'detailIssueSummary');
+  const issueSummary = readRecord(run, 'issueSummary');
+  const summary = detailIssueSummary ?? issueSummary;
+  const issueCount = readNumber(summary, 'issueCount');
+  if (!summary || !issueCount || issueCount <= 0) return undefined;
+
+  const parts: string[] = [`${formatCount(issueCount)} issues`];
+  const errorCount = readNumber(summary, 'errorCount');
+  const rejectedActionCount = readNumber(summary, 'rejectedActionCount');
+  const failedTurnCount = readNumber(summary, 'failedTurnCount');
+  if (errorCount && errorCount > 0) {
+    parts.push(`${formatCount(errorCount)} errors`);
+  }
+  if (rejectedActionCount && rejectedActionCount > 0) {
+    parts.push(`${formatCount(rejectedActionCount)} rejected`);
+  }
+  if (failedTurnCount && failedTurnCount > 0) {
+    parts.push(`${formatCount(failedTurnCount)} failed turns`);
+  }
+
+  const latestIssue =
+    readRecord(detailIssueSummary, 'latestIssue') ?? detailIssueSummary;
+  const latestCode =
+    readString(latestIssue, 'code') ??
+    readString(issueSummary, 'lastIssueCode');
+  const latestTool =
+    readString(latestIssue, 'tool') ??
+    readString(issueSummary, 'lastIssueTool');
+  const latestAt =
+    readTimestampMs(latestIssue, 'occurredAt') ??
+    readTimestampMs(issueSummary, 'lastIssueAt');
+  const latestParts = [
+    latestCode ? `code ${latestCode}` : undefined,
+    latestTool ? `tool ${latestTool}` : undefined,
+    latestAt !== undefined ? formatTimestamp(latestAt) : undefined,
+  ].filter(Boolean);
+
+  if (latestParts.length > 0) {
+    parts.push(`${chalk.gray('latest')} ${latestParts.join(' · ')}`);
+  }
+
+  return parts.join(' / ');
+}
+
 function renderDetail(run: UnknownRecord): string {
   const usage = readRecord(run, 'usage');
   const rows: string[][] = [
@@ -57,6 +102,10 @@ function renderDetail(run: UnknownRecord): string {
     [chalk.bold('Started'), formatStartedAt(run)],
     [chalk.bold('Duration'), formatDurationMs(runDurationMs(run))]
   );
+  const issueSummary = formatIssueSummary(run);
+  if (issueSummary) {
+    rows.push([chalk.bold('Issues'), issueSummary]);
+  }
   const input = readNumber(usage, 'inputTokens', 'promptTokens', 'input');
   const outputTokens = readNumber(
     usage,

--- a/packages/cli/src/commands/agent-runs/issues.ts
+++ b/packages/cli/src/commands/agent-runs/issues.ts
@@ -1,0 +1,148 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import cmd from '../../util/output/cmd';
+import stamp from '../../util/output/stamp';
+import table from '../../util/output/table';
+import { issuesSubcommand } from './command';
+import {
+  fetchAgentRuns,
+  handleAgentRunsApiError,
+  invalidArguments,
+  resolveAgentRunsScope,
+} from './agent-runs-api';
+import {
+  asArray,
+  formatAge,
+  formatCount,
+  readNumber,
+  readString,
+  readTimestampMs,
+  type UnknownRecord,
+} from './format';
+import { AgentIssuesTelemetryClient } from '../../util/telemetry/commands/agent-runs/issues';
+
+const ISSUE_TYPE_LABEL: Record<string, string> = {
+  action_failed: 'Action failed',
+  action_rejected: 'Action rejected',
+  step_failed: 'Step failed',
+  turn_failed: 'Turn failed',
+  session_failed: 'Session failed',
+  policy_blocked: 'Policy blocked',
+};
+
+function issueType(group: UnknownRecord): string {
+  const raw = readString(group, 'type');
+  return raw ? (ISSUE_TYPE_LABEL[raw] ?? raw) : '-';
+}
+
+function issueCode(group: UnknownRecord): string {
+  return readString(group, 'code') ?? '-';
+}
+
+function issueTool(group: UnknownRecord): string {
+  return readString(group, 'tool') ?? '-';
+}
+
+export default async function issues(client: Client): Promise<number> {
+  const telemetry = new AgentIssuesTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(issuesSubcommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const {
+    '--project': projectFlag,
+    '--environment': environment,
+    '--since': since,
+    '--until': until,
+    '--json': json,
+    '--scope': scopeFlag,
+  } = parsedArgs.flags;
+
+  telemetry.trackCliOptionProject(projectFlag);
+  telemetry.trackCliOptionEnvironment(environment);
+  telemetry.trackCliOptionSince(since);
+  telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliFlagJson(json);
+
+  if (until && !since) {
+    return invalidArguments(client, '`--until` requires `--since`.');
+  }
+
+  const scope = await resolveAgentRunsScope(client, {
+    scopeFlag,
+    projectFlag,
+    requireProject: true,
+  });
+  if (!scope.ok) {
+    return scope.exitCode;
+  }
+
+  const fetchStamp = stamp();
+  output.spinner(
+    `Fetching Agent Run issues in ${chalk.bold(scope.contextName)}…`
+  );
+  let data;
+  try {
+    data = await fetchAgentRuns(client, {
+      teamId: scope.teamId,
+      projectId: scope.projectId,
+      environment,
+      since,
+      until,
+      groupBy: 'issue',
+    });
+  } catch (err) {
+    output.stopSpinner();
+    handleAgentRunsApiError(client, err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (json) {
+    client.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+    return 0;
+  }
+
+  const issueGroups = asArray(data.issueGroups);
+  if (issueGroups.length === 0) {
+    output.log('No Agent Run issues found.');
+    return 0;
+  }
+
+  output.log(
+    `Agent Run issues under ${chalk.bold(scope.contextName)} ${fetchStamp()}`
+  );
+
+  const rows = [
+    ['Type', 'Tool', 'Code', 'Turns', 'Runs', 'Last Seen', 'Sample Run'].map(
+      header => chalk.bold(chalk.cyan(header))
+    ),
+    ...issueGroups.map(group => [
+      issueType(group),
+      issueTool(group),
+      issueCode(group),
+      formatCount(readNumber(group, 'turns')),
+      formatCount(readNumber(group, 'runs')),
+      chalk.gray(formatAge(readTimestampMs(group, 'lastSeenAt'))),
+      chalk.bold(readString(group, 'sampleRunId') ?? '-'),
+    ]),
+  ];
+  client.stdout.write(`\n${table(rows, { hsep: 3 }).replace(/^/gm, '  ')}\n\n`);
+
+  output.log(
+    `Run ${cmd('vercel agent-runs list --issue error --project <name>')} to list error-bearing runs.`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/agent-runs/issues.ts
+++ b/packages/cli/src/commands/agent-runs/issues.ts
@@ -39,11 +39,11 @@ function issueType(group: UnknownRecord): string {
   return raw ? (ISSUE_TYPE_LABEL[raw] ?? raw) : '-';
 }
 
-function issueCode(group: UnknownRecord): string {
+function formatIssueCode(group: UnknownRecord): string {
   return readString(group, 'code') ?? '-';
 }
 
-function issueTool(group: UnknownRecord): string {
+function formatIssueTool(group: UnknownRecord): string {
   return readString(group, 'tool') ?? '-';
 }
 
@@ -66,6 +66,8 @@ export default async function issues(client: Client): Promise<number> {
     '--environment': environment,
     '--since': since,
     '--until': until,
+    '--issue-code': issueCode,
+    '--issue-tool': issueTool,
     '--json': json,
     '--scope': scopeFlag,
   } = parsedArgs.flags;
@@ -74,6 +76,8 @@ export default async function issues(client: Client): Promise<number> {
   telemetry.trackCliOptionEnvironment(environment);
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliOptionIssueCode(issueCode);
+  telemetry.trackCliOptionIssueTool(issueTool);
   telemetry.trackCliFlagJson(json);
 
   if (until && !since) {
@@ -101,6 +105,8 @@ export default async function issues(client: Client): Promise<number> {
       environment,
       since,
       until,
+      issueCode,
+      issueTool,
       groupBy: 'issue',
     });
   } catch (err) {
@@ -131,8 +137,8 @@ export default async function issues(client: Client): Promise<number> {
     ),
     ...issueGroups.map(group => [
       issueType(group),
-      issueTool(group),
-      issueCode(group),
+      formatIssueTool(group),
+      formatIssueCode(group),
       formatCount(readNumber(group, 'turns')),
       formatCount(readNumber(group, 'runs')),
       chalk.gray(formatAge(readTimestampMs(group, 'lastSeenAt'))),

--- a/packages/cli/src/commands/agent-runs/issues.ts
+++ b/packages/cli/src/commands/agent-runs/issues.ts
@@ -203,14 +203,22 @@ export default async function issues(client: Client): Promise<number> {
   );
 
   const rows = [
-    ['Type', 'Tool', 'Code', 'Turns', 'Runs', 'Last Seen', 'Sample Run'].map(
-      header => chalk.bold(chalk.cyan(header))
-    ),
+    [
+      'Type',
+      'Tool',
+      'Code',
+      'Occurrences',
+      'Runs',
+      'Last Seen',
+      'Sample Run',
+    ].map(header => chalk.bold(chalk.cyan(header))),
     ...issueGroups.map(group => [
       formatIssueType(group),
       formatIssueTool(group),
       formatIssueCode(group),
-      formatCount(readNumber(group, 'turns')),
+      formatCount(
+        readNumber(group, 'occurrences') ?? readNumber(group, 'turns')
+      ),
       formatCount(readNumber(group, 'runs')),
       chalk.gray(formatAge(readTimestampMs(group, 'lastSeenAt'))),
       chalk.bold(readString(group, 'sampleRunId') ?? '-'),

--- a/packages/cli/src/commands/agent-runs/issues.ts
+++ b/packages/cli/src/commands/agent-runs/issues.ts
@@ -31,7 +31,6 @@ const ISSUE_TYPE_LABEL: Record<string, string> = {
   step_failed: 'Step failed',
   turn_failed: 'Turn failed',
   session_failed: 'Session failed',
-  policy_blocked: 'Policy blocked',
 };
 
 function formatIssueType(group: UnknownRecord): string {
@@ -70,19 +69,10 @@ export default async function issues(client: Client): Promise<number> {
     '--issue-type': issueType,
     '--issue-source': issueSource,
     '--issue-tool': issueTool,
+    '--trigger': trigger,
     '--json': json,
     '--scope': scopeFlag,
   } = parsedArgs.flags;
-
-  telemetry.trackCliOptionProject(projectFlag);
-  telemetry.trackCliOptionEnvironment(environment);
-  telemetry.trackCliOptionSince(since);
-  telemetry.trackCliOptionUntil(until);
-  telemetry.trackCliOptionIssueCode(issueCode);
-  telemetry.trackCliOptionIssueType(issueType);
-  telemetry.trackCliOptionIssueSource(issueSource);
-  telemetry.trackCliOptionIssueTool(issueTool);
-  telemetry.trackCliFlagJson(json);
 
   if (until && !since) {
     return invalidArguments(client, '`--until` requires `--since`.');
@@ -93,12 +83,11 @@ export default async function issues(client: Client): Promise<number> {
     issueType !== 'action_rejected' &&
     issueType !== 'step_failed' &&
     issueType !== 'turn_failed' &&
-    issueType !== 'session_failed' &&
-    issueType !== 'policy_blocked'
+    issueType !== 'session_failed'
   ) {
     return invalidArguments(
       client,
-      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, `session_failed`, or `policy_blocked`.'
+      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, or `session_failed`.'
     );
   }
   const validatedIssueType =
@@ -106,8 +95,7 @@ export default async function issues(client: Client): Promise<number> {
     issueType === 'action_rejected' ||
     issueType === 'step_failed' ||
     issueType === 'turn_failed' ||
-    issueType === 'session_failed' ||
-    issueType === 'policy_blocked'
+    issueType === 'session_failed'
       ? issueType
       : undefined;
   if (
@@ -131,6 +119,38 @@ export default async function issues(client: Client): Promise<number> {
     issueSource === 'workflow'
       ? issueSource
       : undefined;
+  if (
+    trigger &&
+    trigger !== 'slack' &&
+    trigger !== 'http' &&
+    trigger !== 'schedule' &&
+    trigger !== 'manual' &&
+    trigger !== 'unknown'
+  ) {
+    return invalidArguments(
+      client,
+      '`--trigger` supports `slack`, `http`, `schedule`, `manual`, or `unknown`.'
+    );
+  }
+  const validatedTrigger =
+    trigger === 'slack' ||
+    trigger === 'http' ||
+    trigger === 'schedule' ||
+    trigger === 'manual' ||
+    trigger === 'unknown'
+      ? trigger
+      : undefined;
+
+  telemetry.trackCliOptionProject(projectFlag);
+  telemetry.trackCliOptionEnvironment(environment);
+  telemetry.trackCliOptionSince(since);
+  telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliOptionIssueCode(issueCode);
+  telemetry.trackCliOptionIssueType(validatedIssueType);
+  telemetry.trackCliOptionIssueSource(validatedIssueSource);
+  telemetry.trackCliOptionIssueTool(issueTool);
+  telemetry.trackCliOptionTrigger(validatedTrigger);
+  telemetry.trackCliFlagJson(json);
 
   const scope = await resolveAgentRunsScope(client, {
     scopeFlag,
@@ -157,6 +177,7 @@ export default async function issues(client: Client): Promise<number> {
       issueType: validatedIssueType,
       issueSource: validatedIssueSource,
       issueTool,
+      trigger: validatedTrigger,
       groupBy: 'issue',
     });
   } catch (err) {
@@ -198,7 +219,7 @@ export default async function issues(client: Client): Promise<number> {
   client.stdout.write(`\n${table(rows, { hsep: 3 }).replace(/^/gm, '  ')}\n\n`);
 
   output.log(
-    `Run ${cmd('vercel agent-runs list --issue error --project <name>')} to list error-bearing runs.`
+    `Run ${cmd('vercel agent-runs list --issue error --project <name>')} to list issue-bearing runs.`
   );
   return 0;
 }

--- a/packages/cli/src/commands/agent-runs/issues.ts
+++ b/packages/cli/src/commands/agent-runs/issues.ts
@@ -34,7 +34,7 @@ const ISSUE_TYPE_LABEL: Record<string, string> = {
   policy_blocked: 'Policy blocked',
 };
 
-function issueType(group: UnknownRecord): string {
+function formatIssueType(group: UnknownRecord): string {
   const raw = readString(group, 'type');
   return raw ? (ISSUE_TYPE_LABEL[raw] ?? raw) : '-';
 }
@@ -67,6 +67,8 @@ export default async function issues(client: Client): Promise<number> {
     '--since': since,
     '--until': until,
     '--issue-code': issueCode,
+    '--issue-type': issueType,
+    '--issue-source': issueSource,
     '--issue-tool': issueTool,
     '--json': json,
     '--scope': scopeFlag,
@@ -77,12 +79,56 @@ export default async function issues(client: Client): Promise<number> {
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
   telemetry.trackCliOptionIssueCode(issueCode);
+  telemetry.trackCliOptionIssueType(issueType);
+  telemetry.trackCliOptionIssueSource(issueSource);
   telemetry.trackCliOptionIssueTool(issueTool);
   telemetry.trackCliFlagJson(json);
 
   if (until && !since) {
     return invalidArguments(client, '`--until` requires `--since`.');
   }
+  if (
+    issueType &&
+    issueType !== 'action_failed' &&
+    issueType !== 'action_rejected' &&
+    issueType !== 'step_failed' &&
+    issueType !== 'turn_failed' &&
+    issueType !== 'session_failed' &&
+    issueType !== 'policy_blocked'
+  ) {
+    return invalidArguments(
+      client,
+      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, `session_failed`, or `policy_blocked`.'
+    );
+  }
+  const validatedIssueType =
+    issueType === 'action_failed' ||
+    issueType === 'action_rejected' ||
+    issueType === 'step_failed' ||
+    issueType === 'turn_failed' ||
+    issueType === 'session_failed' ||
+    issueType === 'policy_blocked'
+      ? issueType
+      : undefined;
+  if (
+    issueSource &&
+    issueSource !== 'skill' &&
+    issueSource !== 'subagent' &&
+    issueSource !== 'tool' &&
+    issueSource !== 'workflow'
+  ) {
+    return invalidArguments(
+      client,
+      '`--issue-source` supports `skill`, `subagent`, `tool`, or `workflow`.'
+    );
+  }
+  const validatedIssueSource =
+    issueSource === 'skill' ||
+    issueSource === 'subagent' ||
+    issueSource === 'tool' ||
+    issueSource === 'workflow'
+      ? issueSource
+      : undefined;
 
   const scope = await resolveAgentRunsScope(client, {
     scopeFlag,
@@ -106,6 +152,8 @@ export default async function issues(client: Client): Promise<number> {
       since,
       until,
       issueCode,
+      issueType: validatedIssueType,
+      issueSource: validatedIssueSource,
       issueTool,
       groupBy: 'issue',
     });
@@ -136,7 +184,7 @@ export default async function issues(client: Client): Promise<number> {
       header => chalk.bold(chalk.cyan(header))
     ),
     ...issueGroups.map(group => [
-      issueType(group),
+      formatIssueType(group),
       formatIssueTool(group),
       formatIssueCode(group),
       formatCount(readNumber(group, 'turns')),

--- a/packages/cli/src/commands/agent-runs/issues.ts
+++ b/packages/cli/src/commands/agent-runs/issues.ts
@@ -112,6 +112,7 @@ export default async function issues(client: Client): Promise<number> {
       : undefined;
   if (
     issueSource &&
+    issueSource !== 'remote_subagent' &&
     issueSource !== 'skill' &&
     issueSource !== 'subagent' &&
     issueSource !== 'tool' &&
@@ -119,10 +120,11 @@ export default async function issues(client: Client): Promise<number> {
   ) {
     return invalidArguments(
       client,
-      '`--issue-source` supports `skill`, `subagent`, `tool`, or `workflow`.'
+      '`--issue-source` supports `remote_subagent`, `skill`, `subagent`, `tool`, or `workflow`.'
     );
   }
   const validatedIssueSource =
+    issueSource === 'remote_subagent' ||
     issueSource === 'skill' ||
     issueSource === 'subagent' ||
     issueSource === 'tool' ||

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -112,6 +112,7 @@ export default async function list(client: Client): Promise<number> {
       : undefined;
   if (
     issueSource &&
+    issueSource !== 'remote_subagent' &&
     issueSource !== 'skill' &&
     issueSource !== 'subagent' &&
     issueSource !== 'tool' &&
@@ -119,10 +120,11 @@ export default async function list(client: Client): Promise<number> {
   ) {
     return invalidArguments(
       client,
-      '`--issue-source` supports `skill`, `subagent`, `tool`, or `workflow`.'
+      '`--issue-source` supports `remote_subagent`, `skill`, `subagent`, `tool`, or `workflow`.'
     );
   }
   const validatedIssueSource =
+    issueSource === 'remote_subagent' ||
     issueSource === 'skill' ||
     issueSource === 'subagent' ||
     issueSource === 'tool' ||
@@ -173,7 +175,10 @@ export default async function list(client: Client): Promise<number> {
       page,
       pageSize: limit,
       search,
-      issue: issue === 'error' ? 'error' : undefined,
+      issue:
+        issue === 'error' || issueCode || issueType || issueSource || issueTool
+          ? 'error'
+          : undefined,
       issueCode,
       issueType: validatedIssueType,
       issueSource: validatedIssueSource,
@@ -222,7 +227,8 @@ export default async function list(client: Client): Promise<number> {
   ];
   client.stdout.write(`\n${table(rows, { hsep: 3 }).replace(/^/gm, '  ')}\n\n`);
 
-  const pagination = readRecord(data, 'pagination');
+  const pagination =
+    readRecord(data, 'pageInfo') ?? readRecord(data, 'pagination');
   const total = readNumber(pagination, 'total', 'totalCount');
   if (total !== undefined && total > runList.length) {
     const nextPageArgs = [

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -53,6 +53,7 @@ export default async function list(client: Client): Promise<number> {
     '--search': search,
     '--issue': issue,
     '--session-status': sessionStatus,
+    '--trigger': trigger,
     '--page': page,
     '--limit': limit,
     '--json': json,
@@ -66,6 +67,7 @@ export default async function list(client: Client): Promise<number> {
   telemetry.trackCliOptionSearch(search);
   telemetry.trackCliOptionIssue(issue);
   telemetry.trackCliOptionSessionStatus(sessionStatus);
+  telemetry.trackCliOptionTrigger(trigger);
   telemetry.trackCliOptionPage(page);
   telemetry.trackCliOptionLimit(limit);
   telemetry.trackCliFlagJson(json);
@@ -98,6 +100,27 @@ export default async function list(client: Client): Promise<number> {
     sessionStatus === 'waiting'
       ? sessionStatus
       : undefined;
+  if (
+    trigger &&
+    trigger !== 'slack' &&
+    trigger !== 'http' &&
+    trigger !== 'schedule' &&
+    trigger !== 'manual' &&
+    trigger !== 'unknown'
+  ) {
+    return invalidArguments(
+      client,
+      '`--trigger` supports `slack`, `http`, `schedule`, `manual`, or `unknown`.'
+    );
+  }
+  const validatedTrigger =
+    trigger === 'slack' ||
+    trigger === 'http' ||
+    trigger === 'schedule' ||
+    trigger === 'manual' ||
+    trigger === 'unknown'
+      ? trigger
+      : undefined;
 
   const scope = await resolveAgentRunsScope(client, {
     scopeFlag,
@@ -123,6 +146,7 @@ export default async function list(client: Client): Promise<number> {
       search,
       issue: issue === 'error' ? 'error' : undefined,
       sessionStatus: validatedSessionStatus,
+      trigger: validatedTrigger,
     });
   } catch (err) {
     output.stopSpinner();

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -52,6 +52,7 @@ export default async function list(client: Client): Promise<number> {
     '--until': until,
     '--search': search,
     '--issue': issue,
+    '--session-status': sessionStatus,
     '--page': page,
     '--limit': limit,
     '--json': json,
@@ -64,6 +65,7 @@ export default async function list(client: Client): Promise<number> {
   telemetry.trackCliOptionUntil(until);
   telemetry.trackCliOptionSearch(search);
   telemetry.trackCliOptionIssue(issue);
+  telemetry.trackCliOptionSessionStatus(sessionStatus);
   telemetry.trackCliOptionPage(page);
   telemetry.trackCliOptionLimit(limit);
   telemetry.trackCliFlagJson(json);
@@ -77,6 +79,25 @@ export default async function list(client: Client): Promise<number> {
       '`--issue` currently supports only `error`.'
     );
   }
+  if (
+    sessionStatus &&
+    sessionStatus !== 'completed' &&
+    sessionStatus !== 'failed' &&
+    sessionStatus !== 'running' &&
+    sessionStatus !== 'waiting'
+  ) {
+    return invalidArguments(
+      client,
+      '`--session-status` supports `completed`, `failed`, `running`, or `waiting`.'
+    );
+  }
+  const validatedSessionStatus =
+    sessionStatus === 'completed' ||
+    sessionStatus === 'failed' ||
+    sessionStatus === 'running' ||
+    sessionStatus === 'waiting'
+      ? sessionStatus
+      : undefined;
 
   const scope = await resolveAgentRunsScope(client, {
     scopeFlag,
@@ -101,6 +122,7 @@ export default async function list(client: Client): Promise<number> {
       pageSize: limit,
       search,
       issue: issue === 'error' ? 'error' : undefined,
+      sessionStatus: validatedSessionStatus,
     });
   } catch (err) {
     output.stopSpinner();

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -52,6 +52,8 @@ export default async function list(client: Client): Promise<number> {
     '--until': until,
     '--search': search,
     '--issue': issue,
+    '--issue-code': issueCode,
+    '--issue-tool': issueTool,
     '--session-status': sessionStatus,
     '--trigger': trigger,
     '--page': page,
@@ -66,6 +68,8 @@ export default async function list(client: Client): Promise<number> {
   telemetry.trackCliOptionUntil(until);
   telemetry.trackCliOptionSearch(search);
   telemetry.trackCliOptionIssue(issue);
+  telemetry.trackCliOptionIssueCode(issueCode);
+  telemetry.trackCliOptionIssueTool(issueTool);
   telemetry.trackCliOptionSessionStatus(sessionStatus);
   telemetry.trackCliOptionTrigger(trigger);
   telemetry.trackCliOptionPage(page);
@@ -145,6 +149,8 @@ export default async function list(client: Client): Promise<number> {
       pageSize: limit,
       search,
       issue: issue === 'error' ? 'error' : undefined,
+      issueCode,
+      issueTool,
       sessionStatus: validatedSessionStatus,
       trigger: validatedTrigger,
     });

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -53,8 +53,9 @@ export default async function list(client: Client): Promise<number> {
     '--search': search,
     '--issue': issue,
     '--issue-code': issueCode,
+    '--issue-type': issueType,
+    '--issue-source': issueSource,
     '--issue-tool': issueTool,
-    '--session-status': sessionStatus,
     '--trigger': trigger,
     '--page': page,
     '--limit': limit,
@@ -69,8 +70,9 @@ export default async function list(client: Client): Promise<number> {
   telemetry.trackCliOptionSearch(search);
   telemetry.trackCliOptionIssue(issue);
   telemetry.trackCliOptionIssueCode(issueCode);
+  telemetry.trackCliOptionIssueType(issueType);
+  telemetry.trackCliOptionIssueSource(issueSource);
   telemetry.trackCliOptionIssueTool(issueTool);
-  telemetry.trackCliOptionSessionStatus(sessionStatus);
   telemetry.trackCliOptionTrigger(trigger);
   telemetry.trackCliOptionPage(page);
   telemetry.trackCliOptionLimit(limit);
@@ -86,23 +88,46 @@ export default async function list(client: Client): Promise<number> {
     );
   }
   if (
-    sessionStatus &&
-    sessionStatus !== 'completed' &&
-    sessionStatus !== 'failed' &&
-    sessionStatus !== 'running' &&
-    sessionStatus !== 'waiting'
+    issueType &&
+    issueType !== 'action_failed' &&
+    issueType !== 'action_rejected' &&
+    issueType !== 'step_failed' &&
+    issueType !== 'turn_failed' &&
+    issueType !== 'session_failed' &&
+    issueType !== 'policy_blocked'
   ) {
     return invalidArguments(
       client,
-      '`--session-status` supports `completed`, `failed`, `running`, or `waiting`.'
+      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, `session_failed`, or `policy_blocked`.'
     );
   }
-  const validatedSessionStatus =
-    sessionStatus === 'completed' ||
-    sessionStatus === 'failed' ||
-    sessionStatus === 'running' ||
-    sessionStatus === 'waiting'
-      ? sessionStatus
+  const validatedIssueType =
+    issueType === 'action_failed' ||
+    issueType === 'action_rejected' ||
+    issueType === 'step_failed' ||
+    issueType === 'turn_failed' ||
+    issueType === 'session_failed' ||
+    issueType === 'policy_blocked'
+      ? issueType
+      : undefined;
+  if (
+    issueSource &&
+    issueSource !== 'skill' &&
+    issueSource !== 'subagent' &&
+    issueSource !== 'tool' &&
+    issueSource !== 'workflow'
+  ) {
+    return invalidArguments(
+      client,
+      '`--issue-source` supports `skill`, `subagent`, `tool`, or `workflow`.'
+    );
+  }
+  const validatedIssueSource =
+    issueSource === 'skill' ||
+    issueSource === 'subagent' ||
+    issueSource === 'tool' ||
+    issueSource === 'workflow'
+      ? issueSource
       : undefined;
   if (
     trigger &&
@@ -150,8 +175,9 @@ export default async function list(client: Client): Promise<number> {
       search,
       issue: issue === 'error' ? 'error' : undefined,
       issueCode,
+      issueType: validatedIssueType,
+      issueSource: validatedIssueSource,
       issueTool,
-      sessionStatus: validatedSessionStatus,
       trigger: validatedTrigger,
     });
   } catch (err) {

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -197,7 +197,16 @@ export default async function list(client: Client): Promise<number> {
 
   const runList = asArray(data.runs);
   if (runList.length === 0) {
-    if (search || since) {
+    if (
+      search ||
+      since ||
+      trigger ||
+      issue === 'error' ||
+      issueCode ||
+      issueType ||
+      issueSource ||
+      issueTool
+    ) {
       output.log('No Agent Runs match the current filters.');
     } else {
       output.log('No Agent Runs found.');

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -63,21 +63,6 @@ export default async function list(client: Client): Promise<number> {
     '--scope': scopeFlag,
   } = parsedArgs.flags;
 
-  telemetry.trackCliOptionProject(projectFlag);
-  telemetry.trackCliOptionEnvironment(environment);
-  telemetry.trackCliOptionSince(since);
-  telemetry.trackCliOptionUntil(until);
-  telemetry.trackCliOptionSearch(search);
-  telemetry.trackCliOptionIssue(issue);
-  telemetry.trackCliOptionIssueCode(issueCode);
-  telemetry.trackCliOptionIssueType(issueType);
-  telemetry.trackCliOptionIssueSource(issueSource);
-  telemetry.trackCliOptionIssueTool(issueTool);
-  telemetry.trackCliOptionTrigger(trigger);
-  telemetry.trackCliOptionPage(page);
-  telemetry.trackCliOptionLimit(limit);
-  telemetry.trackCliFlagJson(json);
-
   if (until && !since) {
     return invalidArguments(client, '`--until` requires `--since`.');
   }
@@ -93,12 +78,11 @@ export default async function list(client: Client): Promise<number> {
     issueType !== 'action_rejected' &&
     issueType !== 'step_failed' &&
     issueType !== 'turn_failed' &&
-    issueType !== 'session_failed' &&
-    issueType !== 'policy_blocked'
+    issueType !== 'session_failed'
   ) {
     return invalidArguments(
       client,
-      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, `session_failed`, or `policy_blocked`.'
+      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, or `session_failed`.'
     );
   }
   const validatedIssueType =
@@ -106,8 +90,7 @@ export default async function list(client: Client): Promise<number> {
     issueType === 'action_rejected' ||
     issueType === 'step_failed' ||
     issueType === 'turn_failed' ||
-    issueType === 'session_failed' ||
-    issueType === 'policy_blocked'
+    issueType === 'session_failed'
       ? issueType
       : undefined;
   if (
@@ -152,6 +135,21 @@ export default async function list(client: Client): Promise<number> {
     trigger === 'unknown'
       ? trigger
       : undefined;
+
+  telemetry.trackCliOptionProject(projectFlag);
+  telemetry.trackCliOptionEnvironment(environment);
+  telemetry.trackCliOptionSince(since);
+  telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliOptionSearch(search);
+  telemetry.trackCliOptionIssue(issue === 'error' ? issue : undefined);
+  telemetry.trackCliOptionIssueCode(issueCode);
+  telemetry.trackCliOptionIssueType(validatedIssueType);
+  telemetry.trackCliOptionIssueSource(validatedIssueSource);
+  telemetry.trackCliOptionIssueTool(issueTool);
+  telemetry.trackCliOptionTrigger(validatedTrigger);
+  telemetry.trackCliOptionPage(page);
+  telemetry.trackCliOptionLimit(limit);
+  telemetry.trackCliFlagJson(json);
 
   const scope = await resolveAgentRunsScope(client, {
     scopeFlag,
@@ -230,21 +228,51 @@ export default async function list(client: Client): Promise<number> {
   const pagination =
     readRecord(data, 'pageInfo') ?? readRecord(data, 'pagination');
   const total = readNumber(pagination, 'total', 'totalCount');
-  if (total !== undefined && total > runList.length) {
-    const nextPageArgs = [
-      'vercel agent-runs list',
-      scopeFlag ? `--scope ${scopeFlag}` : '',
-      projectFlag ? `--project ${projectFlag}` : '',
-      `--page ${(page ?? 1) + 1}`,
-    ]
-      .filter(Boolean)
-      .join(' ');
+  const currentPage = readNumber(pagination, 'page') ?? page ?? 1;
+  const pageSize =
+    readNumber(pagination, 'pageSize', 'limit') ?? limit ?? runList.length;
+  const consumedRuns = Math.max(0, currentPage - 1) * pageSize + runList.length;
+  if (total !== undefined && total > consumedRuns) {
+    const nextPageArgs = ['vercel agent-runs list'];
+    const pushFlag = (name: string, value: string | number | undefined) => {
+      if (value !== undefined && value !== '') {
+        nextPageArgs.push(`${name} ${shellQuoteArg(value)}`);
+      }
+    };
+    pushFlag('--scope', scopeFlag);
+    pushFlag('--project', projectFlag);
+    pushFlag('--environment', environment);
+    pushFlag('--since', since);
+    pushFlag('--until', until);
+    pushFlag('--search', search);
+    pushFlag(
+      '--issue',
+      issue === 'error' || issueCode || issueType || issueSource || issueTool
+        ? 'error'
+        : undefined
+    );
+    pushFlag('--issue-code', issueCode);
+    pushFlag('--issue-type', validatedIssueType);
+    pushFlag('--issue-source', validatedIssueSource);
+    pushFlag('--issue-tool', issueTool);
+    pushFlag('--trigger', validatedTrigger);
+    pushFlag('--limit', limit);
+    pushFlag('--page', currentPage + 1);
     output.log(
-      `Showing ${runList.length} of ${total} Agent Runs. Run ${cmd(nextPageArgs)} for more.`
+      `Showing ${runList.length} of ${total} Agent Runs. Run ${cmd(nextPageArgs.join(' '))} for more.`
     );
   }
   output.log(
     `Run ${cmd('vercel agent-runs inspect <runId>')} for run details.`
   );
   return 0;
+}
+
+function shellQuoteArg(value: string | number): string {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:@=-]+$/.test(text)) {
+    return text;
+  }
+
+  return `'${text.replace(/'/g, "'\\''")}'`;
 }

--- a/packages/cli/src/commands/agent-runs/list.ts
+++ b/packages/cli/src/commands/agent-runs/list.ts
@@ -51,6 +51,7 @@ export default async function list(client: Client): Promise<number> {
     '--since': since,
     '--until': until,
     '--search': search,
+    '--issue': issue,
     '--page': page,
     '--limit': limit,
     '--json': json,
@@ -62,12 +63,19 @@ export default async function list(client: Client): Promise<number> {
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
   telemetry.trackCliOptionSearch(search);
+  telemetry.trackCliOptionIssue(issue);
   telemetry.trackCliOptionPage(page);
   telemetry.trackCliOptionLimit(limit);
   telemetry.trackCliFlagJson(json);
 
   if (until && !since) {
     return invalidArguments(client, '`--until` requires `--since`.');
+  }
+  if (issue && issue !== 'error') {
+    return invalidArguments(
+      client,
+      '`--issue` currently supports only `error`.'
+    );
   }
 
   const scope = await resolveAgentRunsScope(client, {
@@ -92,6 +100,7 @@ export default async function list(client: Client): Promise<number> {
       page,
       pageSize: limit,
       search,
+      issue: issue === 'error' ? 'error' : undefined,
     });
   } catch (err) {
     output.stopSpinner();

--- a/packages/cli/src/commands/agent-runs/projects.ts
+++ b/packages/cli/src/commands/agent-runs/projects.ts
@@ -46,28 +46,16 @@ export default async function projects(client: Client): Promise<number> {
     '--until': until,
     '--json': json,
     '--scope': scopeFlag,
-    '--stale-threshold': staleThreshold,
   } = parsedArgs.flags;
 
   telemetry.trackCliOptionEnvironment(environment);
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
-  telemetry.trackCliOptionStaleThreshold(staleThreshold);
   telemetry.trackCliFlagJson(json);
 
   if (until && !since) {
     return invalidArguments(client, '`--until` requires `--since`.');
   }
-  if (
-    typeof staleThreshold === 'number' &&
-    (!Number.isFinite(staleThreshold) || staleThreshold <= 0)
-  ) {
-    return invalidArguments(
-      client,
-      '`--stale-threshold` must be a positive number of seconds.'
-    );
-  }
-
   const scope = await resolveAgentRunsScope(client, {
     scopeFlag,
     projectFlag: undefined,
@@ -89,7 +77,6 @@ export default async function projects(client: Client): Promise<number> {
       environment,
       since,
       until,
-      staleThreshold,
     });
   } catch (err) {
     output.stopSpinner();
@@ -121,7 +108,6 @@ export default async function projects(client: Client): Promise<number> {
       'Error Rate',
       'Running',
       'Waiting',
-      'Stale',
       'Last Issue',
       'Avg Duration',
     ].map(header => chalk.bold(chalk.cyan(header))),
@@ -141,7 +127,6 @@ export default async function projects(client: Client): Promise<number> {
       formatRate(readNumber(project, 'errorRate')),
       formatCount(readNumber(project, 'running')),
       formatCount(readNumber(project, 'waiting')),
-      formatCount(readNumber(project, 'stale')),
       formatAge(readTimestampMs(project, 'lastIssueAt')),
       chalk.gray(
         formatDurationMs(

--- a/packages/cli/src/commands/agent-runs/projects.ts
+++ b/packages/cli/src/commands/agent-runs/projects.ts
@@ -106,8 +106,6 @@ export default async function projects(client: Client): Promise<number> {
       'Runs',
       'Errors',
       'Error Rate',
-      'Running',
-      'Waiting',
       'Last Issue',
       'Avg Duration',
     ].map(header => chalk.bold(chalk.cyan(header))),
@@ -125,8 +123,6 @@ export default async function projects(client: Client): Promise<number> {
       formatCount(readNumber(project, 'runs', 'runCount', 'totalRuns')),
       formatCount(readNumber(project, 'errors')),
       formatRate(readNumber(project, 'errorRate')),
-      formatCount(readNumber(project, 'running')),
-      formatCount(readNumber(project, 'waiting')),
       formatAge(readTimestampMs(project, 'lastIssueAt')),
       chalk.gray(
         formatDurationMs(

--- a/packages/cli/src/commands/agent-runs/projects.ts
+++ b/packages/cli/src/commands/agent-runs/projects.ts
@@ -18,9 +18,11 @@ import {
   asArray,
   formatCount,
   formatDurationMs,
+  formatAge,
   formatRate,
   readNumber,
   readString,
+  readTimestampMs,
 } from './format';
 import { AgentProjectsTelemetryClient } from '../../util/telemetry/commands/agent-runs/projects';
 
@@ -44,15 +46,26 @@ export default async function projects(client: Client): Promise<number> {
     '--until': until,
     '--json': json,
     '--scope': scopeFlag,
+    '--stale-threshold': staleThreshold,
   } = parsedArgs.flags;
 
   telemetry.trackCliOptionEnvironment(environment);
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliOptionStaleThreshold(staleThreshold);
   telemetry.trackCliFlagJson(json);
 
   if (until && !since) {
     return invalidArguments(client, '`--until` requires `--since`.');
+  }
+  if (
+    typeof staleThreshold === 'number' &&
+    (!Number.isFinite(staleThreshold) || staleThreshold <= 0)
+  ) {
+    return invalidArguments(
+      client,
+      '`--stale-threshold` must be a positive number of seconds.'
+    );
   }
 
   const scope = await resolveAgentRunsScope(client, {
@@ -76,6 +89,7 @@ export default async function projects(client: Client): Promise<number> {
       environment,
       since,
       until,
+      staleThreshold,
     });
   } catch (err) {
     output.stopSpinner();
@@ -100,9 +114,17 @@ export default async function projects(client: Client): Promise<number> {
   );
 
   const rows = [
-    ['Project', 'Runs', 'Errors', 'Error Rate', 'Avg Duration'].map(header =>
-      chalk.bold(chalk.cyan(header))
-    ),
+    [
+      'Project',
+      'Runs',
+      'Errors',
+      'Error Rate',
+      'Running',
+      'Waiting',
+      'Stale',
+      'Last Issue',
+      'Avg Duration',
+    ].map(header => chalk.bold(chalk.cyan(header))),
     ...projectList.map(project => [
       chalk.bold(
         readString(
@@ -117,6 +139,10 @@ export default async function projects(client: Client): Promise<number> {
       formatCount(readNumber(project, 'runs', 'runCount', 'totalRuns')),
       formatCount(readNumber(project, 'errors')),
       formatRate(readNumber(project, 'errorRate')),
+      formatCount(readNumber(project, 'running')),
+      formatCount(readNumber(project, 'waiting')),
+      formatCount(readNumber(project, 'stale')),
+      formatAge(readTimestampMs(project, 'lastIssueAt')),
       chalk.gray(
         formatDurationMs(
           readNumber(

--- a/packages/cli/src/commands/agent-runs/projects.ts
+++ b/packages/cli/src/commands/agent-runs/projects.ts
@@ -18,6 +18,7 @@ import {
   asArray,
   formatCount,
   formatDurationMs,
+  formatRate,
   readNumber,
   readString,
 } from './format';
@@ -99,7 +100,7 @@ export default async function projects(client: Client): Promise<number> {
   );
 
   const rows = [
-    ['Project', 'Runs', 'Avg Duration'].map(header =>
+    ['Project', 'Runs', 'Errors', 'Error Rate', 'Avg Duration'].map(header =>
       chalk.bold(chalk.cyan(header))
     ),
     ...projectList.map(project => [
@@ -114,6 +115,8 @@ export default async function projects(client: Client): Promise<number> {
         ) ?? '-'
       ),
       formatCount(readNumber(project, 'runs', 'runCount', 'totalRuns')),
+      formatCount(readNumber(project, 'errors')),
+      formatRate(readNumber(project, 'errorRate')),
       chalk.gray(
         formatDurationMs(
           readNumber(

--- a/packages/cli/src/util/telemetry/commands/agent-runs/index.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/index.ts
@@ -33,4 +33,11 @@ export class AgentRunsTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandIssues(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'issues',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/agent-runs/issues.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/issues.ts
@@ -1,0 +1,7 @@
+import type { TelemetryMethods } from '../../types';
+import type { issuesSubcommand } from '../../../../commands/agent-runs/command';
+import { AgentRunsQueryTelemetryClient } from './shared';
+
+export class AgentIssuesTelemetryClient
+  extends AgentRunsQueryTelemetryClient
+  implements TelemetryMethods<typeof issuesSubcommand> {}

--- a/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
@@ -15,6 +15,15 @@ export class AgentRunsListTelemetryClient
     }
   }
 
+  trackCliOptionIssue(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'issue',
+        value,
+      });
+    }
+  }
+
   trackCliOptionPage(value: number | undefined) {
     if (typeof value === 'number') {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
@@ -33,6 +33,15 @@ export class AgentRunsListTelemetryClient
     }
   }
 
+  trackCliOptionTrigger(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'trigger',
+        value,
+      });
+    }
+  }
+
   trackCliOptionPage(value: number | undefined) {
     if (typeof value === 'number') {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
@@ -24,15 +24,6 @@ export class AgentRunsListTelemetryClient
     }
   }
 
-  trackCliOptionSessionStatus(value: string | undefined) {
-    if (value) {
-      this.trackCliOption({
-        option: 'session-status',
-        value,
-      });
-    }
-  }
-
   trackCliOptionTrigger(value: string | undefined) {
     if (value) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
@@ -24,6 +24,15 @@ export class AgentRunsListTelemetryClient
     }
   }
 
+  trackCliOptionSessionStatus(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'session-status',
+        value,
+      });
+    }
+  }
+
   trackCliOptionPage(value: number | undefined) {
     if (typeof value === 'number') {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/list.ts
@@ -24,15 +24,6 @@ export class AgentRunsListTelemetryClient
     }
   }
 
-  trackCliOptionTrigger(value: string | undefined) {
-    if (value) {
-      this.trackCliOption({
-        option: 'trigger',
-        value,
-      });
-    }
-  }
-
   trackCliOptionPage(value: number | undefined) {
     if (typeof value === 'number') {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
@@ -76,6 +76,15 @@ export class AgentRunsQueryTelemetryClient extends TelemetryClient {
     }
   }
 
+  trackCliOptionTrigger(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'trigger',
+        value,
+      });
+    }
+  }
+
   trackCliFlagJson(value: boolean | undefined) {
     if (value) {
       this.trackCliFlag('json');

--- a/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
@@ -49,6 +49,24 @@ export class AgentRunsQueryTelemetryClient extends TelemetryClient {
     }
   }
 
+  trackCliOptionIssueCode(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'issue-code',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionIssueTool(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'issue-tool',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagJson(value: boolean | undefined) {
     if (value) {
       this.trackCliFlag('json');

--- a/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
@@ -40,20 +40,29 @@ export class AgentRunsQueryTelemetryClient extends TelemetryClient {
     }
   }
 
-  trackCliOptionStaleThreshold(value: number | undefined) {
-    if (typeof value === 'number') {
-      this.trackCliOption({
-        option: 'stale-threshold',
-        value: this.redactedValue,
-      });
-    }
-  }
-
   trackCliOptionIssueCode(value: string | undefined) {
     if (value) {
       this.trackCliOption({
         option: 'issue-code',
         value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionIssueType(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'issue-type',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionIssueSource(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'issue-source',
+        value,
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
+++ b/packages/cli/src/util/telemetry/commands/agent-runs/shared.ts
@@ -40,6 +40,15 @@ export class AgentRunsQueryTelemetryClient extends TelemetryClient {
     }
   }
 
+  trackCliOptionStaleThreshold(value: number | undefined) {
+    if (typeof value === 'number') {
+      this.trackCliOption({
+        option: 'stale-threshold',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagJson(value: boolean | undefined) {
     if (value) {
       this.trackCliFlag('json');

--- a/packages/cli/test/unit/commands/agent-runs/inspect.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/inspect.test.ts
@@ -65,10 +65,10 @@ describe('agent-runs inspect', () => {
           durationMs: 4500,
           usage: { inputTokens: 100, outputTokens: 200 },
           detailIssueSummary: {
-            issueCount: 2,
+            issueCount: 1,
             errorCount: 1,
             failedActionCount: 1,
-            rejectedActionCount: 1,
+            rejectedActionCount: 0,
             failedTurnCount: 0,
             failedToolCallIds: ['tool_timeout'],
             rejectedToolCallIds: ['tool_policy'],
@@ -83,7 +83,7 @@ describe('agent-runs inspect', () => {
             },
           },
           events: [{ timestamp: 1_718_000_000_000, type: 'run.started' }],
-          subagents: [
+          subagentRuns: [
             { name: 'researcher', status: 'completed', durationMs: 1200 },
           ],
         },
@@ -105,6 +105,7 @@ describe('agent-runs inspect', () => {
     expect(stdout).toContain('Completed');
     expect(stdout).toContain('1.2.3');
     expect(stdout).toContain('Issues');
+    expect(stdout).toContain('1 issue / 1 error');
     expect(stdout).toContain('ETIMEDOUT');
     expect(stdout).toContain('linear.createIssue');
     expect(stdout).toContain('run.started');

--- a/packages/cli/test/unit/commands/agent-runs/inspect.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/inspect.test.ts
@@ -63,6 +63,24 @@ describe('agent-runs inspect', () => {
           createdAt: 1_718_000_000_000,
           durationMs: 4500,
           usage: { inputTokens: 100, outputTokens: 200 },
+          detailIssueSummary: {
+            issueCount: 2,
+            errorCount: 1,
+            failedActionCount: 1,
+            rejectedActionCount: 1,
+            failedTurnCount: 0,
+            failedToolCallIds: ['tool_timeout'],
+            rejectedToolCallIds: ['tool_policy'],
+            latestIssue: {
+              type: 'action_failed',
+              turnId: 'turn_1',
+              toolCallId: 'tool_timeout',
+              tool: 'linear.createIssue',
+              code: 'ETIMEDOUT',
+              message: 'Linear timed out.',
+              occurredAt: '2026-01-01T00:00:05.000Z',
+            },
+          },
           events: [{ timestamp: 1_718_000_000_000, type: 'run.started' }],
           subagents: [
             { name: 'researcher', status: 'completed', durationMs: 1200 },
@@ -84,6 +102,9 @@ describe('agent-runs inspect', () => {
     const stdout = client.stdout.getFullOutput();
     expect(stdout).toContain('run_001');
     expect(stdout).toContain('Completed');
+    expect(stdout).toContain('Issues');
+    expect(stdout).toContain('ETIMEDOUT');
+    expect(stdout).toContain('linear.createIssue');
     expect(stdout).toContain('run.started');
     expect(stdout).toContain('researcher');
     expect(client.stderr.getFullOutput()).toContain('for full run data.');

--- a/packages/cli/test/unit/commands/agent-runs/inspect.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/inspect.test.ts
@@ -58,6 +58,7 @@ describe('agent-runs inspect', () => {
         run: {
           id: 'run_001',
           status: 'completed',
+          eveVersion: '1.2.3',
           model: 'anthropic/claude-opus-4.8',
           trigger: 'api',
           createdAt: 1_718_000_000_000,
@@ -102,6 +103,7 @@ describe('agent-runs inspect', () => {
     const stdout = client.stdout.getFullOutput();
     expect(stdout).toContain('run_001');
     expect(stdout).toContain('Completed');
+    expect(stdout).toContain('1.2.3');
     expect(stdout).toContain('Issues');
     expect(stdout).toContain('ETIMEDOUT');
     expect(stdout).toContain('linear.createIssue');

--- a/packages/cli/test/unit/commands/agent-runs/issues.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/issues.test.ts
@@ -1,0 +1,111 @@
+import { describe, beforeEach, afterEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import agentRuns from '../../../../src/commands/agent-runs';
+import * as linkModule from '../../../../src/util/projects/link';
+
+vi.mock('../../../../src/util/projects/link', async () => {
+  const actual = await vi.importActual('../../../../src/util/projects/link');
+  return {
+    ...(actual as object),
+    getLinkedProject: vi.fn(),
+  };
+});
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+
+function useLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_test',
+      name: 'agent-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: { id: 'team_dummy', slug: 'my-team', type: 'team' },
+  } as Awaited<ReturnType<typeof linkModule.getLinkedProject>>);
+}
+
+describe('agent-runs issues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    process.env.VERCEL_AGENT_RUNS_API_URL = new URL(
+      '/api/observability/agent-runs',
+      client.apiUrl
+    ).href;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_AGENT_RUNS_API_URL;
+  });
+
+  it('lists issue groups for the linked project', async () => {
+    useLinkedProject();
+    let receivedQuery: Record<string, unknown> | undefined;
+    client.scenario.get('/api/observability/agent-runs', (req, res) => {
+      receivedQuery = req.query;
+      res.json({
+        issueGroups: [
+          {
+            type: 'action_failed',
+            code: 'ETIMEDOUT',
+            tool: 'linear.createIssue',
+            turns: 5,
+            runs: 2,
+            lastSeenAt: new Date(Date.now() - 60_000).toISOString(),
+            sampleRunId: 'run_001',
+          },
+        ],
+      });
+    });
+
+    client.setArgv('agent-runs', 'issues');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(receivedQuery).toMatchObject({
+      teamSlug: 'team_dummy',
+      project: 'prj_test',
+      environment: 'production',
+      groupBy: 'issue',
+    });
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).toContain('Action failed');
+    expect(stdout).toContain('linear.createIssue');
+    expect(stdout).toContain('ETIMEDOUT');
+    expect(stdout).toContain('run_001');
+  });
+
+  it('prints raw JSON', async () => {
+    useLinkedProject();
+    client.scenario.get('/api/observability/agent-runs', (_req, res) => {
+      res.json({ issueGroups: [] });
+    });
+
+    client.setArgv('agent-runs', 'issues', '--json');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      issueGroups: [],
+    });
+  });
+
+  it('tracks telemetry for subcommand and flags', async () => {
+    useLinkedProject();
+    client.scenario.get('/api/observability/agent-runs', (_req, res) => {
+      res.json({ issueGroups: [] });
+    });
+
+    client.setArgv('agent-runs', 'issues', '--json');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:issues', value: 'issues' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/agent-runs/issues.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/issues.test.ts
@@ -93,6 +93,32 @@ describe('agent-runs issues', () => {
     });
   });
 
+  it('forwards issue fingerprint filters', async () => {
+    useLinkedProject();
+    let receivedQuery: Record<string, string> | undefined;
+    client.scenario.get('/api/observability/agent-runs', (req, res) => {
+      receivedQuery = req.query as Record<string, string>;
+      res.json({ issueGroups: [] });
+    });
+
+    client.setArgv(
+      'agent-runs',
+      'issues',
+      '--issue-code',
+      'ETIMEDOUT',
+      '--issue-tool',
+      'linear.createIssue'
+    );
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(receivedQuery).toMatchObject({
+      groupBy: 'issue',
+      issue_code: 'ETIMEDOUT',
+      issue_tool: 'linear.createIssue',
+    });
+  });
+
   it('tracks telemetry for subcommand and flags', async () => {
     useLinkedProject();
     client.scenario.get('/api/observability/agent-runs', (_req, res) => {

--- a/packages/cli/test/unit/commands/agent-runs/issues.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/issues.test.ts
@@ -27,6 +27,12 @@ function useLinkedProject() {
   } as Awaited<ReturnType<typeof linkModule.getLinkedProject>>);
 }
 
+function expectNoTelemetryEvent(key: string, value: string) {
+  expect(client.telemetryEventStore.readonlyEvents).not.toEqual(
+    expect.arrayContaining([expect.objectContaining({ key, value })])
+  );
+}
+
 describe('agent-runs issues', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -112,7 +118,9 @@ describe('agent-runs issues', () => {
       '--issue-source',
       'remote_subagent',
       '--issue-tool',
-      'deployment-reviewer'
+      'deployment-reviewer',
+      '--trigger',
+      'slack'
     );
     const exitCode = await agentRuns(client);
 
@@ -123,6 +131,7 @@ describe('agent-runs issues', () => {
       issue_type: 'action_failed',
       issue_source: 'remote_subagent',
       issue_tool: 'deployment-reviewer',
+      trigger: 'slack',
     });
   });
 
@@ -132,8 +141,9 @@ describe('agent-runs issues', () => {
     const exitCode = await agentRuns(client);
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
-      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, `session_failed`, or `policy_blocked`.'
+      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, or `session_failed`.'
     );
+    expectNoTelemetryEvent('option:issue-type', 'cancelled');
   });
 
   it('errors when --issue-source is not supported', async () => {
@@ -144,6 +154,18 @@ describe('agent-runs issues', () => {
     expect(client.stderr.getFullOutput()).toContain(
       '`--issue-source` supports `remote_subagent`, `skill`, `subagent`, `tool`, or `workflow`.'
     );
+    expectNoTelemetryEvent('option:issue-source', 'browser');
+  });
+
+  it('errors when --trigger is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'issues', '--trigger', 'github');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--trigger` supports `slack`, `http`, `schedule`, `manual`, or `unknown`.'
+    );
+    expectNoTelemetryEvent('option:trigger', 'github');
   });
 
   it('tracks telemetry for subcommand and flags', async () => {
@@ -152,12 +174,13 @@ describe('agent-runs issues', () => {
       res.json({ issueGroups: [] });
     });
 
-    client.setArgv('agent-runs', 'issues', '--json');
+    client.setArgv('agent-runs', 'issues', '--json', '--trigger', 'manual');
     const exitCode = await agentRuns(client);
 
     expect(exitCode).toBe(0);
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'subcommand:issues', value: 'issues' },
+      { key: 'option:trigger', value: 'manual' },
       { key: 'flag:json', value: 'TRUE' },
     ]);
   });

--- a/packages/cli/test/unit/commands/agent-runs/issues.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/issues.test.ts
@@ -51,6 +51,7 @@ describe('agent-runs issues', () => {
           {
             type: 'action_failed',
             code: 'ETIMEDOUT',
+            source: 'tool',
             tool: 'linear.createIssue',
             turns: 5,
             runs: 2,
@@ -106,6 +107,10 @@ describe('agent-runs issues', () => {
       'issues',
       '--issue-code',
       'ETIMEDOUT',
+      '--issue-type',
+      'action_failed',
+      '--issue-source',
+      'tool',
       '--issue-tool',
       'linear.createIssue'
     );
@@ -115,8 +120,30 @@ describe('agent-runs issues', () => {
     expect(receivedQuery).toMatchObject({
       groupBy: 'issue',
       issue_code: 'ETIMEDOUT',
+      issue_type: 'action_failed',
+      issue_source: 'tool',
       issue_tool: 'linear.createIssue',
     });
+  });
+
+  it('errors when --issue-type is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'issues', '--issue-type', 'cancelled');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, `session_failed`, or `policy_blocked`.'
+    );
+  });
+
+  it('errors when --issue-source is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'issues', '--issue-source', 'browser');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--issue-source` supports `skill`, `subagent`, `tool`, or `workflow`.'
+    );
   });
 
   it('tracks telemetry for subcommand and flags', async () => {

--- a/packages/cli/test/unit/commands/agent-runs/issues.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/issues.test.ts
@@ -110,9 +110,9 @@ describe('agent-runs issues', () => {
       '--issue-type',
       'action_failed',
       '--issue-source',
-      'tool',
+      'remote_subagent',
       '--issue-tool',
-      'linear.createIssue'
+      'deployment-reviewer'
     );
     const exitCode = await agentRuns(client);
 
@@ -121,8 +121,8 @@ describe('agent-runs issues', () => {
       groupBy: 'issue',
       issue_code: 'ETIMEDOUT',
       issue_type: 'action_failed',
-      issue_source: 'tool',
-      issue_tool: 'linear.createIssue',
+      issue_source: 'remote_subagent',
+      issue_tool: 'deployment-reviewer',
     });
   });
 
@@ -142,7 +142,7 @@ describe('agent-runs issues', () => {
     const exitCode = await agentRuns(client);
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
-      '`--issue-source` supports `skill`, `subagent`, `tool`, or `workflow`.'
+      '`--issue-source` supports `remote_subagent`, `skill`, `subagent`, `tool`, or `workflow`.'
     );
   });
 

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -127,6 +127,34 @@ describe('agent-runs list', () => {
     );
   });
 
+  it('forwards issue fingerprint filters', async () => {
+    useLinkedProject();
+    let receivedQuery: Record<string, string> | undefined;
+    client.scenario.get('/api/observability/agent-runs', (req, res) => {
+      receivedQuery = req.query as Record<string, string>;
+      res.json({ runs: [] });
+    });
+
+    client.setArgv(
+      'agent-runs',
+      'list',
+      '--issue',
+      'error',
+      '--issue-code',
+      'ETIMEDOUT',
+      '--issue-tool',
+      'linear.createIssue'
+    );
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(receivedQuery).toMatchObject({
+      issue: 'error',
+      issue_code: 'ETIMEDOUT',
+      issue_tool: 'linear.createIssue',
+    });
+  });
+
   it('prints the raw response with --json', async () => {
     useLinkedProject();
     const payload = { runs: [sampleRun], pagination: { page: 1, total: 1 } };
@@ -294,7 +322,11 @@ describe('agent-runs list', () => {
       '--session-status',
       'failed',
       '--trigger',
-      'manual'
+      'manual',
+      '--issue-code',
+      'ETIMEDOUT',
+      '--issue-tool',
+      'linear.createIssue'
     );
     const exitCode = await agentRuns(client);
 
@@ -303,6 +335,8 @@ describe('agent-runs list', () => {
       { key: 'subcommand:list', value: 'list' },
       { key: 'option:search', value: '[REDACTED]' },
       { key: 'option:issue', value: 'error' },
+      { key: 'option:issue-code', value: '[REDACTED]' },
+      { key: 'option:issue-tool', value: '[REDACTED]' },
       { key: 'option:session-status', value: 'failed' },
       { key: 'option:trigger', value: 'manual' },
       { key: 'flag:json', value: 'TRUE' },

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -79,7 +79,7 @@ describe('agent-runs list', () => {
     );
   });
 
-  it('forwards search, issue, session status, trigger, pagination, environment, and time range params', async () => {
+  it('forwards search, issue, trigger, pagination, environment, and time range params', async () => {
     useLinkedProject();
     let receivedQuery: Record<string, string> | undefined;
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
@@ -94,8 +94,6 @@ describe('agent-runs list', () => {
       'checkout',
       '--issue',
       'error',
-      '--session-status',
-      'failed',
       '--trigger',
       'slack',
       '--page',
@@ -113,12 +111,12 @@ describe('agent-runs list', () => {
     expect(receivedQuery).toMatchObject({
       search: 'checkout',
       issue: 'error',
-      session_status: 'failed',
       trigger: 'slack',
       page: '2',
       pageSize: '50',
       environment: 'preview',
     });
+    expect(receivedQuery).not.toHaveProperty('session_status');
     const nowSeconds = Math.floor(Date.now() / 1000);
     expect(Number(receivedQuery?.from)).toBeGreaterThan(0);
     expect(Number(receivedQuery?.to)).toBeGreaterThan(nowSeconds - 60);
@@ -142,6 +140,10 @@ describe('agent-runs list', () => {
       'error',
       '--issue-code',
       'ETIMEDOUT',
+      '--issue-type',
+      'action_failed',
+      '--issue-source',
+      'tool',
       '--issue-tool',
       'linear.createIssue'
     );
@@ -151,6 +153,8 @@ describe('agent-runs list', () => {
     expect(receivedQuery).toMatchObject({
       issue: 'error',
       issue_code: 'ETIMEDOUT',
+      issue_type: 'action_failed',
+      issue_source: 'tool',
       issue_tool: 'linear.createIssue',
     });
   });
@@ -242,13 +246,23 @@ describe('agent-runs list', () => {
     );
   });
 
-  it('errors when --session-status is not supported', async () => {
+  it('errors when --issue-type is not supported', async () => {
     useLinkedProject();
-    client.setArgv('agent-runs', 'list', '--session-status', 'cancelled');
+    client.setArgv('agent-runs', 'list', '--issue-type', 'cancelled');
     const exitCode = await agentRuns(client);
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
-      '`--session-status` supports `completed`, `failed`, `running`, or `waiting`.'
+      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, `session_failed`, or `policy_blocked`.'
+    );
+  });
+
+  it('errors when --issue-source is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'list', '--issue-source', 'browser');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--issue-source` supports `skill`, `subagent`, `tool`, or `workflow`.'
     );
   });
 
@@ -319,12 +333,14 @@ describe('agent-runs list', () => {
       'checkout',
       '--issue',
       'error',
-      '--session-status',
-      'failed',
       '--trigger',
       'manual',
       '--issue-code',
       'ETIMEDOUT',
+      '--issue-type',
+      'action_failed',
+      '--issue-source',
+      'tool',
       '--issue-tool',
       'linear.createIssue'
     );
@@ -336,8 +352,9 @@ describe('agent-runs list', () => {
       { key: 'option:search', value: '[REDACTED]' },
       { key: 'option:issue', value: 'error' },
       { key: 'option:issue-code', value: '[REDACTED]' },
+      { key: 'option:issue-type', value: 'action_failed' },
+      { key: 'option:issue-source', value: 'tool' },
       { key: 'option:issue-tool', value: '[REDACTED]' },
-      { key: 'option:session-status', value: 'failed' },
       { key: 'option:trigger', value: 'manual' },
       { key: 'flag:json', value: 'TRUE' },
     ]);

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -78,7 +78,7 @@ describe('agent-runs list', () => {
     );
   });
 
-  it('forwards search, pagination, environment, and time range params', async () => {
+  it('forwards search, issue, pagination, environment, and time range params', async () => {
     useLinkedProject();
     let receivedQuery: Record<string, string> | undefined;
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
@@ -91,6 +91,8 @@ describe('agent-runs list', () => {
       'list',
       '--search',
       'checkout',
+      '--issue',
+      'error',
       '--page',
       '2',
       '--limit',
@@ -105,6 +107,7 @@ describe('agent-runs list', () => {
     expect(exitCode).toBe(0);
     expect(receivedQuery).toMatchObject({
       search: 'checkout',
+      issue: 'error',
       page: '2',
       pageSize: '50',
       environment: 'preview',
@@ -194,6 +197,16 @@ describe('agent-runs list', () => {
     );
   });
 
+  it('errors when --issue is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'list', '--issue', 'policy_blocked');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--issue` currently supports only `error`.'
+    );
+  });
+
   it('emits a JSON error payload in non-interactive mode for invalid arguments', async () => {
     useLinkedProject();
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -243,13 +256,22 @@ describe('agent-runs list', () => {
       res.json({ runs: [] });
     });
 
-    client.setArgv('agent-runs', 'list', '--json', '--search', 'checkout');
+    client.setArgv(
+      'agent-runs',
+      'list',
+      '--json',
+      '--search',
+      'checkout',
+      '--issue',
+      'error'
+    );
     const exitCode = await agentRuns(client);
 
     expect(exitCode).toBe(0);
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'subcommand:list', value: 'list' },
       { key: 'option:search', value: '[REDACTED]' },
+      { key: 'option:issue', value: 'error' },
       { key: 'flag:json', value: 'TRUE' },
     ]);
   });

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -27,6 +27,12 @@ function useLinkedProject() {
   } as Awaited<ReturnType<typeof linkModule.getLinkedProject>>);
 }
 
+function expectNoTelemetryEvent(key: string, value: string) {
+  expect(client.telemetryEventStore.readonlyEvents).not.toEqual(
+    expect.arrayContaining([expect.objectContaining({ key, value })])
+  );
+}
+
 const sampleRun = {
   id: 'run_001',
   status: 'completed',
@@ -72,7 +78,7 @@ describe('agent-runs list', () => {
     expect(receivedQuery).not.toHaveProperty('view');
     const stdout = client.stdout.getFullOutput();
     expect(stdout).toContain('run_001');
-    expect(stdout).toContain('Waiting');
+    expect(stdout).toContain('Completed');
     expect(stdout).toContain('anthropic/claude-opus-4.8');
     expect(client.stderr.getFullOutput()).toContain(
       'vercel agent-runs inspect <runId>'
@@ -200,13 +206,47 @@ describe('agent-runs list', () => {
       });
     });
 
-    client.setArgv('agent-runs', 'list');
+    client.setArgv(
+      'agent-runs',
+      'list',
+      '--search',
+      'checkout flow',
+      '--issue-source',
+      'remote_subagent',
+      '--trigger',
+      'slack',
+      '--limit',
+      '1',
+      '--since',
+      '1d'
+    );
     const exitCode = await agentRuns(client);
 
     expect(exitCode).toBe(0);
-    expect(client.stderr.getFullOutput()).toContain(
-      'Showing 1 of 3 Agent Runs'
-    );
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Showing 1 of 3 Agent Runs');
+    expect(stderr).toContain("--search 'checkout flow'");
+    expect(stderr).toContain('--issue error');
+    expect(stderr).toContain('--issue-source remote_subagent');
+    expect(stderr).toContain('--trigger slack');
+    expect(stderr).toContain('--limit 1');
+    expect(stderr).toContain('--page 2');
+  });
+
+  it('does not print a next-page hint on the last page', async () => {
+    useLinkedProject();
+    client.scenario.get('/api/observability/agent-runs', (_req, res) => {
+      res.json({
+        runs: [sampleRun],
+        pageInfo: { page: 2, pageSize: 2, total: 3 },
+      });
+    });
+
+    client.setArgv('agent-runs', 'list', '--page', '2', '--limit', '2');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).not.toContain('for more');
   });
 
   it('uses --scope and --project without a linked project', async () => {
@@ -274,12 +314,13 @@ describe('agent-runs list', () => {
 
   it('errors when --issue is not supported', async () => {
     useLinkedProject();
-    client.setArgv('agent-runs', 'list', '--issue', 'policy_blocked');
+    client.setArgv('agent-runs', 'list', '--issue', 'rejection');
     const exitCode = await agentRuns(client);
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
       '`--issue` currently supports only `error`.'
     );
+    expectNoTelemetryEvent('option:issue', 'rejection');
   });
 
   it('errors when --issue-type is not supported', async () => {
@@ -288,8 +329,9 @@ describe('agent-runs list', () => {
     const exitCode = await agentRuns(client);
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
-      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, `session_failed`, or `policy_blocked`.'
+      '`--issue-type` supports `action_failed`, `action_rejected`, `step_failed`, `turn_failed`, or `session_failed`.'
     );
+    expectNoTelemetryEvent('option:issue-type', 'cancelled');
   });
 
   it('errors when --issue-source is not supported', async () => {
@@ -300,6 +342,7 @@ describe('agent-runs list', () => {
     expect(client.stderr.getFullOutput()).toContain(
       '`--issue-source` supports `remote_subagent`, `skill`, `subagent`, `tool`, or `workflow`.'
     );
+    expectNoTelemetryEvent('option:issue-source', 'browser');
   });
 
   it('errors when --trigger is not supported', async () => {
@@ -310,6 +353,7 @@ describe('agent-runs list', () => {
     expect(client.stderr.getFullOutput()).toContain(
       '`--trigger` supports `slack`, `http`, `schedule`, `manual`, or `unknown`.'
     );
+    expectNoTelemetryEvent('option:trigger', 'github');
   });
 
   it('emits a JSON error payload in non-interactive mode for invalid arguments', async () => {

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -30,6 +30,7 @@ function useLinkedProject() {
 const sampleRun = {
   id: 'run_001',
   status: 'completed',
+  sessionStatus: 'waiting',
   model: 'anthropic/claude-opus-4.8',
   trigger: 'api',
   createdAt: Date.now() - 60_000,
@@ -71,14 +72,14 @@ describe('agent-runs list', () => {
     expect(receivedQuery).not.toHaveProperty('view');
     const stdout = client.stdout.getFullOutput();
     expect(stdout).toContain('run_001');
-    expect(stdout).toContain('Completed');
+    expect(stdout).toContain('Waiting');
     expect(stdout).toContain('anthropic/claude-opus-4.8');
     expect(client.stderr.getFullOutput()).toContain(
       'vercel agent-runs inspect <runId>'
     );
   });
 
-  it('forwards search, issue, pagination, environment, and time range params', async () => {
+  it('forwards search, issue, session status, pagination, environment, and time range params', async () => {
     useLinkedProject();
     let receivedQuery: Record<string, string> | undefined;
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
@@ -93,6 +94,8 @@ describe('agent-runs list', () => {
       'checkout',
       '--issue',
       'error',
+      '--session-status',
+      'failed',
       '--page',
       '2',
       '--limit',
@@ -108,6 +111,7 @@ describe('agent-runs list', () => {
     expect(receivedQuery).toMatchObject({
       search: 'checkout',
       issue: 'error',
+      session_status: 'failed',
       page: '2',
       pageSize: '50',
       environment: 'preview',
@@ -207,6 +211,16 @@ describe('agent-runs list', () => {
     );
   });
 
+  it('errors when --session-status is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'list', '--session-status', 'cancelled');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--session-status` supports `completed`, `failed`, `running`, or `waiting`.'
+    );
+  });
+
   it('emits a JSON error payload in non-interactive mode for invalid arguments', async () => {
     useLinkedProject();
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -263,7 +277,9 @@ describe('agent-runs list', () => {
       '--search',
       'checkout',
       '--issue',
-      'error'
+      'error',
+      '--session-status',
+      'failed'
     );
     const exitCode = await agentRuns(client);
 
@@ -272,6 +288,7 @@ describe('agent-runs list', () => {
       { key: 'subcommand:list', value: 'list' },
       { key: 'option:search', value: '[REDACTED]' },
       { key: 'option:issue', value: 'error' },
+      { key: 'option:session-status', value: 'failed' },
       { key: 'flag:json', value: 'TRUE' },
     ]);
   });

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -79,7 +79,7 @@ describe('agent-runs list', () => {
     );
   });
 
-  it('forwards search, issue, session status, pagination, environment, and time range params', async () => {
+  it('forwards search, issue, session status, trigger, pagination, environment, and time range params', async () => {
     useLinkedProject();
     let receivedQuery: Record<string, string> | undefined;
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
@@ -96,6 +96,8 @@ describe('agent-runs list', () => {
       'error',
       '--session-status',
       'failed',
+      '--trigger',
+      'slack',
       '--page',
       '2',
       '--limit',
@@ -112,6 +114,7 @@ describe('agent-runs list', () => {
       search: 'checkout',
       issue: 'error',
       session_status: 'failed',
+      trigger: 'slack',
       page: '2',
       pageSize: '50',
       environment: 'preview',
@@ -221,6 +224,16 @@ describe('agent-runs list', () => {
     );
   });
 
+  it('errors when --trigger is not supported', async () => {
+    useLinkedProject();
+    client.setArgv('agent-runs', 'list', '--trigger', 'github');
+    const exitCode = await agentRuns(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--trigger` supports `slack`, `http`, `schedule`, `manual`, or `unknown`.'
+    );
+  });
+
   it('emits a JSON error payload in non-interactive mode for invalid arguments', async () => {
     useLinkedProject();
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -279,7 +292,9 @@ describe('agent-runs list', () => {
       '--issue',
       'error',
       '--session-status',
-      'failed'
+      'failed',
+      '--trigger',
+      'manual'
     );
     const exitCode = await agentRuns(client);
 
@@ -289,6 +304,7 @@ describe('agent-runs list', () => {
       { key: 'option:search', value: '[REDACTED]' },
       { key: 'option:issue', value: 'error' },
       { key: 'option:session-status', value: 'failed' },
+      { key: 'option:trigger', value: 'manual' },
       { key: 'flag:json', value: 'TRUE' },
     ]);
   });

--- a/packages/cli/test/unit/commands/agent-runs/list.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/list.test.ts
@@ -143,9 +143,9 @@ describe('agent-runs list', () => {
       '--issue-type',
       'action_failed',
       '--issue-source',
-      'tool',
+      'remote_subagent',
       '--issue-tool',
-      'linear.createIssue'
+      'deployment-reviewer'
     );
     const exitCode = await agentRuns(client);
 
@@ -154,8 +154,26 @@ describe('agent-runs list', () => {
       issue: 'error',
       issue_code: 'ETIMEDOUT',
       issue_type: 'action_failed',
-      issue_source: 'tool',
-      issue_tool: 'linear.createIssue',
+      issue_source: 'remote_subagent',
+      issue_tool: 'deployment-reviewer',
+    });
+  });
+
+  it('treats issue fingerprint filters as error filters', async () => {
+    useLinkedProject();
+    let receivedQuery: Record<string, string> | undefined;
+    client.scenario.get('/api/observability/agent-runs', (req, res) => {
+      receivedQuery = req.query as Record<string, string>;
+      res.json({ runs: [] });
+    });
+
+    client.setArgv('agent-runs', 'list', '--issue-source', 'remote_subagent');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(receivedQuery).toMatchObject({
+      issue: 'error',
+      issue_source: 'remote_subagent',
     });
   });
 
@@ -171,6 +189,24 @@ describe('agent-runs list', () => {
 
     expect(exitCode).toBe(0);
     expect(JSON.parse(client.stdout.getFullOutput())).toEqual(payload);
+  });
+
+  it('reads dashboard pageInfo pagination', async () => {
+    useLinkedProject();
+    client.scenario.get('/api/observability/agent-runs', (_req, res) => {
+      res.json({
+        runs: [sampleRun],
+        pageInfo: { page: 1, pageSize: 1, total: 3 },
+      });
+    });
+
+    client.setArgv('agent-runs', 'list');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Showing 1 of 3 Agent Runs'
+    );
   });
 
   it('uses --scope and --project without a linked project', async () => {
@@ -262,7 +298,7 @@ describe('agent-runs list', () => {
     const exitCode = await agentRuns(client);
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
-      '`--issue-source` supports `skill`, `subagent`, `tool`, or `workflow`.'
+      '`--issue-source` supports `remote_subagent`, `skill`, `subagent`, `tool`, or `workflow`.'
     );
   });
 

--- a/packages/cli/test/unit/commands/agent-runs/projects.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/projects.test.ts
@@ -44,7 +44,15 @@ describe('agent-runs projects', () => {
     client.scenario.get('/api/observability/agent-runs', (req, res) => {
       receivedQuery = req.query;
       res.json({
-        projects: [{ projectName: 'my-app', runs: 5, avgDurationMs: 1234 }],
+        projects: [
+          {
+            projectName: 'my-app',
+            runs: 5,
+            errors: 1,
+            errorRate: 0.2,
+            avgDurationMs: 1234,
+          },
+        ],
       });
     });
 
@@ -61,6 +69,8 @@ describe('agent-runs projects', () => {
     const stdout = client.stdout.getFullOutput();
     expect(stdout).toContain('my-app');
     expect(stdout).toContain('5');
+    expect(stdout).toContain('1');
+    expect(stdout).toContain('20%');
   });
 
   it('works with --scope and no linked project', async () => {

--- a/packages/cli/test/unit/commands/agent-runs/projects.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/projects.test.ts
@@ -50,6 +50,10 @@ describe('agent-runs projects', () => {
             runs: 5,
             errors: 1,
             errorRate: 0.2,
+            running: 2,
+            waiting: 1,
+            stale: 1,
+            lastIssueAt: new Date(Date.now() - 60_000).toISOString(),
             avgDurationMs: 1234,
           },
         ],
@@ -71,6 +75,38 @@ describe('agent-runs projects', () => {
     expect(stdout).toContain('5');
     expect(stdout).toContain('1');
     expect(stdout).toContain('20%');
+    expect(stdout).toContain('2');
+    expect(stdout).toContain('1m ago');
+  });
+
+  it('forwards --stale-threshold as seconds', async () => {
+    mockedGetLinkedProject.mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'prj_test',
+        name: 'agent-project',
+        accountId: 'team_dummy',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      },
+      org: { id: 'team_dummy', slug: 'my-team', type: 'team' },
+    } as Awaited<ReturnType<typeof linkModule.getLinkedProject>>);
+
+    let receivedQuery: Record<string, unknown> | undefined;
+    client.scenario.get('/api/observability/agent-runs', (req, res) => {
+      receivedQuery = req.query;
+      res.json({ projects: [] });
+    });
+
+    client.setArgv('agent-runs', 'projects', '--stale-threshold', '900');
+    const exitCode = await agentRuns(client);
+
+    expect(exitCode).toBe(0);
+    expect(receivedQuery).toMatchObject({
+      teamSlug: 'team_dummy',
+      view: 'team',
+      stale_threshold: '900',
+    });
   });
 
   it('works with --scope and no linked project', async () => {

--- a/packages/cli/test/unit/commands/agent-runs/projects.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/projects.test.ts
@@ -52,7 +52,6 @@ describe('agent-runs projects', () => {
             errorRate: 0.2,
             running: 2,
             waiting: 1,
-            stale: 1,
             lastIssueAt: new Date(Date.now() - 60_000).toISOString(),
             avgDurationMs: 1234,
           },
@@ -77,36 +76,7 @@ describe('agent-runs projects', () => {
     expect(stdout).toContain('20%');
     expect(stdout).toContain('2');
     expect(stdout).toContain('1m ago');
-  });
-
-  it('forwards --stale-threshold as seconds', async () => {
-    mockedGetLinkedProject.mockResolvedValue({
-      status: 'linked',
-      project: {
-        id: 'prj_test',
-        name: 'agent-project',
-        accountId: 'team_dummy',
-        updatedAt: Date.now(),
-        createdAt: Date.now(),
-      },
-      org: { id: 'team_dummy', slug: 'my-team', type: 'team' },
-    } as Awaited<ReturnType<typeof linkModule.getLinkedProject>>);
-
-    let receivedQuery: Record<string, unknown> | undefined;
-    client.scenario.get('/api/observability/agent-runs', (req, res) => {
-      receivedQuery = req.query;
-      res.json({ projects: [] });
-    });
-
-    client.setArgv('agent-runs', 'projects', '--stale-threshold', '900');
-    const exitCode = await agentRuns(client);
-
-    expect(exitCode).toBe(0);
-    expect(receivedQuery).toMatchObject({
-      teamSlug: 'team_dummy',
-      view: 'team',
-      stale_threshold: '900',
-    });
+    expect(stdout).not.toContain('Stale');
   });
 
   it('works with --scope and no linked project', async () => {

--- a/packages/cli/test/unit/commands/agent-runs/projects.test.ts
+++ b/packages/cli/test/unit/commands/agent-runs/projects.test.ts
@@ -1,4 +1,5 @@
 import { describe, beforeEach, afterEach, expect, it, vi } from 'vitest';
+import stripAnsi from 'strip-ansi';
 import { client } from '../../../mocks/client';
 import agentRuns from '../../../../src/commands/agent-runs';
 import * as linkModule from '../../../../src/util/projects/link';
@@ -50,8 +51,6 @@ describe('agent-runs projects', () => {
             runs: 5,
             errors: 1,
             errorRate: 0.2,
-            running: 2,
-            waiting: 1,
             lastIssueAt: new Date(Date.now() - 60_000).toISOString(),
             avgDurationMs: 1234,
           },
@@ -69,13 +68,17 @@ describe('agent-runs projects', () => {
       environment: 'production',
     });
     expect(receivedQuery).not.toHaveProperty('project');
-    const stdout = client.stdout.getFullOutput();
+    const stdout = stripAnsi(client.stdout.getFullOutput());
+    expect(stdout).toMatch(
+      /Project\s+Runs\s+Errors\s+Error Rate\s+Last Issue\s+Avg Duration/
+    );
     expect(stdout).toContain('my-app');
     expect(stdout).toContain('5');
     expect(stdout).toContain('1');
     expect(stdout).toContain('20%');
-    expect(stdout).toContain('2');
     expect(stdout).toContain('1m ago');
+    expect(stdout).not.toContain('Running');
+    expect(stdout).not.toContain('Waiting');
     expect(stdout).not.toContain('Stale');
   });
 

--- a/packages/cli/test/unit/util/get-update-command.test.ts
+++ b/packages/cli/test/unit/util/get-update-command.test.ts
@@ -67,7 +67,9 @@ describe('getUpdateCommand', () => {
         '/home/user/.local/share/pnpm/global/v11/150b-19f23dfe656/node_modules/vercel/dist/vc.js'
       );
 
-      expect(await getUpdateCommand()).toEqual('pnpm i -g vercel@latest');
+      expect(await getUpdateCommand()).toEqual(
+        'pnpm i -g vercel@latest --allow-build=esbuild'
+      );
       expect(await isGlobal()).toBe(true);
     });
 
@@ -78,7 +80,9 @@ describe('getUpdateCommand', () => {
         '/home/user/.local/share/pnpm/global/5/node_modules/vercel/dist/vc.js'
       );
 
-      expect(await getUpdateCommand()).toEqual('pnpm i -g vercel@latest');
+      expect(await getUpdateCommand()).toEqual(
+        'pnpm i -g vercel@latest --allow-build=esbuild'
+      );
     });
 
     it('matches PNPM_HOME as a path prefix, not a substring', async () => {
@@ -94,7 +98,8 @@ describe('getUpdateCommand', () => {
       // always yields global pnpm; the repo fallback yields a local install.
       const updateCommand = await getUpdateCommand();
       const viaFastPath =
-        updateCommand === 'pnpm i -g vercel@latest' && (await isGlobal());
+        updateCommand === 'pnpm i -g vercel@latest --allow-build=esbuild' &&
+        (await isGlobal());
       // In the dev repo the fallback resolves a local pnpm install, so the
       // fast path result (global) would only appear if prefix matching leaked.
       expect(viaFastPath).toBe(false);


### PR DESCRIPTION
- Why: operators should be able to triage Agent Runs from the CLI with the same platform-derived semantics as the dashboard.
- What: adds error, trigger, issue-code, issue-type, issue-source, and issue-tool filters.
- What: adds issue-group output, detail issue summaries, and project-level error/running/waiting rollups.
- Keeps the CLI thin over the dashboard API so flags map to the same query params as front and MCP.