### PR TITLE
[cli] Tag build output lines with their service

### DIFF
--- a/.changeset/tag-build-logs-per-service.md
+++ b/.changeset/tag-build-logs-per-service.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Prefix each build-output line with a service tag during multi-service builds. Because each service now builds in its own forked worker with piped stdout/stderr, the CLI reads and tags every line the build produces — including output from subprocesses the builder spawns (e.g. `next build`) — with `[vc:service:<name>]`. The Vercel build-container strips this tag and uses it to attribute each build log line to a service. Single-project builds are unaffected.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1458,6 +1458,9 @@ async function doBuild(
             cwd: buildWorkPath,
             expectsPreDeploy: Boolean(preDeployCmd),
             builderSpan,
+            // Tag every build-output line with the service so the build-container can
+            // attribute it. Only set when this build belongs to a service.
+            serviceName: service?.name,
           },
           builder,
           hasDetectedServices: getHasDetectedServices(),

--- a/packages/cli/src/util/build/build-runner.ts
+++ b/packages/cli/src/util/build/build-runner.ts
@@ -27,6 +27,13 @@ export interface BuildRunnerContext {
   expectsPreDeploy: boolean;
   /** The `vc.builder` span this build runs under; child spans/events attach to it. */
   builderSpan: Span;
+  /**
+   * When set, every stdout/stderr line the forked build produces is prefixed with
+   * `[vc:service:<name>] ` before reaching the terminal. The Vercel build-container strips
+   * this tag and uses it to attribute each build log line to a service. Only meaningful for
+   * subprocess builds; ignored by the in-process runner.
+   */
+  serviceName?: string;
 }
 
 export type RawBuildResult = BuildResultV2 | BuildResultV3 | BuildResultVX;

--- a/packages/cli/src/util/build/builder-process.ts
+++ b/packages/cli/src/util/build/builder-process.ts
@@ -222,6 +222,41 @@ function rehydrateResult(result: BuildResultV2 | BuildResultV3): void {
   }
 }
 
