### PR TITLE
fix(cli): exclude vercel.ts config variants from static serving

### DIFF
--- a/.changeset/hungry-poems-refuse.md
+++ b/.changeset/hungry-poems-refuse.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Exclude `vercel.ts` config file variants from static file serving

--- a/packages/cli/src/util/build/static-builder.ts
+++ b/packages/cli/src/util/build/static-builder.ts
@@ -1,6 +1,7 @@
 import minimatch from 'minimatch';
 import { shouldServe as defaultShouldServe } from '@vercel/build-utils';
 import type { BuildV2, Files, ShouldServe } from '@vercel/build-utils';
+import { VERCEL_CONFIG_EXTENSIONS } from '../compile-vercel-config';
 
 export const version = 2;
 
@@ -8,6 +9,7 @@ const ALWAYS_EXCLUDED_PREFIXES = ['.git/', 'node_modules/'];
 const ALWAYS_EXCLUDED_FILES = [
   'vercel.json',
   'vercel.toml',
+  ...VERCEL_CONFIG_EXTENSIONS.map(ext => `vercel.${ext}`),
   '.vercelignore',
   'now.json',
   '.nowignore',

--- a/packages/cli/test/unit/util/build/static-builder.test.ts
+++ b/packages/cli/test/unit/util/build/static-builder.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import type { Files } from '@vercel/build-utils';
+import { build } from '../../../../src/util/build/static-builder';
+
+function toFiles(names: string[]): Files {
+  return Object.fromEntries(names.map(name => [name, {} as Files[string]]));
+}
+
+describe('static-builder build()', () => {
+  test('excludes platform config files from static output', async () => {
+    const files = toFiles([
+      'index.html',
+      'vercel.json',
+      'vercel.toml',
+      'vercel.ts',
+      'vercel.mts',
+      'vercel.js',
+      'vercel.mjs',
+      'vercel.cjs',
+      '.vercelignore',
+      'now.json',
+      '.nowignore',
+    ]);
+
+    const result = await build({
+      entrypoint: '',
+      files,
+      config: {},
+    } as Parameters<typeof build>[0]);
+
+    if (!('output' in result)) {
+      throw new Error('Expected a typical build result with `output`');
+    }
+    expect(Object.keys(result.output)).toEqual(['index.html']);
+  });
+});


### PR DESCRIPTION
When using `vercel.{ts,js,mts,mjs,cjs}` as a config file without a framework it will serve the contents. 
This PR excludes these the same way the json file is excluded.