### PR TITLE
[cli] Speed up vercel deploy alias assignment detection

### DIFF
--- a/.changeset/fast-alias-assignment.md
+++ b/.changeset/fast-alias-assignment.md
@@ -1,0 +1,6 @@
+---
+'@vercel/client': patch
+'vercel': patch
+---
+
+Finish CLI deployments from alias-assigned build stream events while retaining deployment polling as a fallback.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,7 +93,7 @@
     "@sindresorhus/slugify": "0.11.0",
     "@swc/core": "1.2.218",
     "@tootallnate/once": "1.1.2",
-    "@types/async-retry": "1.2.1",
+    "@types/async-retry": "1.4.5",
     "@types/bytes": "3.0.0",
     "@types/chance": "1.1.3",
     "@types/debug": "0.0.31",

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -6,6 +6,7 @@ import type {
 } from '@vercel-internals/types';
 import {
   type ArchiveFormat,
+  type DeploymentAliasAssignedEvent,
   type DeploymentOptions,
   type VercelClientOptions,
   createDeployment,
@@ -97,6 +98,11 @@ export default async function processDeployment({
     throw new Error('Missing authentication token');
   }
 
+  const aliasAssignedController = new AbortController();
+  const onAliasAssigned = (event: DeploymentAliasAssignedEvent) => {
+    aliasAssignedController.abort(event);
+  };
+
   const clientOptions: VercelClientOptions = {
     teamId: org.type === 'team' ? org.id : undefined,
     apiUrl: now._apiUrl,
@@ -115,6 +121,7 @@ export default async function processDeployment({
     projectName,
     bulkRedirectsPath,
     manual,
+    aliasAssignedSignal: aliasAssignedController.signal,
   };
 
   const deployingSpinnerVal = isSettingUpProject
@@ -236,7 +243,8 @@ export default async function processDeployment({
           ({ abortController, promise } = displayBuildLogs(
             client,
             deployment,
-            true
+            true,
+            onAliasAssigned
           ));
           promise.catch(error =>
             output.warn(`Failed to read build logs: ${error}`)
@@ -248,6 +256,7 @@ export default async function processDeployment({
             deployment.id,
             {
               mode: 'logs',
+              onAliasAssigned,
               onEvent: (event: BuildLog) => {
                 if (!event.created) return;
                 const lines = parseLogLines(event);
@@ -296,7 +305,8 @@ export default async function processDeployment({
         const v2ChecksPending =
           event.payload.checks?.['deployment-alias']?.state === 'pending';
 
-        stopSpinner();
+        // Keep the event stream open while polling waits for alias assignment.
+        output.stopSpinner();
         process.stderr.write(eraseLines(2));
         const isProdDeployment = event.payload.target === 'production';
         const previewUrl = `https://${event.payload.url}`;

--- a/packages/cli/src/util/events.ts
+++ b/packages/cli/src/util/events.ts
@@ -207,8 +207,10 @@ async function printEvents(
     },
     {
       retries: 4,
-      // Don't let stream retry timers keep the CLI alive after polling wins.
-      unref: true,
+      // Don't let deploy stream retry timers keep the CLI alive after polling
+      // wins. Standalone log consumers await these retries, so their timers
+      // must remain referenced.
+      unref: Boolean(onAliasAssigned),
       onRetry: err => {
         // if we are retrying, we clear past logs
         if (!quiet && o) {

--- a/packages/cli/src/util/events.ts
+++ b/packages/cli/src/util/events.ts
@@ -2,6 +2,7 @@
 import { URLSearchParams } from 'url';
 
 // Packages
+import type { DeploymentAliasAssignedEvent } from '@vercel/client';
 import retry from 'async-retry';
 import jsonlines from 'jsonlines';
 import { eraseLines } from 'ansi-escapes';
@@ -25,6 +26,7 @@ export interface FindOpts {
 export interface PrintEventsOptions {
   mode: 'deploy' | string;
   onEvent: (event: BuildLog) => void;
+  onAliasAssigned?: (event: DeploymentAliasAssignedEvent) => void;
   quiet?: boolean;
   findOpts: FindOpts;
 }
@@ -32,7 +34,7 @@ export interface PrintEventsOptions {
 async function printEvents(
   client: Client,
   urlOrDeploymentId: string,
-  { mode, onEvent, quiet, findOpts }: PrintEventsOptions,
+  { mode, onEvent, onAliasAssigned, quiet, findOpts }: PrintEventsOptions,
   abortController?: AbortController
 ) {
   const { log, debug } = output;
@@ -112,6 +114,13 @@ async function printEvents(
             let latestLogDate = 0;
 
             const onData = (data: any) => {
+              if (data.type === 'alias-assigned') {
+                if (data.deploymentId === urlOrDeploymentId) {
+                  onAliasAssigned?.(data);
+                }
+                return;
+              }
+
               const { event, payload, date } = data;
               if (event === 'state' && payload.value === 'READY') {
                 if (mode === 'deploy') {
@@ -149,16 +158,31 @@ async function printEvents(
                 since: latestLogDate,
               };
 
-              setTimeout(() => {
+              const retryTimeout = setTimeout(() => {
+                abortController?.signal.removeEventListener('abort', onAbort);
                 if (abortController?.signal.aborted) return;
                 // retry without maximum amount nor clear past logs etc
-                printEvents(client, urlOrDeploymentId, {
-                  mode,
-                  onEvent,
-                  quiet,
-                  findOpts: retryFindOpts,
-                }).then(resolve, reject);
+                printEvents(
+                  client,
+                  urlOrDeploymentId,
+                  {
+                    mode,
+                    onEvent,
+                    onAliasAssigned,
+                    quiet,
+                    findOpts: retryFindOpts,
+                  },
+                  abortController
+                ).then(resolve, reject);
               }, 2000);
+
+              const onAbort = () => {
+                clearTimeout(retryTimeout);
+                finish();
+              };
+              abortController?.signal.addEventListener('abort', onAbort, {
+                once: true,
+              });
             };
 
             stream.on('end', finish);
@@ -183,6 +207,8 @@ async function printEvents(
     },
     {
       retries: 4,
+      // Don't let stream retry timers keep the CLI alive after polling wins.
+      unref: true,
       onRetry: err => {
         // if we are retrying, we clear past logs
         if (!quiet && o) {

--- a/packages/cli/src/util/logs.ts
+++ b/packages/cli/src/util/logs.ts
@@ -1,4 +1,5 @@
 import type { Deployment } from '@vercel-internals/types';
+import type { DeploymentAliasAssignedEvent } from '@vercel/client';
 import chalk from 'chalk';
 import format from 'date-fns/format';
 import ms from 'ms';
@@ -17,7 +18,8 @@ type Printer = (l: string) => void;
 export function displayBuildLogs(
   client: Client,
   deployment: Deployment,
-  follow: boolean = true
+  follow: boolean = true,
+  onAliasAssigned?: (event: DeploymentAliasAssignedEvent) => void
 ): {
   promise: Promise<void>;
   abortController: AbortController;
@@ -29,6 +31,7 @@ export function displayBuildLogs(
     {
       mode: 'logs',
       onEvent: (event: BuildLog) => printBuildLog(event, output.print),
+      onAliasAssigned,
       quiet: false,
       findOpts: { direction: 'forward', follow },
     },

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -2080,6 +2080,74 @@ describe('deploy', () => {
       expect(callCount).toEqual(2);
     });
 
+    it('should finish from the streamed alias event without a final deployment fetch', async () => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      const deploymentId = 'dpl_streamed_alias';
+      const aliasAssigned = 1783370781619;
+      let statusFetchCount = 0;
+      let statusConnectionClosed = false;
+      let eventsConnectionClosed = false;
+
+      client.scenario.post(`/v13/deployments`, (_req, res) => {
+        res.json({
+          creator: { uid: user.id, username: user.username },
+          id: deploymentId,
+          url: 'streamed-alias.vercel.app',
+          readyState: 'BUILDING',
+          aliasAssigned: false,
+          target: 'production',
+          alias: ['my-streamed-app.vercel.app'],
+        });
+      });
+
+      client.scenario.get(`/v13/deployments/${deploymentId}`, req => {
+        statusFetchCount++;
+        // Leave a raced status request open so the alias signal must abort it.
+        req.on('close', () => {
+          statusConnectionClosed = true;
+        });
+      });
+
+      client.scenario.get(
+        `/v3/now/deployments/${deploymentId}/events`,
+        (req, res) => {
+          req.on('close', () => {
+            eventsConnectionClosed = true;
+          });
+          res.write(
+            `${JSON.stringify({
+              type: 'alias-assigned',
+              deploymentId,
+              date: aliasAssigned,
+            })}\n`
+          );
+        }
+      );
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--prod', '--yes');
+
+      const exitCode = await deploy(client);
+
+      expect(exitCode).toEqual(0);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Aliased         https://my-streamed-app.vercel.app'
+      );
+      expect(client.stderr.getFullOutput()).not.toContain('alias-assigned');
+      expect(statusFetchCount).toBeLessThanOrEqual(1);
+      if (statusFetchCount === 1) {
+        await vi.waitFor(() => expect(statusConnectionClosed).toBe(true));
+      }
+      await vi.waitFor(() => expect(eventsConnectionClosed).toBe(true));
+    });
+
     it('should display the ▲ gutter on Production when --no-wait skips the Aliased row', async () => {
       const user = useUser();
       useTeams('team_dummy');

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -2103,7 +2103,7 @@ describe('deploy', () => {
           readyState: 'BUILDING',
           aliasAssigned: false,
           target: 'production',
-          alias: ['my-streamed-app.vercel.app'],
+          alias: ['initial-streamed-app.vercel.app'],
         });
       });
 
@@ -2126,6 +2126,12 @@ describe('deploy', () => {
               type: 'alias-assigned',
               deploymentId,
               date: aliasAssigned,
+              alias: ['my-streamed-app.vercel.app'],
+              aliasError: null,
+              aliasWarning: {
+                code: 'alias_warning',
+                message: 'Alias warning from event',
+              },
             })}\n`
           );
         }
@@ -2139,6 +2145,9 @@ describe('deploy', () => {
       expect(exitCode).toEqual(0);
       expect(client.stderr.getFullOutput()).toContain(
         'Aliased         https://my-streamed-app.vercel.app'
+      );
+      expect(client.stderr.getFullOutput()).toContain(
+        'Alias warning from event'
       );
       expect(client.stderr.getFullOutput()).not.toContain('alias-assigned');
       expect(statusFetchCount).toBeLessThanOrEqual(1);

--- a/packages/cli/test/unit/util/events.test.ts
+++ b/packages/cli/test/unit/util/events.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReadableStream } from 'node:stream/web';
+import { Response } from '../../../src/util/fetch';
+import printEvents from '../../../src/util/events';
+
+const { mockDebug } = vi.hoisted(() => ({ mockDebug: vi.fn() }));
+
+vi.mock('../../../src/output-manager', () => ({
+  default: {
+    debug: mockDebug,
+    log: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/util/get-deployment', () => ({ default: vi.fn() }));
+vi.mock('../../../src/util/get-scope', () => ({ default: vi.fn() }));
+
+describe('printEvents()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces matching alias events without forwarding them as build logs', async () => {
+    const aliasEvent = {
+      type: 'alias-assigned' as const,
+      deploymentId: 'dpl_123',
+      date: 1783370781619,
+    };
+    const buildLog = {
+      type: 'stdout',
+      deploymentId: 'dpl_123',
+      created: 1783370781600,
+      date: 1783370781600,
+      text: 'Build complete',
+    };
+    const client = {
+      fetch: vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            `${JSON.stringify(aliasEvent)}\n${JSON.stringify(buildLog)}\n`
+          )
+        ),
+    };
+    const onAliasAssigned = vi.fn();
+    const onEvent = vi.fn();
+
+    await printEvents(
+      client as never,
+      'dpl_123',
+      {
+        mode: 'logs',
+        onAliasAssigned,
+        onEvent,
+        quiet: true,
+        findOpts: { direction: 'forward', follow: true },
+      },
+      new AbortController()
+    );
+
+    expect(onAliasAssigned).toHaveBeenCalledWith(aliasEvent);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith(buildLog);
+  });
+
+  it('ignores alias events for another deployment', async () => {
+    const aliasEvent = {
+      type: 'alias-assigned',
+      deploymentId: 'dpl_other',
+      date: 1783370781619,
+    };
+    const client = {
+      fetch: vi
+        .fn()
+        .mockResolvedValue(new Response(`${JSON.stringify(aliasEvent)}\n`)),
+    };
+    const onAliasAssigned = vi.fn();
+    const onEvent = vi.fn();
+
+    await printEvents(client as never, 'dpl_123', {
+      mode: 'logs',
+      onAliasAssigned,
+      onEvent,
+      quiet: true,
+      findOpts: { direction: 'forward', follow: true },
+    });
+
+    expect(onAliasAssigned).not.toHaveBeenCalled();
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not signal alias assignment when the stream errors', async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        queueMicrotask(() => controller.error(new Error('stream failed')));
+      },
+    });
+    const client = {
+      fetch: vi.fn().mockResolvedValue(new Response(body)),
+    };
+    const abortController = new AbortController();
+    const onAliasAssigned = vi.fn();
+
+    const promise = printEvents(
+      client as never,
+      'dpl_123',
+      {
+        mode: 'logs',
+        onAliasAssigned,
+        onEvent: vi.fn(),
+        quiet: true,
+        findOpts: { direction: 'forward', follow: true },
+      },
+      abortController
+    );
+
+    await vi.waitFor(() =>
+      expect(mockDebug).toHaveBeenCalledWith(
+        'Deployment event stream error: stream failed'
+      )
+    );
+    abortController.abort();
+    await promise;
+
+    expect(onAliasAssigned).not.toHaveBeenCalled();
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/test/unit/util/events.test.ts
+++ b/packages/cli/test/unit/util/events.test.ts
@@ -25,6 +25,12 @@ describe('printEvents()', () => {
       type: 'alias-assigned' as const,
       deploymentId: 'dpl_123',
       date: 1783370781619,
+      alias: ['final.vercel.app'],
+      aliasError: null,
+      aliasWarning: {
+        code: 'alias_warning',
+        message: 'Alias warning',
+      },
     };
     const buildLog = {
       type: 'stdout',

--- a/packages/client/src/check-deployment-status.ts
+++ b/packages/client/src/check-deployment-status.ts
@@ -11,6 +11,7 @@ import {
 import { createDebug } from './utils';
 import {
   Deployment,
+  DeploymentAliasAssignedEvent,
   VercelClientOptions,
   DeploymentBuild,
   DeploymentEventType,
@@ -31,6 +32,53 @@ const RETRY_DELAY_MIN_MS = 5_000;
 // We add between 0 and RETRY_DELAY_SKEW_MS of skew to the retry duration.
 const RETRY_DELAY_SKEW_MS = 30_000;
 const RETRY_DELAY_DEFAULT_MS = 5_000;
+
+function getAliasAssignedEvent(
+  signal: AbortSignal | undefined,
+  deploymentId: string
+): DeploymentAliasAssignedEvent | undefined {
+  if (!signal?.aborted) return;
+
+  const event = signal.reason;
+  if (
+    event?.type === 'alias-assigned' &&
+    event.deploymentId === deploymentId &&
+    typeof event.date === 'number'
+  ) {
+    return event;
+  }
+
+  return undefined;
+}
+
+async function sleepUntilAliasAssigned(
+  duration: number,
+  signal: AbortSignal | undefined,
+  deploymentId: string
+): Promise<void> {
+  if (getAliasAssignedEvent(signal, deploymentId)) return;
+
+  if (!signal || signal.aborted) {
+    await sleep(duration);
+    return;
+  }
+
+  await new Promise<void>(resolve => {
+    const timeout = setTimeout(finish, duration);
+
+    function finish() {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }
+
+    function onAbort() {
+      if (getAliasAssignedEvent(signal, deploymentId)) finish();
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
 
 export function parseRetryAfterMs(response: any): number | null {
   // HTTP 429 (Too Many Requests) or 503 (Service Unavailable)
@@ -70,6 +118,8 @@ export async function* checkDeploymentStatus(
   const debug = createDebug(clientOptions.debug);
 
   let deploymentState = deployment;
+  const deploymentId = deployment.id || deployment.deploymentId!;
+  let aliasAssignedSignal = clientOptions.aliasAssignedSignal;
 
   const apiDeployments = getApiDeploymentsUrl();
 
@@ -87,17 +137,60 @@ export async function* checkDeploymentStatus(
   const startTime = Date.now();
 
   // Deployment polling
-  while (true) {
+  polling: while (true) {
+    const aliasAssignedEvent = getAliasAssignedEvent(
+      aliasAssignedSignal,
+      deploymentId
+    );
+    if (aliasAssignedEvent) {
+      deploymentState = {
+        ...deploymentState,
+        readyState: 'READY',
+        aliasAssigned: aliasAssignedEvent.date,
+      };
+
+      if (!finishedEvents.has('ready')) {
+        debug('Deployment state changed to READY');
+        finishedEvents.add('ready');
+        yield { type: 'ready', payload: deploymentState };
+      }
+
+      debug('Deployment alias assigned from event stream');
+      return yield { type: 'alias-assigned', payload: deploymentState };
+    }
+
     let deploymentResponse: any;
     let retriesLeft = RETRY_COUNT;
     while (true) {
-      deploymentResponse = await fetchApi(
-        `${apiDeployments}/${deployment.id || deployment.deploymentId}${
-          teamId ? `?teamId=${teamId}` : ''
-        }`,
-        token,
-        { apiUrl, userAgent, agent: clientOptions.agent }
-      );
+      try {
+        deploymentResponse = await fetchApi(
+          `${apiDeployments}/${deploymentId}${
+            teamId ? `?teamId=${teamId}` : ''
+          }`,
+          token,
+          {
+            apiUrl,
+            userAgent,
+            agent: clientOptions.agent,
+            // node-fetch's bundled AbortSignal type predates the native one.
+            signal: aliasAssignedSignal as any,
+          }
+        );
+      } catch (error) {
+        if (getAliasAssignedEvent(aliasAssignedSignal, deploymentId)) {
+          continue polling;
+        }
+        // An invalid abort reason is not a deployment failure. Disable the
+        // enhancement and continue with polling alone.
+        if (aliasAssignedSignal?.aborted) {
+          aliasAssignedSignal = undefined;
+          continue polling;
+        }
+        throw error;
+      }
+      if (getAliasAssignedEvent(aliasAssignedSignal, deploymentId)) {
+        continue polling;
+      }
 
       retriesLeft--;
       if (retriesLeft == 0) {
@@ -117,18 +210,38 @@ export async function* checkDeploymentStatus(
             `status, retrying after ${retryAfterMs + randomSkewMs}ms ` +
             `(${retryAfterMs} + ${randomSkewMs}ms of random skew)`
         );
-        await sleep(retryAfterMs + randomSkewMs);
+        await sleepUntilAliasAssigned(
+          retryAfterMs + randomSkewMs,
+          aliasAssignedSignal,
+          deploymentId
+        );
+        if (getAliasAssignedEvent(aliasAssignedSignal, deploymentId)) {
+          continue polling;
+        }
         continue;
       }
 
       break;
     }
-    const deploymentUpdate = await deploymentResponse.json();
+    let deploymentUpdate: any;
+    try {
+      deploymentUpdate = await deploymentResponse.json();
+    } catch (error) {
+      if (getAliasAssignedEvent(aliasAssignedSignal, deploymentId)) continue;
+      if (aliasAssignedSignal?.aborted) {
+        aliasAssignedSignal = undefined;
+        continue;
+      }
+      throw error;
+    }
+    if (getAliasAssignedEvent(aliasAssignedSignal, deploymentId)) continue;
 
     if (deploymentUpdate.error) {
       debug('Deployment status check has errorred');
       return yield { type: 'error', payload: deploymentUpdate.error };
     }
+
+    deploymentState = deploymentUpdate;
 
     if (
       deploymentUpdate.readyState === 'BUILDING' &&
@@ -236,6 +349,6 @@ export async function* checkDeploymentStatus(
 
     const elapsed = Date.now() - startTime;
     const duration = getPollingDelay(elapsed);
-    await sleep(duration);
+    await sleepUntilAliasAssigned(duration, aliasAssignedSignal, deploymentId);
   }
 }

--- a/packages/client/src/check-deployment-status.ts
+++ b/packages/client/src/check-deployment-status.ts
@@ -43,7 +43,10 @@ function getAliasAssignedEvent(
   if (
     event?.type === 'alias-assigned' &&
     event.deploymentId === deploymentId &&
-    typeof event.date === 'number'
+    typeof event.date === 'number' &&
+    Array.isArray(event.alias) &&
+    'aliasError' in event &&
+    'aliasWarning' in event
   ) {
     return event;
   }
@@ -147,6 +150,9 @@ export async function* checkDeploymentStatus(
         ...deploymentState,
         readyState: 'READY',
         aliasAssigned: aliasAssignedEvent.date,
+        alias: aliasAssignedEvent.alias,
+        aliasError: aliasAssignedEvent.aliasError,
+        aliasWarning: aliasAssignedEvent.aliasWarning,
       };
 
       if (!finishedEvents.has('ready')) {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -21,6 +21,12 @@ export interface Dictionary<T> {
 export const VALID_ARCHIVE_FORMATS = ['tgz'] as const;
 export type ArchiveFormat = (typeof VALID_ARCHIVE_FORMATS)[number];
 
+export interface DeploymentAliasAssignedEvent {
+  type: 'alias-assigned';
+  deploymentId: string;
+  date: number;
+}
+
 export interface VercelClientOptions {
   token: string;
   path: string | string[];
@@ -49,6 +55,11 @@ export interface VercelClientOptions {
    * that the user later continues the deployment with an API call.
    */
   manual?: boolean;
+  /**
+   * Aborted with a `DeploymentAliasAssignedEvent` when an existing deployment
+   * event stream observes alias assignment.
+   */
+  aliasAssignedSignal?: AbortSignal;
 }
 
 /** @deprecated Use VercelClientOptions instead. */
@@ -106,7 +117,7 @@ export interface Deployment {
   };
   target: string;
   alias: string[];
-  aliasAssigned: boolean;
+  aliasAssigned: boolean | number | null;
   aliasError: string | null;
   checks?: Record<
     string,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -21,10 +21,23 @@ export interface Dictionary<T> {
 export const VALID_ARCHIVE_FORMATS = ['tgz'] as const;
 export type ArchiveFormat = (typeof VALID_ARCHIVE_FORMATS)[number];
 
+export interface DeploymentAliasError {
+  code: string;
+  message: string;
+}
+
+export interface DeploymentAliasWarning extends DeploymentAliasError {
+  link?: string;
+  action?: string;
+}
+
 export interface DeploymentAliasAssignedEvent {
   type: 'alias-assigned';
   deploymentId: string;
   date: number;
+  alias: string[];
+  aliasError: DeploymentAliasError | null;
+  aliasWarning: DeploymentAliasWarning | null;
 }
 
 export interface VercelClientOptions {
@@ -118,7 +131,8 @@ export interface Deployment {
   target: string;
   alias: string[];
   aliasAssigned: boolean | number | null;
-  aliasError: string | null;
+  aliasError: string | DeploymentAliasError | null;
+  aliasWarning?: DeploymentAliasWarning | null;
   checks?: Record<
     string,
     {

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -372,11 +372,13 @@ export const fetchApi = async (
 
   debug(`${opts.method || 'GET'} ${url}`);
   time = Date.now();
-  const res = await nodeFetch(url, opts);
-  debug(`DONE in ${Date.now() - time}ms: ${opts.method || 'GET'} ${url}`);
-  semaphore.release();
-
-  return res;
+  try {
+    const res = await nodeFetch(url, opts);
+    debug(`DONE in ${Date.now() - time}ms: ${opts.method || 'GET'} ${url}`);
+    return res;
+  } finally {
+    semaphore.release();
+  }
 };
 
 export interface PreparedFile {

--- a/packages/client/tests/unit.check-deployment-status.test.ts
+++ b/packages/client/tests/unit.check-deployment-status.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import sleep from 'sleep-promise';
-import type { Deployment, VercelClientOptions } from '../src/types';
+import type {
+  Deployment,
+  DeploymentAliasAssignedEvent,
+  VercelClientOptions,
+} from '../src/types';
 import { checkDeploymentStatus } from '../src/check-deployment-status';
 
 const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
@@ -27,6 +31,20 @@ function mockDeployment(): Deployment {
     aliasAssigned: false,
     target: 'production',
   } as Deployment;
+}
+
+function mockAliasAssignedEvent(
+  overrides: Partial<DeploymentAliasAssignedEvent> = {}
+): DeploymentAliasAssignedEvent {
+  return {
+    type: 'alias-assigned',
+    deploymentId: 'dpl_123',
+    date: 1783370781619,
+    alias: ['final.vercel.app'],
+    aliasError: null,
+    aliasWarning: null,
+    ...overrides,
+  };
 }
 
 function mockClientOptions(): VercelClientOptions {
@@ -114,13 +132,27 @@ describe('checkDeploymentStatus()', () => {
     it('finishes from an existing signal without fetching the deployment', async () => {
       const date = 1783370781619;
       const controller = new AbortController();
-      controller.abort({
-        type: 'alias-assigned',
-        deploymentId: 'dpl_123',
-        date,
-      });
+      controller.abort(
+        mockAliasAssignedEvent({
+          date,
+          aliasWarning: {
+            code: 'alias_warning',
+            message: 'Alias warning',
+          },
+        })
+      );
 
-      const iterator = checkDeploymentStatus(mockDeployment(), {
+      const deployment = {
+        ...mockDeployment(),
+        alias: ['initial.vercel.app'],
+        aliasError: {
+          code: 'old_alias_error',
+          message: 'Old alias error',
+        },
+        aliasWarning: null,
+      };
+
+      const iterator = checkDeploymentStatus(deployment, {
         ...mockClientOptions(),
         aliasAssignedSignal: controller.signal,
       });
@@ -132,7 +164,12 @@ describe('checkDeploymentStatus()', () => {
           payload: expect.objectContaining({
             readyState: 'READY',
             aliasAssigned: date,
-            alias: ['test.vercel.app'],
+            alias: ['final.vercel.app'],
+            aliasError: null,
+            aliasWarning: {
+              code: 'alias_warning',
+              message: 'Alias warning',
+            },
             target: 'production',
             url: 'test.vercel.app',
           }),
@@ -174,11 +211,12 @@ describe('checkDeploymentStatus()', () => {
       const nextEvent = iterator.next();
       await Promise.resolve();
       expect(vi.getTimerCount()).toBe(1);
-      controller.abort({
-        type: 'alias-assigned',
-        deploymentId: 'dpl_123',
-        date,
-      });
+      controller.abort(
+        mockAliasAssignedEvent({
+          date,
+          alias: ['final.example.com'],
+        })
+      );
 
       await expect(nextEvent).resolves.toEqual({
         done: false,
@@ -188,7 +226,7 @@ describe('checkDeploymentStatus()', () => {
             readyState: 'READY',
             aliasAssigned: date,
             url: 'latest.vercel.app',
-            alias: ['latest.example.com'],
+            alias: ['final.example.com'],
           }),
         },
       });
@@ -224,11 +262,7 @@ describe('checkDeploymentStatus()', () => {
       const nextEvent = iterator.next();
       await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
 
-      controller.abort({
-        type: 'alias-assigned',
-        deploymentId: 'dpl_123',
-        date: 1783370781619,
-      });
+      controller.abort(mockAliasAssignedEvent());
 
       await expect(nextEvent).resolves.toEqual({
         done: false,
@@ -238,6 +272,40 @@ describe('checkDeploymentStatus()', () => {
         },
       });
       expect(statusSignal?.aborted).toBe(true);
+    });
+
+    it('continues polling for an incomplete stream event', async () => {
+      const controller = new AbortController();
+      controller.abort({
+        type: 'alias-assigned',
+        deploymentId: 'dpl_123',
+        date: 1783370781619,
+      });
+      const deployment = {
+        ...mockDeployment(),
+        readyState: 'READY',
+        aliasAssigned: 1783370781619,
+      };
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+      mockFetch
+        .mockRejectedValueOnce(abortError)
+        .mockResolvedValueOnce(mockResponse(200, deployment));
+
+      const iterator = checkDeploymentStatus(mockDeployment(), {
+        ...mockClientOptions(),
+        aliasAssignedSignal: controller.signal,
+      });
+
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { type: 'ready', payload: deployment },
+      });
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { type: 'alias-assigned', payload: deployment },
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it('continues polling when no stream signal arrives', async () => {

--- a/packages/client/tests/unit.check-deployment-status.test.ts
+++ b/packages/client/tests/unit.check-deployment-status.test.ts
@@ -23,6 +23,9 @@ function mockDeployment(): Deployment {
     name: 'test-deployment',
     url: 'test.vercel.app',
     readyState: 'QUEUED',
+    alias: ['test.vercel.app'],
+    aliasAssigned: false,
+    target: 'production',
   } as Deployment;
 }
 
@@ -104,6 +107,186 @@ describe('checkDeploymentStatus()', () => {
       // 5_000 + 3_000 skew (RETRY_DELAY_SKEW_MS * 0.1)
       expect(sleep).toHaveBeenCalledWith(8_000);
       expect(mockFetch).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe('alias-assigned stream signal', () => {
+    it('finishes from an existing signal without fetching the deployment', async () => {
+      const date = 1783370781619;
+      const controller = new AbortController();
+      controller.abort({
+        type: 'alias-assigned',
+        deploymentId: 'dpl_123',
+        date,
+      });
+
+      const iterator = checkDeploymentStatus(mockDeployment(), {
+        ...mockClientOptions(),
+        aliasAssignedSignal: controller.signal,
+      });
+
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: {
+          type: 'ready',
+          payload: expect.objectContaining({
+            readyState: 'READY',
+            aliasAssigned: date,
+            alias: ['test.vercel.app'],
+            target: 'production',
+            url: 'test.vercel.app',
+          }),
+        },
+      });
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: {
+          type: 'alias-assigned',
+          payload: expect.objectContaining({
+            readyState: 'READY',
+            aliasAssigned: date,
+          }),
+        },
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('keeps the latest polling response and cancels the polling timer', async () => {
+      const date = 1783370781619;
+      const controller = new AbortController();
+      const latestDeployment = {
+        ...mockDeployment(),
+        readyState: 'BUILDING',
+        url: 'latest.vercel.app',
+        alias: ['latest.example.com'],
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse(200, latestDeployment));
+
+      const iterator = checkDeploymentStatus(mockDeployment(), {
+        ...mockClientOptions(),
+        aliasAssignedSignal: controller.signal,
+      });
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { type: 'building', payload: latestDeployment },
+      });
+
+      const nextEvent = iterator.next();
+      await Promise.resolve();
+      expect(vi.getTimerCount()).toBe(1);
+      controller.abort({
+        type: 'alias-assigned',
+        deploymentId: 'dpl_123',
+        date,
+      });
+
+      await expect(nextEvent).resolves.toEqual({
+        done: false,
+        value: {
+          type: 'ready',
+          payload: expect.objectContaining({
+            readyState: 'READY',
+            aliasAssigned: date,
+            url: 'latest.vercel.app',
+            alias: ['latest.example.com'],
+          }),
+        },
+      });
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: {
+          type: 'alias-assigned',
+          payload: expect.objectContaining({ aliasAssigned: date }),
+        },
+      });
+      expect(vi.getTimerCount()).toBe(0);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts an in-flight status request when the signal wins', async () => {
+      const controller = new AbortController();
+      let statusSignal: AbortSignal | undefined;
+      mockFetch.mockImplementation((_url, _token, options) => {
+        statusSignal = options.signal;
+        return new Promise((_resolve, reject) => {
+          statusSignal?.addEventListener('abort', () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        });
+      });
+
+      const iterator = checkDeploymentStatus(mockDeployment(), {
+        ...mockClientOptions(),
+        aliasAssignedSignal: controller.signal,
+      });
+      const nextEvent = iterator.next();
+      await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+      controller.abort({
+        type: 'alias-assigned',
+        deploymentId: 'dpl_123',
+        date: 1783370781619,
+      });
+
+      await expect(nextEvent).resolves.toEqual({
+        done: false,
+        value: {
+          type: 'ready',
+          payload: expect.objectContaining({ readyState: 'READY' }),
+        },
+      });
+      expect(statusSignal?.aborted).toBe(true);
+    });
+
+    it('continues polling when no stream signal arrives', async () => {
+      const controller = new AbortController();
+      const deployment = {
+        ...mockDeployment(),
+        readyState: 'READY',
+        aliasAssigned: 1783370781619,
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse(200, deployment));
+
+      const iterator = checkDeploymentStatus(mockDeployment(), {
+        ...mockClientOptions(),
+        aliasAssignedSignal: controller.signal,
+      });
+
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { type: 'ready', payload: deployment },
+      });
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { type: 'alias-assigned', payload: deployment },
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(controller.signal.aborted).toBe(false);
+    });
+
+    it('continues to return alias errors from polling', async () => {
+      const controller = new AbortController();
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(200, {
+          ...mockDeployment(),
+          aliasError: { code: 'alias_error', message: 'Alias failed' },
+        })
+      );
+
+      const iterator = checkDeploymentStatus(mockDeployment(), {
+        ...mockClientOptions(),
+        aliasAssignedSignal: controller.signal,
+      });
+
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: {
+          type: 'error',
+          payload: { code: 'alias_error', message: 'Alias failed' },
+        },
+      });
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,8 +634,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       '@types/async-retry':
-        specifier: 1.2.1
-        version: 1.2.1
+        specifier: 1.4.5
+        version: 1.4.5
       '@types/bytes':
         specifier: 3.0.0
         version: 3.0.0


### PR DESCRIPTION
Make `vercel deploy` finish faster.

We recently changed the deployment event stream so that it reports when aliases have been assigned. This PR uses this information to finish the CLI immediately using the latest deployment data (using an existing connection, and avoiding an unnecessary final deployment request).

This is a progressive enhancement. Polling continues in parallel and remains the fallback if the event never arrives, the stream closes, or the stream errors. Whichever path wins cancels the other, so pending streams, polling timers, and requests do not keep the CLI alive. Older clients and deployments where the endpoint does not emit the event continue working exactly as before.

From `lhr1` (on my laptop), 10 deployments averaged 4.83s with this change versus 6.19s with the existing CLI (a 1.36s reduction). I expect a smaller improvement for users in the US, where deployment API polling already has lower network latency.

This also bumps `@types/async-retry` to the version already used elsewhere in the monorepo. The newer types expose the underlying `unref` option, which lets us ensure stream retry timers cannot keep a completed CLI process alive without carrying a local type cast.