### PR TITLE
[python] fail hard on unresolvable entrypoint

### DIFF
--- a/.changeset/tool-vercel-entrypoint-hard-error.md
+++ b/.changeset/tool-vercel-entrypoint-hard-error.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Fail the build when `tool.vercel.entrypoint` in pyproject.toml is set but cannot be resolved, instead of silently falling back to filename-based entrypoint detection. A stale or typo'd declaration could previously build a different app than the one declared. Speculative detection (monorepo auto-detection, project linking) still degrades gracefully: one directory's broken config does not abort the sweep.

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -247,15 +247,26 @@ async function resolveModuleAttrEntrypoint(
 }
 
 export async function getVercelToolsEntrypoint(
-  workPath: string
+  workPath: string,
+  repoRootPath?: string
 ): Promise<PythonEntrypoint | null> {
+  const pyprojectPath = join(workPath, 'pyproject.toml');
   const pyprojectData = await readConfigFile<{
     tool?: { vercel?: { entrypoint?: unknown } };
-  }>(join(workPath, 'pyproject.toml'));
+  }>(pyprojectPath);
   if (!pyprojectData) return null;
 
   const vercelEntrypoint = pyprojectData.tool?.vercel?.entrypoint;
   if (vercelEntrypoint === undefined) return null;
+
+  // Name the specific file in errors relative to the repo root: a monorepo
+  // can contain several pyproject.toml files (one per service), so a bare
+  // "pyproject.toml" would not identify which one is broken.
+  const relPyprojectPath = relative(repoRootPath ?? workPath, pyprojectPath);
+  const displayPath =
+    !relPyprojectPath || relPyprojectPath.startsWith('..')
+      ? pyprojectPath
+      : relPyprojectPath;
 
   // `tool.vercel.*` is Vercel-owned configuration: a declared entrypoint that
   // cannot be resolved is a hard error. Silently falling back to filename
