### PR TITLE
[ci] restore update-sandbox auto-update workflow

### DIFF
--- a/.github/workflows/update-sandbox.yml
+++ b/.github/workflows/update-sandbox.yml
@@ -108,7 +108,8 @@ jobs:
             packages/cli/package.json
             pnpm-lock.yaml
           body: ${{ steps.pr_body.outputs.body }}
-          token: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }} # TODO: this secret is deleted, replace with a new bot token or GitHub App
+          sign-commits: true
+          token: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }}
 
       - name: Approve the Pull Request
         if: steps.pr.outputs.pull-request-number != ''
@@ -120,6 +121,6 @@ jobs:
       - name: Enable auto-merge
         if: steps.pr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }} # TODO: this secret is deleted, replace with a new bot token or GitHub App
+          GH_TOKEN: ${{ secrets.VERCEL_CLI_RELEASE_BOT_TOKEN }}
         run: |
           gh pr merge ${{ steps.pr.outputs.pull-request-number }} --auto --squash


### PR DESCRIPTION
## summary
- the update-sandbox workflow is broken: both bot secrets (`VERCEL_CLI_RELEASE_BOT_TOKEN`, `VERCEL_CLI_APPROVER_BOT_TOKEN`) were deleted, and pushes now fail the repo's required-signatures rule
- goal is a fully hands-off flow: bot opens the pr, self-approves, and auto-merges the sandbox bump
- to enable, two secrets must be re-created: `VERCEL_CLI_RELEASE_BOT_TOKEN` (creator/merger, on the `vercel-cli-release-bot` account) and `VERCEL_CLI_APPROVER_BOT_TOKEN` (a second, distinct write-access account — you cannot approve your own pr)

## changes
- add `sign-commits: true` to the create-pull-request step so the bumped files are committed via the github api and pass the required-signatures rule
- remove the stale "secret is deleted" todo comments