### PR TITLE
Add role selection to teams invite

### DIFF
--- a/.changeset/tidy-teams-invite.md
+++ b/.changeset/tidy-teams-invite.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a `--role` option to `vercel teams invite`.

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -1,5 +1,6 @@
 import { packageName } from '../../util/pkg-name';
 import { formatOption, limitOption, nextOption } from '../../util/arg-common';
+import { TEAM_ROLES } from '../../util/teams/invite-user-to-team';
 
 export const requestSubcommand = {
   name: 'request',
@@ -112,7 +113,16 @@ export const inviteSubcommand = {
       multiple: true,
     },
   ],
-  options: [],
+  options: [
+    {
+      name: 'role',
+      shorthand: null,
+      type: String,
+      argument: 'ROLE',
+      deprecated: false,
+      description: `Assign a role (${TEAM_ROLES.join(', ')})`,
+    },
+  ],
   examples: [
     {
       name: 'Invite new members (interactively)',
@@ -121,6 +131,10 @@ export const inviteSubcommand = {
     {
       name: 'Invite multiple members (required in non-interactive mode)',
       value: `${packageName} teams invite abc@vercel.com xyz@vercel.com`,
+    },
+    {
+      name: 'Invite a member with a specific role',
+      value: `${packageName} teams invite abc@vercel.com --role DEVELOPER`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/teams/invite.ts
+++ b/packages/cli/src/commands/teams/invite.ts
@@ -95,12 +95,22 @@ export default async function invite(
   if (role !== undefined && !isTeamRole(role)) {
     const roles = TEAM_ROLES.join(', ');
     if (client.nonInteractive) {
+      const retryCmd = withGlobalFlags(
+        client,
+        'teams invite <email> --role <ROLE>'
+      );
       outputAgentError(
         client,
         {
           status: 'error',
           reason: AGENT_REASON.INVALID_ROLE,
           message: `--role must be one of ${roles}`,
+          next: [
+            {
+              command: retryCmd,
+              when: 'to retry with a valid role',
+            },
+          ],
         },
         1
       );

--- a/packages/cli/src/commands/teams/invite.ts
+++ b/packages/cli/src/commands/teams/invite.ts
@@ -29,6 +29,7 @@ import {
   getGlobalFlagsOnlyFromArgs,
   getSameSubcommandSuggestionFlags,
 } from '../../util/arg-common';
+import { AGENT_REASON } from '../../util/agent-output-constants';
 
 /** Append global argv flags (--cwd, --non-interactive, etc.) so agents can re-run with same context. */
 function withGlobalFlags(client: Client, commandTemplate: string): string {
@@ -98,7 +99,7 @@ export default async function invite(
         client,
         {
           status: 'error',
-          reason: 'invalid_role',
+          reason: AGENT_REASON.INVALID_ROLE,
           message: `--role must be one of ${roles}`,
         },
         1

--- a/packages/cli/src/commands/teams/invite.ts
+++ b/packages/cli/src/commands/teams/invite.ts
@@ -89,9 +89,9 @@ export default async function invite(
     return 1;
   }
   const { args: emails } = parsedArgs;
-  const roleFlag = parsedArgs.flags['--role']?.trim().toUpperCase();
+  const role = parsedArgs.flags['--role']?.trim().toUpperCase();
 
-  if (roleFlag !== undefined && !isTeamRole(roleFlag)) {
+  if (role !== undefined && !isTeamRole(role)) {
     const roles = TEAM_ROLES.join(', ');
     if (client.nonInteractive) {
       outputAgentError(
@@ -107,8 +107,6 @@ export default async function invite(
     output.error(`${param('--role')} must be one of ${roles}`);
     return 1;
   }
-
-  const role = roleFlag;
 
   if (client.nonInteractive && emails.length === 0) {
     const fullArgs = client.argv.slice(2);

--- a/packages/cli/src/commands/teams/invite.ts
+++ b/packages/cli/src/commands/teams/invite.ts
@@ -9,7 +9,10 @@ import getUser from '../../util/get-user';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import { email as regexEmail } from '../../util/input/regexes';
 import getTeams from '../../util/teams/get-teams';
-import inviteUserToTeam from '../../util/teams/invite-user-to-team';
+import inviteUserToTeam, {
+  isTeamRole,
+  TEAM_ROLES,
+} from '../../util/teams/invite-user-to-team';
 import { isAPIError } from '../../util/errors-ts';
 import { errorToString, isError } from '@vercel/error-utils';
 import { TeamsInviteTelemetryClient } from '../../util/telemetry/commands/teams/invite';
@@ -86,6 +89,26 @@ export default async function invite(
     return 1;
   }
   const { args: emails } = parsedArgs;
+  const roleFlag = parsedArgs.flags['--role']?.trim().toUpperCase();
+
+  if (roleFlag !== undefined && !isTeamRole(roleFlag)) {
+    const roles = TEAM_ROLES.join(', ');
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'invalid_role',
+          message: `--role must be one of ${roles}`,
+        },
+        1
+      );
+    }
+    output.error(`${param('--role')} must be one of ${roles}`);
+    return 1;
+  }
+
+  const role = roleFlag;
 
   if (client.nonInteractive && emails.length === 0) {
     const fullArgs = client.argv.slice(2);
@@ -158,6 +181,7 @@ export default async function invite(
   );
 
   telemetry.trackCliArgumentEmail(emails);
+  telemetry.trackCliOptionRole(role);
 
   if (emails.length > 0) {
     for (const email of emails) {
@@ -167,7 +191,12 @@ export default async function invite(
         let userInfo = null;
 
         try {
-          const res = await inviteUserToTeam(client, currentTeam.id, email);
+          const res = await inviteUserToTeam(
+            client,
+            currentTeam.id,
+            email,
+            role
+          );
           userInfo = res.username;
         } catch (err: unknown) {
           if (isAPIError(err) && err.code === 'user_not_found') {
@@ -238,7 +267,8 @@ export default async function invite(
         const { username } = await inviteUserToTeam(
           client,
           currentTeam.id,
-          email
+          email,
+          role
         );
         email = `${email}${username ? ` (${username})` : ''} ${elapsed()}`;
         emails.push(email);

--- a/packages/cli/src/util/agent-output-constants.ts
+++ b/packages/cli/src/util/agent-output-constants.ts
@@ -80,6 +80,8 @@ export const AGENT_REASON = {
   // AI Gateway
   INVALID_BUDGET: 'invalid_budget',
   INVALID_REFRESH_PERIOD: 'invalid_refresh_period',
+  // Teams
+  INVALID_ROLE: 'invalid_role',
   // Redirects
   REDIRECT_NOT_FOUND: 'redirect_not_found',
   VERSION_NOT_FOUND: 'version_not_found',

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -129,6 +129,7 @@ const SUBCOMMAND_FLAG_TAKES_VALUE = new Set([
   '--project',
   '--page',
   '--per-page',
+  '--role',
 ]);
 
 function suggestionFlagTakesSeparateValue(flagName: string): boolean {

--- a/packages/cli/src/util/teams/invite-user-to-team.ts
+++ b/packages/cli/src/util/teams/invite-user-to-team.ts
@@ -1,5 +1,6 @@
 import type Client from '../client';
 
+// Keep in sync with the `role` enum for POST /v2/teams/{teamId}/members.
 export const TEAM_ROLES = [
   'OWNER',
   'MEMBER',

--- a/packages/cli/src/util/teams/invite-user-to-team.ts
+++ b/packages/cli/src/util/teams/invite-user-to-team.ts
@@ -1,5 +1,22 @@
 import type Client from '../client';
 
+export const TEAM_ROLES = [
+  'OWNER',
+  'MEMBER',
+  'DEVELOPER',
+  'SECURITY',
+  'BILLING',
+  'VIEWER',
+  'VIEWER_FOR_PLUS',
+  'CONTRIBUTOR',
+] as const;
+
+export type TeamRole = (typeof TEAM_ROLES)[number];
+
+export function isTeamRole(value: string): value is TeamRole {
+  return TEAM_ROLES.some(role => role === value);
+}
+
 interface InviteResponse {
   uid: string;
   username: string;
@@ -10,13 +27,14 @@ interface InviteResponse {
 export default async function inviteUserToTeam(
   client: Client,
   teamId: string,
-  email: string
+  email: string,
+  role?: TeamRole
 ) {
   const body = await client.fetch<InviteResponse>(
     `/teams/${encodeURIComponent(teamId)}/members`,
     {
       method: 'POST',
-      body: { email },
+      body: role ? { email, role } : { email },
     }
   );
   return body;

--- a/packages/cli/src/util/telemetry/commands/teams/invite.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/invite.ts
@@ -14,4 +14,13 @@ export class TeamsInviteTelemetryClient
       });
     }
   }
+
+  trackCliOptionRole(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'role',
+        value,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/teams/invite.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/invite.ts
@@ -1,5 +1,6 @@
 import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
+import { isTeamRole } from '../../../teams/invite-user-to-team';
 import type { inviteSubcommand } from '../../../../commands/teams/command';
 
 export class TeamsInviteTelemetryClient
@@ -19,7 +20,7 @@ export class TeamsInviteTelemetryClient
     if (value) {
       this.trackCliOption({
         option: 'role',
-        value,
+        value: isTeamRole(value) ? value : this.redactedValue,
       });
     }
   }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -7274,9 +7274,14 @@ exports[`help command > teams help output snapshots > teams help column width 12
 
 exports[`help command > teams help output snapshots > teams invite help output snapshots > teams invite help column width 120 1`] = `
 "
-  ▲ vercel teams invite email ...
+  ▲ vercel teams invite email ... [options]
 
   Invite a new member to a team                                                                                         
+
+  Options:
+
+   --role <ROLE>  Assign a role (OWNER, MEMBER, DEVELOPER, SECURITY, BILLING, VIEWER, VIEWER_FOR_PLUS, CONTRIBUTOR)      
+
 
   Global Options:
 
@@ -7301,6 +7306,10 @@ exports[`help command > teams help output snapshots > teams invite help output s
   - Invite multiple members (required in non-interactive mode)
 
     $ vercel teams invite abc@vercel.com xyz@vercel.com
+
+  - Invite a member with a specific role
+
+    $ vercel teams invite abc@vercel.com --role DEVELOPER
 
 "
 `;

--- a/packages/cli/test/unit/commands/teams/invite.test.ts
+++ b/packages/cli/test/unit/commands/teams/invite.test.ts
@@ -120,6 +120,14 @@ describe('teams invite', () => {
       expect(payload.status).toBe('error');
       expect(payload.reason).toBe('invalid_role');
       expect(payload.message).toContain('--role must be one of');
+      expect(payload.next).toEqual([
+        {
+          command: expect.stringContaining(
+            'teams invite <email> --role <ROLE>'
+          ),
+          when: 'to retry with a valid role',
+        },
+      ]);
 
       logSpy.mockRestore();
       exitSpy.mockRestore();

--- a/packages/cli/test/unit/commands/teams/invite.test.ts
+++ b/packages/cli/test/unit/commands/teams/invite.test.ts
@@ -180,7 +180,13 @@ describe('teams invite', () => {
         throw new Error('exit');
       }) as () => never);
 
-      client.setArgv('teams', 'invite', 'nobody@example.com');
+      client.setArgv(
+        'teams',
+        'invite',
+        'nobody@example.com',
+        '--role',
+        'DEVELOPER'
+      );
       await expect(teams(client)).rejects.toThrow('exit');
 
       const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
@@ -188,6 +194,7 @@ describe('teams invite', () => {
       expect(payload.reason).toBe('user_not_found');
       expect(payload.message).toContain('nobody@example.com');
       expect(payload.next[0].command).toContain('teams invite');
+      expect(payload.next[0].command).toContain('--role DEVELOPER');
 
       logSpy.mockRestore();
       exitSpy.mockRestore();

--- a/packages/cli/test/unit/commands/teams/invite.test.ts
+++ b/packages/cli/test/unit/commands/teams/invite.test.ts
@@ -59,12 +59,71 @@ describe('teams invite', () => {
     it('succeeds when emails are provided', async () => {
       client.nonInteractive = true;
       client.config = { currentTeam: currentTeamId };
-      client.scenario.post(`/teams/${currentTeamId}/members`, (_req, res) => {
+      client.scenario.post(`/teams/${currentTeamId}/members`, (req, res) => {
+        expect(req.body).toEqual({ email: 'me@example.com' });
         return res.json({ username: 'person1' });
       });
       client.setArgv('teams', 'invite', 'me@example.com');
       const exitCode = await teams(client);
       expect(exitCode).toBe(0);
+    });
+
+    it('passes a normalized role in the request and tracks it', async () => {
+      client.nonInteractive = true;
+      client.config = { currentTeam: currentTeamId };
+      client.scenario.post(`/teams/${currentTeamId}/members`, (req, res) => {
+        expect(req.body).toEqual({
+          email: 'me@example.com',
+          role: 'DEVELOPER',
+        });
+        return res.json({ username: 'person1' });
+      });
+      client.setArgv(
+        'teams',
+        'invite',
+        'me@example.com',
+        '--role',
+        'developer'
+      );
+
+      await expect(teams(client)).resolves.toBe(0);
+      await expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:invite',
+          value: 'invite',
+        },
+        {
+          key: 'argument:email',
+          value: 'ONE',
+        },
+        {
+          key: 'option:role',
+          value: 'DEVELOPER',
+        },
+      ]);
+    });
+
+    it('rejects an invalid role before inviting', async () => {
+      client.nonInteractive = true;
+      client.config = { currentTeam: currentTeamId };
+      const logSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined as unknown as void);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.setArgv('teams', 'invite', 'me@example.com', '--role', 'invalid');
+      await expect(teams(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('invalid_role');
+      expect(payload.message).toContain('--role must be one of');
+
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+      client.nonInteractive = false;
     });
 
     it('outputs team_scope_required with global flags in next when no team scope', async () => {

--- a/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
+++ b/packages/cli/test/unit/util/arg-common-suggestion-flags.test.ts
@@ -6,11 +6,21 @@ import {
 
 describe('getSameSubcommandSuggestionFlags', () => {
   it('preserves subcommand value flags and globals for same-command suggestions', () => {
-    const afterAdd = ['--slug', 'acme', '--cwd', '/tmp', '--non-interactive'];
+    const afterAdd = [
+      '--slug',
+      'acme',
+      '--role',
+      'DEVELOPER',
+      '--cwd',
+      '/tmp',
+      '--non-interactive',
+    ];
     const out = getSameSubcommandSuggestionFlags(afterAdd);
     expect(out).toEqual([
       '--slug',
       'acme',
+      '--role',
+      'DEVELOPER',
       '--cwd',
       '/tmp',
       '--non-interactive',


### PR DESCRIPTION
## Summary

- add `--role <ROLE>` to `vercel teams invite`
- normalize and validate supported team roles before the API request
- leave the request body unchanged when `--role` is omitted
- preserve the role in retry suggestions and record option telemetry

This brings the CLI in line with the team members API, which already accepts a role when inviting a user. It follows up on #15567 with the role list and validator kept in the existing invite helper.

## Testing

- `pnpm --dir packages/cli vitest-run --run test/unit/commands/teams/invite.test.ts test/unit/util/arg-common-suggestion-flags.test.ts`
- `pnpm --dir packages/cli vitest-run --run test/unit/commands/help.test.ts -t 'teams invite help column width 120'`
- `pnpm --dir packages/cli type-check`
- `pnpm biome lint` on the touched TypeScript files

No live team invites were sent. The request behavior is covered with mocked API tests.
