### PR TITLE
[cli] add native vercel sandbox lifecycle commands

### DIFF
--- a/.changeset/sandbox-native-commands.md
+++ b/.changeset/sandbox-native-commands.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Natively implement the `vercel sandbox` lifecycle commands (exec, create, connect/ssh/shell, sh, fork, run) on the `@vercel/sandbox` SDK, replacing the pass-through for those subcommands.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,6 +78,7 @@
     "sandbox": "3.4.0",
     "smol-toml": "1.5.2",
     "undici": "5.29.0",
+    "ws": "8.21.0",
     "zod": "4.1.11"
   },
   "devDependencies": {
@@ -121,6 +122,7 @@
     "@types/update-notifier": "5.1.0",
     "@types/which": "3.0.0",
     "@types/write-json-file": "2.2.1",
+    "@types/ws": "8.18.1",
     "@types/yauzl-promise": "2.1.0",
     "@vercel-internals/constants": "workspace:*",
     "@vercel-internals/get-package-json": "workspace:*",

--- a/packages/cli/src/commands/sandbox/command.ts
+++ b/packages/cli/src/commands/sandbox/command.ts
@@ -1,12 +1,13 @@
 import { packageName } from '../../util/pkg-name';
 import { execSubcommand } from './exec/command';
+import { createSubcommand } from './create/command';
 
 export const sandboxCommand = {
   name: 'sandbox',
   aliases: [],
   description: 'Interact with Vercel Sandbox',
   arguments: [],
-  subcommands: [execSubcommand],
+  subcommands: [execSubcommand, createSubcommand],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/sandbox/command.ts
+++ b/packages/cli/src/commands/sandbox/command.ts
@@ -2,13 +2,19 @@ import { packageName } from '../../util/pkg-name';
 import { execSubcommand } from './exec/command';
 import { createSubcommand } from './create/command';
 import { connectSubcommand } from './connect/command';
+import { shSubcommand } from './sh/command';
 
 export const sandboxCommand = {
   name: 'sandbox',
   aliases: [],
   description: 'Interact with Vercel Sandbox',
   arguments: [],
-  subcommands: [execSubcommand, createSubcommand, connectSubcommand],
+  subcommands: [
+    execSubcommand,
+    createSubcommand,
+    connectSubcommand,
+    shSubcommand,
+  ],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/sandbox/command.ts
+++ b/packages/cli/src/commands/sandbox/command.ts
@@ -3,6 +3,7 @@ import { execSubcommand } from './exec/command';
 import { createSubcommand } from './create/command';
 import { connectSubcommand } from './connect/command';
 import { shSubcommand } from './sh/command';
+import { forkSubcommand } from './fork/command';
 
 export const sandboxCommand = {
   name: 'sandbox',
@@ -14,6 +15,7 @@ export const sandboxCommand = {
     createSubcommand,
     connectSubcommand,
     shSubcommand,
+    forkSubcommand,
   ],
   options: [],
   examples: [

--- a/packages/cli/src/commands/sandbox/command.ts
+++ b/packages/cli/src/commands/sandbox/command.ts
@@ -1,11 +1,12 @@
 import { packageName } from '../../util/pkg-name';
+import { execSubcommand } from './exec/command';
 
 export const sandboxCommand = {
   name: 'sandbox',
   aliases: [],
   description: 'Interact with Vercel Sandbox',
   arguments: [],
-  subcommands: [],
+  subcommands: [execSubcommand],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/sandbox/command.ts
+++ b/packages/cli/src/commands/sandbox/command.ts
@@ -4,6 +4,7 @@ import { createSubcommand } from './create/command';
 import { connectSubcommand } from './connect/command';
 import { shSubcommand } from './sh/command';
 import { forkSubcommand } from './fork/command';
+import { runSubcommand } from './run/command';
 
 export const sandboxCommand = {
   name: 'sandbox',
@@ -16,6 +17,7 @@ export const sandboxCommand = {
     connectSubcommand,
     shSubcommand,
     forkSubcommand,
+    runSubcommand,
   ],
   options: [],
   examples: [

--- a/packages/cli/src/commands/sandbox/command.ts
+++ b/packages/cli/src/commands/sandbox/command.ts
@@ -1,13 +1,14 @@
 import { packageName } from '../../util/pkg-name';
 import { execSubcommand } from './exec/command';
 import { createSubcommand } from './create/command';
+import { connectSubcommand } from './connect/command';
 
 export const sandboxCommand = {
   name: 'sandbox',
   aliases: [],
   description: 'Interact with Vercel Sandbox',
   arguments: [],
-  subcommands: [execSubcommand, createSubcommand],
+  subcommands: [execSubcommand, createSubcommand, connectSubcommand],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/sandbox/connect/command.ts
+++ b/packages/cli/src/commands/sandbox/connect/command.ts
@@ -1,0 +1,67 @@
+import { projectOption } from '../../../util/arg-common';
+import { packageName } from '../../../util/pkg-name';
+
+export const connectSubcommand = {
+  name: 'connect',
+  aliases: ['ssh', 'shell'],
+  description: 'Start an interactive shell in an existing sandbox',
+  arguments: [
+    {
+      name: 'name',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'sudo',
+      shorthand: null,
+      type: Boolean,
+      description: 'Give extended privileges to the command.',
+      deprecated: false,
+    },
+    {
+      name: 'no-extend-timeout',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Do not extend the sandbox timeout while running an interactive command. Only affects interactive executions.',
+      deprecated: false,
+    },
+    {
+      name: 'workdir',
+      shorthand: 'w',
+      type: String,
+      argument: 'DIR',
+      description: 'The working directory to run the command in',
+      deprecated: false,
+    },
+    {
+      name: 'env',
+      shorthand: 'e',
+      type: [String],
+      argument: 'KEY=VALUE',
+      description: 'Environment variables to set for the command',
+      deprecated: false,
+    },
+    {
+      name: 'timeout',
+      shorthand: null,
+      type: String,
+      argument: 'DURATION',
+      description:
+        'Maximum duration to wait for the command (e.g. 30s, 5m). On expiry the process is killed with SIGKILL. Cannot be combined with --interactive.',
+      deprecated: false,
+    },
+    projectOption,
+  ],
+  examples: [
+    {
+      name: 'Start an interactive shell in a sandbox',
+      value: `${packageName} sandbox connect my-sandbox`,
+    },
+    {
+      name: 'Connect as root with a custom working directory',
+      value: `${packageName} sandbox connect my-sandbox --sudo --workdir /app`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/sandbox/connect/index.ts
+++ b/packages/cli/src/commands/sandbox/connect/index.ts
@@ -12,7 +12,11 @@ import {
 } from '../../../util/sandbox/target';
 import { sandboxClient } from '../../../util/sandbox/client';
 import { execInSandbox } from '../../../util/sandbox/exec-core';
-import { assertSandboxName, parseKeyValues } from '../../../util/sandbox/args';
+import {
+  assertSandboxName,
+  parseDuration,
+  parseKeyValues,
+} from '../../../util/sandbox/args';
 
 export default async function connect(
   client: Client,
@@ -44,6 +48,10 @@ export default async function connect(
   try {
     assertSandboxName(name);
 
+    const timeout = parsedArgs.flags['--timeout']
+      ? parseDuration(parsedArgs.flags['--timeout'])
+      : undefined;
+
     const { token, teamId, projectId } = await resolveSandboxTarget(client, {
       project: parsedArgs.flags['--project'],
     });
@@ -66,7 +74,7 @@ export default async function connect(
       skipExtendingTimeout: Boolean(parsedArgs.flags['--no-extend-timeout']),
       cwd: parsedArgs.flags['--workdir'],
       env: parseKeyValues(parsedArgs.flags['--env'] ?? []),
-      timeout: undefined,
+      timeout,
     });
 
     return 0;

--- a/packages/cli/src/commands/sandbox/connect/index.ts
+++ b/packages/cli/src/commands/sandbox/connect/index.ts
@@ -1,0 +1,77 @@
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import { help } from '../../help';
+import output from '../../../output-manager';
+import { sandboxCommand } from '../command';
+import { connectSubcommand } from './command';
+import {
+  resolveSandboxTarget,
+  SandboxTargetError,
+} from '../../../util/sandbox/target';
+import { sandboxClient } from '../../../util/sandbox/client';
+import { execInSandbox } from '../../../util/sandbox/exec-core';
+import { assertSandboxName, parseKeyValues } from '../../../util/sandbox/args';
+
+export default async function connect(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(connectSubcommand.options)
+    );
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    output.print(
+      help(connectSubcommand, {
+        parent: sandboxCommand,
+        columns: client.stderr.columns,
+      })
+    );
+    return 2;
+  }
+
+  const [name] = parsedArgs.args;
+
+  try {
+    assertSandboxName(name);
+
+    const { token, teamId, projectId } = await resolveSandboxTarget(client, {
+      project: parsedArgs.flags['--project'],
+    });
+
+    const sandbox = await sandboxClient.get({
+      name,
+      token,
+      teamId,
+      projectId,
+      resume: true,
+      __includeSystemRoutes: true,
+    });
+
+    await execInSandbox({
+      sandbox,
+      command: 'sh',
+      args: [],
+      interactive: true,
+      sudo: Boolean(parsedArgs.flags['--sudo']),
+      skipExtendingTimeout: Boolean(parsedArgs.flags['--no-extend-timeout']),
+      cwd: parsedArgs.flags['--workdir'],
+      env: parseKeyValues(parsedArgs.flags['--env'] ?? []),
+      timeout: undefined,
+    });
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return err instanceof SandboxTargetError ? err.exitCode : 1;
+  }
+}

--- a/packages/cli/src/commands/sandbox/create/command.ts
+++ b/packages/cli/src/commands/sandbox/create/command.ts
@@ -1,0 +1,199 @@
+import { projectOption } from '../../../util/arg-common';
+import { packageName } from '../../../util/pkg-name';
+
+export const createSubcommand = {
+  name: 'create',
+  aliases: [],
+  description: 'Create a sandbox in the specified account and project.',
+  arguments: [],
+  options: [
+    {
+      name: 'name',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      description:
+        'A user-chosen name for the sandbox. It must be unique per project.',
+      deprecated: false,
+    },
+    {
+      name: 'non-persistent',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Disable automatic restore of the filesystem between sessions.',
+      deprecated: false,
+    },
+    {
+      name: 'runtime',
+      shorthand: null,
+      type: String,
+      argument: 'RUNTIME',
+      description:
+        'The sandbox runtime: node22, node24, node26, or python3.13. Defaults to node24 when --image is not set.',
+      deprecated: false,
+    },
+    {
+      name: 'image',
+      shorthand: null,
+      type: String,
+      argument: 'IMAGE',
+      description:
+        'A Vercel Container Registry (VCR) image name and optional tag or sha to start the sandbox from (e.g. my-repo, my-repo:v1).',
+      deprecated: false,
+    },
+    {
+      name: 'timeout',
+      shorthand: null,
+      type: String,
+      argument: 'DURATION',
+      description:
+        'The maximum duration a sandbox can run for. Example: 5m, 30m',
+      deprecated: false,
+    },
+    {
+      name: 'vcpus',
+      shorthand: null,
+      type: Number,
+      argument: 'COUNT',
+      description:
+        'Number of vCPUs to allocate (each vCPU includes 2048 MB of memory)',
+      deprecated: false,
+    },
+    {
+      name: 'publish-port',
+      shorthand: 'p',
+      type: [Number],
+      argument: 'PORT',
+      description: 'Publish sandbox port(s) to DOMAIN.vercel.run',
+      deprecated: false,
+    },
+    {
+      name: 'silent',
+      shorthand: null,
+      type: Boolean,
+      description: "Don't write sandbox name to stdout",
+      deprecated: false,
+    },
+    {
+      name: 'snapshot',
+      shorthand: 's',
+      type: String,
+      argument: 'SNAPSHOT_ID',
+      description: 'Start the sandbox from a snapshot ID',
+      deprecated: false,
+    },
+    {
+      name: 'connect',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Start an interactive shell session after creating the sandbox',
+      deprecated: false,
+    },
+    {
+      name: 'env',
+      shorthand: 'e',
+      type: [String],
+      argument: 'KEY=VALUE',
+      description: 'Default environment variables for sandbox commands',
+      deprecated: false,
+    },
+    {
+      name: 'tag',
+      shorthand: null,
+      type: [String],
+      argument: 'KEY=VALUE',
+      description:
+        'Key-value tags to associate with the sandbox (e.g. --tag env=staging)',
+      deprecated: false,
+    },
+    {
+      name: 'snapshot-expiration',
+      shorthand: null,
+      type: String,
+      argument: 'DURATION',
+      description:
+        'Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d',
+      deprecated: false,
+    },
+    {
+      name: 'keep-last-snapshots',
+      shorthand: null,
+      type: Number,
+      argument: 'COUNT',
+      description:
+        'Keep only the N most recent snapshots of this sandbox (1-10).',
+      deprecated: false,
+    },
+    {
+      name: 'keep-last-snapshots-for',
+      shorthand: null,
+      type: String,
+      argument: 'DURATION',
+      description:
+        'Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d',
+      deprecated: false,
+    },
+    {
+      name: 'delete-evicted-snapshots',
+      shorthand: null,
+      type: String,
+      argument: 'true|false',
+      description:
+        'When "true" (the default), evicted snapshots are deleted immediately; when "false", they keep the default expiration.',
+      deprecated: false,
+    },
+    {
+      name: 'network-policy',
+      shorthand: null,
+      type: String,
+      argument: 'MODE',
+      description:
+        'Network policy mode: "allow-all" or "deny-all"\n  - allow-all: sandbox can access any website/domain\n  - deny-all: sandbox has no network access\nOmit this option and use --allowed-domain / --allowed-cidr / --denied-cidr for custom policies.',
+      deprecated: false,
+    },
+    {
+      name: 'allowed-domain',
+      shorthand: null,
+      type: [String],
+      argument: 'DOMAIN',
+      description:
+        "Domain to allow traffic to (creates a custom network policy). Supports \"*\" for wildcards for a segment (e.g. '*.vercel.com', 'www.*.com'). If used as the first segment, will match any subdomain.",
+      deprecated: false,
+    },
+    {
+      name: 'allowed-cidr',
+      shorthand: null,
+      type: [String],
+      argument: 'CIDR',
+      description:
+        "CIDR to allow traffic to (creates a custom network policy). Takes precedence over 'allowed-domain'.",
+      deprecated: false,
+    },
+    {
+      name: 'denied-cidr',
+      shorthand: null,
+      type: [String],
+      argument: 'CIDR',
+      description:
+        'CIDR to deny traffic to (creates a custom network policy). Takes precedence over allowed domains/CIDRs.',
+      deprecated: false,
+    },
+    projectOption,
+  ],
+  examples: [
+    {
+      name: 'Create a sandbox with the default runtime',
+      value: `${packageName} sandbox create`,
+    },
+    {
+      name: 'Create and connect to a sandbox with no network access',
+      value: `${packageName} sandbox create --network-policy=deny-all --connect`,
+    },
+    {
+      name: 'Create a sandbox from a custom image with a published port',
+      value: `${packageName} sandbox create --image my-repo:v1 --publish-port 3000`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/sandbox/create/index.ts
+++ b/packages/cli/src/commands/sandbox/create/index.ts
@@ -34,6 +34,13 @@ import {
   type Runtime,
 } from '../../../util/sandbox/args';
 
+type CreateFlagsSpec = ReturnType<
+  typeof getFlagsSpecification<typeof createSubcommand.options>
+>;
+export type CreateFlags = ReturnType<
+  typeof parseArguments<CreateFlagsSpec>
+>['flags'];
+
 export interface CreateSandboxOptions {
   project?: string;
   name?: string;
@@ -151,6 +158,43 @@ export async function runCreate(
   return sandbox;
 }
 
+// Maps parsed create flags to CreateSandboxOptions. Consumed by `create` and,
+// via Task 9's `sh` command, by any subcommand that reuses the create flow.
+export function buildCreateOptions(flags: CreateFlags): CreateSandboxOptions {
+  return {
+    project: flags['--project'],
+    name: flags['--name'],
+    nonPersistent: Boolean(flags['--non-persistent']),
+    runtime: flags['--runtime'] ? parseRuntime(flags['--runtime']) : undefined,
+    image: flags['--image'],
+    timeout: parseDuration(flags['--timeout'] ?? '5m'),
+    vcpus:
+      flags['--vcpus'] !== undefined ? parseVcpus(flags['--vcpus']) : undefined,
+    ports: (flags['--publish-port'] ?? []).map(parsePort),
+    silent: Boolean(flags['--silent']),
+    snapshot: flags['--snapshot']
+      ? parseSnapshotId(flags['--snapshot'])
+      : undefined,
+    connect: Boolean(flags['--connect']),
+    env: parseKeyValues(flags['--env'] ?? []),
+    tags: parseKeyValues(flags['--tag'] ?? []),
+    snapshotExpiration: flags['--snapshot-expiration']
+      ? parseSnapshotExpiration(flags['--snapshot-expiration'])
+      : undefined,
+    keepLastSnapshots: flags['--keep-last-snapshots'],
+    keepLastSnapshotsFor: flags['--keep-last-snapshots-for']
+      ? parseSnapshotExpiration(flags['--keep-last-snapshots-for'])
+      : undefined,
+    deleteEvictedSnapshots: flags['--delete-evicted-snapshots'],
+    networkPolicy: flags['--network-policy']
+      ? parseNetworkPolicyMode(flags['--network-policy'])
+      : undefined,
+    allowedDomains: flags['--allowed-domain'] ?? [],
+    allowedCIDRs: flags['--allowed-cidr'] ?? [],
+    deniedCIDRs: flags['--denied-cidr'] ?? [],
+  };
+}
+
 export default async function create(
   client: Client,
   argv: string[]
@@ -177,44 +221,7 @@ export default async function create(
   }
 
   try {
-    const { flags } = parsedArgs;
-
-    await runCreate(client, {
-      project: flags['--project'],
-      name: flags['--name'],
-      nonPersistent: Boolean(flags['--non-persistent']),
-      runtime: flags['--runtime']
-        ? parseRuntime(flags['--runtime'])
-        : undefined,
-      image: flags['--image'],
-      timeout: parseDuration(flags['--timeout'] ?? '5m'),
-      vcpus:
-        flags['--vcpus'] !== undefined
-          ? parseVcpus(flags['--vcpus'])
-          : undefined,
-      ports: (flags['--publish-port'] ?? []).map(parsePort),
-      silent: Boolean(flags['--silent']),
-      snapshot: flags['--snapshot']
-        ? parseSnapshotId(flags['--snapshot'])
-        : undefined,
-      connect: Boolean(flags['--connect']),
-      env: parseKeyValues(flags['--env'] ?? []),
-      tags: parseKeyValues(flags['--tag'] ?? []),
-      snapshotExpiration: flags['--snapshot-expiration']
-        ? parseSnapshotExpiration(flags['--snapshot-expiration'])
-        : undefined,
-      keepLastSnapshots: flags['--keep-last-snapshots'],
-      keepLastSnapshotsFor: flags['--keep-last-snapshots-for']
-        ? parseSnapshotExpiration(flags['--keep-last-snapshots-for'])
-        : undefined,
-      deleteEvictedSnapshots: flags['--delete-evicted-snapshots'],
-      networkPolicy: flags['--network-policy']
-        ? parseNetworkPolicyMode(flags['--network-policy'])
-        : undefined,
-      allowedDomains: flags['--allowed-domain'] ?? [],
-      allowedCIDRs: flags['--allowed-cidr'] ?? [],
-      deniedCIDRs: flags['--denied-cidr'] ?? [],
-    });
+    await runCreate(client, buildCreateOptions(parsedArgs.flags));
 
     return 0;
   } catch (err) {

--- a/packages/cli/src/commands/sandbox/create/index.ts
+++ b/packages/cli/src/commands/sandbox/create/index.ts
@@ -51,7 +51,7 @@ export interface CreateSandboxOptions {
   snapshotExpiration?: string;
   keepLastSnapshots?: number;
   keepLastSnapshotsFor?: string;
-  deleteEvictedSnapshots?: 'true' | 'false';
+  deleteEvictedSnapshots?: string;
   networkPolicy?: 'allow-all' | 'deny-all';
   allowedDomains: string[];
   allowedCIDRs: string[];
@@ -87,7 +87,6 @@ export async function runCreate(
   const { token, teamId, projectId } = await resolveSandboxTarget(client, {
     project: opts.project,
   });
-  const { contextName } = await getScope(client);
 
   const persistent = !opts.nonPersistent;
   const resources = opts.vcpus ? { vcpus: opts.vcpus } : undefined;
@@ -141,6 +140,7 @@ export async function runCreate(
   assertInteractivePort(sandbox, 'created');
 
   if (!opts.silent) {
+    const { contextName } = await getScope(client);
     printSandboxSummary({ sandbox, contextName, action: 'created' });
   }
 
@@ -179,17 +179,6 @@ export default async function create(
   try {
     const { flags } = parsedArgs;
 
-    const deleteEvictedSnapshots = flags['--delete-evicted-snapshots'];
-    if (
-      deleteEvictedSnapshots !== undefined &&
-      deleteEvictedSnapshots !== 'true' &&
-      deleteEvictedSnapshots !== 'false'
-    ) {
-      throw new Error(
-        `Invalid --delete-evicted-snapshots value: ${deleteEvictedSnapshots}. Must be "true" or "false".`
-      );
-    }
-
     await runCreate(client, {
       project: flags['--project'],
       name: flags['--name'],
@@ -199,7 +188,10 @@ export default async function create(
         : undefined,
       image: flags['--image'],
       timeout: parseDuration(flags['--timeout'] ?? '5m'),
-      vcpus: flags['--vcpus'] ? parseVcpus(flags['--vcpus']) : undefined,
+      vcpus:
+        flags['--vcpus'] !== undefined
+          ? parseVcpus(flags['--vcpus'])
+          : undefined,
       ports: (flags['--publish-port'] ?? []).map(parsePort),
       silent: Boolean(flags['--silent']),
       snapshot: flags['--snapshot']
@@ -215,7 +207,7 @@ export default async function create(
       keepLastSnapshotsFor: flags['--keep-last-snapshots-for']
         ? parseSnapshotExpiration(flags['--keep-last-snapshots-for'])
         : undefined,
-      deleteEvictedSnapshots,
+      deleteEvictedSnapshots: flags['--delete-evicted-snapshots'],
       networkPolicy: flags['--network-policy']
         ? parseNetworkPolicyMode(flags['--network-policy'])
         : undefined,

--- a/packages/cli/src/commands/sandbox/create/index.ts
+++ b/packages/cli/src/commands/sandbox/create/index.ts
@@ -1,0 +1,232 @@
+import ms from 'ms';
+import ora from 'ora';
+import type { NetworkPolicy, Sandbox } from '@vercel/sandbox';
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import { help } from '../../help';
+import output from '../../../output-manager';
+import getScope from '../../../util/get-scope';
+import { sandboxCommand } from '../command';
+import { createSubcommand } from './command';
+import {
+  resolveSandboxTarget,
+  SandboxTargetError,
+} from '../../../util/sandbox/target';
+import { sandboxClient } from '../../../util/sandbox/client';
+import {
+  connectToSandbox,
+  assertInteractivePort,
+} from '../../../util/sandbox/exec-core';
+import { printSandboxSummary } from '../../../util/sandbox/print-sandbox-summary';
+import {
+  buildKeepLastSnapshots,
+  buildNetworkPolicy,
+  parseDuration,
+  parseKeyValues,
+  parseNetworkPolicyMode,
+  parsePort,
+  parseRuntime,
+  parseSnapshotExpiration,
+  parseSnapshotId,
+  parseVcpus,
+  type Runtime,
+} from '../../../util/sandbox/args';
+
+export interface CreateSandboxOptions {
+  project?: string;
+  name?: string;
+  nonPersistent: boolean;
+  runtime?: Runtime;
+  image?: string;
+  timeout: string;
+  vcpus?: number;
+  ports: number[];
+  silent: boolean;
+  snapshot?: string;
+  connect: boolean;
+  env: Record<string, string>;
+  tags: Record<string, string>;
+  snapshotExpiration?: string;
+  keepLastSnapshots?: number;
+  keepLastSnapshotsFor?: string;
+  deleteEvictedSnapshots?: 'true' | 'false';
+  networkPolicy?: 'allow-all' | 'deny-all';
+  allowedDomains: string[];
+  allowedCIDRs: string[];
+  deniedCIDRs: string[];
+}
+
+// Consumed directly by `sh` (Task 9) and `run` (Task 11): both call this with
+// their own parsed opts instead of going through the CLI-arg-parsing path
+// below, so all create validation/behavior must live here rather than in the
+// default handler.
+export async function runCreate(
+  client: Client,
+  opts: CreateSandboxOptions
+): Promise<Sandbox> {
+  if (opts.image && opts.runtime) {
+    throw new Error('--image and --runtime cannot be used together.');
+  }
+
+  const networkPolicy: NetworkPolicy =
+    buildNetworkPolicy({
+      networkPolicy: opts.networkPolicy,
+      allowedDomains: opts.allowedDomains,
+      allowedCIDRs: opts.allowedCIDRs,
+      deniedCIDRs: opts.deniedCIDRs,
+    }) ?? 'allow-all';
+
+  const keepLastSnapshots = buildKeepLastSnapshots({
+    keepLastSnapshots: opts.keepLastSnapshots,
+    keepLastSnapshotsFor: opts.keepLastSnapshotsFor,
+    deleteEvictedSnapshots: opts.deleteEvictedSnapshots,
+  });
+
+  const { token, teamId, projectId } = await resolveSandboxTarget(client, {
+    project: opts.project,
+  });
+  const { contextName } = await getScope(client);
+
+  const persistent = !opts.nonPersistent;
+  const resources = opts.vcpus ? { vcpus: opts.vcpus } : undefined;
+  const tags = Object.keys(opts.tags).length > 0 ? opts.tags : undefined;
+  const spinner = opts.silent ? undefined : ora('Creating sandbox...').start();
+
+  const sandbox = opts.snapshot
+    ? await sandboxClient.create({
+        name: opts.name,
+        source: { type: 'snapshot', snapshotId: opts.snapshot },
+        teamId,
+        projectId,
+        token,
+        ports: opts.ports,
+        timeout: ms(opts.timeout),
+        resources,
+        networkPolicy,
+        env: opts.env,
+        tags,
+        persistent,
+        snapshotExpiration: opts.snapshotExpiration
+          ? ms(opts.snapshotExpiration)
+          : undefined,
+        keepLastSnapshots,
+        __interactive: true,
+      })
+    : await sandboxClient.create({
+        name: opts.name,
+        teamId,
+        projectId,
+        token,
+        ports: opts.ports,
+        ...(opts.image
+          ? { image: opts.image }
+          : { runtime: opts.runtime ?? 'node24' }),
+        timeout: ms(opts.timeout),
+        resources,
+        networkPolicy,
+        env: opts.env,
+        tags,
+        persistent,
+        snapshotExpiration: opts.snapshotExpiration
+          ? ms(opts.snapshotExpiration)
+          : undefined,
+        keepLastSnapshots,
+        __interactive: true,
+      });
+
+  spinner?.stop();
+
+  assertInteractivePort(sandbox, 'created');
+
+  if (!opts.silent) {
+    printSandboxSummary({ sandbox, contextName, action: 'created' });
+  }
+
+  if (opts.connect) {
+    await connectToSandbox(sandbox);
+  }
+
+  return sandbox;
+}
+
+export default async function create(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(createSubcommand.options)
+    );
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    output.print(
+      help(createSubcommand, {
+        parent: sandboxCommand,
+        columns: client.stderr.columns,
+      })
+    );
+    return 2;
+  }
+
+  try {
+    const { flags } = parsedArgs;
+
+    const deleteEvictedSnapshots = flags['--delete-evicted-snapshots'];
+    if (
+      deleteEvictedSnapshots !== undefined &&
+      deleteEvictedSnapshots !== 'true' &&
+      deleteEvictedSnapshots !== 'false'
+    ) {
+      throw new Error(
+        `Invalid --delete-evicted-snapshots value: ${deleteEvictedSnapshots}. Must be "true" or "false".`
+      );
+    }
+
+    await runCreate(client, {
+      project: flags['--project'],
+      name: flags['--name'],
+      nonPersistent: Boolean(flags['--non-persistent']),
+      runtime: flags['--runtime']
+        ? parseRuntime(flags['--runtime'])
+        : undefined,
+      image: flags['--image'],
+      timeout: parseDuration(flags['--timeout'] ?? '5m'),
+      vcpus: flags['--vcpus'] ? parseVcpus(flags['--vcpus']) : undefined,
+      ports: (flags['--publish-port'] ?? []).map(parsePort),
+      silent: Boolean(flags['--silent']),
+      snapshot: flags['--snapshot']
+        ? parseSnapshotId(flags['--snapshot'])
+        : undefined,
+      connect: Boolean(flags['--connect']),
+      env: parseKeyValues(flags['--env'] ?? []),
+      tags: parseKeyValues(flags['--tag'] ?? []),
+      snapshotExpiration: flags['--snapshot-expiration']
+        ? parseSnapshotExpiration(flags['--snapshot-expiration'])
+        : undefined,
+      keepLastSnapshots: flags['--keep-last-snapshots'],
+      keepLastSnapshotsFor: flags['--keep-last-snapshots-for']
+        ? parseSnapshotExpiration(flags['--keep-last-snapshots-for'])
+        : undefined,
+      deleteEvictedSnapshots,
+      networkPolicy: flags['--network-policy']
+        ? parseNetworkPolicyMode(flags['--network-policy'])
+        : undefined,
+      allowedDomains: flags['--allowed-domain'] ?? [],
+      allowedCIDRs: flags['--allowed-cidr'] ?? [],
+      deniedCIDRs: flags['--denied-cidr'] ?? [],
+    });
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return err instanceof SandboxTargetError ? err.exitCode : 1;
+  }
+}

--- a/packages/cli/src/commands/sandbox/exec/command.ts
+++ b/packages/cli/src/commands/sandbox/exec/command.ts
@@ -45,7 +45,7 @@ export const execSubcommand = {
     },
     {
       name: 'tty',
-      shorthand: 't',
+      shorthand: null,
       type: Boolean,
       description:
         'Allocate a tty for an interactive command. This is a no-op.',

--- a/packages/cli/src/commands/sandbox/exec/command.ts
+++ b/packages/cli/src/commands/sandbox/exec/command.ts
@@ -1,0 +1,95 @@
+import { projectOption } from '../../../util/arg-common';
+import { packageName } from '../../../util/pkg-name';
+
+export const execSubcommand = {
+  name: 'exec',
+  aliases: [],
+  description: 'Execute a command in an existing sandbox',
+  arguments: [
+    {
+      name: 'name',
+      required: true,
+    },
+    {
+      name: 'command',
+      required: true,
+    },
+    {
+      name: 'args',
+      required: false,
+      multiple: true,
+    },
+  ],
+  options: [
+    {
+      name: 'sudo',
+      shorthand: null,
+      type: Boolean,
+      description: 'Give extended privileges to the command.',
+      deprecated: false,
+    },
+    {
+      name: 'interactive',
+      shorthand: 'i',
+      type: Boolean,
+      description: 'Run the command in a secure interactive shell',
+      deprecated: false,
+    },
+    {
+      name: 'no-extend-timeout',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Do not extend the sandbox timeout while running an interactive command. Only affects interactive executions.',
+      deprecated: false,
+    },
+    {
+      name: 'tty',
+      shorthand: 't',
+      type: Boolean,
+      description:
+        'Allocate a tty for an interactive command. This is a no-op.',
+      deprecated: false,
+    },
+    {
+      name: 'workdir',
+      shorthand: 'w',
+      type: String,
+      argument: 'DIR',
+      description: 'The working directory to run the command in',
+      deprecated: false,
+    },
+    {
+      name: 'env',
+      shorthand: 'e',
+      type: [String],
+      argument: 'KEY=VALUE',
+      description: 'Environment variables to set for the command',
+      deprecated: false,
+    },
+    {
+      name: 'timeout',
+      shorthand: null,
+      type: String,
+      argument: 'DURATION',
+      description:
+        'Maximum duration to wait for the command (e.g. 30s, 5m). On expiry the process is killed with SIGKILL. Cannot be combined with --interactive.',
+      deprecated: false,
+    },
+    projectOption,
+  ],
+  examples: [
+    {
+      name: 'Run a command in a sandbox',
+      value: `${packageName} sandbox exec my-sandbox -- echo hello`,
+    },
+    {
+      name: 'Run a command as root with a custom working directory',
+      value: `${packageName} sandbox exec my-sandbox --sudo --workdir /app -- npm install`,
+    },
+    {
+      name: 'Start an interactive shell in a sandbox',
+      value: `${packageName} sandbox exec my-sandbox --interactive -- bash`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/sandbox/exec/index.ts
+++ b/packages/cli/src/commands/sandbox/exec/index.ts
@@ -1,0 +1,92 @@
+import chalk from 'chalk';
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import { help } from '../../help';
+import output from '../../../output-manager';
+import { sandboxCommand } from '../command';
+import { execSubcommand } from './command';
+import { resolveSandboxTarget } from '../../../util/sandbox/target';
+import { sandboxClient } from '../../../util/sandbox/client';
+import { execInSandbox } from '../../../util/sandbox/exec-core';
+import {
+  assertSandboxName,
+  parseDuration,
+  parseKeyValues,
+} from '../../../util/sandbox/args';
+
+export default async function exec(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(execSubcommand.options)
+    );
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    output.print(
+      help(execSubcommand, {
+        parent: sandboxCommand,
+        columns: client.stderr.columns,
+      })
+    );
+    return 2;
+  }
+
+  const [name, command, ...args] = parsedArgs.args;
+
+  try {
+    assertSandboxName(name);
+
+    if (!command) {
+      throw new Error(
+        [
+          'Missing required argument: command.',
+          `${chalk.bold('hint:')} Usage: vercel sandbox exec <name> <command> [...args]`,
+        ].join('\n')
+      );
+    }
+
+    const timeout = parsedArgs.flags['--timeout']
+      ? parseDuration(parsedArgs.flags['--timeout'])
+      : undefined;
+
+    const { token, teamId, projectId } = await resolveSandboxTarget(client, {
+      project: parsedArgs.flags['--project'],
+    });
+
+    const sandbox = await sandboxClient.get({
+      name,
+      token,
+      teamId,
+      projectId,
+      resume: true,
+      __includeSystemRoutes: true,
+    });
+
+    await execInSandbox({
+      sandbox,
+      command,
+      args,
+      cwd: parsedArgs.flags['--workdir'],
+      env: parseKeyValues(parsedArgs.flags['--env'] ?? []),
+      sudo: Boolean(parsedArgs.flags['--sudo']),
+      interactive: Boolean(parsedArgs.flags['--interactive']),
+      skipExtendingTimeout: Boolean(parsedArgs.flags['--no-extend-timeout']),
+      timeout,
+    });
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/sandbox/exec/index.ts
+++ b/packages/cli/src/commands/sandbox/exec/index.ts
@@ -7,7 +7,10 @@ import { help } from '../../help';
 import output from '../../../output-manager';
 import { sandboxCommand } from '../command';
 import { execSubcommand } from './command';
-import { resolveSandboxTarget } from '../../../util/sandbox/target';
+import {
+  resolveSandboxTarget,
+  SandboxTargetError,
+} from '../../../util/sandbox/target';
 import { sandboxClient } from '../../../util/sandbox/client';
 import { execInSandbox } from '../../../util/sandbox/exec-core';
 import {
@@ -87,6 +90,6 @@ export default async function exec(
     return 0;
   } catch (err) {
     printError(err);
-    return 1;
+    return err instanceof SandboxTargetError ? err.exitCode : 1;
   }
 }

--- a/packages/cli/src/commands/sandbox/fork/command.ts
+++ b/packages/cli/src/commands/sandbox/fork/command.ts
@@ -1,0 +1,176 @@
+import { projectOption } from '../../../util/arg-common';
+import { packageName } from '../../../util/pkg-name';
+
+export const forkSubcommand = {
+  name: 'fork',
+  aliases: [],
+  description:
+    'Fork an existing sandbox into a new one. Copies config (cpu, timeout, network policy, tags, etc.) from the source sandbox; env vars are NOT copied and must be re-supplied via --env.',
+  arguments: [
+    {
+      name: 'source',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'name',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      description:
+        'A user-chosen name for the forked sandbox. Must be unique per project.',
+      deprecated: false,
+    },
+    {
+      name: 'non-persistent',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Disable automatic restore of the filesystem between sessions.',
+      deprecated: false,
+    },
+    {
+      name: 'timeout',
+      shorthand: null,
+      type: String,
+      argument: 'DURATION',
+      description:
+        'Override the maximum sandbox runtime (inherited from source if omitted). Example: 5m, 30m',
+      deprecated: false,
+    },
+    {
+      name: 'vcpus',
+      shorthand: null,
+      type: Number,
+      argument: 'COUNT',
+      description:
+        'Number of vCPUs to allocate (each vCPU includes 2048 MB of memory)',
+      deprecated: false,
+    },
+    {
+      name: 'publish-port',
+      shorthand: 'p',
+      type: [Number],
+      argument: 'PORT',
+      description: 'Publish sandbox port(s) to DOMAIN.vercel.run',
+      deprecated: false,
+    },
+    {
+      name: 'silent',
+      shorthand: null,
+      type: Boolean,
+      description: "Don't write sandbox name to stdout",
+      deprecated: false,
+    },
+    {
+      name: 'connect',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Start an interactive shell session after creating the forked sandbox',
+      deprecated: false,
+    },
+    {
+      name: 'env',
+      shorthand: 'e',
+      type: [String],
+      argument: 'KEY=VALUE',
+      description:
+        'Environment variables to set on the fork. Env vars from the source sandbox are not copied (encrypted server-side).',
+      deprecated: false,
+    },
+    {
+      name: 'tag',
+      shorthand: null,
+      type: [String],
+      argument: 'KEY=VALUE',
+      description:
+        'Key-value tags to associate with the fork. When provided, fully replaces the tags copied from the source (no per-key merge).',
+      deprecated: false,
+    },
+    {
+      name: 'snapshot-expiration',
+      shorthand: null,
+      type: String,
+      argument: 'DURATION',
+      description:
+        'Default snapshot expiration. Use "none" or 0 for no expiration. Example: 7d, 30d',
+      deprecated: false,
+    },
+    {
+      name: 'keep-last-snapshots',
+      shorthand: null,
+      type: Number,
+      argument: 'COUNT',
+      description:
+        'Keep only the N most recent snapshots of this sandbox (1-10).',
+      deprecated: false,
+    },
+    {
+      name: 'keep-last-snapshots-for',
+      shorthand: null,
+      type: String,
+      argument: 'DURATION',
+      description:
+        'Expiration applied to kept snapshots. Use "none" or 0 for no expiration. Example: 7d, 30d',
+      deprecated: false,
+    },
+    {
+      name: 'delete-evicted-snapshots',
+      shorthand: null,
+      type: String,
+      argument: 'true|false',
+      description:
+        'When "true" (the default), evicted snapshots are deleted immediately; when "false", they keep the default expiration.',
+      deprecated: false,
+    },
+    {
+      name: 'network-policy',
+      shorthand: null,
+      type: String,
+      argument: 'MODE',
+      description:
+        'Network policy mode: "allow-all" or "deny-all"\n  - allow-all: sandbox can access any website/domain\n  - deny-all: sandbox has no network access\nOmit this option and use --allowed-domain / --allowed-cidr / --denied-cidr for custom policies.',
+      deprecated: false,
+    },
+    {
+      name: 'allowed-domain',
+      shorthand: null,
+      type: [String],
+      argument: 'DOMAIN',
+      description:
+        "Domain to allow traffic to (creates a custom network policy). Supports \"*\" for wildcards for a segment (e.g. '*.vercel.com', 'www.*.com'). If used as the first segment, will match any subdomain.",
+      deprecated: false,
+    },
+    {
+      name: 'allowed-cidr',
+      shorthand: null,
+      type: [String],
+      argument: 'CIDR',
+      description:
+        "CIDR to allow traffic to (creates a custom network policy). Takes precedence over 'allowed-domain'.",
+      deprecated: false,
+    },
+    {
+      name: 'denied-cidr',
+      shorthand: null,
+      type: [String],
+      argument: 'CIDR',
+      description:
+        'CIDR to deny traffic to (creates a custom network policy). Takes precedence over allowed domains/CIDRs.',
+      deprecated: false,
+    },
+    projectOption,
+  ],
+  examples: [
+    {
+      name: 'Fork a sandbox with all config copied from the source',
+      value: `${packageName} sandbox fork my-source`,
+    },
+    {
+      name: 'Fork with a specific name and overridden vcpus',
+      value: `${packageName} sandbox fork my-source --name my-forked-sandbox --vcpus 4`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/sandbox/fork/index.ts
+++ b/packages/cli/src/commands/sandbox/fork/index.ts
@@ -1,0 +1,163 @@
+import ms from 'ms';
+import ora from 'ora';
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import { help } from '../../help';
+import output from '../../../output-manager';
+import getScope from '../../../util/get-scope';
+import { sandboxCommand } from '../command';
+import { forkSubcommand } from './command';
+import {
+  resolveSandboxTarget,
+  SandboxTargetError,
+} from '../../../util/sandbox/target';
+import { sandboxClient } from '../../../util/sandbox/client';
+import {
+  connectToSandbox,
+  assertInteractivePort,
+} from '../../../util/sandbox/exec-core';
+import { printSandboxSummary } from '../../../util/sandbox/print-sandbox-summary';
+import {
+  assertSandboxName,
+  buildKeepLastSnapshots,
+  buildNetworkPolicy,
+  parseDuration,
+  parseKeyValues,
+  parseNetworkPolicyMode,
+  parsePort,
+  parseSnapshotExpiration,
+  parseVcpus,
+} from '../../../util/sandbox/args';
+
+export default async function fork(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(forkSubcommand.options)
+    );
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    output.print(
+      help(forkSubcommand, {
+        parent: sandboxCommand,
+        columns: client.stderr.columns,
+      })
+    );
+    return 2;
+  }
+
+  const [source] = parsedArgs.args;
+
+  try {
+    assertSandboxName(source);
+
+    const flags = parsedArgs.flags;
+
+    const networkPolicyMode = flags['--network-policy']
+      ? parseNetworkPolicyMode(flags['--network-policy'])
+      : undefined;
+    const allowedDomains = flags['--allowed-domain'] ?? [];
+    const allowedCIDRs = flags['--allowed-cidr'] ?? [];
+    const deniedCIDRs = flags['--denied-cidr'] ?? [];
+    const networkPolicyProvided =
+      networkPolicyMode !== undefined ||
+      allowedDomains.length > 0 ||
+      allowedCIDRs.length > 0 ||
+      deniedCIDRs.length > 0;
+    const networkPolicy = networkPolicyProvided
+      ? buildNetworkPolicy({
+          networkPolicy: networkPolicyMode,
+          allowedDomains,
+          allowedCIDRs,
+          deniedCIDRs,
+        })
+      : undefined;
+
+    const keepLastSnapshots = buildKeepLastSnapshots({
+      keepLastSnapshots: flags['--keep-last-snapshots'],
+      keepLastSnapshotsFor: flags['--keep-last-snapshots-for']
+        ? parseSnapshotExpiration(flags['--keep-last-snapshots-for'])
+        : undefined,
+      deleteEvictedSnapshots: flags['--delete-evicted-snapshots'],
+    });
+
+    const tags = parseKeyValues(flags['--tag'] ?? []);
+    const tagsObj = Object.keys(tags).length > 0 ? tags : undefined;
+    const env = parseKeyValues(flags['--env'] ?? []);
+    const envObj = Object.keys(env).length > 0 ? env : undefined;
+
+    const name = flags['--name'];
+    const ports = (flags['--publish-port'] ?? []).map(parsePort);
+    const timeout = flags['--timeout']
+      ? parseDuration(flags['--timeout'])
+      : undefined;
+    const vcpus =
+      flags['--vcpus'] !== undefined ? parseVcpus(flags['--vcpus']) : undefined;
+    const nonPersistent = Boolean(flags['--non-persistent']);
+    const snapshotExpiration = flags['--snapshot-expiration']
+      ? parseSnapshotExpiration(flags['--snapshot-expiration'])
+      : undefined;
+    const silent = Boolean(flags['--silent']);
+    const connect = Boolean(flags['--connect']);
+
+    const { token, teamId, projectId } = await resolveSandboxTarget(client, {
+      project: flags['--project'],
+    });
+
+    const spinner = silent
+      ? undefined
+      : ora(`Forking sandbox ${source}...`).start();
+
+    const sandbox = await sandboxClient.fork({
+      sourceSandbox: source,
+      teamId,
+      projectId,
+      token,
+      ...(name !== undefined && { name }),
+      ...(ports.length > 0 && { ports }),
+      ...(timeout !== undefined && { timeout: ms(timeout) }),
+      ...(vcpus !== undefined && { resources: { vcpus } }),
+      ...(networkPolicy !== undefined && { networkPolicy }),
+      ...(envObj !== undefined && { env: envObj }),
+      ...(tagsObj !== undefined && { tags: tagsObj }),
+      ...(nonPersistent && { persistent: false }),
+      ...(snapshotExpiration !== undefined && {
+        snapshotExpiration: ms(snapshotExpiration),
+      }),
+      ...(keepLastSnapshots !== undefined && { keepLastSnapshots }),
+      __interactive: true,
+    });
+
+    spinner?.stop();
+
+    assertInteractivePort(sandbox, 'forked');
+
+    if (!silent) {
+      const { contextName } = await getScope(client);
+      printSandboxSummary({
+        sandbox,
+        contextName,
+        action: `forked from ${source}`,
+      });
+    }
+
+    if (connect) {
+      await connectToSandbox(sandbox);
+    }
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return err instanceof SandboxTargetError ? err.exitCode : 1;
+  }
+}

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -9,6 +9,8 @@ import { createSubcommand } from './create/command';
 import create from './create';
 import { connectSubcommand } from './connect/command';
 import connect from './connect';
+import { shSubcommand } from './sh/command';
+import sh from './sh';
 
 type SandboxCliModule = {
   createApp(opts: { appName: string; withoutAuth: boolean }): {
@@ -24,6 +26,7 @@ const COMMAND_CONFIG: Record<string, string[]> = {
   exec: getCommandAliases(execSubcommand),
   create: getCommandAliases(createSubcommand),
   connect: getCommandAliases(connectSubcommand),
+  sh: getCommandAliases(shSubcommand),
 };
 
 export default async function sandbox(client: Client): Promise<number> {
@@ -56,6 +59,9 @@ export default async function sandbox(client: Client): Promise<number> {
     case 'connect':
       telemetry.trackCliSubcommandConnect(subcommandOriginal);
       return connect(client, args);
+    case 'sh':
+      telemetry.trackCliSubcommandSh(subcommandOriginal);
+      return sh(client, args);
     default:
       return runPassThrough(client, argv, commandIndex, sandboxArgs);
   }

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -1,7 +1,10 @@
 import type Client from '../../util/client';
 import { printError } from '../../util/error';
 import getSubcommand from '../../util/get-subcommand';
+import { getCommandAliases } from '..';
 import { SandboxTelemetryClient } from '../../util/telemetry/commands/sandbox';
+import { execSubcommand } from './exec/command';
+import exec from './exec';
 
 type SandboxCliModule = {
   createApp(opts: { appName: string; withoutAuth: boolean }): {
@@ -12,14 +15,13 @@ type SandboxCliModule = {
 // Native subcommands (name -> aliases) are registered here as they are ported
 // off the standalone `sandbox` package: PR #2 adds exec/create/connect/sh/fork/
 // run, PR #3 adds list/stop/remove/cp/snapshot/snapshots/sessions, PR #4 adds
-// config. Empty for now, so every invocation falls through to runPassThrough().
-const COMMAND_CONFIG: Record<string, string[]> = {};
+// config. Unregistered subcommands fall through to runPassThrough().
+const COMMAND_CONFIG: Record<string, string[]> = {
+  exec: getCommandAliases(execSubcommand),
+};
 
 export default async function sandbox(client: Client): Promise<number> {
-  // Instantiated here so each native `case` added in PR #2+ can call the
-  // matching telemetry.trackCliSubcommand* method. No native subcommands exist
-  // yet, so no track method is invoked.
-  new SandboxTelemetryClient({
+  const telemetry = new SandboxTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
     },
@@ -32,11 +34,16 @@ export default async function sandbox(client: Client): Promise<number> {
   // Incremental dispatcher: getSubcommand matches the first sandbox arg against
   // COMMAND_CONFIG. Each ported subcommand adds a `case` here (e.g.
   // `case 'create': return create(client, args)`); anything not yet native hits
-  // `default` and is forwarded to the existing `sandbox` package. Intentionally
-  // default-only until PR #2 adds the first native case.
-  const { subcommand } = getSubcommand(sandboxArgs, COMMAND_CONFIG);
+  // `default` and is forwarded to the existing `sandbox` package.
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    sandboxArgs,
+    COMMAND_CONFIG
+  );
 
   switch (subcommand) {
+    case 'exec':
+      telemetry.trackCliSubcommandExec(subcommandOriginal);
+      return exec(client, args);
     default:
       return runPassThrough(client, argv, commandIndex, sandboxArgs);
   }

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -5,6 +5,8 @@ import { getCommandAliases } from '..';
 import { SandboxTelemetryClient } from '../../util/telemetry/commands/sandbox';
 import { execSubcommand } from './exec/command';
 import exec from './exec';
+import { createSubcommand } from './create/command';
+import create from './create';
 
 type SandboxCliModule = {
   createApp(opts: { appName: string; withoutAuth: boolean }): {
@@ -18,6 +20,7 @@ type SandboxCliModule = {
 // config. Unregistered subcommands fall through to runPassThrough().
 const COMMAND_CONFIG: Record<string, string[]> = {
   exec: getCommandAliases(execSubcommand),
+  create: getCommandAliases(createSubcommand),
 };
 
 export default async function sandbox(client: Client): Promise<number> {
@@ -44,6 +47,9 @@ export default async function sandbox(client: Client): Promise<number> {
     case 'exec':
       telemetry.trackCliSubcommandExec(subcommandOriginal);
       return exec(client, args);
+    case 'create':
+      telemetry.trackCliSubcommandCreate(subcommandOriginal);
+      return create(client, args);
     default:
       return runPassThrough(client, argv, commandIndex, sandboxArgs);
   }

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -13,6 +13,8 @@ import { shSubcommand } from './sh/command';
 import sh from './sh';
 import { forkSubcommand } from './fork/command';
 import fork from './fork';
+import { runSubcommand } from './run/command';
+import run from './run';
 
 type SandboxCliModule = {
   createApp(opts: { appName: string; withoutAuth: boolean }): {
@@ -30,6 +32,7 @@ const COMMAND_CONFIG: Record<string, string[]> = {
   connect: getCommandAliases(connectSubcommand),
   sh: getCommandAliases(shSubcommand),
   fork: getCommandAliases(forkSubcommand),
+  run: getCommandAliases(runSubcommand),
 };
 
 export default async function sandbox(client: Client): Promise<number> {
@@ -68,6 +71,9 @@ export default async function sandbox(client: Client): Promise<number> {
     case 'fork':
       telemetry.trackCliSubcommandFork(subcommandOriginal);
       return fork(client, args);
+    case 'run':
+      telemetry.trackCliSubcommandRun(subcommandOriginal);
+      return run(client, args);
     default:
       return runPassThrough(client, argv, commandIndex, sandboxArgs);
   }

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -7,6 +7,8 @@ import { execSubcommand } from './exec/command';
 import exec from './exec';
 import { createSubcommand } from './create/command';
 import create from './create';
+import { connectSubcommand } from './connect/command';
+import connect from './connect';
 
 type SandboxCliModule = {
   createApp(opts: { appName: string; withoutAuth: boolean }): {
@@ -21,6 +23,7 @@ type SandboxCliModule = {
 const COMMAND_CONFIG: Record<string, string[]> = {
   exec: getCommandAliases(execSubcommand),
   create: getCommandAliases(createSubcommand),
+  connect: getCommandAliases(connectSubcommand),
 };
 
 export default async function sandbox(client: Client): Promise<number> {
@@ -50,6 +53,9 @@ export default async function sandbox(client: Client): Promise<number> {
     case 'create':
       telemetry.trackCliSubcommandCreate(subcommandOriginal);
       return create(client, args);
+    case 'connect':
+      telemetry.trackCliSubcommandConnect(subcommandOriginal);
+      return connect(client, args);
     default:
       return runPassThrough(client, argv, commandIndex, sandboxArgs);
   }

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -11,6 +11,8 @@ import { connectSubcommand } from './connect/command';
 import connect from './connect';
 import { shSubcommand } from './sh/command';
 import sh from './sh';
+import { forkSubcommand } from './fork/command';
+import fork from './fork';
 
 type SandboxCliModule = {
   createApp(opts: { appName: string; withoutAuth: boolean }): {
@@ -27,6 +29,7 @@ const COMMAND_CONFIG: Record<string, string[]> = {
   create: getCommandAliases(createSubcommand),
   connect: getCommandAliases(connectSubcommand),
   sh: getCommandAliases(shSubcommand),
+  fork: getCommandAliases(forkSubcommand),
 };
 
 export default async function sandbox(client: Client): Promise<number> {
@@ -62,6 +65,9 @@ export default async function sandbox(client: Client): Promise<number> {
     case 'sh':
       telemetry.trackCliSubcommandSh(subcommandOriginal);
       return sh(client, args);
+    case 'fork':
+      telemetry.trackCliSubcommandFork(subcommandOriginal);
+      return fork(client, args);
     default:
       return runPassThrough(client, argv, commandIndex, sandboxArgs);
   }

--- a/packages/cli/src/commands/sandbox/run/command.ts
+++ b/packages/cli/src/commands/sandbox/run/command.ts
@@ -1,0 +1,54 @@
+import { packageName } from '../../../util/pkg-name';
+import { createSubcommand } from '../create/command';
+import { execSubcommand } from '../exec/command';
+
+export const runSubcommand = {
+  name: 'run',
+  aliases: [],
+  description: 'Run a command in a sandbox, creating it first if necessary.',
+  arguments: [
+    {
+      name: 'command',
+      required: true,
+    },
+    {
+      name: 'args',
+      required: false,
+      multiple: true,
+    },
+  ],
+  options: [
+    ...createSubcommand.options.filter(
+      option => option.name !== 'env' && option.name !== 'project'
+    ),
+    ...execSubcommand.options.filter(option => option.name !== 'timeout'),
+    {
+      name: 'rm',
+      shorthand: null,
+      type: Boolean,
+      description: 'Remove the sandbox after the command finishes.',
+      deprecated: false,
+    },
+    {
+      name: 'stop',
+      shorthand: null,
+      type: Boolean,
+      description: 'Stop the sandbox after the command finishes.',
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Run a command in a new sandbox, removing it afterward',
+      value: `${packageName} sandbox run --rm -- npm test`,
+    },
+    {
+      name: "Run a command in an existing sandbox, creating it if it doesn't exist",
+      value: `${packageName} sandbox run --name my-sandbox -- npm run build`,
+    },
+    {
+      name: 'Create a sandbox with no network access, run a script, then stop it',
+      value: `${packageName} sandbox run --network-policy=deny-all --stop -- ./ci.sh`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/sandbox/run/index.ts
+++ b/packages/cli/src/commands/sandbox/run/index.ts
@@ -1,0 +1,132 @@
+import chalk from 'chalk';
+import { APIError, type Sandbox } from '@vercel/sandbox';
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import { help } from '../../help';
+import output from '../../../output-manager';
+import { sandboxCommand } from '../command';
+import { runSubcommand } from './command';
+import { buildCreateOptions, runCreate } from '../create';
+import {
+  resolveSandboxTarget,
+  SandboxTargetError,
+} from '../../../util/sandbox/target';
+import { sandboxClient } from '../../../util/sandbox/client';
+import { execInSandbox } from '../../../util/sandbox/exec-core';
+import { parseKeyValues } from '../../../util/sandbox/args';
+
+function isSandboxNotFound(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    err.cause instanceof APIError &&
+    err.cause.response.status === 404
+  );
+}
+
+export default async function run(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(runSubcommand.options)
+    );
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    output.print(
+      help(runSubcommand, {
+        parent: sandboxCommand,
+        columns: client.stderr.columns,
+      })
+    );
+    return 2;
+  }
+
+  const [command, ...args] = parsedArgs.args;
+  const flags = parsedArgs.flags;
+  const removeAfterUse = Boolean(flags['--rm']);
+  const stopAfterUse = Boolean(flags['--stop']);
+
+  let sandbox: Sandbox | undefined;
+
+  try {
+    if (removeAfterUse && stopAfterUse) {
+      throw new Error('--rm and --stop are mutually exclusive.');
+    }
+
+    if (!command) {
+      throw new Error(
+        [
+          'Missing required argument: command.',
+          `${chalk.bold('hint:')} Usage: vercel sandbox run <command> [...args]`,
+        ].join('\n')
+      );
+    }
+
+    const createOpts = buildCreateOptions(flags);
+
+    if (createOpts.name) {
+      const { token, teamId, projectId } = await resolveSandboxTarget(client, {
+        project: createOpts.project,
+      });
+
+      try {
+        sandbox = await sandboxClient.get({
+          name: createOpts.name,
+          token,
+          teamId,
+          projectId,
+          resume: true,
+          __includeSystemRoutes: true,
+        });
+      } catch (err) {
+        if (isSandboxNotFound(err)) {
+          sandbox = await runCreate(client, {
+            ...createOpts,
+            nonPersistent: createOpts.nonPersistent || removeAfterUse,
+          });
+        } else {
+          throw err;
+        }
+      }
+    } else {
+      sandbox = await runCreate(client, {
+        ...createOpts,
+        nonPersistent: createOpts.nonPersistent || removeAfterUse,
+      });
+    }
+
+    try {
+      await execInSandbox({
+        sandbox,
+        command,
+        args,
+        cwd: flags['--workdir'],
+        env: parseKeyValues(flags['--env'] ?? []),
+        sudo: Boolean(flags['--sudo']),
+        interactive: Boolean(flags['--interactive']),
+        skipExtendingTimeout: Boolean(flags['--no-extend-timeout']),
+        timeout: undefined,
+      });
+    } finally {
+      if (removeAfterUse) {
+        await sandbox.delete();
+      } else if (stopAfterUse) {
+        await sandbox.stop();
+      }
+    }
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return err instanceof SandboxTargetError ? err.exitCode : 1;
+  }
+}

--- a/packages/cli/src/commands/sandbox/sh/command.ts
+++ b/packages/cli/src/commands/sandbox/sh/command.ts
@@ -1,0 +1,26 @@
+import { packageName } from '../../../util/pkg-name';
+import { createSubcommand } from '../create/command';
+
+// `sh` == `create` with an interactive shell forced on, so it exposes every
+// create flag except `--connect` (which is always on here).
+const optionsWithoutConnect = createSubcommand.options.filter(
+  option => option.name !== 'connect'
+);
+
+export const shSubcommand = {
+  name: 'sh',
+  aliases: [],
+  description: 'Create a sandbox and start an interactive shell',
+  arguments: [],
+  options: optionsWithoutConnect,
+  examples: [
+    {
+      name: 'Create a sandbox and open an interactive shell',
+      value: `${packageName} sandbox sh`,
+    },
+    {
+      name: 'Open a shell in a sandbox with no network access',
+      value: `${packageName} sandbox sh --network-policy=deny-all`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/sandbox/sh/index.ts
+++ b/packages/cli/src/commands/sandbox/sh/index.ts
@@ -1,0 +1,48 @@
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import { help } from '../../help';
+import output from '../../../output-manager';
+import { sandboxCommand } from '../command';
+import { shSubcommand } from './command';
+import { buildCreateOptions, runCreate } from '../create';
+import { SandboxTargetError } from '../../../util/sandbox/target';
+
+export default async function sh(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(shSubcommand.options)
+    );
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    output.print(
+      help(shSubcommand, {
+        parent: sandboxCommand,
+        columns: client.stderr.columns,
+      })
+    );
+    return 2;
+  }
+
+  try {
+    await runCreate(client, {
+      ...buildCreateOptions(parsedArgs.flags),
+      connect: true,
+    });
+
+    return 0;
+  } catch (err) {
+    printError(err);
+    return err instanceof SandboxTargetError ? err.exitCode : 1;
+  }
+}

--- a/packages/cli/src/util/sandbox/abort-controller.ts
+++ b/packages/cli/src/util/sandbox/abort-controller.ts
@@ -1,0 +1,8 @@
+export function ignoreAbortErrors(signal: AbortSignal) {
+  return (err: unknown) => {
+    if (signal.aborted) {
+      return;
+    }
+    throw err;
+  };
+}

--- a/packages/cli/src/util/sandbox/args.ts
+++ b/packages/cli/src/util/sandbox/args.ts
@@ -1,0 +1,235 @@
+/**
+ * Shared sandbox arg parsing/validation helpers, consumed by the PR #2
+ * (create/exec/fork/run), PR #3 (snapshots), and PR #4 (config) command
+ * handlers.
+ */
+
+import chalk from 'chalk';
+import ms from 'ms';
+import type { NetworkPolicy } from '@vercel/sandbox';
+
+export function parseKeyValues(pairs: string[]): Record<string, string> {
+  const obj: Record<string, string> = Object.create(null);
+  const missingVars: string[] = [];
+
+  for (const input of pairs) {
+    let key: string;
+    let value: string | undefined;
+    if (!input.includes('=')) {
+      key = input;
+      value = process.env[input];
+    } else {
+      const [first, ...rest] = input.split('=');
+      key = first;
+      value = rest.join('=');
+    }
+
+    if (value === undefined) {
+      missingVars.push(key);
+    } else {
+      obj[key] = value;
+    }
+  }
+
+  if (missingVars.length > 0) {
+    const plural = missingVars.length > 1;
+    // biome-ignore lint/suspicious/noConsole: intentional console usage
+    console.error(
+      chalk.yellow(
+        [
+          `${chalk.bold('warn:')} env var${plural ? 's were' : ' was'} not defined and ${plural ? 'were' : 'was'} not passed: ${missingVars.join(', ')}`,
+          `╰▶ ${chalk.bold('hint:')} --env VAR is equivalent to --env VAR=$VAR`,
+        ].join('\n')
+      )
+    );
+  }
+
+  return obj;
+}
+
+const DURATION_REGEX =
+  /^(\d+) ?(ms|milliseconds?|msecs?|s(?:econds?)?|m(?:inutes?)?|h(?:ours?)?|d(?:ays?)?)?$/;
+
+export function parseDuration(value: string): string {
+  const match = value.match(DURATION_REGEX);
+  if (!match) {
+    throw new Error(
+      [
+        `Malformed duration: "${value}".`,
+        `${chalk.bold('hint:')} Use a number followed by a unit: s (seconds), m (minutes), h (hours), d (days).`,
+        '╰▶ Examples: 30s, 5m, 2h, 1d',
+      ].join('\n')
+    );
+  }
+  return match[0];
+}
+
+export function parseSnapshotExpiration(value: string): string {
+  if (value === 'none') {
+    return '0';
+  }
+  return parseDuration(value);
+}
+
+export const RUNTIMES = ['node22', 'node24', 'node26', 'python3.13'] as const;
+export type Runtime = (typeof RUNTIMES)[number];
+
+export function parseRuntime(value: string): Runtime {
+  if (!(RUNTIMES as readonly string[]).includes(value)) {
+    throw new Error(
+      `Invalid runtime: "${value}". Must be one of: ${RUNTIMES.join(', ')}.`
+    );
+  }
+  return value as Runtime;
+}
+
+export function parseVcpus(value: number): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(
+      `Invalid vCPU count: ${value}. Must be a positive integer.`
+    );
+  }
+  return value;
+}
+
+export function parsePort(value: number): number {
+  if (!Number.isInteger(value) || value < 1024 || value > 65535) {
+    throw new Error(
+      [
+        `Invalid port: ${value}.`,
+        `${chalk.bold('hint:')} Ports must be integers between 1024-65535 (privileged ports 0-1023 are reserved).`,
+        'Examples: 3000, 8443',
+      ].join('\n')
+    );
+  }
+  return value;
+}
+
+export function parseNetworkPolicyMode(
+  value: string
+): 'allow-all' | 'deny-all' {
+  const validModes = ['allow-all', 'deny-all'];
+  if (!validModes.includes(value)) {
+    throw new Error(
+      [
+        `Invalid network policy mode: ${value}.`,
+        `${chalk.bold('hint:')} Valid modes are: ${validModes.join(', ')}`,
+      ].join('\n')
+    );
+  }
+  return value as 'allow-all' | 'deny-all';
+}
+
+export function buildNetworkPolicy(opts: {
+  networkPolicy?: 'allow-all' | 'deny-all';
+  allowedDomains: string[];
+  allowedCIDRs: string[];
+  deniedCIDRs: string[];
+}): NetworkPolicy | undefined {
+  const { networkPolicy, allowedDomains, allowedCIDRs, deniedCIDRs } = opts;
+
+  const hasListOptions =
+    allowedDomains.length > 0 ||
+    allowedCIDRs.length > 0 ||
+    deniedCIDRs.length > 0;
+
+  if (networkPolicy && hasListOptions) {
+    throw new Error(
+      [
+        `Cannot combine --network-policy=${networkPolicy} with --allowed-domain, --allowed-cidr, or --denied-cidr.`,
+        `${chalk.bold('hint:')} Use --allowed-domain / --allowed-cidr / --denied-cidr without --network-policy for custom policies.`,
+      ].join('\n')
+    );
+  }
+
+  if (hasListOptions) {
+    return {
+      ...(allowedDomains.length > 0 && { allow: allowedDomains }),
+      ...((allowedCIDRs.length > 0 || deniedCIDRs.length > 0) && {
+        subnets: {
+          ...(allowedCIDRs.length > 0 && { allow: allowedCIDRs }),
+          ...(deniedCIDRs.length > 0 && { deny: deniedCIDRs }),
+        },
+      }),
+    };
+  }
+
+  return networkPolicy;
+}
+
+export function parseSnapshotId(value: string): string {
+  if (!value.startsWith('snap_')) {
+    throw new Error(
+      [
+        `Malformed snapshot ID: "${value}".`,
+        `${chalk.bold('hint:')} Snapshot IDs must start with 'snap_' (e.g., snap_abc123def456).`,
+      ].join('\n')
+    );
+  }
+  return value;
+}
+
+export interface KeepLastSnapshotsPayload {
+  count: number;
+  expiration: number | undefined;
+  deleteEvicted: boolean | undefined;
+}
+
+export function buildKeepLastSnapshots(opts: {
+  keepLastSnapshots: number | undefined;
+  keepLastSnapshotsFor: string | undefined;
+  deleteEvictedSnapshots: 'true' | 'false' | undefined;
+}): KeepLastSnapshotsPayload | undefined {
+  const { keepLastSnapshots, keepLastSnapshotsFor, deleteEvictedSnapshots } =
+    opts;
+
+  if (
+    keepLastSnapshots !== undefined &&
+    (!Number.isInteger(keepLastSnapshots) ||
+      keepLastSnapshots < 1 ||
+      keepLastSnapshots > 10)
+  ) {
+    throw new Error(
+      `Invalid --keep-last-snapshots value: ${keepLastSnapshots}. Must be an integer between 1 and 10.`
+    );
+  }
+
+  if (
+    keepLastSnapshots === undefined &&
+    (keepLastSnapshotsFor !== undefined || deleteEvictedSnapshots !== undefined)
+  ) {
+    throw new Error(
+      [
+        '--keep-last-snapshots-for and --delete-evicted-snapshots require --keep-last-snapshots.',
+        `${chalk.bold('hint:')} Pass --keep-last-snapshots <count> to enable the retention policy.`,
+      ].join('\n')
+    );
+  }
+
+  if (keepLastSnapshots === undefined) {
+    return undefined;
+  }
+
+  return {
+    count: keepLastSnapshots,
+    expiration:
+      keepLastSnapshotsFor !== undefined ? ms(keepLastSnapshotsFor) : undefined,
+    deleteEvicted:
+      deleteEvictedSnapshots !== undefined
+        ? deleteEvictedSnapshots === 'true'
+        : undefined,
+  };
+}
+
+export function assertSandboxName(value: string): string {
+  if (!value || value.trim().length === 0) {
+    throw new Error(
+      [
+        'Sandbox name cannot be empty.',
+        `${chalk.bold('hint:')} Provide a sandbox name.`,
+        '╰▶ run `sandbox list` to see available sandboxes.',
+      ].join('\n')
+    );
+  }
+  return value;
+}

--- a/packages/cli/src/util/sandbox/args.ts
+++ b/packages/cli/src/util/sandbox/args.ts
@@ -181,10 +181,20 @@ export interface KeepLastSnapshotsPayload {
 export function buildKeepLastSnapshots(opts: {
   keepLastSnapshots: number | undefined;
   keepLastSnapshotsFor: string | undefined;
-  deleteEvictedSnapshots: 'true' | 'false' | undefined;
+  deleteEvictedSnapshots: string | undefined;
 }): KeepLastSnapshotsPayload | undefined {
   const { keepLastSnapshots, keepLastSnapshotsFor, deleteEvictedSnapshots } =
     opts;
+
+  if (
+    deleteEvictedSnapshots !== undefined &&
+    deleteEvictedSnapshots !== 'true' &&
+    deleteEvictedSnapshots !== 'false'
+  ) {
+    throw new Error(
+      `Invalid --delete-evicted-snapshots value: ${deleteEvictedSnapshots}. Must be "true" or "false".`
+    );
+  }
 
   if (
     keepLastSnapshots !== undefined &&

--- a/packages/cli/src/util/sandbox/args.ts
+++ b/packages/cli/src/util/sandbox/args.ts
@@ -120,6 +120,9 @@ export function parseNetworkPolicyMode(
   return value as 'allow-all' | 'deny-all';
 }
 
+// Unlike the source's `buildNetworkPolicy`, this returns `undefined` (not
+// `'allow-all'`) when no network flags are given. `create` (Task 7) must
+// apply `?? 'allow-all'`; `fork` must not, so it inherits the source policy.
 export function buildNetworkPolicy(opts: {
   networkPolicy?: 'allow-all' | 'deny-all';
   allowedDomains: string[];

--- a/packages/cli/src/util/sandbox/client.ts
+++ b/packages/cli/src/util/sandbox/client.ts
@@ -20,7 +20,7 @@ async function withErrorHandling<T>(factory: () => Promise<T>): Promise<T> {
     if (error instanceof APIError) {
       const message = await formatSandboxError(error);
       if (message) {
-        throw new Error(message);
+        throw new Error(message, { cause: error });
       }
     }
     throw error;

--- a/packages/cli/src/util/sandbox/disposables.ts
+++ b/packages/cli/src/util/sandbox/disposables.ts
@@ -1,5 +1,19 @@
 import { ignoreAbortErrors } from './abort-controller';
 
+// Ensures `Symbol.dispose`/`Symbol.asyncDispose` resolve to the same key esbuild's
+// downlevel `using`/`await using` helpers fall back to, so Task 2's interactive
+// shell disposes correctly on Node 18-20.3, where these symbols aren't native.
+if (typeof (Symbol as { dispose?: symbol }).dispose === 'undefined') {
+  Object.defineProperty(Symbol, 'dispose', {
+    value: Symbol.for('Symbol.dispose'),
+  });
+}
+if (typeof (Symbol as { asyncDispose?: symbol }).asyncDispose === 'undefined') {
+  Object.defineProperty(Symbol, 'asyncDispose', {
+    value: Symbol.for('Symbol.asyncDispose'),
+  });
+}
+
 export function acquireRelease<T extends object>(
   fn: () => T,
   release: (t: NoInfer<T>) => void

--- a/packages/cli/src/util/sandbox/disposables.ts
+++ b/packages/cli/src/util/sandbox/disposables.ts
@@ -1,0 +1,29 @@
+import { ignoreAbortErrors } from './abort-controller';
+
+export function acquireRelease<T extends object>(
+  fn: () => T,
+  release: (t: NoInfer<T>) => void
+): T & Disposable {
+  const value = fn();
+  return Object.assign(value, {
+    [Symbol.dispose]: () => release(value),
+  });
+}
+
+export function defer(fn: () => void) {
+  return { [Symbol.dispose]: fn };
+}
+
+export function createAbortController(reason: string) {
+  return acquireRelease(
+    () => {
+      const controller = new AbortController();
+      return {
+        abort: (newReason?: string) => controller.abort(newReason ?? reason),
+        signal: controller.signal,
+        ignoreInterruptions: ignoreAbortErrors(controller.signal),
+      };
+    },
+    c => c.abort(reason)
+  );
+}

--- a/packages/cli/src/util/sandbox/exec-core.ts
+++ b/packages/cli/src/util/sandbox/exec-core.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared sandbox exec core, consumed by the PR #2 command handlers: `exec`
+ * (Task 6), `create`/`fork` `--connect` (Tasks 7/10), `connect` (Task 8),
+ * `sh` (Task 9), and `run` (Task 11).
+ */
+
+import type { Sandbox } from '@vercel/sandbox';
+import chalk from 'chalk';
+import ms from 'ms';
+import { printCommand } from './print-command';
+import { startInteractiveShell } from './interactive-shell';
+
+export async function execInSandbox(params: {
+  sandbox: Sandbox;
+  command: string;
+  args: string[];
+  cwd?: string;
+  env: Record<string, string>;
+  sudo: boolean;
+  interactive: boolean;
+  skipExtendingTimeout: boolean;
+  timeout?: string;
+}): Promise<void> {
+  const {
+    sandbox,
+    command,
+    args,
+    cwd,
+    env,
+    sudo,
+    interactive,
+    skipExtendingTimeout,
+    timeout,
+  } = params;
+
+  if (interactive && timeout) {
+    throw new Error(
+      [
+        '--timeout cannot be combined with --interactive.',
+        `${chalk.bold('hint:')} Remove one of the two flags. Interactive sessions do not enforce a command timeout.`,
+      ].join('\n')
+    );
+  }
+
+  if (interactive && !process.stdout.isTTY) {
+    throw new Error(
+      [
+        'The --interactive flag requires a terminal (TTY).',
+        `${chalk.bold('hint:')} Run this command in an interactive terminal, or remove --interactive to run non-interactively.`,
+      ].join('\n')
+    );
+  }
+
+  if (!interactive) {
+    // biome-ignore lint/suspicious/noConsole: intentional console usage
+    console.error(printCommand(command, args));
+    const result = await sandbox.runCommand({
+      cmd: command,
+      args,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      sudo,
+      cwd,
+      env,
+      timeoutMs: timeout ? ms(timeout) : undefined,
+    });
+
+    if (timeout && result.exitCode === 137) {
+      // biome-ignore lint/suspicious/noConsole: intentional console usage
+      console.error(
+        `${chalk.yellow('Command was killed (SIGKILL, exit code 137)')}.`
+      );
+    }
+
+    process.exitCode = result.exitCode;
+  } else {
+    await startInteractiveShell({
+      sandbox,
+      cwd,
+      execution: [command, ...args],
+      envVars: env,
+      sudo,
+      skipExtendingTimeout,
+    });
+  }
+}
+
+export async function connectToSandbox(sandbox: Sandbox): Promise<void> {
+  await execInSandbox({
+    sandbox,
+    command: 'sh',
+    args: [],
+    env: {},
+    sudo: false,
+    interactive: true,
+    skipExtendingTimeout: false,
+    cwd: undefined,
+    timeout: undefined,
+  });
+}
+
+export function assertInteractivePort(
+  sandbox: Sandbox,
+  verb: 'created' | 'forked'
+): void {
+  if (!sandbox.interactivePort) {
+    throw new Error(
+      [
+        `Sandbox ${verb} but interactive port is missing.`,
+        `${chalk.bold('hint:')} This is an internal error. Please try again.`,
+        '╰▶ Report this issue: https://github.com/vercel/sandbox/issues',
+      ].join('\n')
+    );
+  }
+}

--- a/packages/cli/src/util/sandbox/extend-timeout.ts
+++ b/packages/cli/src/util/sandbox/extend-timeout.ts
@@ -1,0 +1,39 @@
+import type { Sandbox } from '@vercel/sandbox';
+import ms from 'ms';
+import createDebugger from 'debug';
+import { setTimeout } from 'node:timers/promises';
+
+const debug = createDebugger('sandbox:timeout');
+
+const BUFFER = ms('10 seconds');
+
+export async function extendSandboxTimeoutPeriodically(
+  sandbox: Sandbox,
+  signal: AbortSignal
+): Promise<void> {
+  const session = sandbox.currentSession();
+  const timeout = session.timeout;
+  if (timeout == null) return;
+
+  const nextTick = session.createdAt.getTime() + timeout;
+  debug(`next tick: ${new Date(nextTick).toISOString()}`);
+
+  while (!signal.aborted) {
+    const currentTimeout = session.timeout;
+    if (currentTimeout == null) return;
+
+    const sleepMs =
+      session.createdAt.getTime() + currentTimeout - Date.now() - BUFFER;
+    if (sleepMs > 2000) {
+      debug(`sleeping for ${sleepMs}ms until next timeout extension`);
+      await setTimeout(sleepMs, null, { signal });
+    }
+    await sandbox.extendTimeout(ms('5 minutes'));
+    const updatedTimeout = session.timeout;
+    if (updatedTimeout == null) return;
+    const updatedNextTick = session.createdAt.getTime() + updatedTimeout;
+    debug(
+      `extended sandbox timeout by 5 minutes. next tick: ${new Date(updatedNextTick).toISOString()}`
+    );
+  }
+}

--- a/packages/cli/src/util/sandbox/interactive-shell.ts
+++ b/packages/cli/src/util/sandbox/interactive-shell.ts
@@ -1,0 +1,147 @@
+import type { Sandbox } from '@vercel/sandbox';
+import createDebugger from 'debug';
+import { WebSocket } from 'ws';
+import ora from 'ora';
+import chalk from 'chalk';
+import { printCommand } from './print-command';
+import { acquireRelease, createAbortController, defer } from './disposables';
+import { extendSandboxTimeoutPeriodically } from './extend-timeout';
+
+const debug = createDebugger('sandbox:interactive-shell');
+
+const TERM = 'xterm-256color';
+
+const PS1 = `▲ \x01\x1b[2m\x02$PWD/\x01\x1b[0m\x02 `;
+
+export async function startInteractiveShell(options: {
+  sandbox: Sandbox;
+  cwd?: string;
+  execution: [string, ...string[]];
+  envVars: Record<string, string>;
+  sudo: boolean;
+  skipExtendingTimeout: boolean;
+}): Promise<void> {
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) {
+      return;
+    }
+
+    process.stdin.removeAllListeners();
+    try {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      process.stdin.unref();
+    } catch {}
+    cleaned = true;
+  };
+  process.once('beforeExit', cleanup);
+  using _cleanup = defer(cleanup);
+
+  using progress = acquireRelease(
+    () => ora().start(),
+    s => s.stop()
+  );
+
+  progress.text = 'Opening interactive session...';
+  const { url, token } = await options.sandbox.openInteractive();
+
+  const [command, ...args] = options.execution;
+  const execution: [string, ...string[]] = options.sudo
+    ? ['sudo', command, ...args]
+    : [command, ...args];
+
+  progress.text = 'Connecting...';
+  const client = new WebSocket(`${url}?token=${encodeURIComponent(token)}`);
+  using _client = defer(() => {
+    try {
+      client.close();
+    } catch {}
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    client.once('open', () => resolve());
+    client.once('error', err => reject(err));
+  });
+  debug('connected to %s', url);
+
+  client.send(
+    JSON.stringify({
+      type: 'start',
+      command: execution[0],
+      args: execution.slice(1),
+      env: toEnvArray({ TERM, PS1, ...options.envVars }),
+      cwd: options.cwd ?? options.sandbox.cwd,
+      cols: process.stdout.columns,
+      rows: process.stdout.rows,
+    })
+  );
+
+  progress.stop();
+
+  using extension = createAbortController('stopped extensions');
+  if (!options.skipExtendingTimeout) {
+    extendSandboxTimeoutPeriodically(options.sandbox, extension.signal).catch(
+      extension.ignoreInterruptions
+    );
+  }
+
+  client.on('message', (data: Buffer, isBinary: boolean) => {
+    if (isBinary) {
+      process.stdout.write(data as unknown as Uint8Array);
+      return;
+    }
+    try {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === 'exit') {
+        process.exitCode = typeof msg.code === 'number' ? msg.code : undefined;
+      }
+    } catch {
+      process.stdout.write(data as unknown as Uint8Array);
+    }
+  });
+
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+  }
+  process.stdin.resume();
+  const onStdin = (chunk: Buffer) => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(chunk);
+    }
+  };
+  process.stdin.on('data', onStdin);
+
+  const onResize = () => {
+    if (client.readyState !== WebSocket.OPEN) return;
+    client.send(
+      JSON.stringify({
+        type: 'resize',
+        cols: process.stdout.columns,
+        rows: process.stdout.rows,
+      })
+    );
+  };
+  process.on('SIGWINCH', onResize);
+
+  // biome-ignore lint/suspicious/noConsole: intentional console usage
+  console.error(printCommand(options.execution[0], options.execution.slice(1)));
+
+  await new Promise<void>((resolve, reject) => {
+    client.once('close', () => resolve());
+    client.once('error', err => reject(err));
+  });
+
+  extension.abort('client disconnected');
+  process.removeListener('SIGWINCH', onResize);
+  process.stdin.removeListener('data', onStdin);
+
+  // biome-ignore lint/suspicious/noConsole: intentional console usage
+  console.error(
+    chalk.dim(`\n╰▶ connection to ▲ ${options.sandbox.name} closed.`)
+  );
+}
+
+function toEnvArray(env: Record<string, string>): string[] {
+  return Object.entries(env).map(([key, value]) => `${key}=${value}`);
+}

--- a/packages/cli/src/util/sandbox/print-command.ts
+++ b/packages/cli/src/util/sandbox/print-command.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk';
+
+export function printCommand(command: string, args: string[]) {
+  return chalk.gray(chalk.dim('$ ') + [command, ...args].join(' '));
+}

--- a/packages/cli/src/util/sandbox/print-sandbox-summary.ts
+++ b/packages/cli/src/util/sandbox/print-sandbox-summary.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+import type { Sandbox } from '@vercel/sandbox';
+
+// name goes to stdout so `sandbox create | xargs ...` keeps working; everything else goes to stderr.
+export function printSandboxSummary(opts: {
+  sandbox: Sandbox;
+  contextName: string;
+  action: string;
+}) {
+  const { sandbox, contextName, action } = opts;
+  const routes = sandbox.routes.filter(x => x.port !== sandbox.interactivePort);
+  const hasPorts = routes.length > 0;
+
+  process.stderr.write('✅ Sandbox ');
+  process.stdout.write(chalk.cyan(sandbox.name));
+  process.stderr.write(' ' + action + '.\n');
+
+  if (hasPorts) {
+    process.stderr.write(
+      chalk.dim('   │ ') + 'team: ' + chalk.cyan(contextName) + '\n'
+    );
+    process.stderr.write(chalk.dim('   │ ') + 'ports:\n');
+    for (let i = 0; i < routes.length; i++) {
+      const route = routes[i];
+      const isLast = i === routes.length - 1;
+      const prefix = isLast ? chalk.dim('   ╰ ') : chalk.dim('   │ ');
+      process.stderr.write(
+        prefix + '• ' + route.port + ' -> ' + chalk.cyan(route.url) + '\n'
+      );
+    }
+  } else {
+    process.stderr.write(
+      chalk.dim('   ╰ ') + 'team: ' + chalk.cyan(contextName) + '\n'
+    );
+  }
+}

--- a/packages/cli/src/util/sandbox/target.ts
+++ b/packages/cli/src/util/sandbox/target.ts
@@ -1,41 +1,146 @@
 import type Client from '../client';
 import getScope from '../get-scope';
+import getProjectByNameOrId from '../projects/get-project-by-id-or-name';
+import { isAPIError, ProjectNotFound } from '../errors-ts';
 import { getLinkedProject } from '../projects/link';
+import { outputAgentError } from '../agent-output';
+import { AGENT_REASON } from '../agent-output-constants';
 
+/**
+ * Thrown by resolveSandboxTarget on any resolution failure. `exitCode` mirrors
+ * the exit code of whatever it wraps (e.g. getLinkedProject's own exitCode),
+ * so PR #2's native sandbox commands can `return err.exitCode` on catch
+ * instead of always assuming 1.
+ */
+export class SandboxTargetError extends Error {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode = 1) {
+    super(message);
+    this.name = 'SandboxTargetError';
+    this.exitCode = exitCode;
+  }
+}
+
+/**
+ * `VERCEL_TOKEN` is applied to `client.authConfig.token` during CLI startup
+ * (see src/index.ts), so it's covered by the primary source below.
+ * `VERCEL_AUTH_TOKEN` is a back-compat fallback read directly by the
+ * standalone `sandbox` package (see src/commands/sandbox/index.ts).
+ */
 function resolveToken(client: Client): string | undefined {
   return client.authConfig.token ?? process.env.VERCEL_AUTH_TOKEN;
 }
 
+function failSandboxTarget(
+  client: Client,
+  reason: string,
+  message: string,
+  exitCode = 1
+): never {
+  outputAgentError(client, { status: 'error', reason, message }, exitCode);
+  throw new SandboxTargetError(message, exitCode);
+}
+
+/**
+ * Resolves the `{ token, teamId, projectId }` a native sandbox command needs
+ * to call the Sandbox API, following the same team/project resolution shape
+ * as resolveVcrScope/resolveAlertsScope: an explicit `--project` is resolved
+ * by name-or-id within the team scope, otherwise the local `.vercel` link
+ * is used.
+ */
 export async function resolveSandboxTarget(
   client: Client,
   opts: { project?: string; team?: string } = {}
 ): Promise<{ token: string; teamId: string; projectId: string }> {
   const token = resolveToken(client);
   if (!token) {
-    throw new Error(
-      'Not authenticated. Run `vercel login` or set `VERCEL_TOKEN`.'
+    failSandboxTarget(
+      client,
+      AGENT_REASON.LOGIN_REQUIRED,
+      'Not authenticated. Run `vercel login`, or set `VERCEL_TOKEN` (or `VERCEL_AUTH_TOKEN`).'
     );
   }
 
-  let teamId = opts.team;
-  if (!teamId) {
-    const scope = await getScope(client);
-    teamId = scope.team?.id;
-  }
-
-  let projectId = opts.project;
-  if (!projectId) {
-    const link = await getLinkedProject(client);
-    if (link.status === 'linked') {
-      projectId = link.project.id;
+  if (opts.project) {
+    let teamId = opts.team;
+    if (!teamId) {
+      const scope = await getScope(client);
+      teamId = scope.team?.id;
     }
+    if (!teamId) {
+      failSandboxTarget(
+        client,
+        AGENT_REASON.MISSING_SCOPE,
+        'No team context found. Run `vercel switch` to select a team, or pass `--scope`/`--team`.'
+      );
+    }
+
+    let projectResult: Awaited<ReturnType<typeof getProjectByNameOrId>>;
+    try {
+      projectResult = await getProjectByNameOrId(client, opts.project, teamId);
+    } catch (err) {
+      if (isAPIError(err)) {
+        const reason =
+          err.status === 401
+            ? 'not_authorized'
+            : err.status === 403
+              ? 'forbidden'
+              : AGENT_REASON.API_ERROR;
+        const message =
+          err.serverMessage ||
+          (err.status === 403
+            ? `You do not have permission to access project "${opts.project}" in this team.`
+            : `API error (${err.status}).`);
+        failSandboxTarget(client, reason, message);
+      }
+      throw err;
+    }
+
+    if (projectResult instanceof ProjectNotFound) {
+      failSandboxTarget(
+        client,
+        AGENT_REASON.PROJECT_NOT_FOUND,
+        `Project "${opts.project}" was not found in the current team scope.`
+      );
+    }
+
+    return { token, teamId, projectId: projectResult.id };
   }
 
-  if (!teamId || !projectId) {
-    throw new Error(
+  const link = await getLinkedProject(client);
+
+  if (link.status === 'error') {
+    // getLinkedProject already printed its own diagnostic (see
+    // ../projects/link.ts); surface its exitCode instead of the generic
+    // "run `vercel link`" message below, which would be misleading here.
+    failSandboxTarget(
+      client,
+      AGENT_REASON.NOT_LINKED,
+      'Could not resolve the linked project; see the error above, or pass `--project`.',
+      link.exitCode
+    );
+  }
+
+  if (link.status === 'not_linked') {
+    failSandboxTarget(
+      client,
+      AGENT_REASON.NOT_LINKED,
       'Could not determine team/project scope. Pass `--scope` and `--project`, or run `vercel link`.'
     );
   }
 
-  return { token, teamId, projectId };
+  if (opts.team && link.org.id !== opts.team) {
+    failSandboxTarget(
+      client,
+      AGENT_REASON.SCOPE_NOT_ACCESSIBLE,
+      `Linked project "${link.project.name}" belongs to team "${link.org.slug}", not the requested team. Pass \`--project\` to use a project in this team.`
+    );
+  }
+
+  return {
+    token,
+    teamId: opts.team ?? link.org.id,
+    projectId: link.project.id,
+  };
 }

--- a/packages/cli/src/util/sandbox/target.ts
+++ b/packages/cli/src/util/sandbox/target.ts
@@ -22,12 +22,6 @@ export class SandboxTargetError extends Error {
   }
 }
 
-/**
- * `VERCEL_TOKEN` is applied to `client.authConfig.token` during CLI startup
- * (see src/index.ts), so it's covered by the primary source below.
- * `VERCEL_AUTH_TOKEN` is a back-compat fallback read directly by the
- * standalone `sandbox` package (see src/commands/sandbox/index.ts).
- */
 function resolveToken(client: Client): string | undefined {
   return client.authConfig.token ?? process.env.VERCEL_AUTH_TOKEN;
 }
@@ -48,6 +42,8 @@ function failSandboxTarget(
  * as resolveVcrScope/resolveAlertsScope: an explicit `--project` is resolved
  * by name-or-id within the team scope, otherwise the local `.vercel` link
  * is used.
+ *
+ * @param opts.team An already-resolved team ID, expected to be passed by PR #2's native sandbox command tasks.
  */
 export async function resolveSandboxTarget(
   client: Client,
@@ -100,7 +96,7 @@ export async function resolveSandboxTarget(
     if (projectResult instanceof ProjectNotFound) {
       failSandboxTarget(
         client,
-        AGENT_REASON.PROJECT_NOT_FOUND,
+        AGENT_REASON.NOT_FOUND,
         `Project "${opts.project}" was not found in the current team scope.`
       );
     }
@@ -111,9 +107,6 @@ export async function resolveSandboxTarget(
   const link = await getLinkedProject(client);
 
   if (link.status === 'error') {
-    // getLinkedProject already printed its own diagnostic (see
-    // ../projects/link.ts); surface its exitCode instead of the generic
-    // "run `vercel link`" message below, which would be misleading here.
     failSandboxTarget(
       client,
       AGENT_REASON.NOT_LINKED,

--- a/packages/cli/src/util/sandbox/target.ts
+++ b/packages/cli/src/util/sandbox/target.ts
@@ -43,6 +43,14 @@ function failSandboxTarget(
  * by name-or-id within the team scope, otherwise the local `.vercel` link
  * is used.
  *
+ * Not wired to runtime yet — the only current references are this file's tests.
+ * Its consumers are the native command handlers added in later tasks/PRs:
+ * PR #2 (exec/create/connect/sh/fork/run), PR #3 (list/stop/remove/cp/snapshot/
+ * snapshots/sessions), PR #4 (config). Each handler calls it near the top and
+ * passes the result into the SDK client wrapper, e.g.:
+ *   const { token, teamId, projectId } = await resolveSandboxTarget(client, { project, team });
+ *   await sandboxClient.create({ token, teamId, projectId, ...flags });
+ *
  * @param opts.team An already-resolved team ID, expected to be passed by PR #2's native sandbox command tasks.
  */
 export async function resolveSandboxTarget(

--- a/packages/cli/src/util/telemetry/commands/sandbox/index.ts
+++ b/packages/cli/src/util/telemetry/commands/sandbox/index.ts
@@ -19,4 +19,11 @@ export class SandboxTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandConnect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'connect',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/sandbox/index.ts
+++ b/packages/cli/src/util/telemetry/commands/sandbox/index.ts
@@ -26,4 +26,11 @@ export class SandboxTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandSh(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'sh',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/sandbox/index.ts
+++ b/packages/cli/src/util/telemetry/commands/sandbox/index.ts
@@ -33,4 +33,11 @@ export class SandboxTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandFork(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'fork',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/sandbox/index.ts
+++ b/packages/cli/src/util/telemetry/commands/sandbox/index.ts
@@ -40,4 +40,11 @@ export class SandboxTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandRun(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'run',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/sandbox/index.ts
+++ b/packages/cli/src/util/telemetry/commands/sandbox/index.ts
@@ -4,4 +4,12 @@ import type { sandboxCommand } from '../../../../commands/sandbox/command';
 
 export class SandboxTelemetryClient
   extends TelemetryClient
-  implements TelemetryMethods<typeof sandboxCommand> {}
+  implements TelemetryMethods<typeof sandboxCommand>
+{
+  trackCliSubcommandExec(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'exec',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/sandbox/index.ts
+++ b/packages/cli/src/util/telemetry/commands/sandbox/index.ts
@@ -12,4 +12,11 @@ export class SandboxTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandCreate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'create',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/sandbox/connect.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/connect.test.ts
@@ -222,3 +222,33 @@ describe.each([
     ]);
   });
 });
+
+describe('sandbox connect --timeout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    sandboxGet.mockResolvedValue(fakeSandbox);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forwards --timeout and surfaces the execInSandbox mutual-exclusion error', async () => {
+    execInSandbox.mockRejectedValue(
+      new Error('--timeout cannot be combined with --interactive.')
+    );
+    client.setArgv('sandbox', 'connect', 'my-sandbox', '--timeout', '30s');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(execInSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: '30s' })
+    );
+    expect(client.stderr.getFullOutput()).toContain(
+      '--timeout cannot be combined with --interactive'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/sandbox/connect.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/connect.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import sandbox from '../../../../src/commands/sandbox';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+import * as getProjectModule from '../../../../src/util/projects/get-project-by-id-or-name';
+
+const { sandboxGet, execInSandbox } = vi.hoisted(() => ({
+  sandboxGet: vi.fn(),
+  execInSandbox: vi.fn(),
+}));
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+vi.mock('../../../../src/util/projects/get-project-by-id-or-name');
+vi.mock('../../../../src/util/sandbox/client', () => ({
+  sandboxClient: { get: sandboxGet },
+}));
+vi.mock('../../../../src/util/sandbox/exec-core', () => ({
+  execInSandbox,
+}));
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+const mockedGetProject = vi.mocked(getProjectModule.default);
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_sandbox',
+      name: 'sandbox-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockNotLinked() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'not_linked',
+    org: null,
+    project: null,
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+const fakeSandbox = { name: 'my-sandbox' } as any;
+
+describe.each([
+  ['connect', 'connect'],
+  ['ssh', 'ssh'],
+  ['shell', 'shell'],
+])('sandbox %s', (invokedAs, _label) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    sandboxGet.mockResolvedValue(fakeSandbox);
+    execInSandbox.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints help and returns 2 for --help', async () => {
+    client.setArgv('sandbox', invokedAs, '--help');
+    const exitCode = await sandbox(client);
+    expect(exitCode).toBe(2);
+    expect(sandboxGet).not.toHaveBeenCalled();
+  });
+
+  it('resolves the linked project and resumes the named sandbox', async () => {
+    client.setArgv('sandbox', invokedAs, 'my-sandbox');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxGet).toHaveBeenCalledWith({
+      name: 'my-sandbox',
+      token: expect.any(String),
+      teamId: 'team_dummy',
+      projectId: 'prj_sandbox',
+      resume: true,
+      __includeSystemRoutes: true,
+    });
+  });
+
+  it('forces an interactive sh shell with the parsed flags', async () => {
+    client.setArgv(
+      'sandbox',
+      invokedAs,
+      'my-sandbox',
+      '--sudo',
+      '--workdir',
+      '/app',
+      '--env',
+      'A=1',
+      '-e',
+      'B=2'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(execInSandbox).toHaveBeenCalledWith({
+      sandbox: fakeSandbox,
+      command: 'sh',
+      args: [],
+      interactive: true,
+      sudo: true,
+      skipExtendingTimeout: false,
+      cwd: '/app',
+      env: { A: '1', B: '2' },
+      timeout: undefined,
+    });
+  });
+
+  it('defaults sudo/skipExtendingTimeout/cwd/env when no flags are passed', async () => {
+    client.setArgv('sandbox', invokedAs, 'my-sandbox');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(execInSandbox).toHaveBeenCalledWith({
+      sandbox: fakeSandbox,
+      command: 'sh',
+      args: [],
+      interactive: true,
+      sudo: false,
+      skipExtendingTimeout: false,
+      cwd: undefined,
+      env: {},
+      timeout: undefined,
+    });
+  });
+
+  it('passes --no-extend-timeout through', async () => {
+    client.setArgv('sandbox', invokedAs, 'my-sandbox', '--no-extend-timeout');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(execInSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ skipExtendingTimeout: true })
+    );
+  });
+
+  it('surfaces the execInSandbox TTY error unchanged when it rejects', async () => {
+    execInSandbox.mockRejectedValue(
+      new Error('The --interactive flag requires a terminal (TTY).')
+    );
+    client.setArgv('sandbox', invokedAs, 'my-sandbox');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '--interactive flag requires a terminal (TTY)'
+    );
+  });
+
+  it('resolves --project via the current team scope', async () => {
+    mockedGetProject.mockResolvedValue({ id: 'prj_other' } as any);
+    client.setArgv(
+      'sandbox',
+      invokedAs,
+      'my-sandbox',
+      '--project',
+      'other-app'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(mockedGetProject).toHaveBeenCalledWith(
+      client,
+      'other-app',
+      'team_dummy'
+    );
+    expect(sandboxGet).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'prj_other' })
+    );
+  });
+
+  it('errors when there is no linked project and no --project flag', async () => {
+    mockNotLinked();
+    client.setArgv('sandbox', invokedAs, 'my-sandbox');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(sandboxGet).not.toHaveBeenCalled();
+  });
+
+  it('errors when the name positional is missing', async () => {
+    client.setArgv('sandbox', invokedAs);
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(sandboxGet).not.toHaveBeenCalled();
+  });
+
+  it('tracks subcommand invocation with the original alias', async () => {
+    client.setArgv('sandbox', invokedAs, 'my-sandbox');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:connect',
+        value: invokedAs,
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/sandbox/create.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/create.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import sandbox from '../../../../src/commands/sandbox';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+import * as getProjectModule from '../../../../src/util/projects/get-project-by-id-or-name';
+import { createSubcommand } from '../../../../src/commands/sandbox/create/command';
+import { parseArguments } from '../../../../src/util/get-args';
+import { getFlagsSpecification } from '../../../../src/util/get-flags-specification';
+
+const { sandboxCreate, connectToSandbox, printSandboxSummary } = vi.hoisted(
+  () => ({
+    sandboxCreate: vi.fn(),
+    connectToSandbox: vi.fn(),
+    printSandboxSummary: vi.fn(),
+  })
+);
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+vi.mock('../../../../src/util/projects/get-project-by-id-or-name');
+vi.mock('../../../../src/util/sandbox/client', () => ({
+  sandboxClient: { create: sandboxCreate },
+}));
+vi.mock('../../../../src/util/sandbox/exec-core', () => ({
+  connectToSandbox,
+  assertInteractivePort: vi.fn(),
+}));
+vi.mock('../../../../src/util/sandbox/print-sandbox-summary', () => ({
+  printSandboxSummary,
+}));
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+const mockedGetProject = vi.mocked(getProjectModule.default);
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_sandbox',
+      name: 'sandbox-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockNotLinked() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'not_linked',
+    org: null,
+    project: null,
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+const fakeSandbox = {
+  name: 'my-sandbox',
+  interactivePort: 39375,
+  routes: [],
+} as any;
+
+describe('sandbox create', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    sandboxCreate.mockResolvedValue(fakeSandbox);
+    connectToSandbox.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints help and returns 2 for --help', async () => {
+    client.setArgv('sandbox', 'create', '--help');
+    const exitCode = await sandbox(client);
+    expect(exitCode).toBe(2);
+    expect(sandboxCreate).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the node24 runtime when neither --image nor --runtime is given', async () => {
+    client.setArgv('sandbox', 'create');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ runtime: 'node24' })
+    );
+    expect(sandboxCreate.mock.calls[0][0]).not.toHaveProperty('image');
+  });
+
+  it('throws when both --image and --runtime are given', async () => {
+    client.setArgv(
+      'sandbox',
+      'create',
+      '--image',
+      'my-repo:v1',
+      '--runtime',
+      'node22'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '--image and --runtime cannot be used together.'
+    );
+    expect(sandboxCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates from a snapshot source when --snapshot is given', async () => {
+    client.setArgv('sandbox', 'create', '--snapshot', 'snap_abc123');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: { type: 'snapshot', snapshotId: 'snap_abc123' },
+      })
+    );
+    const call = sandboxCreate.mock.calls[0][0];
+    expect(call).not.toHaveProperty('runtime');
+    expect(call).not.toHaveProperty('image');
+  });
+
+  it('connects to the sandbox after creating it when --connect is given', async () => {
+    client.setArgv('sandbox', 'create', '--connect');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(connectToSandbox).toHaveBeenCalledWith(fakeSandbox);
+  });
+
+  it('does not connect when --connect is omitted', async () => {
+    client.setArgv('sandbox', 'create');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(connectToSandbox).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the summary when --silent is given, but still prints the name to stdout', async () => {
+    client.setArgv('sandbox', 'create', '--silent');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(printSandboxSummary).not.toHaveBeenCalled();
+  });
+
+  it('prints the summary when --silent is omitted', async () => {
+    client.setArgv('sandbox', 'create');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(printSandboxSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandbox: fakeSandbox,
+        contextName: 'my-team',
+        action: 'created',
+      })
+    );
+  });
+
+  it('parses --tag flags into a key/value map', async () => {
+    client.setArgv(
+      'sandbox',
+      'create',
+      '--tag',
+      'env=staging',
+      '--tag',
+      'team=infra'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: { env: 'staging', team: 'infra' } })
+    );
+  });
+
+  it('defaults the network policy to allow-all when no network flags are given', async () => {
+    client.setArgv('sandbox', 'create');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ networkPolicy: 'allow-all' })
+    );
+  });
+
+  it('passes through an explicit --network-policy value', async () => {
+    client.setArgv('sandbox', 'create', '--network-policy', 'deny-all');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ networkPolicy: 'deny-all' })
+    );
+  });
+
+  it('does not let -t shadow the global --token shorthand', () => {
+    const hasShortTag = createSubcommand.options.some(
+      opt => 'name' in opt && opt.name === 'tag' && opt.shorthand === 't'
+    );
+    expect(hasShortTag).toBe(false);
+
+    const { flags } = parseArguments(
+      ['-t', 'my-token'],
+      getFlagsSpecification(createSubcommand.options)
+    );
+
+    expect(flags['--token']).toBe('my-token');
+    expect(flags['--tag']).toBeUndefined();
+  });
+
+  it('resolves --project via the current team scope', async () => {
+    mockedGetProject.mockResolvedValue({ id: 'prj_other' } as any);
+    client.setArgv('sandbox', 'create', '--project', 'other-app');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(mockedGetProject).toHaveBeenCalledWith(
+      client,
+      'other-app',
+      'team_dummy'
+    );
+    expect(sandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'prj_other' })
+    );
+  });
+
+  it('errors when there is no linked project and no --project flag', async () => {
+    mockNotLinked();
+    client.setArgv('sandbox', 'create');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(sandboxCreate).not.toHaveBeenCalled();
+  });
+
+  it('tracks subcommand invocation', async () => {
+    client.setArgv('sandbox', 'create');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:create',
+        value: 'create',
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/sandbox/create.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/create.test.ts
@@ -106,6 +106,15 @@ describe('sandbox create', () => {
     expect(sandboxCreate.mock.calls[0][0]).not.toHaveProperty('image');
   });
 
+  it('throws for --vcpus 0', async () => {
+    client.setArgv('sandbox', 'create', '--vcpus', '0');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Invalid vCPU count: 0');
+    expect(sandboxCreate).not.toHaveBeenCalled();
+  });
+
   it('throws when both --image and --runtime are given', async () => {
     client.setArgv(
       'sandbox',
@@ -161,6 +170,7 @@ describe('sandbox create', () => {
 
     expect(exitCode).toBe(0);
     expect(printSandboxSummary).not.toHaveBeenCalled();
+    expect(mockedGetScope).not.toHaveBeenCalled();
   });
 
   it('prints the summary when --silent is omitted', async () => {
@@ -175,6 +185,7 @@ describe('sandbox create', () => {
         action: 'created',
       })
     );
+    expect(mockedGetScope).toHaveBeenCalled();
   });
 
   it('parses --tag flags into a key/value map', async () => {
@@ -191,6 +202,33 @@ describe('sandbox create', () => {
     expect(exitCode).toBe(0);
     expect(sandboxCreate).toHaveBeenCalledWith(
       expect.objectContaining({ tags: { env: 'staging', team: 'infra' } })
+    );
+  });
+
+  it('parses --env flags into a key/value map', async () => {
+    client.setArgv('sandbox', 'create', '--env', 'FOO=bar', '--env', 'BAZ=qux');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ env: { FOO: 'bar', BAZ: 'qux' } })
+    );
+  });
+
+  it('parses --publish-port flags into a ports array', async () => {
+    client.setArgv(
+      'sandbox',
+      'create',
+      '--publish-port',
+      '3000',
+      '--publish-port',
+      '8080'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ ports: [3000, 8080] })
     );
   });
 

--- a/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
@@ -107,6 +107,7 @@ describe('sandbox dispatcher', () => {
       exec: ['exec'],
       create: ['create'],
       connect: ['connect', 'ssh', 'shell'],
+      sh: ['sh'],
     });
     expect(telemetryConstructorSpy).toHaveBeenCalledWith({
       opts: { store: client.telemetryEventStore },
@@ -203,6 +204,34 @@ describe('sandbox dispatcher', () => {
     expect(run).not.toHaveBeenCalled();
 
     vi.doUnmock('../../../../src/commands/sandbox/connect');
+  });
+
+  it('routes sh to the native handler instead of the pass-through', async () => {
+    vi.resetModules();
+    client.reset();
+    const run = vi.fn(async () => {});
+    vi.doMock('sandbox', () => ({ createApp: () => ({ run }) }));
+
+    const shHandler = vi.fn(async () => 0);
+    vi.doMock('../../../../src/commands/sandbox/sh', () => ({
+      default: shHandler,
+    }));
+
+    const { default: sandbox } = await import(
+      '../../../../src/commands/sandbox'
+    );
+
+    client.setArgv('sandbox', 'sh', '--runtime', 'node22');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(shHandler).toHaveBeenCalledWith(
+      client,
+      expect.arrayContaining(['--runtime', 'node22'])
+    );
+    expect(run).not.toHaveBeenCalled();
+
+    vi.doUnmock('../../../../src/commands/sandbox/sh');
   });
 
   it('returns 1 and prints the error when the pass-through throws', async () => {

--- a/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
@@ -108,6 +108,7 @@ describe('sandbox dispatcher', () => {
       create: ['create'],
       connect: ['connect', 'ssh', 'shell'],
       sh: ['sh'],
+      fork: ['fork'],
     });
     expect(telemetryConstructorSpy).toHaveBeenCalledWith({
       opts: { store: client.telemetryEventStore },
@@ -232,6 +233,34 @@ describe('sandbox dispatcher', () => {
     expect(run).not.toHaveBeenCalled();
 
     vi.doUnmock('../../../../src/commands/sandbox/sh');
+  });
+
+  it('routes fork to the native handler instead of the pass-through', async () => {
+    vi.resetModules();
+    client.reset();
+    const run = vi.fn(async () => {});
+    vi.doMock('sandbox', () => ({ createApp: () => ({ run }) }));
+
+    const forkHandler = vi.fn(async () => 0);
+    vi.doMock('../../../../src/commands/sandbox/fork', () => ({
+      default: forkHandler,
+    }));
+
+    const { default: sandbox } = await import(
+      '../../../../src/commands/sandbox'
+    );
+
+    client.setArgv('sandbox', 'fork', 'my-source', '--vcpus', '4');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(forkHandler).toHaveBeenCalledWith(
+      client,
+      expect.arrayContaining(['my-source', '--vcpus', '4'])
+    );
+    expect(run).not.toHaveBeenCalled();
+
+    vi.doUnmock('../../../../src/commands/sandbox/fork');
   });
 
   it('returns 1 and prints the error when the pass-through throws', async () => {

--- a/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
@@ -109,6 +109,7 @@ describe('sandbox dispatcher', () => {
       connect: ['connect', 'ssh', 'shell'],
       sh: ['sh'],
       fork: ['fork'],
+      run: ['run'],
     });
     expect(telemetryConstructorSpy).toHaveBeenCalledWith({
       opts: { store: client.telemetryEventStore },
@@ -261,6 +262,34 @@ describe('sandbox dispatcher', () => {
     expect(run).not.toHaveBeenCalled();
 
     vi.doUnmock('../../../../src/commands/sandbox/fork');
+  });
+
+  it('routes run to the native handler instead of the pass-through', async () => {
+    vi.resetModules();
+    client.reset();
+    const run = vi.fn(async () => {});
+    vi.doMock('sandbox', () => ({ createApp: () => ({ run }) }));
+
+    const runHandler = vi.fn(async () => 0);
+    vi.doMock('../../../../src/commands/sandbox/run', () => ({
+      default: runHandler,
+    }));
+
+    const { default: sandbox } = await import(
+      '../../../../src/commands/sandbox'
+    );
+
+    client.setArgv('sandbox', 'run', '--rm', '--', 'echo', 'hi');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(runHandler).toHaveBeenCalledWith(
+      client,
+      expect.arrayContaining(['--rm', 'echo', 'hi'])
+    );
+    expect(run).not.toHaveBeenCalled();
+
+    vi.doUnmock('../../../../src/commands/sandbox/run');
   });
 
   it('returns 1 and prints the error when the pass-through throws', async () => {

--- a/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
@@ -103,7 +103,9 @@ describe('sandbox dispatcher', () => {
     const exitCode = await sandbox(client);
 
     expect(exitCode).toBe(0);
-    expect(getSubcommandSpy).toHaveBeenCalledWith(['list'], {});
+    expect(getSubcommandSpy).toHaveBeenCalledWith(['list'], {
+      exec: ['exec'],
+    });
     expect(telemetryConstructorSpy).toHaveBeenCalledWith({
       opts: { store: client.telemetryEventStore },
     });
@@ -111,6 +113,34 @@ describe('sandbox dispatcher', () => {
 
     vi.doUnmock('../../../../src/util/get-subcommand');
     vi.doUnmock('../../../../src/util/telemetry/commands/sandbox');
+  });
+
+  it('routes exec to the native handler instead of the pass-through', async () => {
+    vi.resetModules();
+    client.reset();
+    const run = vi.fn(async () => {});
+    vi.doMock('sandbox', () => ({ createApp: () => ({ run }) }));
+
+    const execHandler = vi.fn(async () => 0);
+    vi.doMock('../../../../src/commands/sandbox/exec', () => ({
+      default: execHandler,
+    }));
+
+    const { default: sandbox } = await import(
+      '../../../../src/commands/sandbox'
+    );
+
+    client.setArgv('sandbox', 'exec', 'my-sandbox', '--', 'echo', 'hi');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(execHandler).toHaveBeenCalledWith(
+      client,
+      expect.arrayContaining(['my-sandbox', 'echo', 'hi'])
+    );
+    expect(run).not.toHaveBeenCalled();
+
+    vi.doUnmock('../../../../src/commands/sandbox/exec');
   });
 
   it('returns 1 and prints the error when the pass-through throws', async () => {

--- a/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
@@ -15,12 +15,12 @@ describe('sandbox dispatcher', () => {
       '../../../../src/commands/sandbox'
     );
 
-    client.setArgv('sandbox', 'create', '--connect');
+    client.setArgv('sandbox', 'list', '--connect');
     const exitCode = await sandbox(client);
 
     expect(exitCode).toBe(0);
     expect(run).toHaveBeenCalledWith(
-      expect.arrayContaining(['create', '--connect'])
+      expect.arrayContaining(['list', '--connect'])
     );
   });
 
@@ -105,6 +105,7 @@ describe('sandbox dispatcher', () => {
     expect(exitCode).toBe(0);
     expect(getSubcommandSpy).toHaveBeenCalledWith(['list'], {
       exec: ['exec'],
+      create: ['create'],
     });
     expect(telemetryConstructorSpy).toHaveBeenCalledWith({
       opts: { store: client.telemetryEventStore },
@@ -143,6 +144,34 @@ describe('sandbox dispatcher', () => {
     vi.doUnmock('../../../../src/commands/sandbox/exec');
   });
 
+  it('routes create to the native handler instead of the pass-through', async () => {
+    vi.resetModules();
+    client.reset();
+    const run = vi.fn(async () => {});
+    vi.doMock('sandbox', () => ({ createApp: () => ({ run }) }));
+
+    const createHandler = vi.fn(async () => 0);
+    vi.doMock('../../../../src/commands/sandbox/create', () => ({
+      default: createHandler,
+    }));
+
+    const { default: sandbox } = await import(
+      '../../../../src/commands/sandbox'
+    );
+
+    client.setArgv('sandbox', 'create', '--connect');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(createHandler).toHaveBeenCalledWith(
+      client,
+      expect.arrayContaining(['--connect'])
+    );
+    expect(run).not.toHaveBeenCalled();
+
+    vi.doUnmock('../../../../src/commands/sandbox/create');
+  });
+
   it('returns 1 and prints the error when the pass-through throws', async () => {
     vi.resetModules();
     client.reset();
@@ -154,7 +183,7 @@ describe('sandbox dispatcher', () => {
       '../../../../src/commands/sandbox'
     );
 
-    client.setArgv('sandbox', 'create');
+    client.setArgv('sandbox', 'list');
     const exitCode = await sandbox(client);
 
     expect(exitCode).toBe(1);

--- a/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/dispatch.test.ts
@@ -106,6 +106,7 @@ describe('sandbox dispatcher', () => {
     expect(getSubcommandSpy).toHaveBeenCalledWith(['list'], {
       exec: ['exec'],
       create: ['create'],
+      connect: ['connect', 'ssh', 'shell'],
     });
     expect(telemetryConstructorSpy).toHaveBeenCalledWith({
       opts: { store: client.telemetryEventStore },
@@ -170,6 +171,38 @@ describe('sandbox dispatcher', () => {
     expect(run).not.toHaveBeenCalled();
 
     vi.doUnmock('../../../../src/commands/sandbox/create');
+  });
+
+  it.each([
+    'connect',
+    'ssh',
+    'shell',
+  ])('routes %s to the native connect handler instead of the pass-through', async invokedAs => {
+    vi.resetModules();
+    client.reset();
+    const run = vi.fn(async () => {});
+    vi.doMock('sandbox', () => ({ createApp: () => ({ run }) }));
+
+    const connectHandler = vi.fn(async () => 0);
+    vi.doMock('../../../../src/commands/sandbox/connect', () => ({
+      default: connectHandler,
+    }));
+
+    const { default: sandbox } = await import(
+      '../../../../src/commands/sandbox'
+    );
+
+    client.setArgv('sandbox', invokedAs, 'my-sandbox');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(connectHandler).toHaveBeenCalledWith(
+      client,
+      expect.arrayContaining(['my-sandbox'])
+    );
+    expect(run).not.toHaveBeenCalled();
+
+    vi.doUnmock('../../../../src/commands/sandbox/connect');
   });
 
   it('returns 1 and prints the error when the pass-through throws', async () => {

--- a/packages/cli/test/unit/commands/sandbox/exec.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/exec.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import sandbox from '../../../../src/commands/sandbox';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+import * as getProjectModule from '../../../../src/util/projects/get-project-by-id-or-name';
+
+const { sandboxGet, execInSandbox } = vi.hoisted(() => ({
+  sandboxGet: vi.fn(),
+  execInSandbox: vi.fn(),
+}));
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+vi.mock('../../../../src/util/projects/get-project-by-id-or-name');
+vi.mock('../../../../src/util/sandbox/client', () => ({
+  sandboxClient: { get: sandboxGet },
+}));
+vi.mock('../../../../src/util/sandbox/exec-core', () => ({
+  execInSandbox,
+}));
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+const mockedGetProject = vi.mocked(getProjectModule.default);
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_sandbox',
+      name: 'sandbox-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockNotLinked() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'not_linked',
+    org: null,
+    project: null,
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+const fakeSandbox = { name: 'my-sandbox' } as any;
+
+describe('sandbox exec', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    sandboxGet.mockResolvedValue(fakeSandbox);
+    execInSandbox.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints help and returns 2 for --help', async () => {
+    client.setArgv('sandbox', 'exec', '--help');
+    const exitCode = await sandbox(client);
+    expect(exitCode).toBe(2);
+    expect(sandboxGet).not.toHaveBeenCalled();
+  });
+
+  it('resolves the linked project and resumes the named sandbox', async () => {
+    client.setArgv('sandbox', 'exec', 'my-sandbox', 'echo', 'hi');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxGet).toHaveBeenCalledWith({
+      name: 'my-sandbox',
+      token: expect.any(String),
+      teamId: 'team_dummy',
+      projectId: 'prj_sandbox',
+      resume: true,
+      __includeSystemRoutes: true,
+    });
+  });
+
+  it('delegates to execInSandbox with parsed flags for a non-interactive command', async () => {
+    client.setArgv(
+      'sandbox',
+      'exec',
+      'my-sandbox',
+      '--workdir',
+      '/app',
+      '--sudo',
+      '--timeout',
+      '30s',
+      '--',
+      'npm',
+      'install'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(execInSandbox).toHaveBeenCalledWith({
+      sandbox: fakeSandbox,
+      command: 'npm',
+      args: ['install'],
+      cwd: '/app',
+      env: {},
+      sudo: true,
+      interactive: false,
+      skipExtendingTimeout: false,
+      timeout: '30s',
+    });
+  });
+
+  it('parses repeated --env flags into a key/value map', async () => {
+    client.setArgv(
+      'sandbox',
+      'exec',
+      'my-sandbox',
+      '--env',
+      'A=1',
+      '-e',
+      'B=2',
+      '--',
+      'node',
+      'x.js'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(execInSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ env: { A: '1', B: '2' } })
+    );
+  });
+
+  it('passes --interactive through without re-validating the TTY itself', async () => {
+    client.setArgv(
+      'sandbox',
+      'exec',
+      'my-sandbox',
+      '--interactive',
+      '--',
+      'bash'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(execInSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ interactive: true, command: 'bash', args: [] })
+    );
+  });
+
+  it('surfaces the execInSandbox TTY error unchanged when it rejects', async () => {
+    execInSandbox.mockRejectedValue(
+      new Error('The --interactive flag requires a terminal (TTY).')
+    );
+    client.setArgv(
+      'sandbox',
+      'exec',
+      'my-sandbox',
+      '--interactive',
+      '--',
+      'bash'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '--interactive flag requires a terminal (TTY)'
+    );
+  });
+
+  it('resolves --project via the current team scope', async () => {
+    mockedGetProject.mockResolvedValue({ id: 'prj_other' } as any);
+    client.setArgv(
+      'sandbox',
+      'exec',
+      'my-sandbox',
+      '--project',
+      'other-app',
+      '--',
+      'echo',
+      'hi'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(mockedGetProject).toHaveBeenCalledWith(
+      client,
+      'other-app',
+      'team_dummy'
+    );
+    expect(sandboxGet).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'prj_other' })
+    );
+  });
+
+  it('errors when there is no linked project and no --project flag', async () => {
+    mockNotLinked();
+    client.setArgv('sandbox', 'exec', 'my-sandbox', '--', 'echo', 'hi');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(sandboxGet).not.toHaveBeenCalled();
+  });
+
+  it('errors when the command positional is missing', async () => {
+    client.setArgv('sandbox', 'exec', 'my-sandbox');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('command');
+    expect(sandboxGet).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed --timeout before calling execInSandbox', async () => {
+    client.setArgv(
+      'sandbox',
+      'exec',
+      'my-sandbox',
+      '--timeout',
+      'nonsense',
+      '--',
+      'echo',
+      'hi'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Malformed duration');
+    expect(execInSandbox).not.toHaveBeenCalled();
+  });
+
+  it('tracks subcommand invocation', async () => {
+    client.setArgv('sandbox', 'exec', 'my-sandbox', '--', 'echo', 'hi');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:exec',
+        value: 'exec',
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/sandbox/exec.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/exec.test.ts
@@ -4,6 +4,9 @@ import sandbox from '../../../../src/commands/sandbox';
 import * as linkModule from '../../../../src/util/projects/link';
 import * as getScopeModule from '../../../../src/util/get-scope';
 import * as getProjectModule from '../../../../src/util/projects/get-project-by-id-or-name';
+import { execSubcommand } from '../../../../src/commands/sandbox/exec/command';
+import { parseArguments } from '../../../../src/util/get-args';
+import { getFlagsSpecification } from '../../../../src/util/get-flags-specification';
 
 const { sandboxGet, execInSandbox } = vi.hoisted(() => ({
   sandboxGet: vi.fn(),
@@ -243,6 +246,21 @@ describe('sandbox exec', () => {
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain('Malformed duration');
     expect(execInSandbox).not.toHaveBeenCalled();
+  });
+
+  it('does not let -t shadow the global --token shorthand', () => {
+    const hasShortTty = execSubcommand.options.some(
+      opt => 'name' in opt && opt.name === 'tty' && opt.shorthand === 't'
+    );
+    expect(hasShortTty).toBe(false);
+
+    const { flags } = parseArguments(
+      ['-t', 'my-token', 'my-sandbox', 'echo', 'hi'],
+      getFlagsSpecification(execSubcommand.options)
+    );
+
+    expect(flags['--token']).toBe('my-token');
+    expect(flags['--tty']).toBeUndefined();
   });
 
   it('tracks subcommand invocation', async () => {

--- a/packages/cli/test/unit/commands/sandbox/fork.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/fork.test.ts
@@ -1,0 +1,389 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import sandbox from '../../../../src/commands/sandbox';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+import * as getProjectModule from '../../../../src/util/projects/get-project-by-id-or-name';
+import { forkSubcommand } from '../../../../src/commands/sandbox/fork/command';
+import { parseArguments } from '../../../../src/util/get-args';
+import { getFlagsSpecification } from '../../../../src/util/get-flags-specification';
+
+const { sandboxFork, connectToSandbox, printSandboxSummary } = vi.hoisted(
+  () => ({
+    sandboxFork: vi.fn(),
+    connectToSandbox: vi.fn(),
+    printSandboxSummary: vi.fn(),
+  })
+);
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+vi.mock('../../../../src/util/projects/get-project-by-id-or-name');
+vi.mock('../../../../src/util/sandbox/client', () => ({
+  sandboxClient: { fork: sandboxFork },
+}));
+vi.mock('../../../../src/util/sandbox/exec-core', () => ({
+  connectToSandbox,
+  assertInteractivePort: vi.fn(),
+}));
+vi.mock('../../../../src/util/sandbox/print-sandbox-summary', () => ({
+  printSandboxSummary,
+}));
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+const mockedGetProject = vi.mocked(getProjectModule.default);
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_sandbox',
+      name: 'sandbox-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockNotLinked() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'not_linked',
+    org: null,
+    project: null,
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+const fakeSandbox = {
+  name: 'my-forked-sandbox',
+  interactivePort: 39375,
+  routes: [],
+} as any;
+
+describe('sandbox fork', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    sandboxFork.mockResolvedValue(fakeSandbox);
+    connectToSandbox.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints help and returns 2 for --help', async () => {
+    client.setArgv('sandbox', 'fork', '--help');
+    const exitCode = await sandbox(client);
+    expect(exitCode).toBe(2);
+    expect(sandboxFork).not.toHaveBeenCalled();
+  });
+
+  it('errors when the source positional is missing', async () => {
+    client.setArgv('sandbox', 'fork');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(sandboxFork).not.toHaveBeenCalled();
+  });
+
+  it('forks with only the required fields when no optional flags are given', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceSandbox: 'my-source',
+        teamId: 'team_dummy',
+        projectId: 'prj_sandbox',
+        token: expect.any(String),
+        __interactive: true,
+      })
+    );
+
+    const call = sandboxFork.mock.calls[0][0];
+    expect(call).not.toHaveProperty('name');
+    expect(call).not.toHaveProperty('ports');
+    expect(call).not.toHaveProperty('timeout');
+    expect(call).not.toHaveProperty('resources');
+    expect(call).not.toHaveProperty('networkPolicy');
+    expect(call).not.toHaveProperty('env');
+    expect(call).not.toHaveProperty('tags');
+    expect(call).not.toHaveProperty('persistent');
+    expect(call).not.toHaveProperty('snapshotExpiration');
+    expect(call).not.toHaveProperty('keepLastSnapshots');
+  });
+
+  it('passes --name through as an override', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source', '--name', 'my-fork');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'my-fork' })
+    );
+  });
+
+  it('passes --vcpus through as a resources override', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source', '--vcpus', '4');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ resources: { vcpus: 4 } })
+    );
+  });
+
+  it('passes --timeout through as an override with no default applied', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source', '--timeout', '30m');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 30 * 60 * 1000 })
+    );
+  });
+
+  it('passes --publish-port through as a ports override', async () => {
+    client.setArgv(
+      'sandbox',
+      'fork',
+      'my-source',
+      '--publish-port',
+      '3000',
+      '--publish-port',
+      '8080'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ ports: [3000, 8080] })
+    );
+  });
+
+  it('does not set a network policy when no network flags are given (inherit from source)', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    const call = sandboxFork.mock.calls[0][0];
+    expect(call).not.toHaveProperty('networkPolicy');
+  });
+
+  it('passes through an explicit --network-policy value', async () => {
+    client.setArgv(
+      'sandbox',
+      'fork',
+      'my-source',
+      '--network-policy',
+      'deny-all'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ networkPolicy: 'deny-all' })
+    );
+  });
+
+  it('builds a custom network policy from --allowed-domain', async () => {
+    client.setArgv(
+      'sandbox',
+      'fork',
+      'my-source',
+      '--allowed-domain',
+      '*.vercel.com'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkPolicy: { allow: ['*.vercel.com'] },
+      })
+    );
+  });
+
+  it('sets env only when --env is given', async () => {
+    client.setArgv(
+      'sandbox',
+      'fork',
+      'my-source',
+      '--env',
+      'FOO=bar',
+      '--env',
+      'BAZ=qux'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ env: { FOO: 'bar', BAZ: 'qux' } })
+    );
+  });
+
+  it('sets tags only when --tag is given, replacing rather than merging', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source', '--tag', 'env=staging');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: { env: 'staging' } })
+    );
+  });
+
+  it('passes persistent: false only when --non-persistent is given', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source', '--non-persistent');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ persistent: false })
+    );
+  });
+
+  it('does not pass persistent when --non-persistent is omitted', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    const call = sandboxFork.mock.calls[0][0];
+    expect(call).not.toHaveProperty('persistent');
+  });
+
+  it('passes snapshotExpiration and keepLastSnapshots overrides through', async () => {
+    client.setArgv(
+      'sandbox',
+      'fork',
+      'my-source',
+      '--snapshot-expiration',
+      '7d',
+      '--keep-last-snapshots',
+      '3'
+    );
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotExpiration: 7 * 24 * 60 * 60 * 1000,
+        keepLastSnapshots: {
+          count: 3,
+          expiration: undefined,
+          deleteEvicted: undefined,
+        },
+      })
+    );
+  });
+
+  it('connects to the sandbox after forking it when --connect is given', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source', '--connect');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(connectToSandbox).toHaveBeenCalledWith(fakeSandbox);
+  });
+
+  it('does not connect when --connect is omitted', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(connectToSandbox).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the summary and getScope when --silent is given', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source', '--silent');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(printSandboxSummary).not.toHaveBeenCalled();
+    expect(mockedGetScope).not.toHaveBeenCalled();
+  });
+
+  it('prints the summary with a "forked from" action when --silent is omitted', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(printSandboxSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandbox: fakeSandbox,
+        contextName: 'my-team',
+        action: 'forked from my-source',
+      })
+    );
+    expect(mockedGetScope).toHaveBeenCalled();
+  });
+
+  it('does not let -t shadow the global --token shorthand', () => {
+    const hasShortTag = forkSubcommand.options.some(
+      opt => 'name' in opt && opt.name === 'tag' && opt.shorthand === 't'
+    );
+    expect(hasShortTag).toBe(false);
+
+    const { flags } = parseArguments(
+      ['-t', 'my-token'],
+      getFlagsSpecification(forkSubcommand.options)
+    );
+
+    expect(flags['--token']).toBe('my-token');
+    expect(flags['--tag']).toBeUndefined();
+  });
+
+  it('resolves --project via the current team scope', async () => {
+    mockedGetProject.mockResolvedValue({ id: 'prj_other' } as any);
+    client.setArgv('sandbox', 'fork', 'my-source', '--project', 'other-app');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(mockedGetProject).toHaveBeenCalledWith(
+      client,
+      'other-app',
+      'team_dummy'
+    );
+    expect(sandboxFork).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'prj_other' })
+    );
+  });
+
+  it('errors when there is no linked project and no --project flag', async () => {
+    mockNotLinked();
+    client.setArgv('sandbox', 'fork', 'my-source');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(1);
+    expect(sandboxFork).not.toHaveBeenCalled();
+  });
+
+  it('tracks subcommand invocation', async () => {
+    client.setArgv('sandbox', 'fork', 'my-source');
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:fork',
+        value: 'fork',
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/sandbox/run.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/run.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { APIError } from '@vercel/sandbox';
+import { client } from '../../../mocks/client';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+import { runSubcommand } from '../../../../src/commands/sandbox/run/command';
+import { parseArguments } from '../../../../src/util/get-args';
+import { getFlagsSpecification } from '../../../../src/util/get-flags-specification';
+
+const { sandboxGet, execInSandbox, runCreate } = vi.hoisted(() => ({
+  sandboxGet: vi.fn(),
+  execInSandbox: vi.fn(),
+  runCreate: vi.fn(),
+}));
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+vi.mock('../../../../src/util/sandbox/client', () => ({
+  sandboxClient: { get: sandboxGet },
+}));
+vi.mock('../../../../src/util/sandbox/exec-core', () => ({
+  execInSandbox,
+}));
+vi.mock('../../../../src/commands/sandbox/create', async importActual => {
+  const actual =
+    await importActual<
+      typeof import('../../../../src/commands/sandbox/create')
+    >();
+  return { ...actual, runCreate };
+});
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_sandbox',
+      name: 'sandbox-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+function makeFakeSandbox(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'my-sandbox',
+    delete: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as any;
+}
+
+function makeNotFoundError() {
+  const response = new Response(null, { status: 404 });
+  const apiError = new APIError(response);
+  return new Error('Sandbox not found', { cause: apiError });
+}
+
+describe('sandbox run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    execInSandbox.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints help and returns 2 for --help', async () => {
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+    const exitCode = await run(client, ['--help']);
+
+    expect(exitCode).toBe(2);
+    expect(runCreate).not.toHaveBeenCalled();
+    expect(sandboxGet).not.toHaveBeenCalled();
+  });
+
+  it('rejects --rm combined with --stop', async () => {
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+    const exitCode = await run(client, ['--rm', '--stop', '--', 'echo', 'hi']);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('mutually exclusive');
+    expect(runCreate).not.toHaveBeenCalled();
+    expect(sandboxGet).not.toHaveBeenCalled();
+  });
+
+  it('errors when the command positional is missing', async () => {
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+    const exitCode = await run(client, ['--name', 'my-sandbox']);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('command');
+    expect(sandboxGet).not.toHaveBeenCalled();
+    expect(runCreate).not.toHaveBeenCalled();
+  });
+
+  it('execs without creating when a named sandbox already exists', async () => {
+    const fakeSandbox = makeFakeSandbox();
+    sandboxGet.mockResolvedValue(fakeSandbox);
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+
+    const exitCode = await run(client, [
+      '--name',
+      'my-sandbox',
+      '--',
+      'echo',
+      'hi',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxGet).toHaveBeenCalledWith({
+      name: 'my-sandbox',
+      token: expect.any(String),
+      teamId: 'team_dummy',
+      projectId: 'prj_sandbox',
+      resume: true,
+      __includeSystemRoutes: true,
+    });
+    expect(runCreate).not.toHaveBeenCalled();
+    expect(execInSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandbox: fakeSandbox,
+        command: 'echo',
+        args: ['hi'],
+        timeout: undefined,
+      })
+    );
+  });
+
+  it('creates the sandbox when the named lookup 404s', async () => {
+    sandboxGet.mockRejectedValue(makeNotFoundError());
+    const fakeSandbox = makeFakeSandbox();
+    runCreate.mockResolvedValue(fakeSandbox);
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+
+    const exitCode = await run(client, [
+      '--name',
+      'my-sandbox',
+      '--',
+      'echo',
+      'hi',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(runCreate).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({ name: 'my-sandbox' })
+    );
+    expect(execInSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ sandbox: fakeSandbox })
+    );
+  });
+
+  it('propagates a non-404 error from the named lookup without creating', async () => {
+    sandboxGet.mockRejectedValue(new Error('boom'));
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+
+    const exitCode = await run(client, [
+      '--name',
+      'my-sandbox',
+      '--',
+      'echo',
+      'hi',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(runCreate).not.toHaveBeenCalled();
+    expect(execInSandbox).not.toHaveBeenCalled();
+  });
+
+  it('always creates when no --name is given', async () => {
+    const fakeSandbox = makeFakeSandbox();
+    runCreate.mockResolvedValue(fakeSandbox);
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+
+    const exitCode = await run(client, ['--', 'echo', 'hi']);
+
+    expect(exitCode).toBe(0);
+    expect(sandboxGet).not.toHaveBeenCalled();
+    expect(runCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('forces nonPersistent when --rm is set and deletes the sandbox after a successful run', async () => {
+    const fakeSandbox = makeFakeSandbox();
+    runCreate.mockResolvedValue(fakeSandbox);
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+
+    const exitCode = await run(client, ['--rm', '--', 'echo', 'hi']);
+
+    expect(exitCode).toBe(0);
+    expect(runCreate).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({ nonPersistent: true })
+    );
+    expect(fakeSandbox.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes the sandbox in finally even when the exec throws, with --rm', async () => {
+    const fakeSandbox = makeFakeSandbox();
+    runCreate.mockResolvedValue(fakeSandbox);
+    execInSandbox.mockRejectedValue(new Error('exec failed'));
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+
+    const exitCode = await run(client, ['--rm', '--', 'echo', 'hi']);
+
+    expect(exitCode).toBe(1);
+    expect(fakeSandbox.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops the sandbox after a successful run with --stop', async () => {
+    const fakeSandbox = makeFakeSandbox();
+    runCreate.mockResolvedValue(fakeSandbox);
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+
+    const exitCode = await run(client, ['--stop', '--', 'echo', 'hi']);
+
+    expect(exitCode).toBe(0);
+    expect(fakeSandbox.stop).toHaveBeenCalledTimes(1);
+    expect(fakeSandbox.delete).not.toHaveBeenCalled();
+  });
+
+  it('does not clean up when neither --rm nor --stop is set', async () => {
+    const fakeSandbox = makeFakeSandbox();
+    runCreate.mockResolvedValue(fakeSandbox);
+    const { default: run } = await import(
+      '../../../../src/commands/sandbox/run'
+    );
+
+    const exitCode = await run(client, ['--', 'echo', 'hi']);
+
+    expect(exitCode).toBe(0);
+    expect(fakeSandbox.delete).not.toHaveBeenCalled();
+    expect(fakeSandbox.stop).not.toHaveBeenCalled();
+  });
+
+  it('does not let -t shadow the global --token shorthand for --tag', () => {
+    const hasShortTag = runSubcommand.options.some(
+      opt => 'name' in opt && opt.name === 'tag' && opt.shorthand === 't'
+    );
+    expect(hasShortTag).toBe(false);
+
+    const { flags } = parseArguments(
+      ['-t', 'my-token', '--', 'echo', 'hi'],
+      getFlagsSpecification(runSubcommand.options)
+    );
+
+    expect(flags['--token']).toBe('my-token');
+    expect(flags['--tag']).toBeUndefined();
+  });
+
+  it('does not let -t shadow the global --token shorthand for --tty', () => {
+    const hasShortTty = runSubcommand.options.some(
+      opt => 'name' in opt && opt.name === 'tty' && opt.shorthand === 't'
+    );
+    expect(hasShortTty).toBe(false);
+
+    const { flags } = parseArguments(
+      ['-t', 'my-token', '--', 'echo', 'hi'],
+      getFlagsSpecification(runSubcommand.options)
+    );
+
+    expect(flags['--token']).toBe('my-token');
+    expect(flags['--tty']).toBeUndefined();
+  });
+});

--- a/packages/cli/test/unit/commands/sandbox/sh.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/sh.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { shSubcommand } from '../../../../src/commands/sandbox/sh/command';
+
+const { runCreate } = vi.hoisted(() => ({
+  runCreate: vi.fn(),
+}));
+
+vi.mock('../../../../src/commands/sandbox/create', async importActual => {
+  const actual =
+    await importActual<
+      typeof import('../../../../src/commands/sandbox/create')
+    >();
+  return { ...actual, runCreate };
+});
+
+const fakeSandbox = { name: 'my-sandbox' } as any;
+
+describe('sandbox sh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    runCreate.mockResolvedValue(fakeSandbox);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes the create flags minus --connect', () => {
+    const names = shSubcommand.options.map(option => String(option.name));
+    expect(names).toContain('runtime');
+    expect(names).toContain('network-policy');
+    expect(names).not.toContain('connect');
+  });
+
+  it('prints help and returns 2 for --help', async () => {
+    const { default: sh } = await import('../../../../src/commands/sandbox/sh');
+    const exitCode = await sh(client, ['--help']);
+    expect(exitCode).toBe(2);
+    expect(runCreate).not.toHaveBeenCalled();
+  });
+
+  it('runs the create flow with connect forced true and the parsed flags', async () => {
+    const { default: sh } = await import('../../../../src/commands/sandbox/sh');
+    const exitCode = await sh(client, [
+      '--runtime',
+      'node22',
+      '--network-policy',
+      'deny-all',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(runCreate).toHaveBeenCalledTimes(1);
+    expect(runCreate).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        connect: true,
+        runtime: 'node22',
+        networkPolicy: 'deny-all',
+      })
+    );
+  });
+
+  it('returns 1 when parsing fails', async () => {
+    const { default: sh } = await import('../../../../src/commands/sandbox/sh');
+    const exitCode = await sh(client, ['--connect']);
+    expect(exitCode).toBe(1);
+    expect(runCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/unit/util/sandbox/args.test.ts
+++ b/packages/cli/test/unit/util/sandbox/args.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  RUNTIMES,
+  assertSandboxName,
+  buildKeepLastSnapshots,
+  buildNetworkPolicy,
+  parseDuration,
+  parseKeyValues,
+  parseNetworkPolicyMode,
+  parsePort,
+  parseRuntime,
+  parseSnapshotExpiration,
+  parseSnapshotId,
+  parseVcpus,
+} from '../../../../src/util/sandbox/args';
+
+describe('parseKeyValues', () => {
+  const originalB = process.env.B;
+
+  afterEach(() => {
+    if (originalB === undefined) {
+      delete process.env.B;
+    } else {
+      process.env.B = originalB;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('splits KEY=VALUE pairs and puns bare KEY to $KEY', () => {
+    process.env.B = '2';
+    expect(parseKeyValues(['A=1', 'B'])).toEqual({ A: '1', B: '2' });
+  });
+
+  it('splits on the first = only, keeping later = in the value', () => {
+    expect(parseKeyValues(['A=x=y'])).toEqual({ A: 'x=y' });
+  });
+
+  it('omits keys with no value and warns to stderr', () => {
+    delete process.env.MISSING_VAR;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseKeyValues(['MISSING_VAR'])).toEqual({});
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain('MISSING_VAR');
+    expect(errorSpy.mock.calls[0][0]).toContain(
+      '--env VAR is equivalent to --env VAR=$VAR'
+    );
+  });
+});
+
+describe('parseDuration', () => {
+  it('accepts a valid duration and returns it unmodified', () => {
+    expect(parseDuration('5m')).toBe('5m');
+  });
+
+  it('throws a friendly error on malformed input', () => {
+    expect(() => parseDuration('nope')).toThrow(/Malformed duration: "nope"/);
+  });
+});
+
+describe('parseSnapshotExpiration', () => {
+  it('maps "none" to "0"', () => {
+    expect(parseSnapshotExpiration('none')).toBe('0');
+  });
+
+  it('delegates to parseDuration otherwise', () => {
+    expect(parseSnapshotExpiration('7d')).toBe('7d');
+  });
+
+  it('throws the same malformed-duration error as parseDuration', () => {
+    expect(() => parseSnapshotExpiration('nope')).toThrow(
+      /Malformed duration: "nope"/
+    );
+  });
+});
+
+describe('parseRuntime', () => {
+  it('accepts each of the four known runtimes', () => {
+    for (const runtime of RUNTIMES) {
+      expect(parseRuntime(runtime)).toBe(runtime);
+    }
+  });
+
+  it('throws listing all four runtimes for an invalid value', () => {
+    expect(() => parseRuntime('go')).toThrow(
+      /node22.*node24.*node26.*python3\.13/
+    );
+  });
+});
+
+describe('parseVcpus', () => {
+  it('accepts a positive integer', () => {
+    expect(parseVcpus(4)).toBe(4);
+  });
+
+  it('throws for a non-positive value', () => {
+    expect(() => parseVcpus(0)).toThrow(/Invalid vCPU count: 0/);
+  });
+
+  it('throws for a non-integer value', () => {
+    expect(() => parseVcpus(1.5)).toThrow(/Invalid vCPU count: 1\.5/);
+  });
+});
+
+describe('parsePort', () => {
+  it('rejects a privileged port', () => {
+    expect(() => parsePort(80)).toThrow(/Invalid port: 80/);
+  });
+
+  it('accepts a port within range', () => {
+    expect(parsePort(3000)).toBe(3000);
+  });
+
+  it('rejects a port above the max', () => {
+    expect(() => parsePort(70000)).toThrow(/Invalid port: 70000/);
+  });
+});
+
+describe('parseNetworkPolicyMode', () => {
+  it('accepts allow-all and deny-all', () => {
+    expect(parseNetworkPolicyMode('allow-all')).toBe('allow-all');
+    expect(parseNetworkPolicyMode('deny-all')).toBe('deny-all');
+  });
+
+  it('throws listing the valid modes for anything else', () => {
+    expect(() => parseNetworkPolicyMode('block-all')).toThrow(
+      /Invalid network policy mode: block-all/
+    );
+  });
+});
+
+describe('buildNetworkPolicy', () => {
+  it('returns undefined when nothing was specified', () => {
+    expect(
+      buildNetworkPolicy({
+        allowedDomains: [],
+        allowedCIDRs: [],
+        deniedCIDRs: [],
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns the mode string when only --network-policy is given', () => {
+    expect(
+      buildNetworkPolicy({
+        networkPolicy: 'deny-all',
+        allowedDomains: [],
+        allowedCIDRs: [],
+        deniedCIDRs: [],
+      })
+    ).toBe('deny-all');
+  });
+
+  it('builds an object policy from allow/deny lists', () => {
+    expect(
+      buildNetworkPolicy({
+        allowedDomains: ['example.com'],
+        allowedCIDRs: ['10.0.0.0/8'],
+        deniedCIDRs: ['10.1.0.0/16'],
+      })
+    ).toEqual({
+      allow: ['example.com'],
+      subnets: { allow: ['10.0.0.0/8'], deny: ['10.1.0.0/16'] },
+    });
+  });
+
+  it('throws when --network-policy is combined with list options', () => {
+    expect(() =>
+      buildNetworkPolicy({
+        networkPolicy: 'allow-all',
+        allowedDomains: ['example.com'],
+        allowedCIDRs: [],
+        deniedCIDRs: [],
+      })
+    ).toThrow(/Cannot combine --network-policy=allow-all/);
+  });
+});
+
+describe('parseSnapshotId', () => {
+  it('accepts an id with the snap_ prefix', () => {
+    expect(parseSnapshotId('snap_abc123')).toBe('snap_abc123');
+  });
+
+  it('throws for an id missing the snap_ prefix', () => {
+    expect(() => parseSnapshotId('x')).toThrow(/Malformed snapshot ID: "x"/);
+  });
+});
+
+describe('buildKeepLastSnapshots', () => {
+  it('returns undefined when nothing was specified', () => {
+    expect(
+      buildKeepLastSnapshots({
+        keepLastSnapshots: undefined,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: undefined,
+      })
+    ).toBeUndefined();
+  });
+
+  it('throws when keepLastSnapshotsFor is given without keepLastSnapshots', () => {
+    expect(() =>
+      buildKeepLastSnapshots({
+        keepLastSnapshots: undefined,
+        keepLastSnapshotsFor: '7d',
+        deleteEvictedSnapshots: undefined,
+      })
+    ).toThrow(
+      /--keep-last-snapshots-for and --delete-evicted-snapshots require --keep-last-snapshots/
+    );
+  });
+
+  it('throws when deleteEvictedSnapshots is given without keepLastSnapshots', () => {
+    expect(() =>
+      buildKeepLastSnapshots({
+        keepLastSnapshots: undefined,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: 'true',
+      })
+    ).toThrow(/require --keep-last-snapshots/);
+  });
+
+  it('throws when the count is out of range', () => {
+    expect(() =>
+      buildKeepLastSnapshots({
+        keepLastSnapshots: 11,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: undefined,
+      })
+    ).toThrow(/Invalid --keep-last-snapshots value: 11/);
+  });
+
+  it('builds the full payload with expiration and deleteEvicted', () => {
+    expect(
+      buildKeepLastSnapshots({
+        keepLastSnapshots: 3,
+        keepLastSnapshotsFor: '7d',
+        deleteEvictedSnapshots: 'false',
+      })
+    ).toEqual({
+      count: 3,
+      expiration: 7 * 24 * 60 * 60 * 1000,
+      deleteEvicted: false,
+    });
+  });
+
+  it('builds a minimal payload when only the count is given', () => {
+    expect(
+      buildKeepLastSnapshots({
+        keepLastSnapshots: 5,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: undefined,
+      })
+    ).toEqual({ count: 5, expiration: undefined, deleteEvicted: undefined });
+  });
+});
+
+describe('assertSandboxName', () => {
+  it('returns a non-empty name unchanged', () => {
+    expect(assertSandboxName('my-sandbox')).toBe('my-sandbox');
+  });
+
+  it('throws for an empty string', () => {
+    expect(() => assertSandboxName('')).toThrow(/Sandbox name cannot be empty/);
+  });
+
+  it('throws for a whitespace-only string', () => {
+    expect(() => assertSandboxName('   ')).toThrow(
+      /Sandbox name cannot be empty/
+    );
+  });
+});

--- a/packages/cli/test/unit/util/sandbox/args.test.ts
+++ b/packages/cli/test/unit/util/sandbox/args.test.ts
@@ -220,6 +220,18 @@ describe('buildKeepLastSnapshots', () => {
     ).toBeUndefined();
   });
 
+  it('throws when deleteEvictedSnapshots is not "true" or "false"', () => {
+    expect(() =>
+      buildKeepLastSnapshots({
+        keepLastSnapshots: 3,
+        keepLastSnapshotsFor: undefined,
+        deleteEvictedSnapshots: 'yes',
+      })
+    ).toThrow(
+      /Invalid --delete-evicted-snapshots value: yes\. Must be "true" or "false"/
+    );
+  });
+
   it('throws when keepLastSnapshotsFor is given without keepLastSnapshots', () => {
     expect(() =>
       buildKeepLastSnapshots({

--- a/packages/cli/test/unit/util/sandbox/args.test.ts
+++ b/packages/cli/test/unit/util/sandbox/args.test.ts
@@ -163,6 +163,30 @@ describe('buildNetworkPolicy', () => {
     });
   });
 
+  it('builds a subnets-only allow policy when only allowedCIDRs is given', () => {
+    expect(
+      buildNetworkPolicy({
+        allowedDomains: [],
+        allowedCIDRs: ['10.0.0.0/8'],
+        deniedCIDRs: [],
+      })
+    ).toEqual({
+      subnets: { allow: ['10.0.0.0/8'] },
+    });
+  });
+
+  it('builds a subnets-only deny policy when only deniedCIDRs is given', () => {
+    expect(
+      buildNetworkPolicy({
+        allowedDomains: [],
+        allowedCIDRs: [],
+        deniedCIDRs: ['10.1.0.0/16'],
+      })
+    ).toEqual({
+      subnets: { deny: ['10.1.0.0/16'] },
+    });
+  });
+
   it('throws when --network-policy is combined with list options', () => {
     expect(() =>
       buildNetworkPolicy({

--- a/packages/cli/test/unit/util/sandbox/client.test.ts
+++ b/packages/cli/test/unit/util/sandbox/client.test.ts
@@ -70,4 +70,54 @@ describe('sandboxClient', () => {
       sandboxClient.list({ token: 't', teamId: 'team_1' } as never)
     ).rejects.toThrow(/nope/);
   });
+
+  it('preserves the original APIError as the cause of the wrapped Error', async () => {
+    vi.resetModules();
+    const response = new Response('{"error":{"message":"not found"}}', {
+      status: 404,
+      statusText: 'Not Found',
+    });
+    Object.defineProperty(response, 'url', {
+      value: 'https://vercel.com/api/x',
+    });
+    const { APIError } =
+      await vi.importActual<typeof import('@vercel/sandbox')>(
+        '@vercel/sandbox'
+      );
+    const apiError = new APIError(response, {
+      json: { error: { message: 'not found' } },
+      text: '{}',
+    });
+    vi.doMock('@vercel/sandbox', async () => {
+      const actual =
+        await vi.importActual<typeof import('@vercel/sandbox')>(
+          '@vercel/sandbox'
+        );
+      return {
+        ...actual,
+        Sandbox: {
+          get: async () => {
+            throw apiError;
+          },
+        },
+      };
+    });
+    const { sandboxClient } = await import(
+      '../../../../src/util/sandbox/client'
+    );
+
+    let caught: unknown;
+    try {
+      await sandboxClient.get({
+        name: 'x',
+        token: 't',
+        teamId: 'team_1',
+      } as never);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).cause).toBe(apiError);
+  });
 });

--- a/packages/cli/test/unit/util/sandbox/disposables.test.ts
+++ b/packages/cli/test/unit/util/sandbox/disposables.test.ts
@@ -6,6 +6,13 @@ import {
 } from '../../../../src/util/sandbox/disposables';
 import { ignoreAbortErrors } from '../../../../src/util/sandbox/abort-controller';
 
+describe('Symbol.dispose polyfill', () => {
+  it('defines Symbol.dispose and Symbol.asyncDispose', () => {
+    expect(typeof Symbol.dispose).not.toBe('undefined');
+    expect(typeof Symbol.asyncDispose).not.toBe('undefined');
+  });
+});
+
 describe('acquireRelease', () => {
   it('runs release with the acquired value on dispose', () => {
     const release = vi.fn();
@@ -13,6 +20,16 @@ describe('acquireRelease', () => {
     expect(release).not.toHaveBeenCalled();
     resource[Symbol.dispose]();
     expect(release).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+  });
+
+  it('runs release via a real `using` block on exit', () => {
+    const release = vi.fn();
+    {
+      using resource = acquireRelease(() => ({ id: 2 }), release);
+      expect(release).not.toHaveBeenCalled();
+      expect(resource.id).toBe(2);
+    }
+    expect(release).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }));
   });
 });
 
@@ -22,6 +39,15 @@ describe('defer', () => {
     const disposable = defer(fn);
     expect(fn).not.toHaveBeenCalled();
     disposable[Symbol.dispose]();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs fn via a real `using` block on exit', () => {
+    const fn = vi.fn();
+    {
+      using _disposable = defer(fn);
+      expect(fn).not.toHaveBeenCalled();
+    }
     expect(fn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/test/unit/util/sandbox/disposables.test.ts
+++ b/packages/cli/test/unit/util/sandbox/disposables.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  acquireRelease,
+  createAbortController,
+  defer,
+} from '../../../../src/util/sandbox/disposables';
+import { ignoreAbortErrors } from '../../../../src/util/sandbox/abort-controller';
+
+describe('acquireRelease', () => {
+  it('runs release with the acquired value on dispose', () => {
+    const release = vi.fn();
+    const resource = acquireRelease(() => ({ id: 1 }), release);
+    expect(release).not.toHaveBeenCalled();
+    resource[Symbol.dispose]();
+    expect(release).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+  });
+});
+
+describe('defer', () => {
+  it('runs fn on Symbol.dispose', () => {
+    const fn = vi.fn();
+    const disposable = defer(fn);
+    expect(fn).not.toHaveBeenCalled();
+    disposable[Symbol.dispose]();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createAbortController', () => {
+  it('sets signal.aborted on abort()', () => {
+    const controller = createAbortController('test reason');
+    expect(controller.signal.aborted).toBe(false);
+    controller.abort();
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('aborts with the provided reason by default', () => {
+    const controller = createAbortController('default reason');
+    controller.abort();
+    expect(controller.signal.reason).toBe('default reason');
+  });
+
+  it('aborts with an override reason when given', () => {
+    const controller = createAbortController('default reason');
+    controller.abort('override reason');
+    expect(controller.signal.reason).toBe('override reason');
+  });
+
+  it('aborts on Symbol.dispose', () => {
+    const controller = createAbortController('disposed');
+    controller[Symbol.dispose]();
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('ignoreInterruptions swallows an AbortError once aborted', () => {
+    const controller = createAbortController('test reason');
+    controller.abort();
+    const abortError = Object.assign(new Error('aborted'), {
+      name: 'AbortError',
+    });
+    expect(() => controller.ignoreInterruptions(abortError)).not.toThrow();
+  });
+
+  it('ignoreInterruptions rethrows a normal Error', () => {
+    const controller = createAbortController('test reason');
+    const err = new Error('boom');
+    expect(() => controller.ignoreInterruptions(err)).toThrow('boom');
+  });
+});
+
+describe('ignoreAbortErrors', () => {
+  it('swallows any error once the signal is aborted', () => {
+    const controller = new AbortController();
+    controller.abort();
+    const ignore = ignoreAbortErrors(controller.signal);
+    expect(() => ignore(new Error('boom'))).not.toThrow();
+  });
+
+  it('rethrows when the signal is not aborted', () => {
+    const controller = new AbortController();
+    const ignore = ignoreAbortErrors(controller.signal);
+    const err = new Error('boom');
+    expect(() => ignore(err)).toThrow('boom');
+  });
+});

--- a/packages/cli/test/unit/util/sandbox/exec-core.test.ts
+++ b/packages/cli/test/unit/util/sandbox/exec-core.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { startInteractiveShell } = vi.hoisted(() => ({
+  startInteractiveShell: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../../../src/util/sandbox/interactive-shell', () => ({
+  startInteractiveShell,
+}));
+
+import {
+  assertInteractivePort,
+  connectToSandbox,
+  execInSandbox,
+} from '../../../../src/util/sandbox/exec-core';
+
+function fakeSandbox(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'my-sandbox',
+    cwd: '/vercel/sandbox',
+    interactivePort: 39821,
+    runCommand: vi.fn().mockResolvedValue({ exitCode: 0 }),
+    ...overrides,
+  };
+}
+
+describe('execInSandbox', () => {
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    originalIsTTY = process.stdout.isTTY;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    startInteractiveShell.mockClear();
+    startInteractiveShell.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    process.exitCode = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('runs a command non-interactively with stdout/stderr wired and sets process.exitCode', async () => {
+    const sandbox = fakeSandbox({
+      runCommand: vi.fn().mockResolvedValue({ exitCode: 0 }),
+    });
+
+    await execInSandbox({
+      sandbox: sandbox as never,
+      command: 'node',
+      args: ['x.js'],
+      cwd: '/app',
+      env: { FOO: 'bar' },
+      sudo: false,
+      interactive: false,
+      skipExtendingTimeout: false,
+    });
+
+    expect(sandbox.runCommand).toHaveBeenCalledWith({
+      cmd: 'node',
+      args: ['x.js'],
+      stdout: process.stdout,
+      stderr: process.stderr,
+      sudo: false,
+      cwd: '/app',
+      env: { FOO: 'bar' },
+      timeoutMs: undefined,
+    });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('prints the command echo to stderr before running', async () => {
+    const sandbox = fakeSandbox();
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+
+    await execInSandbox({
+      sandbox: sandbox as never,
+      command: 'echo',
+      args: ['hi'],
+      env: {},
+      sudo: false,
+      interactive: false,
+      skipExtendingTimeout: false,
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('echo hi')
+    );
+  });
+
+  it('passes ms(timeout) as timeoutMs when a timeout is given', async () => {
+    const sandbox = fakeSandbox({
+      runCommand: vi.fn().mockResolvedValue({ exitCode: 0 }),
+    });
+
+    await execInSandbox({
+      sandbox: sandbox as never,
+      command: 'sleep',
+      args: ['10'],
+      env: {},
+      sudo: false,
+      interactive: false,
+      skipExtendingTimeout: false,
+      timeout: '5s',
+    });
+
+    expect(sandbox.runCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 5000 })
+    );
+  });
+
+  it('prints the SIGKILL note to stderr on exit code 137 with a timeout', async () => {
+    const sandbox = fakeSandbox({
+      runCommand: vi.fn().mockResolvedValue({ exitCode: 137 }),
+    });
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+
+    await execInSandbox({
+      sandbox: sandbox as never,
+      command: 'sleep',
+      args: ['100'],
+      env: {},
+      sudo: false,
+      interactive: false,
+      skipExtendingTimeout: false,
+      timeout: '1s',
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Command was killed (SIGKILL, exit code 137)')
+    );
+    expect(process.exitCode).toBe(137);
+  });
+
+  it('does not print the SIGKILL note on exit code 137 without a timeout', async () => {
+    const sandbox = fakeSandbox({
+      runCommand: vi.fn().mockResolvedValue({ exitCode: 137 }),
+    });
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+
+    await execInSandbox({
+      sandbox: sandbox as never,
+      command: 'sleep',
+      args: ['100'],
+      env: {},
+      sudo: false,
+      interactive: false,
+      skipExtendingTimeout: false,
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('SIGKILL')
+    );
+    expect(process.exitCode).toBe(137);
+  });
+
+  it('throws when interactive and timeout are both given', async () => {
+    const sandbox = fakeSandbox();
+
+    await expect(
+      execInSandbox({
+        sandbox: sandbox as never,
+        command: 'sh',
+        args: [],
+        env: {},
+        sudo: false,
+        interactive: true,
+        skipExtendingTimeout: false,
+        timeout: '5s',
+      })
+    ).rejects.toThrow('--timeout cannot be combined with --interactive');
+
+    expect(sandbox.runCommand).not.toHaveBeenCalled();
+    expect(startInteractiveShell).not.toHaveBeenCalled();
+  });
+
+  it('throws when interactive is requested without a TTY', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: false,
+      configurable: true,
+    });
+    const sandbox = fakeSandbox();
+
+    await expect(
+      execInSandbox({
+        sandbox: sandbox as never,
+        command: 'sh',
+        args: [],
+        env: {},
+        sudo: false,
+        interactive: true,
+        skipExtendingTimeout: false,
+      })
+    ).rejects.toThrow('--interactive flag requires a terminal (TTY)');
+
+    expect(startInteractiveShell).not.toHaveBeenCalled();
+  });
+
+  it('delegates to startInteractiveShell when interactive and TTY are both satisfied', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    const sandbox = fakeSandbox();
+
+    await execInSandbox({
+      sandbox: sandbox as never,
+      command: 'bash',
+      args: ['-l'],
+      cwd: '/app',
+      env: { FOO: 'bar' },
+      sudo: true,
+      interactive: true,
+      skipExtendingTimeout: true,
+    });
+
+    expect(startInteractiveShell).toHaveBeenCalledWith({
+      sandbox,
+      cwd: '/app',
+      execution: ['bash', '-l'],
+      envVars: { FOO: 'bar' },
+      sudo: true,
+      skipExtendingTimeout: true,
+    });
+    expect(sandbox.runCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe('connectToSandbox', () => {
+  beforeEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    startInteractiveShell.mockClear();
+    startInteractiveShell.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts an interactive sh shell with no cwd/env/sudo overrides', async () => {
+    const sandbox = fakeSandbox();
+
+    await connectToSandbox(sandbox as never);
+
+    expect(startInteractiveShell).toHaveBeenCalledWith({
+      sandbox,
+      cwd: undefined,
+      execution: ['sh'],
+      envVars: {},
+      sudo: false,
+      skipExtendingTimeout: false,
+    });
+  });
+});
+
+describe('assertInteractivePort', () => {
+  it('throws mentioning "created" when the sandbox has no interactive port', () => {
+    const sandbox = fakeSandbox({ interactivePort: undefined });
+
+    expect(() => assertInteractivePort(sandbox as never, 'created')).toThrow(
+      /created/
+    );
+  });
+
+  it('throws mentioning "forked" when the sandbox has no interactive port', () => {
+    const sandbox = fakeSandbox({ interactivePort: undefined });
+
+    expect(() => assertInteractivePort(sandbox as never, 'forked')).toThrow(
+      /forked/
+    );
+  });
+
+  it('does not throw when the sandbox has an interactive port', () => {
+    const sandbox = fakeSandbox({ interactivePort: 39821 });
+
+    expect(() =>
+      assertInteractivePort(sandbox as never, 'created')
+    ).not.toThrow();
+  });
+});

--- a/packages/cli/test/unit/util/sandbox/extend-timeout.test.ts
+++ b/packages/cli/test/unit/util/sandbox/extend-timeout.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { extendSandboxTimeoutPeriodically } from '../../../../src/util/sandbox/extend-timeout';
+
+function fakeSandbox(session: { timeout: number | null; createdAt: Date }) {
+  return {
+    currentSession: vi.fn(() => session),
+    extendTimeout: vi.fn(async (duration: number) => {
+      if (session.timeout != null) {
+        session.timeout += duration;
+      }
+    }),
+  };
+}
+
+describe('extendSandboxTimeoutPeriodically', () => {
+  it('extends the timeout and stops once the signal aborts', async () => {
+    const controller = new AbortController();
+    const session = { timeout: 5000, createdAt: new Date(Date.now() - 1000) };
+    const sandbox = fakeSandbox(session);
+    sandbox.extendTimeout.mockImplementation(async (duration: number) => {
+      session.timeout! += duration;
+      controller.abort();
+    });
+
+    await extendSandboxTimeoutPeriodically(sandbox as never, controller.signal);
+
+    expect(sandbox.extendTimeout).toHaveBeenCalledTimes(1);
+    expect(sandbox.extendTimeout).toHaveBeenCalledWith(5 * 60 * 1000);
+  });
+
+  it('does nothing when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const session = { timeout: 5000, createdAt: new Date() };
+    const sandbox = fakeSandbox(session);
+
+    await extendSandboxTimeoutPeriodically(sandbox as never, controller.signal);
+
+    expect(sandbox.extendTimeout).not.toHaveBeenCalled();
+  });
+
+  it('returns without extending when the session has no timeout', async () => {
+    const controller = new AbortController();
+    const session = { timeout: null, createdAt: new Date() };
+    const sandbox = fakeSandbox(session);
+
+    await extendSandboxTimeoutPeriodically(sandbox as never, controller.signal);
+
+    expect(sandbox.extendTimeout).not.toHaveBeenCalled();
+  });
+
+  it('rejects promptly if the signal aborts mid-sleep', async () => {
+    const controller = new AbortController();
+    const session = { timeout: 60_000, createdAt: new Date() };
+    const sandbox = fakeSandbox(session);
+
+    const promise = extendSandboxTimeoutPeriodically(
+      sandbox as never,
+      controller.signal
+    );
+    queueMicrotask(() => controller.abort());
+
+    await expect(promise).rejects.toThrow();
+    expect(sandbox.extendTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/unit/util/sandbox/interactive-shell.test.ts
+++ b/packages/cli/test/unit/util/sandbox/interactive-shell.test.ts
@@ -316,6 +316,7 @@ describe('startInteractiveShell', () => {
   });
 
   it('prepends sudo to the executed command but not the printed command', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error');
     const sandbox = fakeSandbox();
     const donePromise = startInteractiveShell({
       sandbox: sandbox as never,
@@ -333,6 +334,45 @@ describe('startInteractiveShell', () => {
     const startFrame = JSON.parse(ws.sent[0] as string);
     expect(startFrame.command).toBe('sudo');
     expect(startFrame.args).toEqual(['whoami']);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('whoami')
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('sudo')
+    );
+
+    ws.emit('close');
+    await donePromise;
+  });
+
+  it('sends a resize control frame over the ws on SIGWINCH', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['bash'],
+      envVars: {},
+      sudo: false,
+      skipExtendingTimeout: true,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    fakeStdout.columns = 120;
+    fakeStdout.rows = 40;
+    process.emit('SIGWINCH');
+
+    await vi.waitFor(() =>
+      expect(
+        ws.sent.some(
+          frame =>
+            frame === JSON.stringify({ type: 'resize', cols: 120, rows: 40 })
+        )
+      ).toBe(true)
+    );
 
     ws.emit('close');
     await donePromise;

--- a/packages/cli/test/unit/util/sandbox/interactive-shell.test.ts
+++ b/packages/cli/test/unit/util/sandbox/interactive-shell.test.ts
@@ -1,0 +1,340 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+const { FakeWebSocket, wsInstances } = vi.hoisted(() => {
+  type Listener = (...args: unknown[]) => void;
+
+  class FakeWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    readyState = FakeWebSocket.CONNECTING;
+    sent: Array<string | Buffer> = [];
+    url: string;
+    private listenersByEvent: Record<string, Listener[]> = {};
+
+    constructor(url: string) {
+      this.url = url;
+      wsInstances.push(this);
+    }
+
+    on(event: string, listener: Listener) {
+      (this.listenersByEvent[event] ??= []).push(listener);
+      return this;
+    }
+
+    once(event: string, listener: Listener) {
+      const wrapped: Listener = (...args) => {
+        this.removeListener(event, wrapped);
+        listener(...args);
+      };
+      return this.on(event, wrapped);
+    }
+
+    removeListener(event: string, listener: Listener) {
+      this.listenersByEvent[event] = (
+        this.listenersByEvent[event] ?? []
+      ).filter(l => l !== listener);
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      for (const listener of this.listenersByEvent[event] ?? []) {
+        listener(...args);
+      }
+    }
+
+    send(data: string | Buffer) {
+      this.sent.push(data);
+    }
+
+    close() {
+      this.readyState = FakeWebSocket.CLOSED;
+    }
+  }
+  const wsInstances: InstanceType<typeof FakeWebSocket>[] = [];
+  return { FakeWebSocket, wsInstances };
+});
+
+vi.mock('ws', () => ({ WebSocket: FakeWebSocket }));
+
+const { extendSandboxTimeoutPeriodically } = vi.hoisted(() => ({
+  extendSandboxTimeoutPeriodically: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../../../src/util/sandbox/extend-timeout', () => ({
+  extendSandboxTimeoutPeriodically,
+}));
+
+import { startInteractiveShell } from '../../../../src/util/sandbox/interactive-shell';
+
+function openSocket(ws: InstanceType<typeof FakeWebSocket>) {
+  ws.readyState = FakeWebSocket.OPEN;
+  ws.emit('open');
+}
+
+class FakeStdin extends EventEmitter {
+  isTTY = true;
+  setRawMode = vi.fn();
+  resume = vi.fn();
+  pause = vi.fn();
+  unref = vi.fn();
+}
+
+function createFakeStdout() {
+  return {
+    columns: 80,
+    rows: 24,
+    write: vi.fn(() => true),
+  };
+}
+
+function fakeSandbox() {
+  return {
+    cwd: '/vercel/sandbox',
+    name: 'my-sandbox',
+    openInteractive: vi
+      .fn()
+      .mockResolvedValue({ url: 'ws://fake-host/pty', token: 'tok123' }),
+  };
+}
+
+describe('startInteractiveShell', () => {
+  let originalStdin: NodeJS.ReadStream & { fd: 0 };
+  let originalStdout: NodeJS.WriteStream & { fd: 1 };
+  let fakeStdin: FakeStdin;
+  let fakeStdout: ReturnType<typeof createFakeStdout>;
+
+  beforeEach(() => {
+    originalStdin = process.stdin;
+    originalStdout = process.stdout;
+    fakeStdin = new FakeStdin();
+    fakeStdout = createFakeStdout();
+    Object.defineProperty(process, 'stdin', {
+      value: fakeStdin,
+      configurable: true,
+    });
+    Object.defineProperty(process, 'stdout', {
+      value: fakeStdout,
+      configurable: true,
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    extendSandboxTimeoutPeriodically.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      configurable: true,
+    });
+    Object.defineProperty(process, 'stdout', {
+      value: originalStdout,
+      configurable: true,
+    });
+    process.removeAllListeners('beforeExit');
+    process.removeAllListeners('SIGWINCH');
+    process.exitCode = undefined;
+    wsInstances.length = 0;
+    extendSandboxTimeoutPeriodically.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it('sends a start frame with command, args, TERM and cols/rows', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['bash'],
+      envVars: { FOO: 'bar' },
+      sudo: false,
+      skipExtendingTimeout: true,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    const startFrame = JSON.parse(ws.sent[0] as string);
+    expect(startFrame.type).toBe('start');
+    expect(startFrame.command).toBe('bash');
+    expect(startFrame.args).toEqual([]);
+    expect(startFrame.cwd).toBe('/vercel/sandbox');
+    expect(startFrame.env).toEqual(
+      expect.arrayContaining(['TERM=xterm-256color', 'FOO=bar'])
+    );
+    expect(
+      startFrame.env.some((entry: string) => entry.startsWith('PS1='))
+    ).toBe(true);
+    expect(typeof startFrame.cols).toBe('number');
+    expect(typeof startFrame.rows).toBe('number');
+
+    ws.emit('close');
+    await donePromise;
+  });
+
+  it('forwards a stdin data chunk as a binary ws.send', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['bash'],
+      envVars: {},
+      sudo: false,
+      skipExtendingTimeout: true,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    const chunk = Buffer.from('ls -la\n');
+    fakeStdin.emit('data', chunk);
+
+    expect(ws.sent).toContainEqual(chunk);
+
+    ws.emit('close');
+    await donePromise;
+  });
+
+  it('writes binary server frames to stdout', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['bash'],
+      envVars: {},
+      sudo: false,
+      skipExtendingTimeout: true,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    const outputChunk = Buffer.from('hello from sandbox\n');
+    ws.emit('message', outputChunk, true);
+
+    expect(fakeStdout.write).toHaveBeenCalledWith(outputChunk);
+
+    ws.emit('close');
+    await donePromise;
+  });
+
+  it('sets process.exitCode from an exit control frame', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['bash'],
+      envVars: {},
+      sudo: false,
+      skipExtendingTimeout: true,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    ws.emit(
+      'message',
+      Buffer.from(JSON.stringify({ type: 'exit', code: 7 })),
+      false
+    );
+
+    ws.emit('close');
+    await donePromise;
+
+    expect(process.exitCode).toBe(7);
+  });
+
+  it('sets raw mode on start and restores it on close', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['bash'],
+      envVars: {},
+      sudo: false,
+      skipExtendingTimeout: true,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() =>
+      expect(fakeStdin.setRawMode).toHaveBeenCalledWith(true)
+    );
+
+    ws.emit('close');
+    await donePromise;
+
+    expect(fakeStdin.setRawMode).toHaveBeenLastCalledWith(false);
+  });
+
+  it('skips the timeout-extension loop when skipExtendingTimeout is true', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['bash'],
+      envVars: {},
+      sudo: false,
+      skipExtendingTimeout: true,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    expect(extendSandboxTimeoutPeriodically).not.toHaveBeenCalled();
+
+    ws.emit('close');
+    await donePromise;
+  });
+
+  it('starts the timeout-extension loop unless skipped', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['bash'],
+      envVars: {},
+      sudo: false,
+      skipExtendingTimeout: false,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() =>
+      expect(extendSandboxTimeoutPeriodically).toHaveBeenCalledWith(
+        sandbox,
+        expect.anything()
+      )
+    );
+
+    ws.emit('close');
+    await donePromise;
+  });
+
+  it('prepends sudo to the executed command but not the printed command', async () => {
+    const sandbox = fakeSandbox();
+    const donePromise = startInteractiveShell({
+      sandbox: sandbox as never,
+      execution: ['whoami'],
+      envVars: {},
+      sudo: true,
+      skipExtendingTimeout: true,
+    });
+
+    await vi.waitFor(() => expect(wsInstances).toHaveLength(1));
+    const ws = wsInstances[0];
+    openSocket(ws);
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    const startFrame = JSON.parse(ws.sent[0] as string);
+    expect(startFrame.command).toBe('sudo');
+    expect(startFrame.args).toEqual(['whoami']);
+
+    ws.emit('close');
+    await donePromise;
+  });
+});

--- a/packages/cli/test/unit/util/sandbox/print-command.test.ts
+++ b/packages/cli/test/unit/util/sandbox/print-command.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { printCommand } from '../../../../src/util/sandbox/print-command';
+
+describe('printCommand', () => {
+  it('formats a command with its arguments', () => {
+    expect(printCommand('node', ['x.js'])).toContain('$ node x.js');
+  });
+
+  it('handles no arguments', () => {
+    expect(printCommand('ls', [])).toContain('$ ls');
+  });
+});

--- a/packages/cli/test/unit/util/sandbox/print-sandbox-summary.test.ts
+++ b/packages/cli/test/unit/util/sandbox/print-sandbox-summary.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Sandbox } from '@vercel/sandbox';
+import { printSandboxSummary } from '../../../../src/util/sandbox/print-sandbox-summary';
+
+function fakeSandbox(routes: { port: number; url: string }[]) {
+  return {
+    name: 'my-sandbox',
+    interactivePort: 39375,
+    routes: [
+      { port: 39375, url: 'https://interactive.example.com' },
+      ...routes,
+    ],
+  } as unknown as Sandbox;
+}
+
+function spyOnWrite(stream: NodeJS.WriteStream) {
+  return vi.spyOn(stream, 'write').mockReturnValue(true);
+}
+
+describe('printSandboxSummary', () => {
+  let stdoutWrite: ReturnType<typeof spyOnWrite>;
+  let stderrWrite: ReturnType<typeof spyOnWrite>;
+
+  beforeEach(() => {
+    stdoutWrite = spyOnWrite(process.stdout);
+    stderrWrite = spyOnWrite(process.stderr);
+  });
+
+  afterEach(() => {
+    stdoutWrite.mockRestore();
+    stderrWrite.mockRestore();
+  });
+
+  function stdoutOutput() {
+    return stdoutWrite.mock.calls.map(call => call[0]).join('');
+  }
+
+  function stderrOutput() {
+    return stderrWrite.mock.calls.map(call => call[0]).join('');
+  }
+
+  it('writes only the sandbox name to stdout', () => {
+    printSandboxSummary({
+      sandbox: fakeSandbox([]),
+      contextName: 'my-team',
+      action: 'created',
+    });
+
+    expect(stdoutOutput()).toContain('my-sandbox');
+    for (const call of stdoutWrite.mock.calls) {
+      expect(String(call[0])).toContain('my-sandbox');
+    }
+  });
+
+  it('writes the decorative summary (team, action) to stderr', () => {
+    printSandboxSummary({
+      sandbox: fakeSandbox([]),
+      contextName: 'my-team',
+      action: 'created',
+    });
+
+    const stderrText = stderrOutput();
+    expect(stderrText).toContain('created');
+    expect(stderrText).toContain('my-team');
+    expect(stderrText).not.toContain('my-sandbox');
+  });
+
+  it('writes each published port route to stderr, excluding the interactive port', () => {
+    printSandboxSummary({
+      sandbox: fakeSandbox([
+        { port: 3000, url: 'https://three-thousand.example.com' },
+        { port: 8080, url: 'https://eighty-eighty.example.com' },
+      ]),
+      contextName: 'my-team',
+      action: 'created',
+    });
+
+    const stderrText = stderrOutput();
+    expect(stderrText).toContain('3000');
+    expect(stderrText).toContain('https://three-thousand.example.com');
+    expect(stderrText).toContain('8080');
+    expect(stderrText).toContain('https://eighty-eighty.example.com');
+    expect(stderrText).not.toContain('39375');
+    expect(stderrText).not.toContain('interactive.example.com');
+  });
+
+  it('supports a custom action string, e.g. for fork', () => {
+    printSandboxSummary({
+      sandbox: fakeSandbox([]),
+      contextName: 'my-team',
+      action: 'forked from source-sandbox',
+    });
+
+    expect(stderrOutput()).toContain('forked from source-sandbox');
+  });
+
+  it('writes nothing but the sandbox name to stdout even with ports', () => {
+    printSandboxSummary({
+      sandbox: fakeSandbox([{ port: 3000, url: 'https://example.com' }]),
+      contextName: 'my-team',
+      action: 'created',
+    });
+
+    for (const call of stdoutWrite.mock.calls) {
+      expect(String(call[0])).toContain('my-sandbox');
+    }
+    expect(stdoutOutput()).not.toContain('team');
+    expect(stdoutOutput()).not.toContain('3000');
+  });
+});

--- a/packages/cli/test/unit/util/sandbox/target.test.ts
+++ b/packages/cli/test/unit/util/sandbox/target.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveSandboxTarget } from '../../../../src/util/sandbox/target';
 import * as getScopeModule from '../../../../src/util/get-scope';
 import * as linkModule from '../../../../src/util/projects/link';
+import * as getProjectByNameOrIdModule from '../../../../src/util/projects/get-project-by-id-or-name';
 
 vi.mock('../../../../src/util/get-scope');
 vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/projects/get-project-by-id-or-name');
 
 function fakeClient(token?: string) {
   return { authConfig: { token }, config: {} } as never;
@@ -16,16 +18,63 @@ describe('resolveSandboxTarget', () => {
     vi.clearAllMocks();
   });
 
-  it('resolves token/team/project from opts without a network call', async () => {
+  it('resolves token/team from opts and project by id via getProjectByNameOrId', async () => {
+    vi.mocked(getProjectByNameOrIdModule.default).mockResolvedValue({
+      id: 'proj_1',
+      name: 'proj-1',
+      accountId: 'team_1',
+    } as never);
+
     const t = await resolveSandboxTarget(fakeClient('tok'), {
       team: 'team_1',
       project: 'proj_1',
     });
+
     expect(t).toEqual({ token: 'tok', teamId: 'team_1', projectId: 'proj_1' });
+    expect(getProjectByNameOrIdModule.default).toHaveBeenCalledWith(
+      expect.anything(),
+      'proj_1',
+      'team_1'
+    );
+    expect(getScopeModule.default).not.toHaveBeenCalled();
+  });
+
+  it('resolves --project by name via getProjectByNameOrId within the resolved team', async () => {
+    vi.mocked(getScopeModule.default).mockResolvedValue({
+      contextName: 'my-team',
+      team: { id: 'team_x', slug: 'my-team' } as never,
+      user: { id: 'user_x' } as never,
+    });
+    vi.mocked(getProjectByNameOrIdModule.default).mockResolvedValue({
+      id: 'proj_named',
+      name: 'my-app',
+      accountId: 'team_x',
+    } as never);
+
+    const t = await resolveSandboxTarget(fakeClient('tok'), {
+      project: 'my-app',
+    });
+
+    expect(t).toEqual({
+      token: 'tok',
+      teamId: 'team_x',
+      projectId: 'proj_named',
+    });
+    expect(getProjectByNameOrIdModule.default).toHaveBeenCalledWith(
+      expect.anything(),
+      'my-app',
+      'team_x'
+    );
   });
 
   it('prefers VERCEL_AUTH_TOKEN when the client has no token', async () => {
     process.env.VERCEL_AUTH_TOKEN = 'env-tok';
+    vi.mocked(getProjectByNameOrIdModule.default).mockResolvedValue({
+      id: 'proj_1',
+      name: 'proj-1',
+      accountId: 'team_1',
+    } as never);
+
     const t = await resolveSandboxTarget(fakeClient(), {
       team: 'team_1',
       project: 'proj_1',
@@ -35,6 +84,12 @@ describe('resolveSandboxTarget', () => {
 
   it('prefers the client token over VERCEL_AUTH_TOKEN', async () => {
     process.env.VERCEL_AUTH_TOKEN = 'env-tok';
+    vi.mocked(getProjectByNameOrIdModule.default).mockResolvedValue({
+      id: 'proj_1',
+      name: 'proj-1',
+      accountId: 'team_1',
+    } as never);
+
     const t = await resolveSandboxTarget(fakeClient('client-tok'), {
       team: 'team_1',
       project: 'proj_1',
@@ -49,6 +104,21 @@ describe('resolveSandboxTarget', () => {
         project: 'proj_1',
       })
     ).rejects.toThrow(/not authenticated|vercel login/i);
+  });
+
+  it('names the honored token env vars (VERCEL_TOKEN, VERCEL_AUTH_TOKEN) in the not-authenticated message', async () => {
+    await expect(
+      resolveSandboxTarget(fakeClient(), {
+        team: 'team_1',
+        project: 'proj_1',
+      })
+    ).rejects.toThrow(/VERCEL_TOKEN/);
+    await expect(
+      resolveSandboxTarget(fakeClient(), {
+        team: 'team_1',
+        project: 'proj_1',
+      })
+    ).rejects.toThrow(/VERCEL_AUTH_TOKEN/);
   });
 
   it('falls back to getScope/getLinkedProject when opts are omitted', async () => {
@@ -75,11 +145,6 @@ describe('resolveSandboxTarget', () => {
   });
 
   it('throws a friendly scope error when neither team nor project can be resolved', async () => {
-    vi.mocked(getScopeModule.default).mockResolvedValue({
-      contextName: 'someone',
-      team: null,
-      user: { id: 'user_x' } as never,
-    });
     vi.mocked(linkModule.getLinkedProject).mockResolvedValue({
       status: 'not_linked',
       org: null,
@@ -89,5 +154,43 @@ describe('resolveSandboxTarget', () => {
     await expect(resolveSandboxTarget(fakeClient('tok'))).rejects.toThrow(
       /--scope.*--project.*vercel link/i
     );
+  });
+
+  it('surfaces getLinkedProject status:"error" distinctly, propagating its exitCode', async () => {
+    vi.mocked(linkModule.getLinkedProject).mockResolvedValue({
+      status: 'error',
+      exitCode: 7,
+    });
+
+    let caught: unknown;
+    try {
+      await resolveSandboxTarget(fakeClient('tok'));
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as Error & { exitCode?: number };
+    expect(err.exitCode).toBe(7);
+    expect(err.message).not.toMatch(/--scope.*--project.*vercel link/i);
+  });
+
+  it('throws when opts.team is given but the linked project belongs to a different team', async () => {
+    vi.mocked(linkModule.getLinkedProject).mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'proj_x',
+        name: 'proj-x',
+        accountId: 'team_other',
+        updatedAt: 0,
+        createdAt: 0,
+      } as never,
+      org: { id: 'team_other', slug: 'other-team', type: 'team' },
+    });
+
+    await expect(
+      resolveSandboxTarget(fakeClient('tok'), { team: 'team_1' })
+    ).rejects.toThrow(/belongs to team "other-team"/i);
+    expect(getScopeModule.default).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/unit/util/sandbox/target.test.ts
+++ b/packages/cli/test/unit/util/sandbox/target.test.ts
@@ -193,4 +193,25 @@ describe('resolveSandboxTarget', () => {
     ).rejects.toThrow(/belongs to team "other-team"/i);
     expect(getScopeModule.default).not.toHaveBeenCalled();
   });
+
+  it('resolves via the linked project when opts.team matches the linked project team', async () => {
+    vi.mocked(linkModule.getLinkedProject).mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'proj_x',
+        name: 'proj-x',
+        accountId: 'team_x',
+        updatedAt: 0,
+        createdAt: 0,
+      } as never,
+      org: { id: 'team_x', slug: 'my-team', type: 'team' },
+    });
+
+    const t = await resolveSandboxTarget(fakeClient('tok'), {
+      team: 'team_x',
+    });
+
+    expect(t).toEqual({ token: 'tok', teamId: 'team_x', projectId: 'proj_x' });
+    expect(getScopeModule.default).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "lib": ["ES2021", "ESNext.Disposable"],
     "module": "es2022",
     "noImplicitReturns": false,
     "noUnusedLocals": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,6 +593,9 @@ importers:
       undici:
         specifier: 5.29.0
         version: 5.29.0
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
       zod:
         specifier: 4.1.11
         version: 4.1.11
@@ -717,6 +720,9 @@ importers:
       '@types/write-json-file':
         specifier: 2.2.1
         version: 2.2.1
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
       '@types/yauzl-promise':
         specifier: 2.1.0
         version: 2.1.0


### PR DESCRIPTION
## summary
- second pr of the sandbox cli unification: natively implement the `vercel sandbox` lifecycle commands (exec, create, connect/ssh/shell, sh, fork, run) on the `@vercel/sandbox` sdk, replacing the pass-through for those subcommands
- stacked on pr #1 (native sandbox foundation) — merge after #1
- behavior preserved 1:1 except: `--tag` and `--tty` are now long-only because the global `-t` is `--token` (a subcommand `-t` would silently shadow the token and leak it); config/login/logout still fall through to the old cli (removed in a later pr)

## changes
- add interactive websocket/tty shell + periodic timeout extension (`util/sandbox/interactive-shell.ts`, `extend-timeout.ts`; adds `ws`) with a node 18-20.3 `Symbol.dispose` polyfill for the down-leveled `using` declarations
- add shared helpers: arg parsers, summary printer (name→stdout, rest→stderr), exec-core (`execInSandbox`/`connectToSandbox`), disposables/print-command
- add native commands exec/create/connect(ssh,shell)/sh/fork/run, each wired into the dispatcher with per-subcommand telemetry
- harden the token/scope resolver (name-or-id `--project`, agent-friendly errors)
- preserve the `@vercel/sandbox` api-error `cause` in the client wrapper so `run`'s get-or-create can detect a 404