@@ -265,8 +276,7 @@ export async function getVercelToolsEntrypoint(
   if (typeof vercelEntrypoint !== 'string') {
     throw new NowBuildError({
       code: 'PYTHON_INVALID_ENTRYPOINT',
-      message:
-        '"tool.vercel.entrypoint" in pyproject.toml must be a string in "module:object" format (e.g. "main:app").',
+      message: `"tool.vercel.entrypoint" in "${displayPath}" must be a string in "module:object" format (e.g. "main:app").`,
       link: PYTHON_ENTRYPOINT_DOCS_URL,
       action: 'Learn More',
     });
@@ -278,7 +288,7 @@ export async function getVercelToolsEntrypoint(
   if (!resolved) {
     throw new NowBuildError({
       code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
-      message: `"tool.vercel.entrypoint" in pyproject.toml is "${vercelEntrypoint}" but no matching module file was found. Use "module:object" format (e.g. "main:app") and ensure the module file exists, or remove the setting to use automatic entrypoint detection.`,
+      message: `"tool.vercel.entrypoint" in "${displayPath}" is "${vercelEntrypoint}" but no matching module file was found. Use "module:object" format (e.g. "main:app") and ensure the module file exists, or remove the setting to use automatic entrypoint detection.`,
       link: PYTHON_ENTRYPOINT_DOCS_URL,
       action: 'Learn More',
     });
@@ -521,7 +531,8 @@ export async function detectPythonEntrypoint(
   framework: PythonFramework | undefined,
   workPath: string,
   configuredEntrypoint?: { filePath: string; varName?: string },
-  service?: { type?: ServiceType; trigger?: JobTrigger }
+  service?: { type?: ServiceType; trigger?: JobTrigger },
+  repoRootPath?: string
 ): Promise<DetectedPythonEntrypoint | null> {
   // If a configured entrypoint was provided, check it first
   if (configuredEntrypoint) {
@@ -579,7 +590,7 @@ export async function detectPythonEntrypoint(
   }
 
   // Check `tool.vercel.entrypoint` in pyproject.toml first.
-  const vercelEntry = await getVercelToolsEntrypoint(workPath);
+  const vercelEntry = await getVercelToolsEntrypoint(workPath, repoRootPath);
   if (vercelEntry) return { entrypoint: vercelEntry };
 
   // Then do a framework-specific search, collecting diagnostics for better error messages

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -255,8 +255,35 @@ export async function getVercelToolsEntrypoint(
   if (!pyprojectData) return null;
 
   const vercelEntrypoint = pyprojectData.tool?.vercel?.entrypoint;
-  if (typeof vercelEntrypoint !== 'string') return null;
-  return resolveModuleAttrEntrypoint(workPath, vercelEntrypoint);
+  if (vercelEntrypoint === undefined) return null;
+
+  // `tool.vercel.*` is Vercel-owned configuration: a declared entrypoint that
+  // cannot be resolved is a hard error. Silently falling back to filename
+  // detection could build a different app than the one the user declared —
+  // and the fallback's failure message would suggest setting the very field
+  // that is already set.
+  if (typeof vercelEntrypoint !== 'string') {
+    throw new NowBuildError({
+      code: 'PYTHON_INVALID_ENTRYPOINT',
+      message:
+        '"tool.vercel.entrypoint" in pyproject.toml must be a string in "module:object" format (e.g. "main:app").',
+      link: PYTHON_ENTRYPOINT_DOCS_URL,
+      action: 'Learn More',
+    });
+  }
+  const resolved = await resolveModuleAttrEntrypoint(
+    workPath,
+    vercelEntrypoint
+  );
+  if (!resolved) {
+    throw new NowBuildError({
+      code: 'PYTHON_ENTRYPOINT_NOT_FOUND',
+      message: `"tool.vercel.entrypoint" in pyproject.toml is "${vercelEntrypoint}" but no matching module file was found. Use "module:object" format (e.g. "main:app") and ensure the module file exists, or remove the setting to use automatic entrypoint detection.`,
+      link: PYTHON_ENTRYPOINT_DOCS_URL,
+      action: 'Learn More',
+    });
+  }
+  return resolved;
 }
 
 // Legacy: kept for compatibility. Prefer tool.vercel.entrypoint.
@@ -603,16 +630,33 @@ export async function detectPythonEntrypoint(
  * Returns `null` for non-Python frameworks, when no entrypoint is found,
  * and for Django when only a `manage.py` baseDir was discovered (the
  * Django framework hook resolves the WSGI/ASGI entrypoint at build time).
+ *
+ * Detection errors (e.g. an unresolvable `tool.vercel.entrypoint`) also
+ * return `null`: this function runs speculatively over many candidate
+ * directories during monorepo auto-detection and project linking, where one
+ * directory's broken config must not abort the whole sweep. The same error
+ * is a hard failure on the build and dev paths, which call
+ * {@link detectPythonEntrypoint} directly.
  */
 export const detectEntrypoint: DetectEntrypointFn = async ({
   workPath,
   framework,
 }) => {
   if (!isPythonFramework(framework)) return null;
-  const detected = await detectPythonEntrypoint(
-    framework as PythonFramework,
-    workPath
-  );
+  let detected: DetectedPythonEntrypoint | null;
+  try {
+    detected = await detectPythonEntrypoint(
+      framework as PythonFramework,
+      workPath
+    );
+  } catch (err) {
+    debug(
+      `Python entrypoint detection failed for ${workPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return null;
+  }
   if (!detected?.entrypoint) return null;
   const { entrypoint, variableName } = detected.entrypoint;
   return {

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -625,7 +625,8 @@ export const build: BuildVX = async ({
                 : handlerFunction,
           }
         : undefined,
-      service
+      service,
+      repoRootPath
     )) ?? undefined;
 
   if (detected?.error && detected?.baseDir === undefined) {

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -730,7 +730,8 @@ export const startDevServer: StartDevServer = async opts => {
               : handlerFunction,
         }
       : undefined,
-    service
+    service,
+    opts.repoRootPath
   );
   let hookResult: Awaited<ReturnType<typeof runFrameworkHook>> | undefined;
   if (detected?.entrypoint) {

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -83,7 +83,11 @@ import {
   sanitizeConsumerName,
 } from '@vercel/build-utils';
 import { getServiceCrons } from '../src/crons';
-import { entrypointToModule, detectPythonEntrypoint } from '../src/entrypoint';
+import {
+  entrypointToModule,
+  detectPythonEntrypoint,
+  detectEntrypoint,
+} from '../src/entrypoint';
 import execa from 'execa';
 
 function getBuildOutputV2(result: Awaited<ReturnType<typeof build>>) {
@@ -1970,6 +1974,86 @@ describe('pyproject.toml entrypoint detection', () => {
     expect(content.includes('other/server.py')).toBe(false);
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+});
+
+describe('tool.vercel.entrypoint validation', () => {
+  let workPath: string;
+
+  beforeEach(() => {
+    workPath = path.join(
+      tmpdir(),
+      `python-tool-vercel-validation-${Date.now()}`
+    );
+    fs.mkdirSync(workPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('hard-errors when the declared module does not exist', async () => {
+    fs.writeFileSync(
+      path.join(workPath, 'pyproject.toml'),
+      '[tool.vercel]\nentrypoint = "backend.api:app"\n'
+    );
+    // A detectable candidate exists, but the broken declaration must not
+    // silently fall back to it — that could build the wrong app.
+    fs.writeFileSync(path.join(workPath, 'main.py'), 'app = object()\n');
+
+    await expect(detectPythonEntrypoint('fastapi', workPath)).rejects.toThrow(
+      /"tool\.vercel\.entrypoint" in pyproject\.toml is "backend\.api:app" but no matching module file was found/
+    );
+  });
+
+  it('hard-errors when the declared value is not module:object format', async () => {
+    fs.writeFileSync(
+      path.join(workPath, 'pyproject.toml'),
+      '[tool.vercel]\nentrypoint = "main.py"\n'
+    );
+    fs.writeFileSync(path.join(workPath, 'main.py'), 'app = object()\n');
+
+    await expect(detectPythonEntrypoint('fastapi', workPath)).rejects.toThrow(
+      /no matching module file was found/
+    );
+  });
+
+  it('hard-errors when the declared value is not a string', async () => {
+    fs.writeFileSync(
+      path.join(workPath, 'pyproject.toml'),
+      '[tool.vercel]\nentrypoint = 42\n'
+    );
+
+    await expect(detectPythonEntrypoint('fastapi', workPath)).rejects.toThrow(
+      /must be a string in "module:object" format/
+    );
+  });
+
+  it('still resolves a valid declared entrypoint', async () => {
+    fs.mkdirSync(path.join(workPath, 'backend'), { recursive: true });
+    fs.writeFileSync(
+      path.join(workPath, 'pyproject.toml'),
+      '[tool.vercel]\nentrypoint = "backend.api:app"\n'
+    );
+    fs.writeFileSync(
+      path.join(workPath, 'backend', 'api.py'),
+      'app = object()\n'
+    );
+
+    await expect(detectPythonEntrypoint('fastapi', workPath)).resolves.toEqual({
+      entrypoint: { entrypoint: 'backend/api.py', variableName: 'app' },
+    });
+  });
+
+  it('detectEntrypoint returns null instead of throwing for speculative detection', async () => {
+    fs.writeFileSync(
+      path.join(workPath, 'pyproject.toml'),
+      '[tool.vercel]\nentrypoint = "backend.api:app"\n'
+    );
+
+    await expect(
+      detectEntrypoint({ workPath, framework: 'fastapi' })
+    ).resolves.toBeNull();
   });
 });
 

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -2002,7 +2002,30 @@ describe('tool.vercel.entrypoint validation', () => {
     fs.writeFileSync(path.join(workPath, 'main.py'), 'app = object()\n');
 
     await expect(detectPythonEntrypoint('fastapi', workPath)).rejects.toThrow(
-      /"tool\.vercel\.entrypoint" in pyproject\.toml is "backend\.api:app" but no matching module file was found/
+      /"tool\.vercel\.entrypoint" in "pyproject\.toml" is "backend\.api:app" but no matching module file was found/
+    );
+  });
+
+  it('names the broken pyproject.toml relative to the repo root', async () => {
+    // Monorepos can contain several pyproject.toml files (one per service);
+    // the error must identify which one is broken.
+    const serviceRoot = path.join(workPath, 'backend');
+    fs.mkdirSync(serviceRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(serviceRoot, 'pyproject.toml'),
+      '[tool.vercel]\nentrypoint = "api:app"\n'
+    );
+
+    await expect(
+      detectPythonEntrypoint(
+        'fastapi',
+        serviceRoot,
+        undefined,
+        undefined,
+        workPath
+      )
+    ).rejects.toThrow(
+      /"tool\.vercel\.entrypoint" in "backend[/\\]pyproject\.toml"/
     );
   });
 


### PR DESCRIPTION
Currently, if we fail to resolve an entrypoint from `tool.vercel.entrypoint` in `pyproject.toml`, we fall back to searching the default list. 
We should instead be failing loudly when you configure an entrypoint that does not exist

```toml
[tool.vercel]
entrypoint = "bad_main:app"
```
Now loudly errors during build