### PR TITLE
[CLI] adding multi-phase plan to remove builders

### DIFF
--- a/.changeset/builder-install-reasons.md
+++ b/.changeset/builder-install-reasons.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add per-Builder install reasons to the `vc.installBuilders` trace span, distinguishing Builders that are not installed from ones whose entrypoint fails to load and from explicit version or range mismatches

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -36,7 +36,7 @@ export interface BuilderWithPkg {
 }
 
 type ResolveBuildersResult =
-  | { buildersToAdd: Set<string> }
+  | { buildersToAdd: Set<string>; installReasons: Map<string, string> }
   | { builders: Map<string, BuilderWithPkg> };
 
 // Get a real `require()` reference that esbuild won't mutate
@@ -56,11 +56,12 @@ export async function importBuilders(
   let importResult = await resolveBuilders(buildersDir, builderSpecs);
 
   if ('buildersToAdd' in importResult) {
-    const { buildersToAdd } = importResult;
+    const { buildersToAdd, installReasons } = importResult;
     const installResult = await installBuilders(
       buildersDir,
       buildersToAdd,
-      span
+      span,
+      installReasons
     );
 
     importResult = await resolveBuilders(
@@ -84,6 +85,22 @@ export async function importBuilders(
   return importResult.builders;
 }
 
+/**
+ * Extracts the module ID from a `MODULE_NOT_FOUND` error message when it is
+ * a package-style ID (not a filesystem path), for use in trace attributes.
+ */
+function missingModuleId(err: Error): string | undefined {
+  const match = /Cannot find module '([^']+)'/.exec(err.message);
+  const id = match?.[1];
+  if (!id) {
+    return undefined;
+  }
+  if (id.startsWith('/') || id.startsWith('.') || /^[A-Za-z]:[\\/]/.test(id)) {
+    return undefined;
+  }
+  return id.replace(/[,=]/g, '_').slice(0, 100);
+}
+
 async function resolveBuilders(
   buildersDir: string,
   builderSpecs: Set<string>,
@@ -91,6 +108,7 @@ async function resolveBuilders(
 ): Promise<ResolveBuildersResult> {
   const builders = new Map<string, BuilderWithPkg>();
   const buildersToAdd = new Set<string>();
+  const installReasons = new Map<string, string>();
 
   for (const spec of builderSpecs) {
     const resolvedSpec = resolvedSpecs?.get(spec) || spec;
@@ -101,6 +119,7 @@ async function resolveBuilders(
       // A URL was specified - will need to install it and resolve the
       // proper package name from the written `package.json` file
       buildersToAdd.add(spec);
+      installReasons.set(spec, 'url-spec');
       continue;
     }
 
@@ -116,6 +135,7 @@ async function resolveBuilders(
       continue;
     }
 
+    let entrypointLoadFailed = false;
     try {
       let pkgPath: string | undefined;
       let builderPkg: PackageJson | undefined;
@@ -159,6 +179,7 @@ async function resolveBuilders(
           `Installed version "${name}@${builderPkg.version}" does not match "${parsed.rawSpec}"`
         );
         buildersToAdd.add(spec);
+        installReasons.set(spec, 'version-mismatch');
         continue;
       }
 
@@ -172,13 +193,23 @@ async function resolveBuilders(
           `Installed version "${name}@${builderPkg.version}" is not compatible with "${parsed.rawSpec}"`
         );
         buildersToAdd.add(spec);
+        installReasons.set(spec, 'range-mismatch');
         continue;
       }
 
       // TODO: handle `parsed.type === 'tag'` ("latest" vs. anything else?)
       const path = join(dirname(pkgPath), builderPkg.main || 'index.js');
 
-      const builder = require_(path);
+      let builder;
+      try {
+        builder = require_(path);
+      } catch (requireErr: unknown) {
+        // The Builder's `package.json` was found but loading its entrypoint
+        // failed — track separately from "not installed" so traces can tell
+        // a broken installation apart from a missing one.
+        entrypointLoadFailed = true;
+        throw requireErr;
+      }
 
       const dynamicallyInstalled = pkgPath.startsWith(buildersDir);
 
@@ -200,6 +231,17 @@ async function resolveBuilders(
       if (err.code === 'MODULE_NOT_FOUND' && !resolvedSpecs) {
         output.debug(`Failed to import "${name}": ${err}`);
         buildersToAdd.add(spec);
+        if (entrypointLoadFailed) {
+          const missing = missingModuleId(err);
+          installReasons.set(
+            spec,
+            missing
+              ? `entrypoint-load-failed:${missing}`
+              : 'entrypoint-load-failed'
+          );
+        } else {
+          installReasons.set(spec, 'not-installed');
+        }
       } else {
         err.message = `Importing "${name}": ${err.message}`;
         throw err;
@@ -209,7 +251,7 @@ async function resolveBuilders(
 
   // Add any Builders that are not yet present into `.vercel/builders`
   if (buildersToAdd.size > 0) {
-    return { buildersToAdd };
+    return { buildersToAdd, installReasons };
   }
 
   return { builders };

--- a/packages/cli/src/util/build/install-builders.ts
+++ b/packages/cli/src/util/build/install-builders.ts
@@ -128,14 +128,21 @@ async function untracedInstallBuilders(
 export async function installBuilders(
   buildersDir: string,
   buildersToAdd: Set<string>,
-  span?: Span
+  span?: Span,
+  installReasons?: Map<string, string>
 ): Promise<Map<string, string>> {
   if (!span) {
     return untracedInstallBuilders(buildersDir, buildersToAdd);
   }
-  const installSpan = span.child('vc.installBuilders', {
+  const attributes: Record<string, string> = {
     packages: Array.from(buildersToAdd).join(','),
-  });
+  };
+  if (installReasons && installReasons.size > 0) {
+    attributes.reasons = Array.from(installReasons)
+      .map(([spec, reason]) => `${spec}=${reason}`)
+      .join(',');
+  }
+  const installSpan = span.child('vc.installBuilders', attributes);
   return installSpan.trace(async s => {
     try {
       return await untracedInstallBuilders(buildersDir, buildersToAdd);

--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -225,7 +225,8 @@ describe('importBuilders()', () => {
     expect(installBuildersModule.installBuilders).toHaveBeenCalledWith(
       buildersDir,
       new Set([spec]),
-      undefined
+      undefined,
+      new Map([[spec, 'not-installed']])
     );
     if (!err) {
       throw new Error('Expected `err` to be defined');
@@ -233,6 +234,53 @@ describe('importBuilders()', () => {
     expect(
       err.message.startsWith('Importing "@vercel/does-not-exist": Cannot')
     ).toBe(true);
+  });
+
+  it('should report `entrypoint-load-failed` when a Builder is present but fails to load', async () => {
+    const pkgName = 'broken-builder';
+    const spec = pkgName;
+    const cwd = await getWriteableDirectory();
+    const buildersDir = join(cwd, '.vercel', 'builders');
+    const builderModuleDir = join(buildersDir, 'node_modules', pkgName);
+
+    // A Builder whose `package.json` resolves but whose entrypoint
+    // requires a package that is not installed
+    await outputJSON(join(builderModuleDir, 'package.json'), {
+      name: pkgName,
+      version: '1.0.0',
+      main: 'index.js',
+    });
+    await writeFile(
+      join(builderModuleDir, 'index.js'),
+      `require('some-package-that-does-not-exist');`
+    );
+
+    vi.mocked(installBuildersModule.installBuilders).mockImplementationOnce(
+      async () => {
+        // Reinstalling repairs the broken entrypoint
+        await writeFile(
+          join(builderModuleDir, 'index.js'),
+          `exports.version = 3; exports.build = async function() { return { output: {} }; };`
+        );
+        return new Map();
+      }
+    );
+
+    try {
+      const builders = await importBuilders(new Set([spec]), cwd);
+      expect(installBuildersModule.installBuilders).toHaveBeenCalledWith(
+        buildersDir,
+        new Set([spec]),
+        undefined,
+        new Map([
+          [spec, 'entrypoint-load-failed:some-package-that-does-not-exist'],
+        ])
+      );
+      expect(builders.get(spec)?.pkg.version).toBe('1.0.0');
+      expect(builders.get(spec)?.dynamicallyInstalled).toBe(true);
+    } finally {
+      await remove(cwd);
+    }
   });
 
   it('should install and import builder', async () => {


### PR DESCRIPTION
This is phase 0 of how we can safely remove builders from build container
Tags each dynamic builder install with why it happened: not-installed, entrypoint-load-failed:<missing-module>, version-mismatch, range-mismatch, or url-spec.

Today ~17k builds/week dynamically install @vercel/next/@vercel/static-build even though they ship with the CLI, and we can't tell whether resolution fails or the installed builder is broken. This data gates removing builders from the CLI bundle (Phase 0 of that project, see inc-5156).

No behavior change — tracing only, on a path that already takes seconds.