### PR TITLE
[cli] Fix alert rules flag forwarding

### DIFF
--- a/.changeset/tidy-alert-rules-flags.md
+++ b/.changeset/tidy-alert-rules-flags.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Forward alert rule scope and format flags to nested subcommands.

--- a/packages/cli/src/commands/alerts/index.ts
+++ b/packages/cli/src/commands/alerts/index.ts
@@ -152,7 +152,13 @@ export default async function alerts(client: Client): Promise<number> {
     case 'rules': {
       telemetry.trackCliSubcommandRules(args[0] ?? 'ls');
       const rulesFn = (await import('./rules')).default;
-      return rulesFn(client, args);
+      const rulesArgs = [...args];
+      const project = parsedArgs.flags['--project'];
+      const format = parsedArgs.flags['--format'];
+      if (project) rulesArgs.push('--project', project);
+      if (parsedArgs.flags['--all']) rulesArgs.push('--all');
+      if (format) rulesArgs.push('--format', format);
+      return rulesFn(client, rulesArgs);
     }
     default: {
       telemetry.trackCliSubcommandLs(subcommandOriginal);

--- a/packages/cli/src/commands/alerts/rules/index.ts
+++ b/packages/cli/src/commands/alerts/rules/index.ts
@@ -19,9 +19,9 @@ export default async function rules(
   client: Client,
   argv: string[]
 ): Promise<number> {
-  if (argv.length === 0) {
+  if (argv.length === 0 || argv[0].startsWith('-')) {
     const lsFn = (await import('./ls')).default;
-    return lsFn(client, []);
+    return lsFn(client, argv);
   }
 
   const { subcommand, args, subcommandOriginal } = getSubcommand(

--- a/packages/cli/test/unit/commands/alerts/rules.test.ts
+++ b/packages/cli/test/unit/commands/alerts/rules.test.ts
@@ -6,12 +6,15 @@ import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 import alerts from '../../../../src/commands/alerts';
 import * as linkModule from '../../../../src/util/projects/link';
 import * as getScopeModule from '../../../../src/util/get-scope';
+import * as getProjectModule from '../../../../src/util/projects/get-project-by-id-or-name';
 
 vi.mock('../../../../src/util/projects/link');
 vi.mock('../../../../src/util/get-scope');
+vi.mock('../../../../src/util/projects/get-project-by-id-or-name');
 
 const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
 const mockedGetScope = vi.mocked(getScopeModule.default);
+const mockedGetProject = vi.mocked(getProjectModule.default);
 
 let tmpDir: string;
 
@@ -74,6 +77,56 @@ describe('alerts rules', () => {
     expect(path).toContain('/alerts/v2/alert-rules');
     expect(client.stderr.getFullOutput()).toContain('ar_1');
     expect(client.stderr.getFullOutput()).toContain('My rule');
+  });
+
+  it('lists team-wide alert rules without a linked project', async () => {
+    mockedGetLinkedProject.mockResolvedValue({
+      status: 'not_linked',
+      org: null,
+      project: null,
+    });
+    client.scenario.get('/alerts/v2/alert-rules', (req, res) => {
+      expect(req.query.teamId).toBe('team_dummy');
+      expect(req.query.projectId).toBeUndefined();
+      res.json([{ id: 'ar_1', name: 'Team rule', teamId: 'team_dummy' }]);
+    });
+
+    client.setArgv('alerts', 'rules', 'ls', '--all', '--format', 'json');
+
+    const exitCode = await alerts(client);
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      rules: [{ id: 'ar_1', name: 'Team rule', teamId: 'team_dummy' }],
+    });
+    expect(mockedGetLinkedProject).not.toHaveBeenCalled();
+  });
+
+  it('lists alert rules for an explicit project', async () => {
+    mockedGetProject.mockResolvedValue({ id: 'prj_explicit' } as any);
+    client.scenario.get('/alerts/v2/alert-rules', (req, res) => {
+      expect(req.query.teamId).toBe('team_dummy');
+      expect(req.query.projectId).toBe('prj_explicit');
+      res.json([]);
+    });
+
+    client.setArgv(
+      'alerts',
+      'rules',
+      'ls',
+      '--project',
+      'explicit-project',
+      '--format',
+      'json'
+    );
+
+    const exitCode = await alerts(client);
+    expect(exitCode).toBe(0);
+    expect(mockedGetProject).toHaveBeenCalledWith(
+      client,
+      'explicit-project',
+      'team_dummy'
+    );
+    expect(mockedGetLinkedProject).not.toHaveBeenCalled();
   });
 
   it('creates a rule with POST', async () => {

--- a/packages/cli/test/unit/commands/alerts/rules.test.ts
+++ b/packages/cli/test/unit/commands/alerts/rules.test.ts
@@ -91,7 +91,7 @@ describe('alerts rules', () => {
       res.json([{ id: 'ar_1', name: 'Team rule', teamId: 'team_dummy' }]);
     });
 
-    client.setArgv('alerts', 'rules', 'ls', '--all', '--format', 'json');
+    client.setArgv('alerts', 'rules', '--all', '--format', 'json');
 
     const exitCode = await alerts(client);
     expect(exitCode).toBe(0);
@@ -112,7 +112,6 @@ describe('alerts rules', () => {
     client.setArgv(
       'alerts',
       'rules',
-      'ls',
       '--project',
       'explicit-project',
       '--format',


### PR DESCRIPTION
## Why / Summary

- `vercel alerts` parsed shared flags before dispatching nested `alerts rules` commands, so `--all`, `--project`, and `--format` never reached the rule handler.
- Forward those parsed flags to the nested command and cover team-wide and explicit-project JSON listing from an unlinked directory.

## Validation
- tested tarball locally (w/ agent)
