### PR TITLE
[cli] Validate `services/<name>/` output in vc build

### DIFF
--- a/.changeset/cli-validate-build-output-services.md
+++ b/.changeset/cli-validate-build-output-services.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vc build` output validation now understands the `services/<name>/` layout. A services-only build no longer false-warns about missing `functions`/`static` output, and each service's `config.json` and deployable output are validated the same way as the top-level Build Output API directory.

--- a/packages/cli/src/util/build/validate-build-output.ts
+++ b/packages/cli/src/util/build/validate-build-output.ts
@@ -18,6 +18,47 @@ export interface BuildOutputProblem {
 }
 
 /**
+ * Validate a Build Output API `config.json` (top-level or per-service),
+ * appending any problems found. The `label` prefixes each message so callers
+ * can distinguish the top-level config from a service's config.
+ */
+async function validateOutputConfig(
+  configPath: string,
+  label: string,
+  problems: BuildOutputProblem[]
+): Promise<void> {
+  const configExists = await fs.pathExists(configPath);
+
+  if (!configExists) {
+    problems.push({
+      severity: 'error',
+      message: `${label} is missing config.json.`,
+    });
+    return;
+  }
+
+  let config: { version?: unknown } | undefined;
+  try {
+    config = await fs.readJSON(configPath);
+  } catch (err) {
+    problems.push({
+      severity: 'error',
+      message: `${label} config.json is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }.`,
+    });
+    return;
+  }
+
+  if (config && config.version !== 3) {
+    problems.push({
+      severity: 'warning',
+      message: `${label} config.json has unexpected version "${config.version}" (expected 3).`,
+    });
+  }
+}
+
+/**
  * Validate the contents of a Build Output API directory (`.vercel/output`),
  * returning a list of problems. Never throws.
  */
@@ -29,32 +70,24 @@ export async function validateBuildOutput(
   logDebug(`Validating build output at "${outputDir}"`);
 
   try {
-    const configPath = join(outputDir, 'config.json');
-    const configExists = await fs.pathExists(configPath);
+    await validateOutputConfig(
+      join(outputDir, 'config.json'),
+      'Build output',
+      problems
+    );
 
-    if (!configExists) {
-      problems.push({
-        severity: 'error',
-        message: 'Build output is missing config.json.',
-      });
-    } else {
-      let config: { version?: unknown } | undefined;
-      try {
-        config = await fs.readJSON(configPath);
-      } catch (err) {
-        problems.push({
-          severity: 'error',
-          message: `Build output config.json is not valid JSON: ${
-            err instanceof Error ? err.message : String(err)
-          }.`,
-        });
-      }
-
-      if (config && config.version !== 3) {
-        problems.push({
-          severity: 'warning',
-          message: `Build output config.json has unexpected version "${config.version}" (expected 3).`,
-        });
+    // Builds may emit a `services/<name>/` layout, where each service is a
+    // nested Build Output API root. A missing `services` dir is the normal
+    // (non-services) case; rethrow anything other than ENOENT so the outer
+    // catch produces the single-error fallback.
+    const servicesDir = join(outputDir, 'services');
+    let serviceNames: string[] = [];
+    try {
+      const entries = await fs.readdir(servicesDir, { withFileTypes: true });
+      serviceNames = entries.filter(e => e.isDirectory()).map(e => e.name);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        throw err;
       }
     }
 
@@ -62,13 +95,36 @@ export async function validateBuildOutput(
       fs.pathExists(join(outputDir, 'functions')),
       fs.pathExists(join(outputDir, 'static')),
     ]);
+    const hasServices = serviceNames.length > 0;
 
-    if (!hasFunctions && !hasStatic) {
+    if (!hasFunctions && !hasStatic && !hasServices) {
       problems.push({
         severity: 'warning',
         message:
-          'Build output contains no "functions" or "static" directory; the build may not have produced any deployable output.',
+          'Build output contains no "functions", "static", or "services" directory; the build may not have produced any deployable output.',
       });
+    }
+
+    for (const name of serviceNames) {
+      const serviceDir = join(servicesDir, name);
+      const label = `Build output service "${name}"`;
+
+      await validateOutputConfig(
+        join(serviceDir, 'config.json'),
+        label,
+        problems
+      );
+
+      const [svcHasFunctions, svcHasStatic] = await Promise.all([
+        fs.pathExists(join(serviceDir, 'functions')),
+        fs.pathExists(join(serviceDir, 'static')),
+      ]);
+      if (!svcHasFunctions && !svcHasStatic) {
+        problems.push({
+          severity: 'warning',
+          message: `${label} contains no "functions" or "static" directory; the service may not have produced any deployable output.`,
+        });
+      }
     }
 
     logDebug(

--- a/packages/cli/test/unit/util/build/validate-build-output.test.ts
+++ b/packages/cli/test/unit/util/build/validate-build-output.test.ts
@@ -57,7 +57,7 @@ describe('validateBuildOutput()', () => {
     });
   });
 
-  it('warns when there is no functions or static directory', async () => {
+  it('warns when there is no functions, static, or services directory', async () => {
     const dir = await makeTempDir();
     created.push(dir);
 
@@ -67,7 +67,142 @@ describe('validateBuildOutput()', () => {
     expect(problems).toContainEqual({
       severity: 'warning',
       message:
-        'Build output contains no "functions" or "static" directory; the build may not have produced any deployable output.',
+        'Build output contains no "functions", "static", or "services" directory; the build may not have produced any deployable output.',
     });
+  });
+
+  it('returns no problems for a services-only build', async () => {
+    const dir = await makeTempDir();
+    created.push(dir);
+
+    await fs.writeJSON(join(dir, 'config.json'), { version: 3 });
+    await fs.ensureDir(join(dir, 'services', 'api'));
+    await fs.writeJSON(join(dir, 'services', 'api', 'config.json'), {
+      version: 3,
+    });
+    await fs.ensureDir(join(dir, 'services', 'api', 'static'));
+
+    const problems = await validateBuildOutput(dir);
+    expect(problems).toEqual([]);
+  });
+
+  it('returns an error when a service is missing config.json', async () => {
+    const dir = await makeTempDir();
+    created.push(dir);
+
+    await fs.writeJSON(join(dir, 'config.json'), { version: 3 });
+    await fs.ensureDir(join(dir, 'services', 'api', 'static'));
+
+    const problems = await validateBuildOutput(dir);
+    expect(problems).toContainEqual({
+      severity: 'error',
+      message: 'Build output service "api" is missing config.json.',
+    });
+  });
+
+  it('warns on an unexpected service config version', async () => {
+    const dir = await makeTempDir();
+    created.push(dir);
+
+    await fs.writeJSON(join(dir, 'config.json'), { version: 3 });
+    await fs.ensureDir(join(dir, 'services', 'api'));
+    await fs.writeJSON(join(dir, 'services', 'api', 'config.json'), {
+      version: 2,
+    });
+    await fs.ensureDir(join(dir, 'services', 'api', 'static'));
+
+    const problems = await validateBuildOutput(dir);
+    expect(problems).toContainEqual({
+      severity: 'warning',
+      message:
+        'Build output service "api" config.json has unexpected version "2" (expected 3).',
+    });
+  });
+
+  it('returns an error when a service config.json is invalid JSON', async () => {
+    const dir = await makeTempDir();
+    created.push(dir);
+
+    await fs.writeJSON(join(dir, 'config.json'), { version: 3 });
+    await fs.ensureDir(join(dir, 'services', 'api'));
+    await fs.writeFile(
+      join(dir, 'services', 'api', 'config.json'),
+      '{ not json'
+    );
+    await fs.ensureDir(join(dir, 'services', 'api', 'static'));
+
+    const problems = await validateBuildOutput(dir);
+    expect(problems).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        message: expect.stringContaining(
+          'Build output service "api" config.json is not valid JSON:'
+        ),
+      })
+    );
+  });
+
+  it('validates multiple services independently', async () => {
+    const dir = await makeTempDir();
+    created.push(dir);
+
+    await fs.writeJSON(join(dir, 'config.json'), { version: 3 });
+    await fs.ensureDir(join(dir, 'services', 'api'));
+    await fs.writeJSON(join(dir, 'services', 'api', 'config.json'), {
+      version: 3,
+    });
+    await fs.ensureDir(join(dir, 'services', 'api', 'static'));
+    await fs.ensureDir(join(dir, 'services', 'web'));
+    await fs.writeJSON(join(dir, 'services', 'web', 'config.json'), {
+      version: 2,
+    });
+    await fs.ensureDir(join(dir, 'services', 'web', 'static'));
+
+    const problems = await validateBuildOutput(dir);
+    const versionWarnings = problems.filter(p =>
+      p.message.includes('unexpected version')
+    );
+    expect(versionWarnings).toEqual([
+      {
+        severity: 'warning',
+        message:
+          'Build output service "web" config.json has unexpected version "2" (expected 3).',
+      },
+    ]);
+  });
+
+  it('warns when a service has no functions or static directory', async () => {
+    const dir = await makeTempDir();
+    created.push(dir);
+
+    await fs.writeJSON(join(dir, 'config.json'), { version: 3 });
+    await fs.ensureDir(join(dir, 'services', 'api'));
+    await fs.writeJSON(join(dir, 'services', 'api', 'config.json'), {
+      version: 3,
+    });
+    await fs.ensureDir(join(dir, 'services', 'api', 'routes'));
+
+    const problems = await validateBuildOutput(dir);
+    expect(problems).toContainEqual({
+      severity: 'warning',
+      message:
+        'Build output service "api" contains no "functions" or "static" directory; the service may not have produced any deployable output.',
+    });
+  });
+
+  it('ignores non-directory entries under services', async () => {
+    const dir = await makeTempDir();
+    created.push(dir);
+
+    await fs.writeJSON(join(dir, 'config.json'), { version: 3 });
+    await fs.ensureDir(join(dir, 'services', 'api'));
+    await fs.writeJSON(join(dir, 'services', 'api', 'config.json'), {
+      version: 3,
+    });
+    await fs.ensureDir(join(dir, 'services', 'api', 'static'));
+    await fs.writeFile(join(dir, 'services', 'readme.txt'), 'hello');
+
+    const problems = await validateBuildOutput(dir);
+    expect(problems).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Extends `validateBuildOutput` (`packages/cli/src/util/build/validate-build-output.ts`) to understand the `services/<name>/` Build Output API layout that some `vc build` runs emit, where each service is a nested Build Output API root (its own `config.json`, `functions/`, `routes/`, `static/`).

- **Fixes a false positive:** a services-only build has no top-level `functions`/`static` — its deployable output lives under `services/<name>/`. Services now count as deployable output, so the "no deployable output" warning no longer misfires. The message became `... "functions", "static", or "services" ...`.
- **Validates each service:** a reusable `validateOutputConfig` helper (extracted from the existing top-level checks, messages preserved byte-for-byte) validates each service's `config.json` (present / valid JSON / `version === 3`), and a per-service `functions`/`static` check warns when a service produced no deployable output (e.g. routes-only).
- Service dirs are discovered with `fs.readdir(..., { withFileTypes: true })`, swallowing `ENOENT` for the normal non-services case; the function still never throws.
- Caller (`commands/build/index.ts`) and `reportBuildOutputProblems` consume `BuildOutputProblem[]` generically — no change needed.

## Testing

`test/unit/util/build/validate-build-output.test.ts` — updated the deployable-output message assertion and added 7 cases (services-only build, missing/invalid/wrong-version service config, multi-service independence, routes-only service warning, non-directory entries ignored). 11 tests pass; `tsc --noEmit` and `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)