### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/.changeset/cloud-agent-setup-notes.md
+++ b/.changeset/cloud-agent-setup-notes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add "Cursor Cloud specific instructions" to AGENTS.md documenting Node/pnpm/corepack setup and how to build, test, and run the CLI in Cloud Agent VMs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,3 +174,14 @@ This runs your local CLI build against any project without needing to install it
 2. **Don't skip CI hooks** - Lint and type checks run in pre-commit
 3. **Don't forget type-check** - Run `pnpm type-check` before pushing
 4. **Don't modify examples for testing** - They're used for integration tests
+
+## Cursor Cloud specific instructions
+
+Dependency installation is handled automatically by the environment update script; the notes below are durable runtime caveats for Cloud Agents. This repo installs and runs fully in the Cloud VM (all packages are public — no npm token needed).
+
+- **Node version**: Node 22 (`.nvmrc`). Cloud VMs manage Node with `nvm`, and a `/exec-daemon/node` shim precedes `nvm` on `PATH`. Prepend the desired version explicitly before running `node`/`pnpm`, e.g. `export PATH="$HOME/.nvm/versions/node/$(nvm version 22)/bin:$PATH"`.
+- **pnpm via corepack**: the pnpm version is pinned in `packageManager`. In non-interactive shells set `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` so corepack fetches pnpm without prompting.
+- **Build before tests**: every turbo test task `dependsOn build`, so run `pnpm build` once after install before `pnpm test-unit` or per-package tests. `pnpm build` also compiles the Rust crate for `@vercel/python-analysis` (cargo is available); the first build downloads crates.
+- **Fast smoke test**: `cd packages/error-utils && pnpm test` (self-contained, no `workspace:*` deps).
+- **Running the CLI**: after `pnpm build`, run `node packages/cli/dist/vc.js --version` / `--help`, and `node packages/cli/dist/vc.js init <example> <name>` to scaffold a project offline. Auth-dependent commands (`vc build`, `vc deploy`) need a valid `VERCEL_TOKEN`; the injected token may be stale, so `env -u VERCEL_TOKEN` avoids a "token is not valid" error on offline commands.
+- e2e/integration tests deploy to a live Vercel account and need real credentials — not runnable in a sandbox; stick to unit tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

When setting up this repo in a Cursor Cloud Agent VM, several non-obvious runtime details cost time to rediscover (Node version selection with a `/exec-daemon/node` PATH shim, corepack's interactive download prompt, the build-before-test requirement, and which CLI commands need a valid token). This adds a durable `## Cursor Cloud specific instructions` section to `AGENTS.md` so future agents start from that knowledge.

This repo installs, builds, tests, and runs fully in the Cloud VM (all packages are public — no npm token required).

## Validation

- `pnpm install --frozen-lockfile` (Node 22) — clean.
- `pnpm build` — 49/49 turbo tasks succeed (includes the `@vercel/python-analysis` Rust crate).
- `cd packages/error-utils && pnpm test` — 19/19 tests pass.
- `node packages/cli/dist/vc.js --version` → `Vercel CLI 54.21.1`; `vc init nextjs my-next-app` scaffolds a project offline.

Docs-only change; empty-frontmatter changeset included.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44a57931-b0ff-48b3-af17-0fa3d4220e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44a57931-b0ff-48b3-af17-0fa3d4220e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

