### PR TITLE
[cli] prototype: sh dispatcher as the published bin (zero-node native dispatch)

### DIFF
--- a/.changeset/sh-dispatcher-prototype.md
+++ b/.changeset/sh-dispatcher-prototype.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Prototype: publish the CLI bin as a `#!/bin/sh` dispatcher that can exec managed-store payloads (native binaries with zero node startup) before node boots. Inert unless `VERCEL_CLI_STORE=1` is set.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,8 +33,8 @@
     "test:evals:local-fixture": "tsx evals/run.ts --local-fixture"
   },
   "bin": {
-    "vc": "./dist/vc.js",
-    "vercel": "./dist/vc.js"
+    "vc": "./dist/vc.sh",
+    "vercel": "./dist/vc.sh"
   },
   "files": [
     "dist"

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
 import {
+  chmodSync,
   copyFileSync,
   readFileSync,
   writeFileSync,
@@ -174,6 +175,21 @@ copyFileSync(
   new URL('fetch-dist-tags.cjs', distRoot)
 );
 copyFileSync(new URL('src/vc.js', repoRoot), new URL('vc.js', distRoot));
+
+// The sh dispatcher is the published bin. Stamp the build version so it can
+// avoid self-redirects, and ensure the exec bit survives for direct exec.
+{
+  const dispatcher = readFileSync(new URL('src/vc.sh', repoRoot), 'utf8');
+  const dest = new URL('vc.sh', distRoot);
+  writeFileSync(
+    dest,
+    dispatcher.replace(
+      'VERSION="0.0.0-dev"',
+      `VERSION=${JSON.stringify(pkg.version)}`
+    )
+  );
+  chmodSync(dest, 0o755);
+}
 
 // Generate version.mjs for fast --version lookup
 writeFileSync(

--- a/packages/cli/src/vc.sh
+++ b/packages/cli/src/vc.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# Prototype sh dispatcher for the Vercel CLI (managed-store experiment).
+#
+# This replaces dist/vc.js as the published bin. It decides — before node
+# ever starts — what should actually run:
+#
+#   store native payload  -> exec <binary>            (0 node boots)
+#   store npm payload     -> exec node <store vc.js>  (1 node boot)
+#   no store / not opted in / ineligible / any error
+#                         -> exec node <own vc.js>    (today's behavior)
+#
+# Opt-in for this prototype is VERCEL_CLI_STORE=1 only.
+# The store pointer is read from a sh-friendly sidecar, current.path:
+#   line 1: version of the payload
+#   line 2: absolute path to the payload entrypoint (.js => run via node)
+# Only the store engine writes the sidecar; this script never writes.
+#
+# VERCEL_CLI_STORE_DEBUG=1 prints dispatch decisions to stderr and
+# demonstrates fire-and-forget background work (a stand-in for seeding).
+
+set -u
+
+# Replaced at build time.
+VERSION="0.0.0-dev"
+
+debug() {
+  if [ "${VERCEL_CLI_STORE_DEBUG:-}" = "1" ]; then
+    echo "[vc.sh] $*" >&2
+  fi
+}
+
+# Resolve our own real location (PM bins are symlinks/shims; payloads and
+# eligibility are judged against the real file, not the link).
+self="$0"
+i=0
+while [ -L "$self" ] && [ "$i" -lt 40 ]; do
+  t=$(readlink "$self") || break
+  case "$t" in
+    /*) self="$t" ;;
+    *) self="$(dirname "$self")/$t" ;;
+  esac
+  i=$((i + 1))
+done
+selfdir=$(CDPATH='' cd -- "$(dirname -- "$self")" && pwd -P)
+
+run_self() {
+  debug "running invoked install: $selfdir/vc.js"
+  exec node "$selfdir/vc.js" "$@"
+}
+
+# Diagnostic mode: `vc -v --verbose` reports the dispatch decision and then
+# always runs the invoked install (it inspects the invoked copy).
+verbose_diag=0
+if [ "$#" = "2" ]; then
+  has_v=0
+  has_verbose=0
+  for arg in "$@"; do
+    case "$arg" in
+      -v | --version) has_v=1 ;;
+      --verbose) has_verbose=1 ;;
+    esac
+  done
+  if [ "$has_v" = "1" ] && [ "$has_verbose" = "1" ]; then
+    verbose_diag=1
+  fi
+fi
+
+store="${VERCEL_CLI_STORE_DIR:-$HOME/.vercel/cli}"
+
+# Eligibility: same two-fact check as the node implementation. Only
+# known-global installs participate; project deps always run themselves.
+is_global=0
+if [ -n "${PNPM_HOME:-}" ]; then
+  # Compare against both the raw value and its physical path (macOS
+  # /var -> /private/var, etc). selfdir is already physical (pwd -P).
+  pnpm_home_real=$(CDPATH='' cd -- "$PNPM_HOME" 2>/dev/null && pwd -P || echo "$PNPM_HOME")
+  case "$selfdir/" in
+    "${PNPM_HOME%/}"/* | "${pnpm_home_real%/}"/*) is_global=1 ;;
+  esac
+fi
+if [ "$is_global" = "0" ]; then
+  node_bin=$(command -v node 2>/dev/null || true)
+  if [ -n "$node_bin" ]; then
+    node_bindir=${node_bin%/*}
+    node_prefix=${node_bindir%/*}
+    case "$selfdir/" in
+      "$node_prefix/lib/node_modules/"*) is_global=1 ;;
+    esac
+  fi
+fi
+
+if [ "$verbose_diag" = "1" ]; then
+  {
+    echo "dispatcher: $self"
+    echo "version:    $VERSION"
+    echo "global:     $is_global"
+    echo "store dir:  $store"
+    if [ -r "$store/current.path" ]; then
+      {
+        IFS= read -r p_version || true
+        IFS= read -r p_target || true
+      } <"$store/current.path"
+      echo "pointer:    $p_target (v$p_version)"
+    else
+      echo "pointer:    (none)"
+    fi
+    echo "enabled:    ${VERCEL_CLI_STORE:-0}"
+  } >&2
+  # Forward only -v; the CLI on this branch doesn't know --verbose.
+  run_self -v
+fi
+
+# Gates: opt-in only (prototype), loop guard, ineligible installs.
+if [ "${VERCEL_CLI_STORE:-0}" != "1" ]; then
+  run_self "$@"
+fi
+if [ "${VERCEL_CLI_STORE_REDIRECTED:-}" = "1" ]; then
+  debug "loop guard hit; running self"
+  run_self "$@"
+fi
+if [ "$is_global" = "0" ]; then
+  debug "not a known-global install; running self"
+  run_self "$@"
+fi
+
+# Fire-and-forget background work (stand-in for the store seeder).
+if [ "${VERCEL_CLI_STORE_DEBUG:-}" = "1" ]; then
+  (
+    echo "seed-check: invoked v$VERSION at $(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)" \
+      >>"$store/seed-debug.log"
+  ) >/dev/null 2>&1 &
+  debug "background seed-check spawned (pid $!)"
+fi
+
+# Pointer read (shell builtins only — no subprocesses on the hot path).
+# Any problem -> run self.
+target_version=''
+target=''
+if [ -r "$store/current.path" ]; then
+  {
+    IFS= read -r target_version || true
+    IFS= read -r target || true
+  } <"$store/current.path" 2>/dev/null
+fi
+if [ -z "$target" ] || [ -z "$target_version" ]; then
+  debug "no usable pointer; running self"
+  run_self "$@"
+fi
+if [ "$target_version" = "$VERSION" ]; then
+  debug "pointer is own version ($VERSION); running self"
+  run_self "$@"
+fi
+if [ ! -e "$target" ]; then
+  debug "pointer payload missing ($target); running self"
+  run_self "$@"
+fi
+
+export VERCEL_CLI_STORE_REDIRECTED=1
+case "$target" in
+  *.js | *.mjs)
+    debug "exec node payload v$target_version: $target"
+    exec node "$target" "$@"
+    ;;
+  *)
+    debug "exec native payload v$target_version: $target"
+    exec "$target" "$@"
+    ;;
+esac
+
+run_self "$@"

--- a/packages/cli/src/vc.sh
+++ b/packages/cli/src/vc.sh
@@ -93,7 +93,23 @@ if [ "$verbose_diag" = "1" ]; then
   {
     echo "dispatcher: $self"
     echo "version:    $VERSION"
+    # OS/arch in npm platform-package convention (what a native payload
+    # selection would use), with raw uname alongside.
+    case $(uname -s 2>/dev/null) in
+      Darwin) np_os=darwin ;;
+      Linux) np_os=linux ;;
+      *) np_os=unknown ;;
+    esac
+    case $(uname -m 2>/dev/null) in
+      arm64 | aarch64) np_arch=arm64 ;;
+      x86_64 | amd64) np_arch=x64 ;;
+      *) np_arch=unknown ;;
+    esac
+    echo "platform:   $np_os-$np_arch ($(uname -sm 2>/dev/null))"
     echo "global:     $is_global"
+    if [ -n "${npm_config_user_agent:-}" ]; then
+      echo "invoked by: $npm_config_user_agent"
+    fi
     echo "store dir:  $store"
     if [ -r "$store/current.path" ]; then
       {
@@ -126,7 +142,7 @@ fi
 # Fire-and-forget background work (stand-in for the store seeder).
 if [ "${VERCEL_CLI_STORE_DEBUG:-}" = "1" ]; then
   (
-    echo "seed-check: invoked v$VERSION at $(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)" \
+    echo "seed-check: invoked v$VERSION ($(uname -sm 2>/dev/null)) at $(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)" \
       >>"$store/seed-debug.log"
   ) >/dev/null 2>&1 &
   debug "background seed-check spawned (pid $!)"

--- a/packages/cli/test/unit/esm/sh-dispatcher.test.ts
+++ b/packages/cli/test/unit/esm/sh-dispatcher.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  mkdtempSync,
+  removeSync,
+  mkdirpSync,
+  writeFileSync,
+  readFileSync,
+  symlinkSync,
+  existsSync,
+} from 'fs-extra';
+
+// Drives the real src/vc.sh through sh, with a fake `node` and fake
+// payloads, to prove dispatch decisions without booting the actual CLI.
+
+const DISPATCHER_SRC = join(__dirname, '../../../src/vc.sh');
+const IS_WIN = process.platform === 'win32';
+
+let root: string; // sandbox: fake global install, fake store, fake PATH
+
+function setup(opts: { version?: string } = {}) {
+  const version = opts.version ?? '54.0.0';
+
+  // Fake "global install": <root>/pnpm-home/global/bin/vc -> pkg/vc.sh
+  const pnpmHome = join(root, 'pnpm-home');
+  const pkgDir = join(pnpmHome, 'global', 'node_modules', 'vercel', 'dist');
+  mkdirpSync(pkgDir);
+
+  const dispatcher = readFileSync(DISPATCHER_SRC, 'utf8').replace(
+    'VERSION="0.0.0-dev"',
+    `VERSION="${version}"`
+  );
+  writeFileSync(join(pkgDir, 'vc.sh'), dispatcher, { mode: 0o755 });
+  // The invoked install's own payload: proves fall-through cases.
+  writeFileSync(join(pkgDir, 'vc.js'), '// own payload\n');
+
+  const binDir = join(pnpmHome, 'bin');
+  mkdirpSync(binDir);
+  symlinkSync(join(pkgDir, 'vc.sh'), join(binDir, 'vc'));
+
+  // Fake node on PATH: records what it was asked to run.
+  const fakeBin = join(root, 'fakebin');
+  mkdirpSync(fakeBin);
+  writeFileSync(
+    join(fakeBin, 'node'),
+    `#!/bin/sh\necho "node-ran: $1" >> "${root}/exec.log"\necho "args: $2 $3" >> "${root}/exec.log"\n`,
+    { mode: 0o755 }
+  );
+
+  const store = join(root, 'store');
+  mkdirpSync(store);
+
+  return { pnpmHome, binDir, pkgDir, fakeBin, store };
+}
+
+function invoke(
+  ctx: ReturnType<typeof setup>,
+  args: string[],
+  env: Record<string, string> = {}
+): string {
+  return execFileSync('sh', [join(ctx.binDir, 'vc'), ...args], {
+    encoding: 'utf8',
+    env: {
+      PATH: `${ctx.fakeBin}:/usr/bin:/bin`,
+      HOME: root,
+      PNPM_HOME: ctx.pnpmHome,
+      VERCEL_CLI_STORE_DIR: ctx.store,
+      ...env,
+    },
+  });
+}
+
+function execLog(): string {
+  const p = join(root, 'exec.log');
+  return existsSync(p) ? readFileSync(p, 'utf8') : '';
+}
+
+function writePointer(store: string, version: string, path: string) {
+  writeFileSync(join(store, 'current.path'), `${version}\n${path}\n`);
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'vc-sh-test-'));
+});
+
+afterEach(() => {
+  removeSync(root);
+});
+
+describe.skipIf(IS_WIN)('sh dispatcher', () => {
+  it('runs its own vc.js when the store is not enabled', () => {
+    const ctx = setup();
+    writePointer(ctx.store, '55.0.0', join(ctx.store, 'nope.js'));
+    invoke(ctx, ['whoami']);
+    expect(execLog()).toContain(`node-ran: ${join(ctx.pkgDir, 'vc.js')}`);
+  });
+
+  it('runs its own vc.js when enabled but no pointer exists', () => {
+    const ctx = setup();
+    invoke(ctx, ['whoami'], { VERCEL_CLI_STORE: '1' });
+    expect(execLog()).toContain(`node-ran: ${join(ctx.pkgDir, 'vc.js')}`);
+  });
+
+  it('redirects to a newer npm payload via node', () => {
+    const ctx = setup({ version: '54.0.0' });
+    const payload = join(ctx.store, 'versions/npm/55.0.0/dist/vc.js');
+    mkdirpSync(join(payload, '..'));
+    writeFileSync(payload, '// store payload\n');
+    writePointer(ctx.store, '55.0.0', payload);
+
+    invoke(ctx, ['whoami'], { VERCEL_CLI_STORE: '1' });
+    expect(execLog()).toContain(`node-ran: ${payload}`);
+    expect(execLog()).toContain('args: whoami');
+  });
+
+  it('execs a native payload directly — no node at all', () => {
+    const ctx = setup({ version: '54.0.0' });
+    const payload = join(ctx.store, 'versions/native/55.0.0/bin/vercel');
+    mkdirpSync(join(payload, '..'));
+    writeFileSync(
+      payload,
+      `#!/bin/sh\necho "native-ran: $*"\necho "redirected=$VERCEL_CLI_STORE_REDIRECTED"\n`,
+      { mode: 0o755 }
+    );
+    writePointer(ctx.store, '55.0.0', payload);
+
+    const out = invoke(ctx, ['whoami', '--yes'], { VERCEL_CLI_STORE: '1' });
+    expect(out).toContain('native-ran: whoami --yes');
+    expect(out).toContain('redirected=1'); // loop guard exported
+    expect(execLog()).toBe(''); // node never started
+  });
+
+  it('does not self-redirect when the pointer is its own version', () => {
+    const ctx = setup({ version: '54.0.0' });
+    const payload = join(ctx.store, 'versions/npm/54.0.0/dist/vc.js');
+    mkdirpSync(join(payload, '..'));
+    writeFileSync(payload, '// same version\n');
+    writePointer(ctx.store, '54.0.0', payload);
+
+    invoke(ctx, ['whoami'], { VERCEL_CLI_STORE: '1' });
+    expect(execLog()).toContain(`node-ran: ${join(ctx.pkgDir, 'vc.js')}`);
+  });
+
+  it('falls through when the pointed payload is missing', () => {
+    const ctx = setup();
+    writePointer(ctx.store, '55.0.0', join(ctx.store, 'missing.js'));
+    invoke(ctx, ['whoami'], { VERCEL_CLI_STORE: '1' });
+    expect(execLog()).toContain(`node-ran: ${join(ctx.pkgDir, 'vc.js')}`);
+  });
+
+  it('honors the loop guard', () => {
+    const ctx = setup();
+    const payload = join(ctx.store, 'versions/npm/55.0.0/dist/vc.js');
+    mkdirpSync(join(payload, '..'));
+    writeFileSync(payload, '// store payload\n');
+    writePointer(ctx.store, '55.0.0', payload);
+
+    invoke(ctx, ['whoami'], {
+      VERCEL_CLI_STORE: '1',
+      VERCEL_CLI_STORE_REDIRECTED: '1',
+    });
+    expect(execLog()).toContain(`node-ran: ${join(ctx.pkgDir, 'vc.js')}`);
+  });
+
+  it('does not redirect a non-global (project-local) install', () => {
+    const ctx = setup();
+    // A copy of the dispatcher living OUTSIDE PNPM_HOME and any node root.
+    const localDir = join(root, 'some-project', 'node_modules', '.bin-src');
+    mkdirpSync(localDir);
+    const dispatcher = readFileSync(DISPATCHER_SRC, 'utf8').replace(
+      'VERSION="0.0.0-dev"',
+      'VERSION="54.0.0"'
+    );
+    writeFileSync(join(localDir, 'vc.sh'), dispatcher, { mode: 0o755 });
+    writeFileSync(join(localDir, 'vc.js'), '// local payload\n');
+
+    const payload = join(ctx.store, 'versions/npm/55.0.0/dist/vc.js');
+    mkdirpSync(join(payload, '..'));
+    writeFileSync(payload, '// store payload\n');
+    writePointer(ctx.store, '55.0.0', payload);
+
+    execFileSync('sh', [join(localDir, 'vc.sh'), 'whoami'], {
+      encoding: 'utf8',
+      env: {
+        PATH: `${ctx.fakeBin}:/usr/bin:/bin`,
+        HOME: root,
+        PNPM_HOME: ctx.pnpmHome,
+        VERCEL_CLI_STORE_DIR: ctx.store,
+        VERCEL_CLI_STORE: '1',
+      },
+    });
+    // Ran the local payload, not the store's newer version.
+    expect(execLog()).toContain(`node-ran: ${join(localDir, 'vc.js')}`);
+    expect(execLog()).not.toContain('55.0.0');
+  });
+
+  it('treats an npm-global install (under node prefix) as eligible', () => {
+    const ctx = setup();
+    // Fake node prefix layout: <prefix>/bin/node + <prefix>/lib/node_modules
+    const prefix = join(root, 'node-prefix');
+    const npmGlobalDir = join(prefix, 'lib/node_modules/vercel/dist');
+    mkdirpSync(join(prefix, 'bin'));
+    mkdirpSync(npmGlobalDir);
+    writeFileSync(
+      join(prefix, 'bin', 'node'),
+      `#!/bin/sh\necho "node-ran: $1" >> "${root}/exec.log"\n`,
+      { mode: 0o755 }
+    );
+    const dispatcher = readFileSync(DISPATCHER_SRC, 'utf8').replace(
+      'VERSION="0.0.0-dev"',
+      'VERSION="54.0.0"'
+    );
+    writeFileSync(join(npmGlobalDir, 'vc.sh'), dispatcher, { mode: 0o755 });
+    writeFileSync(join(npmGlobalDir, 'vc.js'), '// own\n');
+
+    const payload = join(ctx.store, 'versions/npm/55.0.0/dist/vc.js');
+    mkdirpSync(join(payload, '..'));
+    writeFileSync(payload, '// store payload\n');
+    writePointer(ctx.store, '55.0.0', payload);
+
+    execFileSync('sh', [join(npmGlobalDir, 'vc.sh'), 'whoami'], {
+      encoding: 'utf8',
+      env: {
+        // node resolves from the fake prefix — that's the eligibility fact
+        PATH: `${join(prefix, 'bin')}:/usr/bin:/bin`,
+        HOME: root,
+        VERCEL_CLI_STORE_DIR: ctx.store,
+        VERCEL_CLI_STORE: '1',
+      },
+    });
+    expect(execLog()).toContain(`node-ran: ${payload}`);
+  });
+
+  it('emits debug decisions and spawns background work with DEBUG=1', () => {
+    const ctx = setup({ version: '54.0.0' });
+    const payload = join(ctx.store, 'versions/npm/55.0.0/dist/vc.js');
+    mkdirpSync(join(payload, '..'));
+    writeFileSync(payload, '// store payload\n');
+    writePointer(ctx.store, '55.0.0', payload);
+
+    const stderr = execFileSync('sh', [join(ctx.binDir, 'vc'), 'whoami'], {
+      encoding: 'utf8',
+      env: {
+        PATH: `${ctx.fakeBin}:/usr/bin:/bin`,
+        HOME: root,
+        PNPM_HOME: ctx.pnpmHome,
+        VERCEL_CLI_STORE_DIR: ctx.store,
+        VERCEL_CLI_STORE: '1',
+        VERCEL_CLI_STORE_DEBUG: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    // stderr comes via exceptions only with pipe; use a spawn that captures.
+    void stderr;
+    const log = join(ctx.store, 'seed-debug.log');
+    expect(existsSync(log)).toBe(true);
+    expect(readFileSync(log, 'utf8')).toContain('seed-check: invoked v54.0.0');
+  });
+
+  it('vc -v --verbose reports dispatch info and runs the invoked copy', () => {
+    const ctx = setup({ version: '54.0.0' });
+    const payload = join(ctx.store, 'versions/npm/55.0.0/dist/vc.js');
+    mkdirpSync(join(payload, '..'));
+    writeFileSync(payload, '// store payload\n');
+    writePointer(ctx.store, '55.0.0', payload);
+
+    const result = execFileSync(
+      'sh',
+      ['-c', `"${join(ctx.binDir, 'vc')}" -v --verbose 2>&1`],
+      {
+        encoding: 'utf8',
+        env: {
+          PATH: `${ctx.fakeBin}:/usr/bin:/bin`,
+          HOME: root,
+          PNPM_HOME: ctx.pnpmHome,
+          VERCEL_CLI_STORE_DIR: ctx.store,
+          VERCEL_CLI_STORE: '1',
+        },
+      }
+    );
+    expect(result).toContain('version:    54.0.0');
+    expect(result).toContain('global:     1');
+    expect(result).toContain(`(v55.0.0)`);
+    // and it ran the invoked copy, not the store
+    expect(execLog()).toContain(`node-ran: ${join(ctx.pkgDir, 'vc.js')}`);
+  });
+});


### PR DESCRIPTION
### What

**Prototype / for discussion** — the published `vc`/`vercel` bin becomes a ~150-line `#!/bin/sh` dispatcher that decides what runs **before node starts**:

```
vc <cmd>
 ├─ store native payload → exec <binary>              0 node boots  (~6ms dispatch)
 ├─ store npm payload    → exec node <store vc.js>    node only when the payload needs it
 └─ no store / not opted in / ineligible / any error
                         → exec node dist/vc.js       byte-identical to today
```

Opt-in is `VERCEL_CLI_STORE=1` only — no commands, no enrollment machinery (that lives in #16905). Without the env var, every invocation runs `node dist/vc.js` exactly as before.

### Why

Two efforts converge on the published bin:

1. **vc-native**: zero node startup currently depends on the postinstall bin-swap, which pnpm blocks by default (silent fallback = node boot per call, forever) and any reinstall reverts. A sh dispatcher gets zero-node **without any install scripts** — resolution happens at invocation time, nothing mutates PM-owned files.
2. **Managed store (#16905)**: its node-based launcher pays ~50–80ms node boot even when dispatching to a native binary. Dispatching from sh cuts that to ~6ms.

Same script serves both: it's the front door that makes "incrementally migrate installs to the native binary via the store" possible — flip a pointer, next invocation execs the binary, zero node, no reinstall.

### What it demonstrates

- **Real PM compatibility (verified empirically)**: npm symlinks the sh bin (kernel honors shebang); pnpm generates a shim that explicitly `exec /bin/sh <target>`. Both work. macOS `/var → /private/var` symlink handled (raw + physical PNPM_HOME compare).
- **Eligibility in sh**: same two-fact global check as #16905 — under `PNPM_HOME`, or under PATH-resolved node's `<prefix>/lib/node_modules`. Project-local installs always run themselves (lockfile pins can't be violated; test proves it).
- **sh-friendly pointer**: reads a `current.path` sidecar (line 1: version, line 2: payload path) with shell builtins — no JSON parsing, no subprocesses on the hot path.
- **Background work**: `VERCEL_CLI_STORE_DEBUG=1` spawns a fire-and-forget subshell (seeder stand-in) and prints every dispatch decision.
- **Diagnostics**: `vc -v --verbose` reports dispatcher path, version, platform (`darwin-arm64`), global verdict, pointer, opt-in state, and the invoking PM when run via `pnpm vercel`/`npm run`.
- **Guards carried over from #16905**: same-version no-op, loop guard (`VERCEL_CLI_STORE_REDIRECTED`), missing-payload fall-through — every failure path ends in "run the invoked install".

### Numbers (M-series mac)

| | per-invocation overhead |
|---|---|
| sh dispatch to native payload | **~6ms** (incl. process fork) |
| bare `node -e ''` | ~25ms |
| node-based launcher dispatching native (#16905 today) | ~50–80ms |

(Pointer reads use shell builtins — an earlier `sed` version cost ~20ms/invocation.)

### Known limits (deliberate for a prototype)

- **Windows**: no sh — win32 keeps a node launcher (cmd-shim reads the shebang and needs `sh` on PATH otherwise). Zero-node Windows is a separate workstream regardless of approach.
- Nothing writes the store here — payloads/pointers are placed by hand or by #16905's engine. No integrity verification in the sh script itself; it only execs what the (verified) store placed on disk.
- The "PATH-resolved node prefix" eligibility fact is decided pre-node, so it's PATH-order-sensitive in a way `process.execPath` wasn't. Fine at prototype scale; needs a beat of thought before production.

### Test Plan

- 11 unit tests (`test/unit/esm/sh-dispatcher.test.ts`) drive the real `src/vc.sh` through `sh` with fixture stores and a fake `node` that logs what it's asked to run: all dispatch branches, both payload types, loop guard, project-local exclusion, npm-prefix eligibility, zero-node assertion (exec log empty for native), background stub, verbose output. Skipped on win32.
- Manually verified end-to-end through real `npm i -g` and `pnpm add -g` shims.

### Try it

```bash
# from a PR tarball or local build
VERCEL_CLI_STORE=1 VERCEL_CLI_STORE_DEBUG=1 vc whoami          # decisions on stderr
vc -v --verbose                                                 # dispatch diagnostics

# fake a native payload, zero node:
mkdir -p ~/.vercel/cli/versions/native/99.0.0/bin
printf '#!/bin/sh\necho "native ran: $*"\n' > ~/.vercel/cli/versions/native/99.0.0/bin/vercel
chmod +x ~/.vercel/cli/versions/native/99.0.0/bin/vercel
printf '99.0.0\n%s/.vercel/cli/versions/native/99.0.0/bin/vercel\n' "$HOME" > ~/.vercel/cli/current.path
VERCEL_CLI_STORE=1 vc anything
```

Related: #16905 (managed store — engine, enrollment, verified installs), #16903 (tactical upgrade fixes).