+/**
+ * Prepends `[vc:service:<name>] ` to each complete line read from a child's stdout/stderr and
+ * forwards it to `dest`. Buffers an unterminated trailing line until more data arrives (or the
+ * `flush` on teardown), so the tag only ever lands at real line starts. Must stay in sync with
+ * the tag matcher in api/build-container/container/src/utils/logging.ts.
+ */
+export function createServiceLinePrefixer(
+  serviceName: string,
+  dest: Pick<NodeJS.WriteStream, 'write'>
+): { onData: (chunk: string) => void; flush: () => void } {
+  const tag = `[vc:service:${serviceName}] `;
+  let pending = '';
+  return {
+    onData(chunk: string) {
+      pending += chunk;
+      const newlineIndex = pending.lastIndexOf('\n');
+      if (newlineIndex === -1) return;
+      const complete = pending.slice(0, newlineIndex + 1);
+      pending = pending.slice(newlineIndex + 1);
+      const tagged = complete
+        .split('\n')
+        .slice(0, -1)
+        .map(line => `${tag}${line}`)
+        .join('\n');
+      dest.write(`${tagged}\n`);
+    },
+    flush() {
+      if (pending.length > 0) {
+        dest.write(`${tag}${pending}`);
+        pending = '';
+      }
+    },
+  };
+}
+
 /** Runs a builder in a forked worker process. */
 export class SubprocessBuildRunner extends BuildRunner {
   private child?: ChildProcess;
@@ -229,17 +264,32 @@ export class SubprocessBuildRunner extends BuildRunner {
   private diagnosticsResult?: BuilderDiagnostics;
 
   /**
+   * Line prefixers for the child's piped stdout/stderr, present only when `ctx.serviceName` is
+   * set. Flushed on teardown so a trailing partial line isn't lost.
+   */
+  private stdoutPrefixer?: ReturnType<typeof createServiceLinePrefixer>;
+
+  private stderrPrefixer?: ReturnType<typeof createServiceLinePrefixer>;
+
+  /**
    * Fork a worker, run one build, and return the deserialized result. `buildOptions.span` is
    * dropped (a class instance that can't be serialized); the caller keeps its own tracing.
    *
-   * The child inherits stdout/stderr so its build output reaches the terminal directly, matching
-   * the previous in-process behavior. When the build registers a pre-deploy command, the worker
-   * is kept alive: its `registerPreDeploy` callback runs the command in the worker later, when the
-   * command invokes the deferred callback. Teardown is owned by the caller (via `teardown()`), so
-   * a kept-alive worker is released even if that deferred callback is never reached.
+   * When `ctx.serviceName` is set, the child's stdout/stderr are piped so each line can be
+   * prefixed with the service tag before forwarding to the terminal (covering the builder's own
+   * output and any subprocess it spawns). Otherwise the child inherits stdout/stderr and writes
+   * directly, matching the previous in-process behavior.
+   *
+   * When the build registers a pre-deploy
+   * command, the worker is kept alive: its `registerPreDeploy` callback runs the command in the
+   * worker later, when the command invokes the deferred callback. Teardown is owned by the caller
+   * (via `teardown()`), so a kept-alive worker is released even if that deferred callback is never
+   * reached.
    */
   async build(): Promise<BuildResultV2 | BuildResultV3> {
     const workerPath = join(__dirname, 'builder-worker.cjs');
+
+    const { serviceName } = this.ctx;
 
     const child = fork(workerPath, [], {
       cwd: this.ctx.cwd,
@@ -249,8 +299,32 @@ export class SubprocessBuildRunner extends BuildRunner {
       // Buffers, cycles (e.g. `@vercel/next`'s `childProcesses`), and shared object identity
       // (one Lambda referenced by many outputs stays one instance) intact.
       serialization: 'advanced',
+      // Pipe stdout/stderr (keeping stdin inherited and the IPC channel) only when we need to
+      // tag lines; otherwise inherit so output goes straight to the terminal.
+      stdio: serviceName
+        ? ['inherit', 'pipe', 'pipe', 'ipc']
+        : ['inherit', 'inherit', 'inherit', 'ipc'],
     });
     this.child = child;
+
+    // When piping, read the child's streams line-by-line, prefix with the service tag, and
+    // forward to our own stdout/stderr. Flushed on teardown so a trailing partial line isn't lost.
+    this.stdoutPrefixer = serviceName
+      ? createServiceLinePrefixer(serviceName, process.stdout)
+      : undefined;
+    this.stderrPrefixer = serviceName
+      ? createServiceLinePrefixer(serviceName, process.stderr)
+      : undefined;
+    if (this.stdoutPrefixer && child.stdout) {
+      const prefixer = this.stdoutPrefixer;
+      child.stdout.setEncoding('utf8');
+      child.stdout.on('data', chunk => prefixer.onData(chunk));
+    }
+    if (this.stderrPrefixer && child.stderr) {
+      const prefixer = this.stderrPrefixer;
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', chunk => prefixer.onData(chunk));
+    }
 
     // Wait for the worker's `ready` handshake before sending the build request.
     await new Promise<void>((resolve, reject) => {
@@ -443,6 +517,10 @@ export class SubprocessBuildRunner extends BuildRunner {
   teardown(): void {
     const { child } = this;
     if (!child) return;
+
+    // Emit any buffered trailing (unterminated) line before we stop reading the streams.
+    this.stdoutPrefixer?.flush();
+    this.stderrPrefixer?.flush();
 
     if (child.connected) child.disconnect();
     if (child.exitCode === null && child.signalCode === null) {

--- a/packages/cli/src/util/build/builder-process.ts
+++ b/packages/cli/src/util/build/builder-process.ts
@@ -225,7 +225,7 @@ function rehydrateResult(result: BuildResultV2 | BuildResultV3): void {
 /**
  * Prepends `[vc:service:<name>] ` to each complete line read from a child's stdout/stderr and
  * forwards it to `dest`. Buffers an unterminated trailing line until more data arrives (or the
- * `flush` on teardown), so the tag only ever lands at real line starts. Must stay in sync with
+ * `flush` on stream end), so the tag only ever lands at real line starts. Must stay in sync with
  * the tag matcher in api/build-container/container/src/utils/logging.ts.
  */
 export function createServiceLinePrefixer(
@@ -265,7 +265,7 @@ export class SubprocessBuildRunner extends BuildRunner {
 
   /**
    * Line prefixers for the child's piped stdout/stderr, present only when `ctx.serviceName` is
-   * set. Flushed on teardown so a trailing partial line isn't lost.
+   * set. Flushed on each stream's `end` so a trailing partial line isn't lost.
    */
   private stdoutPrefixer?: ReturnType<typeof createServiceLinePrefixer>;
 
@@ -308,7 +308,7 @@ export class SubprocessBuildRunner extends BuildRunner {
     this.child = child;
 
     // When piping, read the child's streams line-by-line, prefix with the service tag, and
-    // forward to our own stdout/stderr. Flushed on teardown so a trailing partial line isn't lost.
+    // forward to our own stdout/stderr. Flushed on stream end so a trailing partial line isn't lost.
     this.stdoutPrefixer = serviceName
       ? createServiceLinePrefixer(serviceName, process.stdout)
       : undefined;
@@ -319,11 +319,18 @@ export class SubprocessBuildRunner extends BuildRunner {
       const prefixer = this.stdoutPrefixer;
       child.stdout.setEncoding('utf8');
       child.stdout.on('data', chunk => prefixer.onData(chunk));
+      // Flush the trailing (unterminated) line only once the stream reaches EOF, so we never
+      // split a line that is still arriving. The child's stdout/stderr are piped over separate
+      // file descriptors from the IPC channel, so data written just before the worker sends its
+      // `buildResult` message can still be sitting in the OS pipe buffer when the parent tears
+      // the worker down; flushing here (rather than in teardown) guarantees it isn't dropped.
+      child.stdout.on('end', () => prefixer.flush());
     }
     if (this.stderrPrefixer && child.stderr) {
       const prefixer = this.stderrPrefixer;
       child.stderr.setEncoding('utf8');
       child.stderr.on('data', chunk => prefixer.onData(chunk));
+      child.stderr.on('end', () => prefixer.flush());
     }
 
     // Wait for the worker's `ready` handshake before sending the build request.
@@ -517,10 +524,6 @@ export class SubprocessBuildRunner extends BuildRunner {
   teardown(): void {
     const { child } = this;
     if (!child) return;
-
-    // Emit any buffered trailing (unterminated) line before we stop reading the streams.
-    this.stdoutPrefixer?.flush();
-    this.stderrPrefixer?.flush();
 
     if (child.connected) child.disconnect();
     if (child.exitCode === null && child.signalCode === null) {

--- a/packages/cli/test/unit/util/build/builder-process.test.ts
+++ b/packages/cli/test/unit/util/build/builder-process.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { createServiceLinePrefixer } from '../../../../src/util/build/builder-process';
+
+// createServiceLinePrefixer tags each complete line of a forked build's piped output with its
+// service, so the build-container can attribute build log lines. The tricky part is line
+// buffering: a data chunk may contain zero, partial, or several newlines.
+describe('createServiceLinePrefixer', () => {
+  function sink() {
+    const chunks: string[] = [];
+    return {
+      chunks,
+      dest: {
+        write: (s: string) => {
+          chunks.push(s);
+          return true;
+        },
+      },
+    };
+  }
+
+  it('prefixes each complete line', () => {
+    const { chunks, dest } = sink();
+    const p = createServiceLinePrefixer('frontend', dest);
+    p.onData('building\ncompiled\n');
+    p.flush();
+    expect(chunks.join('')).toBe(
+      '[vc:service:frontend] building\n[vc:service:frontend] compiled\n'
+    );
+  });
+
+  it('buffers a partial line across chunks and only tags at line starts', () => {
+    const { chunks, dest } = sink();
+    const p = createServiceLinePrefixer('api', dest);
+    p.onData('Instal');
+    p.onData('ling deps\nDone\n');
+    p.flush();
+    expect(chunks.join('')).toBe(
+      '[vc:service:api] Installing deps\n[vc:service:api] Done\n'
+    );
+  });
+
+  it('flushes an unterminated trailing line on flush', () => {
+    const { chunks, dest } = sink();
+    const p = createServiceLinePrefixer('api', dest);
+    p.onData('no newline yet');
+    expect(chunks.join('')).toBe('');
+    p.flush();
+    expect(chunks.join('')).toBe('[vc:service:api] no newline yet');
+  });
+
+  it('handles multiple newlines in one chunk', () => {
+    const { chunks, dest } = sink();
+    const p = createServiceLinePrefixer('web', dest);
+    p.onData('a\nb\nc\n');
+    p.flush();
+    expect(chunks.join('')).toBe(
+      '[vc:service:web] a\n[vc:service:web] b\n[vc:service:web] c\n'
+    );
+  });
+
+  it('does not emit anything until a newline arrives', () => {
+    const { chunks, dest } = sink();
+    const p = createServiceLinePrefixer('web', dest);
+    p.onData('partial');
+    expect(chunks).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Why

Multi-service deployments build several services in one `vercel build`, and the build-container captures the output line-by-line with no way to tell which service produced a given line — so their build logs mix together. This tags each build-output line with its service so the build-container can attribute every line.

An earlier attempt (https://github.com/vercel/vercel/pull/16911) patched the parent's `process.stdout.write`, but that **cannot** see output from build subprocesses spawned with `stdio: 'inherit'` (e.g. `next build`, `npm install`) — they write straight to the inherited OS descriptors. This version builds on the fork-per-build change (#16962): each service builds in its own forked worker with **piped** stdout/stderr, so the parent reads every line the child (and its subprocesses) produce and prefixes it.

**Stacked on #16962** — review/merge that first.

## What

- `buildInSubprocess` forks the worker with piped stdout/stderr when a `serviceName` is provided, reads each stream line-by-line, prepends `[vc:service:<name>] `, and forwards to the parent's own stdout/stderr (buffering partial lines, flushing on teardown).
- The build command passes `service.name`. Non-service builds keep inherited stdio and emit untagged output — no behavior change.
- The build-container strips the `[vc:service:<name>]` tag and attributes the line to a service (https://github.com/vercel/api/pull/78869).

## Validation

- Unit tests for the line prefixer (chunk boundaries, partial lines, multiple newlines, trailing flush).
- Full `vc build` suite green (103/103).
- Verified end-to-end: a real multi-service build (`with-services-cron-nested`) tags all output with `[vc:service:cleanup]` / `[vc:service:report]`, **including subprocess output** (`Installing dependencies...`, pnpm/corepack lines, Node deprecation warnings) — the case the old fd-patch missed. A single-project build emits zero tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)