### PR TITLE
[python] Skip bytecode precompilation for services with a preDeployCommand

### DIFF
--- a/.changeset/python-predeploy-no-compileall.md
+++ b/.changeset/python-predeploy-no-compileall.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Skip bytecode precompilation when a service has a `preDeployCommand`. Precompiled bytecode uses `--invalidation-mode unchecked-hash`, which trusts the `.pyc` without re-checking the source at import — safe only because build output is normally immutable. A `preDeployCommand` runs after the build and can rewrite source files, leaving the already-compiled bytecode stale so the old source is served at runtime. Precompilation is now disabled for such services so the pre-deploy changes take effect.

--- a/packages/python/src/compileall.ts
+++ b/packages/python/src/compileall.ts
@@ -22,9 +22,11 @@ function isCompileAllFlagEnabled(): boolean {
 export function shouldCompileAll({
   isDev,
   hasCustomCommand,
+  hasPreDeployCommand,
 }: {
   isDev?: boolean;
   hasCustomCommand: boolean;
+  hasPreDeployCommand?: boolean;
 }): boolean {
   if (isDev) return false;
 
@@ -33,6 +35,13 @@ export function shouldCompileAll({
   // safe: they run after the standard install, and bytecode collection
   // degrades gracefully.
   if (hasCustomCommand) return false;
+
+  // Precompiled bytecode uses `--invalidation-mode unchecked-hash`, which trusts
+  // the .pyc without re-hashing the source at import — safe only because the
+  // build output is normally immutable. A `preDeployCommand` runs after the build
+  // and can rewrite source files, which would leave the (already-compiled) bytecode
+  // stale and served instead of the updated source. Skip precompilation in that case.
+  if (hasPreDeployCommand) return false;
 
   return isCompileAllFlagEnabled();
 }

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -990,6 +990,9 @@ export const build: BuildVX = async ({
   const compileAllEnabled = shouldCompileAll({
     isDev: meta.isDev,
     hasCustomCommand,
+    // A pre-deploy command can rewrite source after the build, which would make
+    // unchecked-hash precompiled bytecode stale; skip precompilation to avoid serving it.
+    hasPreDeployCommand: typeof preDeployCommand === 'string',
   });
 
   const predefinedExcludes = [

--- a/packages/python/test/compileall.test.ts
+++ b/packages/python/test/compileall.test.ts
@@ -106,6 +106,20 @@ describe('shouldCompileAll', () => {
     );
   });
 
+  it('does not enable compileall when a pre-deploy command is configured', () => {
+    // A preDeployCommand can rewrite source after the build, which would make
+    // unchecked-hash bytecode stale, so precompilation must be skipped.
+    process.env.VERCEL_PYTHON_COMPILEALL = '1';
+
+    expect(
+      shouldCompileAll({
+        isDev: false,
+        hasCustomCommand: false,
+        hasPreDeployCommand: true,
+      })
+    ).toBe(false);
+  });
+
   it('keeps the fill ceiling safely below the Lambda size threshold', () => {
     expect(BYTECODE_FILL_CEILING_BYTES).toBeLessThan(
       LAMBDA_SIZE_THRESHOLD_BYTES


### PR DESCRIPTION
`compileAll` precompiles bytecode with `--invalidation-mode unchecked-hash`, which trusts the .pyc without re-hashing the source at import — safe only because the build output is normally immutable. But a service `preDeployCommand` runs after the build and can rewrite source files; the already-compiled unchecked-hash bytecode is then stale and gets loaded at runtime instead of the updated source.

This surfaced as the flaky `18-services-pre-deploy-command` e2e fixture: its pre-deploy rewrites `src/version.py` to `v0.0.0`, but the deployed app served the pre-build `to-be-modified` whenever precompilation had run. (https://github.com/vercel/vercel/actions/runs/28939349512/job/85865097472)

Disable precompilation when a `preDeployCommand` is configured so the pre-deploy source changes take effect.

This PR doesn't seem to have triggered the fs-detector tests where the failures happens, but cherry picking to a branch that does seems to fix the tests: https://github.com/vercel/vercel/actions/runs/28951144930/job/85898185102