### PR TITLE
[cli] Add feature flag version history commands

### DIFF
--- a/.changeset/fuzzy-flags-history.md
+++ b/.changeset/fuzzy-flags-history.md
@@ -1,0 +1,13 @@
+---
+'vercel': patch
+---
+
+Add `vercel flags versions <flag>` and `vercel flags versions diff <flag> --revision <number>` to inspect feature flag version history and changes.
+
+Examples:
+
+```bash
+vercel flags versions my-flag
+vercel flags versions my-flag --environment production
+vercel flags versions diff my-flag --revision 4
+```

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -118,6 +118,134 @@ export const inspectSubcommand = {
   ],
 } as const;
 
+export const versionsListSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  default: true,
+  description: 'List version history for a feature flag',
+  arguments: [
+    {
+      name: 'flag',
+      required: true,
+    },
+  ],
+  options: [
+    projectOption,
+    {
+      name: 'environment',
+      shorthand: 'e',
+      type: String,
+      deprecated: false,
+      description: 'Filter versions by changed environment',
+      argument: 'ENV',
+    },
+    {
+      name: 'limit',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Return at most NUMBER versions (1-100)',
+      argument: 'NUMBER',
+    },
+    {
+      name: 'cursor',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Pagination cursor from a previous versions response',
+      argument: 'CURSOR',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output in JSON format',
+    },
+  ],
+  examples: [
+    {
+      name: 'List version history for a feature flag',
+      value: `${packageName} flags versions my-feature-flag`,
+    },
+    {
+      name: 'List version history using the explicit list subcommand',
+      value: `${packageName} flags versions list my-feature-flag`,
+    },
+    {
+      name: 'List production version history',
+      value: `${packageName} flags versions my-feature-flag --environment production`,
+    },
+    {
+      name: 'List the next page of version history',
+      value: `${packageName} flags versions my-feature-flag --limit 10 --cursor <cursor>`,
+    },
+    {
+      name: 'List version history as JSON',
+      value: `${packageName} flags versions my-feature-flag --json`,
+    },
+  ],
+} as const;
+
+export const versionsDiffSubcommand = {
+  name: 'diff',
+  aliases: [],
+  description: 'Show changes introduced by a feature flag version',
+  arguments: [
+    {
+      name: 'flag',
+      required: true,
+    },
+  ],
+  options: [
+    projectOption,
+    {
+      name: 'revision',
+      shorthand: null,
+      type: Number,
+      deprecated: false,
+      description: 'Revision number to compare with the previous revision',
+      argument: 'NUMBER',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output the diff in JSON format',
+    },
+  ],
+  examples: [
+    {
+      name: 'Show what changed in a revision',
+      value: `${packageName} flags versions diff my-feature-flag --revision 4`,
+    },
+    {
+      name: 'Show the revision diff as JSON',
+      value: `${packageName} flags versions diff my-feature-flag --revision 4 --json`,
+    },
+  ],
+} as const;
+
+export const versionsSubcommand = {
+  name: 'versions',
+  aliases: [],
+  description: 'List and compare version history for a feature flag',
+  arguments: [],
+  subcommands: [versionsListSubcommand, versionsDiffSubcommand],
+  options: [],
+  examples: [
+    {
+      name: 'List version history for a feature flag',
+      value: `${packageName} flags versions my-feature-flag`,
+    },
+    {
+      name: 'Show what changed in a revision',
+      value: `${packageName} flags versions diff my-feature-flag --revision 4`,
+    },
+  ],
+} as const;
+
 export const createSubcommand = {
   name: 'create',
   aliases: ['add'],
@@ -1408,6 +1536,7 @@ export const flagsCommand = {
   subcommands: [
     listSubcommand,
     inspectSubcommand,
+    versionsSubcommand,
     createSubcommand,
     openSubcommand,
     updateSubcommand,

--- a/packages/cli/src/commands/flags/index.ts
+++ b/packages/cli/src/commands/flags/index.ts
@@ -9,6 +9,7 @@ import { getCommandAliases } from '..';
 import { FlagsTelemetryClient } from '../../util/telemetry/commands/flags';
 import ls from './ls';
 import inspect from './inspect';
+import versions from './versions';
 import create from './add';
 import openFlag from './open';
 import update from './update';
@@ -26,6 +27,7 @@ import {
   flagsCommand,
   listSubcommand,
   inspectSubcommand,
+  versionsSubcommand,
   createSubcommand,
   openSubcommand,
   updateSubcommand,
@@ -48,6 +50,7 @@ import override from './override';
 const COMMAND_CONFIG = {
   ls: getCommandAliases(listSubcommand),
   inspect: getCommandAliases(inspectSubcommand),
+  versions: getCommandAliases(versionsSubcommand),
   create: getCommandAliases(createSubcommand),
   open: getCommandAliases(openSubcommand),
   update: getCommandAliases(updateSubcommand),
@@ -120,6 +123,9 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandInspect(subcommandOriginal);
       return inspect(client, args);
+    case 'versions':
+      telemetry.trackCliSubcommandVersions(subcommandOriginal);
+      return versions(client, needHelp ? [...args, '--help'] : args);
     case 'open':
       if (needHelp) {
         telemetry.trackCliFlagHelp('flags', subcommandOriginal);

--- a/packages/cli/src/commands/flags/ls.ts
+++ b/packages/cli/src/commands/flags/ls.ts
@@ -14,6 +14,7 @@ import output from '../../output-manager';
 import { FlagsLsTelemetryClient } from '../../util/telemetry/commands/flags/ls';
 import { listSubcommand } from './command';
 import type { Flag } from '../../util/flags/types';
+import { quoteArg } from '../../util/flags/quote-arg';
 import { formatProject } from '../../util/projects/format-project';
 import { getLinkedFlagsProject, getProjectNameFromFlags } from './project';
 
@@ -151,17 +152,6 @@ function buildNextPageCommand(
   ];
   const suffix = repeatable.length > 0 ? ` ${repeatable.join(' ')}` : '';
   return `flags ls${baseFlags}${suffix} --next ${nextCursor}`;
-}
-
-// Wrap a value in single quotes only when it contains characters the shell
-// would otherwise interpret, so the printed next-page command stays
-// copy-pasteable for tags that include spaces or special characters. The
-// cursor is base64url and therefore always shell-safe.
-function quoteArg(value: string): string {
-  if (/^[A-Za-z0-9_./@:-]+$/.test(value)) {
-    return value;
-  }
-  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function outputJson(client: Client, flags: Flag[], next: string | null) {

--- a/packages/cli/src/commands/flags/versions.ts
+++ b/packages/cli/src/commands/flags/versions.ts
@@ -1,0 +1,547 @@
+import chalk from 'chalk';
+import plural from 'pluralize';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getSubcommand from '../../util/get-subcommand';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import getCommandFlags from '../../util/get-command-flags';
+import {
+  getFlagVersions,
+  MAX_FLAG_VERSIONS_PAGE_LIMIT,
+} from '../../util/flags/get-flags';
+import formatTable from '../../util/format-table';
+import formatDate from '../../util/format-date';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { FlagsVersionsTelemetryClient } from '../../util/telemetry/commands/flags/versions';
+import {
+  flagsCommand,
+  versionsDiffSubcommand,
+  versionsListSubcommand,
+  versionsSubcommand,
+} from './command';
+import { formatProject } from '../../util/projects/format-project';
+import { getLinkedFlagsProject, getProjectNameFromFlags } from './project';
+import { quoteArg } from '../../util/flags/quote-arg';
+import type { FlagVersion } from '../../util/flags/types';
+import {
+  diffVersionData,
+  formatVersionDataDiff,
+  type VersionDiffChange,
+} from '../../util/flags/format-version-diff';
+import { type Command, help } from '../help';
+import { getCommandAliases } from '..';
+
+type LinkedFlagsProject = Extract<
+  Awaited<ReturnType<typeof getLinkedFlagsProject>>,
+  { status: 'linked' }
+>;
+
+const COMMAND_CONFIG = {
+  list: getCommandAliases(versionsListSubcommand),
+  diff: getCommandAliases(versionsDiffSubcommand),
+};
+
+export default async function versions(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetryClient = new FlagsVersionsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(versionsSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification, {
+      permissive: true,
+    });
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    parsedArgs.args,
+    COMMAND_CONFIG
+  );
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetryClient.trackCliFlagHelp('flags versions', subcommandOriginal);
+    output.print(
+      help(
+        parsedArgs.args.length > 0
+          ? versionsListSubcommand
+          : versionsSubcommand,
+        {
+          parent:
+            parsedArgs.args.length > 0 ? getVersionsHelpParent() : flagsCommand,
+          columns: client.stderr.columns,
+        }
+      )
+    );
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        parent: getVersionsHelpParent(),
+        columns: client.stderr.columns,
+      })
+    );
+  }
+
+  switch (subcommand) {
+    case 'diff':
+      if (needHelp) {
+        telemetryClient.trackCliFlagHelp('flags versions', subcommandOriginal);
+        printHelp(versionsDiffSubcommand);
+        return 2;
+      }
+      telemetryClient.trackCliSubcommandDiff(subcommandOriginal);
+      return diffVersions(client, args, telemetryClient);
+    case 'list':
+      if (needHelp) {
+        telemetryClient.trackCliFlagHelp('flags versions', subcommandOriginal);
+        printHelp(versionsListSubcommand);
+        return 2;
+      }
+      telemetryClient.trackCliSubcommandList(subcommandOriginal);
+      return listVersions(client, args, telemetryClient);
+    default:
+      telemetryClient.trackCliSubcommandList('default');
+      return listVersions(client, argv, telemetryClient);
+  }
+}
+
+async function listVersions(
+  client: Client,
+  argv: string[],
+  telemetryClient: FlagsVersionsTelemetryClient
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    versionsListSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { args, flags } = parsedArgs;
+  const [flagArg] = args;
+  const environment = flags['--environment'] as string | undefined;
+  const limit = flags['--limit'] as number | undefined;
+  const cursor = flags['--cursor'] as string | undefined;
+  const json = flags['--json'] as boolean | undefined;
+  const projectName = getProjectNameFromFlags(flags);
+
+  if (!flagArg) {
+    output.error(
+      `Missing required argument: flag. Usage: ${getCommandName('flags versions <flag>')}`
+    );
+    return 1;
+  }
+
+  telemetryClient.trackCliArgumentFlag(flagArg);
+  telemetryClient.trackCliOptionProject(projectName);
+  telemetryClient.trackCliOptionEnvironment(environment);
+  telemetryClient.trackCliOptionLimit(limit);
+  telemetryClient.trackCliOptionCursor(cursor);
+  telemetryClient.trackCliFlagJson(json);
+
+  if (
+    limit !== undefined &&
+    (!Number.isInteger(limit) ||
+      limit < 1 ||
+      limit > MAX_FLAG_VERSIONS_PAGE_LIMIT)
+  ) {
+    output.error(
+      `The --limit option must be an integer between 1 and ${MAX_FLAG_VERSIONS_PAGE_LIMIT}.`
+    );
+    return 1;
+  }
+
+  const link = await resolveLinkedProject(client, projectName);
+  if (typeof link === 'number') return link;
+
+  const { project, org } = link;
+  const projectSlugLink = formatProject(org.slug, project.name);
+  const versionsStamp = stamp();
+  const environmentLabel = environment ? ` in ${environment}` : '';
+
+  output.spinner(
+    `Fetching version history for ${chalk.bold(flagArg)}${environmentLabel} in ${projectSlugLink}`
+  );
+
+  try {
+    const { versions: versionList, next } = await getFlagVersions(
+      client,
+      project.id,
+      flagArg,
+      {
+        environment,
+        limit,
+        cursor,
+      }
+    );
+    output.stopSpinner();
+
+    if (json) {
+      outputJson(client, versionList, next);
+    } else if (versionList.length === 0) {
+      output.log(
+        `No versions found for ${chalk.bold(flagArg)}${environmentLabel} in ${projectSlugLink} ${chalk.gray(versionsStamp())}`
+      );
+    } else {
+      output.log(
+        `${plural('version', versionList.length, true)} found for ${chalk.bold(flagArg)}${environmentLabel} in ${projectSlugLink} ${chalk.gray(versionsStamp())}`
+      );
+      printVersionsTable(versionList);
+      if (next) {
+        const nextCmd = buildNextPageCommand(flagArg, flags, next);
+        output.log(`To display the next page, run ${getCommandName(nextCmd)}`);
+      }
+    }
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+
+  return 0;
+}
+
+async function diffVersions(
+  client: Client,
+  argv: string[],
+  telemetryClient: FlagsVersionsTelemetryClient
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    versionsDiffSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { args, flags } = parsedArgs;
+  const [flagArg] = args;
+  const revision = flags['--revision'] as number | undefined;
+  const json = flags['--json'] as boolean | undefined;
+  const projectName = getProjectNameFromFlags(flags);
+
+  if (!flagArg) {
+    output.error(
+      `Missing required argument: flag. Usage: ${getCommandName('flags versions diff <flag> --revision <number>')}`
+    );
+    return 1;
+  }
+
+  telemetryClient.trackCliArgumentFlag(flagArg);
+  telemetryClient.trackCliOptionProject(projectName);
+  telemetryClient.trackCliOptionRevision(revision);
+  telemetryClient.trackCliFlagJson(json);
+
+  if (revision === undefined || !Number.isInteger(revision) || revision < 0) {
+    output.error('The --revision option must be a non-negative integer.');
+    return 1;
+  }
+
+  if (revision === 0) {
+    output.error('Revision 0 has no previous revision to compare.');
+    return 1;
+  }
+
+  const link = await resolveLinkedProject(client, projectName);
+  if (typeof link === 'number') return link;
+
+  const { project, org } = link;
+  const projectSlugLink = formatProject(org.slug, project.name);
+  const diffStamp = stamp();
+
+  output.spinner(
+    `Fetching version diff for ${chalk.bold(flagArg)} revision ${revision} in ${projectSlugLink}`
+  );
+
+  try {
+    const { version, previousVersion, availableRevisionCount } =
+      await getVersionPair(client, project.id, flagArg, revision);
+    output.stopSpinner();
+
+    if (!version) {
+      output.error(
+        `${formatAvailableRevisionCount(availableRevisionCount)} Revision ${revision} was not found for ${chalk.bold(flagArg)} in ${projectSlugLink}.`
+      );
+      return 1;
+    }
+
+    if (!previousVersion) {
+      output.error(
+        `${formatAvailableRevisionCount(availableRevisionCount)} Previous revision ${revision - 1} was not found for ${chalk.bold(flagArg)} in ${projectSlugLink}.`
+      );
+      return 1;
+    }
+
+    if (json) {
+      outputDiffJson(
+        client,
+        flagArg,
+        version,
+        previousVersion,
+        diffVersionData(previousVersion.data, version.data)
+      );
+    } else {
+      printVersionDiff({
+        flagArg,
+        projectSlugLink,
+        version,
+        previousVersion,
+        diffStamp,
+      });
+    }
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+
+  return 0;
+}
+
+async function resolveLinkedProject(
+  client: Client,
+  projectName?: string
+): Promise<LinkedFlagsProject | number> {
+  const link = await getLinkedFlagsProject(client, projectName);
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. Pass --project <name>, or run ${getCommandName('link')} to link it.`
+    );
+    return 1;
+  }
+
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+  return link;
+}
+
+async function getVersionPair(
+  client: Client,
+  projectId: string,
+  flagArg: string,
+  revision: number
+): Promise<{
+  version?: FlagVersion;
+  previousVersion?: FlagVersion;
+  availableRevisionCount: number;
+}> {
+  let cursor: string | undefined;
+  let version: FlagVersion | undefined;
+  let previousVersion: FlagVersion | undefined;
+  const availableRevisions = new Set<number>();
+
+  do {
+    const result = await getFlagVersions(client, projectId, flagArg, {
+      limit: MAX_FLAG_VERSIONS_PAGE_LIMIT,
+      cursor,
+    });
+
+    for (const candidate of result.versions) {
+      availableRevisions.add(candidate.revision);
+    }
+
+    version ??= result.versions.find(
+      candidate => candidate.revision === revision
+    );
+    previousVersion ??= result.versions.find(
+      candidate => candidate.revision === revision - 1
+    );
+
+    if (version && previousVersion) {
+      break;
+    }
+
+    cursor = result.next ?? undefined;
+  } while (cursor);
+
+  return {
+    version,
+    previousVersion,
+    availableRevisionCount: availableRevisions.size,
+  };
+}
+
+function formatAvailableRevisionCount(count: number): string {
+  return `Only ${plural('revision', count, true)} ${count === 1 ? 'is' : 'are'} available.`;
+}
+
+function outputJson(
+  client: Client,
+  versions: FlagVersion[],
+  next: string | null
+) {
+  const jsonOutput = {
+    versions: versions.map(version => ({
+      ...formatVersionSummary(version),
+      data: version.data,
+    })),
+    pagination: { next },
+  };
+  client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+}
+
+function outputDiffJson(
+  client: Client,
+  flagArg: string,
+  version: FlagVersion,
+  previousVersion: FlagVersion,
+  changes: VersionDiffChange[]
+) {
+  const jsonOutput = {
+    flag: flagArg,
+    revision: version.revision,
+    previousRevision: previousVersion.revision,
+    version: formatVersionSummary(version),
+    previousVersion: formatVersionSummary(previousVersion),
+    changes,
+  };
+  client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+}
+
+function formatVersionSummary(version: FlagVersion) {
+  return {
+    id: version.id,
+    flagId: version.flagId,
+    revision: version.revision,
+    author: getVersionAuthor(version),
+    createdBy: version.createdBy ?? null,
+    message: getVersionMessage(version),
+    createdAt: version.createdAt,
+    changedEnvironments: version.changedEnvironments,
+  };
+}
+
+function printVersionsTable(versions: FlagVersion[]) {
+  const headers = [
+    'Revision',
+    'Author',
+    'Message',
+    'Timestamp',
+    'Changed Environments',
+  ];
+
+  const rows = versions.map(version => [
+    String(version.revision),
+    getVersionAuthor(version) ?? chalk.gray('-'),
+    getVersionMessage(version) ?? chalk.gray('-'),
+    formatDate(version.createdAt),
+    formatChangedEnvironments(version.changedEnvironments),
+  ]);
+
+  const table = formatTable(
+    headers,
+    ['r', 'l', 'l', 'l', 'l'],
+    [{ name: '', rows }]
+  );
+  output.print(`\n${table}\n`);
+}
+
+function printVersionDiff({
+  flagArg,
+  projectSlugLink,
+  version,
+  previousVersion,
+  diffStamp,
+}: {
+  flagArg: string;
+  projectSlugLink: string;
+  version: FlagVersion;
+  previousVersion: FlagVersion;
+  diffStamp: ReturnType<typeof stamp>;
+}) {
+  output.log(
+    `Changes in revision ${chalk.bold(String(version.revision))} for ${chalk.bold(flagArg)} compared with revision ${chalk.bold(String(previousVersion.revision))} in ${projectSlugLink} ${chalk.gray(diffStamp())}`
+  );
+  output.print(
+    `\n  ${chalk.dim('Author:')} ${getVersionAuthor(version) ?? chalk.gray('-')}\n`
+  );
+  output.print(
+    `  ${chalk.dim('Message:')} ${getVersionMessage(version) ?? chalk.gray('-')}\n`
+  );
+  output.print(
+    `  ${chalk.dim('Changed environments:')} ${formatChangedEnvironments(version.changedEnvironments)}\n`
+  );
+
+  const formattedDiff = formatVersionDataDiff(
+    previousVersion.data,
+    version.data
+  );
+  if (formattedDiff.length === 0) {
+    output.print(`\n  ${chalk.gray('No changes detected.')}\n\n`);
+    return;
+  }
+
+  output.print(`\n${formattedDiff}\n\n`);
+}
+
+function formatChangedEnvironments(environments: string[]): string {
+  if (environments.length === 0) {
+    return chalk.gray('-');
+  }
+  return environments.join(', ');
+}
+
+function getVersionAuthor(version: FlagVersion): string | null {
+  return version.metadata?.creator?.name ?? version.createdBy ?? null;
+}
+
+function getVersionMessage(version: FlagVersion): string | null {
+  if (version.message) {
+    return version.message;
+  }
+
+  if (version.revision === 0) {
+    return 'Flag created';
+  }
+
+  return null;
+}
+
+function getVersionsHelpParent(): Command {
+  return {
+    ...versionsSubcommand,
+    name: 'flags versions',
+  };
+}
+
+function buildNextPageCommand(
+  flagArg: string,
+  flags: { [key: string]: unknown },
+  nextCursor: string
+): string {
+  const environment = flags['--environment'] as string | undefined;
+  const baseFlags = getCommandFlags(flags, [
+    '_',
+    '--cursor',
+    '--environment',
+    '--json',
+  ]);
+  const environmentFlag = environment
+    ? ` --environment ${quoteArg(environment)}`
+    : '';
+  return `flags versions ${quoteArg(flagArg)}${baseFlags}${environmentFlag} --cursor ${quoteArg(nextCursor)}`;
+}

--- a/packages/cli/src/util/flags/format-flag-details.ts
+++ b/packages/cli/src/util/flags/format-flag-details.ts
@@ -1,0 +1,94 @@
+import chalk from 'chalk';
+import { formatFlagConditionComparator } from './comparators';
+import type { FlagCondition, FlagSettings } from './types';
+
+export function resolveTargetingLabel(
+  settings: FlagSettings | undefined,
+  entityKind: string,
+  attribute: string,
+  value: string
+): string | undefined {
+  if (!settings) {
+    return undefined;
+  }
+
+  const entity = settings.entities.find(e => e.kind === entityKind);
+  if (!entity) {
+    return undefined;
+  }
+
+  const attr = entity.attributes.find(a => a.key === attribute);
+  if (!attr?.labels) {
+    return undefined;
+  }
+
+  const labelEntry = attr.labels.find(l => l.value === value);
+  return labelEntry?.label;
+}
+
+export function formatFlagCondition(
+  condition: FlagCondition,
+  settings: FlagSettings | undefined
+): { text: string; listItems?: string[] } {
+  let lhs: string;
+  if (condition.lhs.type === 'segment') {
+    lhs = 'segment';
+  } else {
+    lhs = `${condition.lhs.kind}.${condition.lhs.attribute}`;
+  }
+
+  const cmp = chalk.dim(
+    formatFlagConditionComparator(condition.cmp, condition.cmpOptions)
+  );
+
+  if (condition.rhs === undefined || condition.rhs === null) {
+    return { text: `${lhs} ${cmp}` };
+  }
+
+  if (typeof condition.rhs === 'object') {
+    if (
+      (condition.rhs.type === 'list' || condition.rhs.type === 'list/inline') &&
+      Array.isArray(condition.rhs.items)
+    ) {
+      const items = condition.rhs.items.map(item => {
+        const itemValue =
+          typeof item === 'object' && item !== null && 'value' in item
+            ? String((item as { value: unknown }).value)
+            : String(item);
+
+        if (condition.lhs.type === 'entity') {
+          const label = resolveTargetingLabel(
+            settings,
+            condition.lhs.kind,
+            condition.lhs.attribute,
+            itemValue
+          );
+          return label ? `${itemValue} ${chalk.gray(label)}` : itemValue;
+        }
+
+        return itemValue;
+      });
+
+      return { text: `${lhs} ${cmp}`, listItems: items };
+    }
+
+    return { text: `${lhs} ${cmp} ${JSON.stringify(condition.rhs)}` };
+  }
+
+  let rhs: string;
+  if (condition.lhs.type === 'entity') {
+    const label = resolveTargetingLabel(
+      settings,
+      condition.lhs.kind,
+      condition.lhs.attribute,
+      String(condition.rhs)
+    );
+    rhs = label
+      ? `${condition.rhs} ${chalk.gray(label)}`
+      : String(condition.rhs);
+  } else {
+    rhs = String(condition.rhs);
+  }
+
+  return { text: `${lhs} ${cmp} ${rhs}` };
+}

--- a/packages/cli/src/util/flags/format-flag-outcome.ts
+++ b/packages/cli/src/util/flags/format-flag-outcome.ts
@@ -10,46 +10,59 @@ import type {
 
 export function formatFlagOutcome(
   outcome: FlagOutcome | FlagSplitOutcome | FlagRolloutOutcome,
-  variants: FlagVariant[]
+  variants: FlagVariant[],
+  includeVariantId = false
 ): string {
   if (outcome.type === 'variant') {
     const variant = variants.find(v => v.id === outcome.variantId);
-    return formatFlagVariantSummary(variant, outcome.variantId);
+    return formatFlagVariantSummary(
+      variant,
+      outcome.variantId,
+      includeVariantId
+    );
   }
 
   if (outcome.type === 'split') {
-    const weights = formatFlagSplitWeights(outcome.weights, variants);
+    const weights = formatFlagSplitWeights(
+      outcome.weights,
+      variants,
+      includeVariantId
+    );
     return `split (${weights})`;
   }
 
-  return formatRolloutOutcome(outcome, variants);
+  return formatRolloutOutcome(outcome, variants, includeVariantId);
 }
 
 export function formatFlagVariantSummary(
   variant: FlagVariant | undefined,
-  fallback: string
+  fallback: string,
+  includeVariantId = false
 ): string {
   if (!variant) {
     return chalk.bold(fallback);
   }
 
-  if (variant.label) {
-    return chalk.bold(variant.label);
-  }
+  const summary = variant.label
+    ? chalk.bold(variant.label)
+    : chalk.bold(formatVariantValue(variant.value));
 
-  return chalk.bold(formatVariantValue(variant.value));
+  return includeVariantId
+    ? `${summary} ${chalk.dim(`(${variant.id})`)}`
+    : summary;
 }
 
 export function formatFlagSplitWeights(
   weights: Record<string, number>,
-  variants: FlagVariant[]
+  variants: FlagVariant[],
+  includeVariantId = false
 ): string {
   const total = Object.values(weights).reduce((sum, weight) => sum + weight, 0);
 
   return Object.entries(weights)
     .map(([id, weight]) => {
       const variant = variants.find(v => v.id === id);
-      const summary = formatFlagVariantSummary(variant, id);
+      const summary = formatFlagVariantSummary(variant, id, includeVariantId);
       const percentage = total > 0 ? (weight / total) * 100 : 0;
       const formattedPercentage = Number.isInteger(percentage)
         ? String(percentage)
@@ -62,7 +75,8 @@ export function formatFlagSplitWeights(
 
 function formatRolloutOutcome(
   outcome: FlagRolloutOutcome,
-  variants: FlagVariant[]
+  variants: FlagVariant[],
+  includeVariantId = false
 ): string {
   const fromVariant = variants.find(v => v.id === outcome.rollFromVariantId);
   const toVariant = variants.find(v => v.id === outcome.rollToVariantId);
@@ -79,12 +93,15 @@ function formatRolloutOutcome(
 
   return `${formatFlagVariantSummary(
     fromVariant,
-    outcome.rollFromVariantId
+    outcome.rollFromVariantId,
+    includeVariantId
   )} -> ${formatFlagVariantSummary(
     toVariant,
-    outcome.rollToVariantId
+    outcome.rollToVariantId,
+    includeVariantId
   )}; ${stages}; then 100%; Fallback: ${formatFlagVariantSummary(
     defaultVariant,
-    outcome.defaultVariantId
+    outcome.defaultVariantId,
+    includeVariantId
   )}`;
 }

--- a/packages/cli/src/util/flags/format-version-diff.ts
+++ b/packages/cli/src/util/flags/format-version-diff.ts
@@ -546,12 +546,10 @@ function appendEnvironmentSummary(
       indent
     )
   );
-  if (environment.rules.length > 0) {
+  const ruleCount = environment.rules?.length ?? 0;
+  if (ruleCount > 0) {
     lines.push(
-      line(
-        `${chalk.dim('Rules:')} ${chalk.bold(String(environment.rules.length))}`,
-        indent
-      )
+      line(`${chalk.dim('Rules:')} ${chalk.bold(String(ruleCount))}`, indent)
     );
   }
   const targets = formatTargets(environment.targets, variants);

--- a/packages/cli/src/util/flags/format-version-diff.ts
+++ b/packages/cli/src/util/flags/format-version-diff.ts
@@ -1,0 +1,953 @@
+import chalk from 'chalk';
+import deepEqual from 'fast-deep-equal';
+import { formatFlagCondition } from './format-flag-details';
+import {
+  formatFlagOutcome,
+  formatFlagVariantSummary,
+} from './format-flag-outcome';
+import { formatVariantValue } from './resolve-variant';
+import type {
+  FlagCondition,
+  FlagEnvironmentConfig,
+  FlagOutcome,
+  FlagRolloutOutcome,
+  FlagRule,
+  FlagSplitOutcome,
+  FlagVariant,
+  FlagVersion,
+} from './types';
+
+type VersionData = FlagVersion['data'];
+
+type VersionDataForDiff = Omit<VersionData, 'environments'> & {
+  environments: Record<string, Omit<FlagEnvironmentConfig, 'revision'>>;
+};
+
+export type VersionDiffChange = {
+  path: string;
+  action: 'added' | 'removed' | 'changed';
+  before: unknown;
+  after: unknown;
+};
+
+type DiffMarker = '+' | '-' | '~';
+
+const ENVIRONMENT_ORDER = ['production', 'preview', 'development'];
+
+export function normalizeVersionDataForDiff(
+  data: VersionData
+): VersionDataForDiff {
+  return {
+    ...data,
+    permanent: data.permanent ?? false,
+    environments: Object.fromEntries(
+      Object.entries(data.environments).map(([environment, config]) => {
+        const diffConfig = { ...config };
+        delete diffConfig.revision;
+        return [environment, diffConfig];
+      })
+    ),
+  };
+}
+
+export function diffVersionData(
+  before: VersionData,
+  after: VersionData
+): VersionDiffChange[] {
+  return diffValues(
+    normalizeVersionDataForDiff(before),
+    normalizeVersionDataForDiff(after)
+  );
+}
+
+export function formatVersionDataDiff(
+  before: VersionData,
+  after: VersionData
+): string {
+  const beforeData = normalizeVersionDataForDiff(before);
+  const afterData = normalizeVersionDataForDiff(after);
+  const lines: string[] = [];
+
+  appendGeneralChanges(lines, beforeData, afterData);
+  appendEnvironmentChanges(lines, beforeData, afterData);
+  appendUnknownChanges(lines, beforeData, afterData);
+
+  return lines.join('\n');
+}
+
+function appendGeneralChanges(
+  lines: string[],
+  before: VersionDataForDiff,
+  after: VersionDataForDiff
+) {
+  const section: string[] = [];
+
+  appendScalarChange(
+    section,
+    'Description',
+    before.description,
+    after.description
+  );
+  appendScalarChange(section, 'State', before.state, after.state);
+  appendScalarChange(section, 'Permanent', before.permanent, after.permanent);
+  appendListChange(section, 'Tags', before.tags ?? [], after.tags ?? []);
+  appendListChange(
+    section,
+    'Maintainers',
+    before.maintainerIds ?? [],
+    after.maintainerIds ?? []
+  );
+  appendScalarChange(section, 'Seed', before.seed, after.seed);
+  appendVariantChanges(section, before.variants, after.variants);
+
+  appendSection(lines, 'General', section);
+}
+
+function appendEnvironmentChanges(
+  lines: string[],
+  before: VersionDataForDiff,
+  after: VersionDataForDiff
+) {
+  const environments = new Set([
+    ...Object.keys(before.environments),
+    ...Object.keys(after.environments),
+  ]);
+
+  for (const environment of Array.from(environments).sort(sortEnvironments)) {
+    const beforeEnvironment = before.environments[environment];
+    const afterEnvironment = after.environments[environment];
+    const section: string[] = [];
+
+    if (!beforeEnvironment && afterEnvironment) {
+      section.push(diffLine('+', 'Environment added', 4));
+      appendEnvironmentSummary(section, afterEnvironment, after.variants, 6);
+      appendSection(lines, formatEnvironmentName(environment), section);
+      continue;
+    }
+
+    if (beforeEnvironment && !afterEnvironment) {
+      section.push(diffLine('-', 'Environment removed', 4));
+      appendEnvironmentSummary(section, beforeEnvironment, before.variants, 6);
+      appendSection(lines, formatEnvironmentName(environment), section);
+      continue;
+    }
+
+    if (
+      !beforeEnvironment ||
+      !afterEnvironment ||
+      deepEqual(beforeEnvironment, afterEnvironment)
+    ) {
+      continue;
+    }
+
+    appendScalarChange(
+      section,
+      'Status',
+      formatEnvironmentStatus(beforeEnvironment, before.variants),
+      formatEnvironmentStatus(afterEnvironment, after.variants)
+    );
+    appendReuseChange(section, beforeEnvironment, afterEnvironment);
+    appendOutcomeChange(
+      section,
+      'Paused outcome',
+      beforeEnvironment.pausedOutcome,
+      afterEnvironment.pausedOutcome,
+      before.variants,
+      after.variants
+    );
+    appendOutcomeChange(
+      section,
+      'Fallthrough',
+      beforeEnvironment.fallthrough,
+      afterEnvironment.fallthrough,
+      before.variants,
+      after.variants
+    );
+    appendRuleChanges(
+      section,
+      beforeEnvironment.rules ?? [],
+      afterEnvironment.rules ?? [],
+      before.variants,
+      after.variants
+    );
+    appendTargetChanges(
+      section,
+      beforeEnvironment.targets,
+      afterEnvironment.targets,
+      before.variants,
+      after.variants
+    );
+    appendUnknownEnvironmentChanges(
+      section,
+      beforeEnvironment,
+      afterEnvironment
+    );
+
+    appendSection(lines, formatEnvironmentName(environment), section);
+  }
+}
+
+function appendUnknownChanges(
+  lines: string[],
+  before: VersionDataForDiff,
+  after: VersionDataForDiff
+) {
+  const beforeUnknown = omitKeys(before, [
+    'description',
+    'environments',
+    'maintainerIds',
+    'permanent',
+    'seed',
+    'state',
+    'tags',
+    'variants',
+  ]);
+  const afterUnknown = omitKeys(after, [
+    'description',
+    'environments',
+    'maintainerIds',
+    'permanent',
+    'seed',
+    'state',
+    'tags',
+    'variants',
+  ]);
+  const changes = diffValues(beforeUnknown, afterUnknown);
+  if (changes.length > 0) {
+    appendFallbackChanges(lines, 'Other', changes);
+  }
+}
+
+function appendUnknownEnvironmentChanges(
+  section: string[],
+  before: Omit<FlagEnvironmentConfig, 'revision'>,
+  after: Omit<FlagEnvironmentConfig, 'revision'>
+) {
+  const beforeUnknown = omitKeys(before, [
+    'active',
+    'fallthrough',
+    'pausedOutcome',
+    'reuse',
+    'rules',
+    'targets',
+  ]);
+  const afterUnknown = omitKeys(after, [
+    'active',
+    'fallthrough',
+    'pausedOutcome',
+    'reuse',
+    'rules',
+    'targets',
+  ]);
+  const changes = diffValues(beforeUnknown, afterUnknown);
+
+  if (changes.length > 0) {
+    section.push(line(chalk.bold('Other'), 4));
+    appendFallbackChangeLines(section, changes, 6);
+  }
+}
+
+function appendVariantChanges(
+  section: string[],
+  beforeVariants: FlagVariant[],
+  afterVariants: FlagVariant[]
+) {
+  if (deepEqual(beforeVariants, afterVariants)) {
+    return;
+  }
+
+  const beforeById = new Map(
+    beforeVariants.map(variant => [variant.id, variant])
+  );
+  const afterById = new Map(
+    afterVariants.map(variant => [variant.id, variant])
+  );
+  const variantLines: string[] = [];
+  const beforeOrder = beforeVariants.map(variant => variant.id);
+  const afterOrder = afterVariants.map(variant => variant.id);
+  const commonBeforeOrder = beforeOrder.filter(id => afterById.has(id));
+  const commonAfterOrder = afterOrder.filter(id => beforeById.has(id));
+
+  if (
+    commonBeforeOrder.length > 1 &&
+    !deepEqual(commonBeforeOrder, commonAfterOrder)
+  ) {
+    variantLines.push(line(chalk.bold('Order'), 6));
+    variantLines.push(diffLine('-', formatItemOrder(beforeOrder), 8));
+    variantLines.push(diffLine('+', formatItemOrder(afterOrder), 8));
+  }
+
+  for (const id of Array.from(
+    new Set([...beforeById.keys(), ...afterById.keys()])
+  ).sort()) {
+    const before = beforeById.get(id);
+    const after = afterById.get(id);
+
+    if (!before && after) {
+      variantLines.push(diffLine('+', formatVariantSummary(after), 6));
+      continue;
+    }
+
+    if (before && !after) {
+      variantLines.push(diffLine('-', formatVariantSummary(before), 6));
+      continue;
+    }
+
+    if (!before || !after || deepEqual(before, after)) {
+      continue;
+    }
+
+    variantLines.push(
+      diffLine('~', formatVariantChangeTitle(before, after), 6)
+    );
+    appendScalarChange(variantLines, 'Value', before.value, after.value, 8);
+    appendScalarChange(variantLines, 'Label', before.label, after.label, 8);
+    appendScalarChange(
+      variantLines,
+      'Description',
+      before.description,
+      after.description,
+      8
+    );
+  }
+
+  if (variantLines.length > 0) {
+    section.push(line(chalk.bold('Variants'), 4));
+    section.push(...variantLines);
+  }
+}
+
+function appendRuleChanges(
+  section: string[],
+  beforeRules: FlagRule[],
+  afterRules: FlagRule[],
+  beforeVariants: FlagVariant[],
+  afterVariants: FlagVariant[]
+) {
+  if (deepEqual(beforeRules, afterRules)) {
+    return;
+  }
+
+  const beforeById = new Map(beforeRules.map(rule => [rule.id, rule]));
+  const afterById = new Map(afterRules.map(rule => [rule.id, rule]));
+  const ruleLines: string[] = [];
+  const beforeOrder = beforeRules.map(rule => rule.id);
+  const afterOrder = afterRules.map(rule => rule.id);
+  const commonBeforeOrder = beforeOrder.filter(id => afterById.has(id));
+  const commonAfterOrder = afterOrder.filter(id => beforeById.has(id));
+
+  if (
+    commonBeforeOrder.length > 1 &&
+    !deepEqual(commonBeforeOrder, commonAfterOrder)
+  ) {
+    ruleLines.push(line(chalk.bold('Order'), 6));
+    ruleLines.push(diffLine('-', formatItemOrder(beforeOrder), 8));
+    ruleLines.push(diffLine('+', formatItemOrder(afterOrder), 8));
+  }
+
+  for (const id of Array.from(
+    new Set([...beforeById.keys(), ...afterById.keys()])
+  ).sort()) {
+    const before = beforeById.get(id);
+    const after = afterById.get(id);
+
+    if (!before && after) {
+      ruleLines.push(
+        diffLine(
+          '+',
+          formatRuleTitle(after.id, afterOrder.indexOf(after.id), afterOrder),
+          6
+        )
+      );
+      ruleLines.push(...formatRuleDetails(after, afterVariants, 8));
+      continue;
+    }
+
+    if (before && !after) {
+      ruleLines.push(
+        diffLine(
+          '-',
+          formatRuleTitle(
+            before.id,
+            beforeOrder.indexOf(before.id),
+            beforeOrder
+          ),
+          6
+        )
+      );
+      ruleLines.push(...formatRuleDetails(before, beforeVariants, 8));
+      continue;
+    }
+
+    if (!before || !after || deepEqual(before, after)) {
+      continue;
+    }
+
+    ruleLines.push(diffLine('~', after.id, 6));
+    appendConditionChanges(ruleLines, before.conditions, after.conditions, 8);
+    appendOutcomeChange(
+      ruleLines,
+      'Serve',
+      before.outcome,
+      after.outcome,
+      beforeVariants,
+      afterVariants,
+      8,
+      false
+    );
+  }
+
+  if (ruleLines.length > 0) {
+    section.push(line(chalk.bold('Rules'), 4));
+    section.push(...ruleLines);
+  }
+}
+
+function appendConditionChanges(
+  lines: string[],
+  beforeConditions: FlagCondition[],
+  afterConditions: FlagCondition[],
+  indent: number
+) {
+  const before = beforeConditions.map(condition => ({
+    condition,
+    key: JSON.stringify(condition),
+  }));
+  const after = afterConditions.map(condition => ({
+    condition,
+    key: JSON.stringify(condition),
+  }));
+  const removed = before.filter(
+    beforeCondition =>
+      !after.some(afterCondition => afterCondition.key === beforeCondition.key)
+  );
+  const added = after.filter(
+    afterCondition =>
+      !before.some(
+        beforeCondition => beforeCondition.key === afterCondition.key
+      )
+  );
+
+  if (removed.length === 0 && added.length === 0) {
+    return;
+  }
+
+  lines.push(line(chalk.bold('Conditions'), indent));
+  for (const { condition } of removed) {
+    appendConditionDiff(lines, '-', condition, indent + 2);
+  }
+  for (const { condition } of added) {
+    appendConditionDiff(lines, '+', condition, indent + 2);
+  }
+}
+
+function appendTargetChanges(
+  section: string[],
+  beforeTargets: FlagEnvironmentConfig['targets'],
+  afterTargets: FlagEnvironmentConfig['targets'],
+  beforeVariants: FlagVariant[],
+  afterVariants: FlagVariant[]
+) {
+  if (deepEqual(beforeTargets, afterTargets)) {
+    return;
+  }
+
+  let before = formatTargets(beforeTargets, beforeVariants);
+  let after = formatTargets(afterTargets, afterVariants);
+  if (deepEqual(before, after)) {
+    before = formatTargets(beforeTargets, beforeVariants, true);
+    after = formatTargets(afterTargets, afterVariants, true);
+  }
+  appendStringSetChange(section, 'Targeting', before, after);
+}
+
+function appendOutcomeChange(
+  lines: string[],
+  label: string,
+  before: FlagOutcome | FlagSplitOutcome | FlagRolloutOutcome | undefined,
+  after: FlagOutcome | FlagSplitOutcome | FlagRolloutOutcome | undefined,
+  beforeVariants: FlagVariant[],
+  afterVariants: FlagVariant[],
+  indent = 4,
+  includeServe = true
+) {
+  if (deepEqual(before, after)) {
+    return;
+  }
+
+  let beforeSummary = before
+    ? formatOutcome(before, beforeVariants, includeServe)
+    : undefined;
+  let afterSummary = after
+    ? formatOutcome(after, afterVariants, includeServe)
+    : undefined;
+
+  if (deepEqual(beforeSummary, afterSummary)) {
+    beforeSummary = before
+      ? formatOutcome(before, beforeVariants, includeServe, true)
+      : undefined;
+    afterSummary = after
+      ? formatOutcome(after, afterVariants, includeServe, true)
+      : undefined;
+  }
+
+  appendScalarChange(lines, label, beforeSummary, afterSummary, indent);
+}
+
+function appendReuseChange(
+  section: string[],
+  before: Omit<FlagEnvironmentConfig, 'revision'>,
+  after: Omit<FlagEnvironmentConfig, 'revision'>
+) {
+  appendScalarChange(
+    section,
+    'Reuse',
+    formatReuse(before.reuse),
+    formatReuse(after.reuse)
+  );
+}
+
+function appendEnvironmentSummary(
+  lines: string[],
+  environment: Omit<FlagEnvironmentConfig, 'revision'>,
+  variants: FlagVariant[],
+  indent: number
+) {
+  lines.push(
+    line(
+      `${chalk.dim('Status:')} ${formatEnvironmentStatus(environment, variants)}`,
+      indent
+    )
+  );
+  if (environment.reuse?.active) {
+    lines.push(
+      line(`${chalk.dim('Reuse:')} ${formatReuse(environment.reuse)}`, indent)
+    );
+    return;
+  }
+  if (!environment.active && environment.pausedOutcome) {
+    lines.push(
+      line(
+        `${chalk.dim('Paused outcome:')} ${formatOutcome(
+          environment.pausedOutcome,
+          variants
+        )}`,
+        indent
+      )
+    );
+    return;
+  }
+  lines.push(
+    line(
+      `${chalk.dim('Fallthrough:')} ${formatOutcome(
+        environment.fallthrough,
+        variants
+      )}`,
+      indent
+    )
+  );
+  if (environment.rules.length > 0) {
+    lines.push(
+      line(
+        `${chalk.dim('Rules:')} ${chalk.bold(String(environment.rules.length))}`,
+        indent
+      )
+    );
+  }
+  const targets = formatTargets(environment.targets, variants);
+  if (targets.length > 0) {
+    lines.push(
+      line(
+        `${chalk.dim('Targets:')} ${chalk.bold(String(targets.length))}`,
+        indent
+      )
+    );
+  }
+}
+
+function appendScalarChange(
+  lines: string[],
+  label: string,
+  before: unknown,
+  after: unknown,
+  indent = 4
+) {
+  if (deepEqual(before, after)) {
+    return;
+  }
+
+  lines.push(line(chalk.bold(label), indent));
+  lines.push(diffLine('-', formatScalarValue(before), indent + 2));
+  lines.push(diffLine('+', formatScalarValue(after), indent + 2));
+}
+
+function appendListChange(
+  lines: string[],
+  label: string,
+  before: string[],
+  after: string[],
+  indent = 4
+) {
+  appendStringSetChange(lines, label, before, after, indent);
+}
+
+function appendStringSetChange(
+  lines: string[],
+  label: string,
+  before: string[],
+  after: string[],
+  indent = 4
+) {
+  const removed = before.filter(item => !after.includes(item)).sort();
+  const added = after.filter(item => !before.includes(item)).sort();
+
+  if (removed.length === 0 && added.length === 0) {
+    return;
+  }
+
+  lines.push(line(chalk.bold(label), indent));
+  for (const item of removed) {
+    lines.push(diffLine('-', item, indent + 2));
+  }
+  for (const item of added) {
+    lines.push(diffLine('+', item, indent + 2));
+  }
+}
+
+function appendSection(lines: string[], title: string, section: string[]) {
+  if (section.length === 0) {
+    return;
+  }
+
+  if (lines.length > 0) {
+    lines.push('');
+  }
+  lines.push(line(chalk.bold(title), 2));
+  lines.push(...section);
+}
+
+function appendFallbackChanges(
+  lines: string[],
+  title: string,
+  changes: VersionDiffChange[]
+) {
+  const section: string[] = [];
+  appendFallbackChangeLines(section, changes, 4);
+  appendSection(lines, title, section);
+}
+
+function appendFallbackChangeLines(
+  lines: string[],
+  changes: VersionDiffChange[],
+  indent: number
+) {
+  for (const change of changes) {
+    lines.push(line(chalk.bold(change.path || 'value'), indent));
+    if (change.action !== 'added') {
+      lines.push(diffLine('-', formatScalarValue(change.before), indent + 2));
+    }
+    if (change.action !== 'removed') {
+      lines.push(diffLine('+', formatScalarValue(change.after), indent + 2));
+    }
+  }
+}
+
+function formatRuleDetails(
+  rule: FlagRule,
+  variants: FlagVariant[],
+  indent: number
+): string[] {
+  const lines: string[] = [];
+  lines.push(
+    line(
+      `${chalk.dim('→')} ${formatOutcome(rule.outcome, variants, false)}`,
+      indent
+    )
+  );
+  for (const condition of rule.conditions) {
+    appendConditionDetails(lines, condition, indent + 2);
+  }
+  return lines;
+}
+
+function appendConditionDetails(
+  lines: string[],
+  condition: FlagCondition,
+  indent: number
+) {
+  const { text, listItems } = formatFlagCondition(condition, undefined);
+  lines.push(line(`${chalk.dim('if')} ${text}`, indent));
+  for (const item of listItems ?? []) {
+    lines.push(line(`${chalk.dim('-')} ${item}`, indent + 3));
+  }
+}
+
+function appendConditionDiff(
+  lines: string[],
+  marker: DiffMarker,
+  condition: FlagCondition,
+  indent: number
+) {
+  const { text, listItems } = formatFlagCondition(condition, undefined);
+  lines.push(diffLine(marker, `${chalk.dim('if')} ${text}`, indent));
+  for (const item of listItems ?? []) {
+    lines.push(line(`${chalk.dim('-')} ${item}`, indent + 3));
+  }
+}
+
+function formatTargets(
+  targets: FlagEnvironmentConfig['targets'],
+  variants: FlagVariant[],
+  includeVariantId = false
+): string[] {
+  const lines: string[] = [];
+
+  for (const [variantId, entityKinds] of Object.entries(targets ?? {})) {
+    for (const [entityKind, attributes] of Object.entries(entityKinds)) {
+      for (const [attribute, values] of Object.entries(attributes)) {
+        for (const target of values) {
+          const variant = variants.find(
+            candidate => candidate.id === variantId
+          );
+          lines.push(
+            `${chalk.dim(`${entityKind}.${attribute}:`)} ${formatTargetValue(
+              target
+            )} ${chalk.dim('→')} ${formatFlagVariantSummary(
+              variant,
+              variantId,
+              includeVariantId
+            )}`
+          );
+        }
+      }
+    }
+  }
+
+  return lines.sort();
+}
+
+function formatTargetValue(target: { value: string; note?: string }): string {
+  if (!target.note) {
+    return target.value;
+  }
+  return `${target.value} ${chalk.gray(`(${target.note})`)}`;
+}
+
+function formatEnvironmentStatus(
+  environment: Omit<FlagEnvironmentConfig, 'revision'>,
+  variants: FlagVariant[]
+): string {
+  if (environment.active) {
+    return chalk.green('active');
+  }
+
+  if (!environment.pausedOutcome) {
+    return chalk.gray('paused');
+  }
+
+  return `${chalk.gray('paused')}, ${chalk.dim('serving')} ${formatOutcome(
+    environment.pausedOutcome,
+    variants,
+    false
+  )}`;
+}
+
+function formatReuse(reuse: FlagEnvironmentConfig['reuse']): string {
+  if (!reuse?.active) {
+    return chalk.gray('none');
+  }
+  return `${chalk.dim('reusing')} ${chalk.cyan(
+    formatEnvironmentName(reuse.environment)
+  )}`;
+}
+
+function formatOutcome(
+  outcome: FlagOutcome | FlagSplitOutcome | FlagRolloutOutcome,
+  variants: FlagVariant[],
+  includeServe = true,
+  includeVariantId = false
+): string {
+  const prefix = includeServe ? `${chalk.dim('Serve')} ` : '';
+  const summary = formatFlagOutcome(outcome, variants, includeVariantId);
+
+  if (outcome.type === 'split') {
+    const defaultVariant = variants.find(
+      variant => variant.id === outcome.defaultVariantId
+    );
+    return `${prefix}${summary}; ${chalk.dim('by')} ${formatBucketingBase(
+      outcome.base
+    )}; ${chalk.dim('Fallback:')} ${formatFlagVariantSummary(
+      defaultVariant,
+      outcome.defaultVariantId,
+      includeVariantId
+    )}`;
+  }
+
+  if (outcome.type === 'rollout') {
+    return `${prefix}${summary}; ${chalk.dim('by')} ${formatBucketingBase(
+      outcome.base
+    )}; ${chalk.dim('Starts:')} ${formatTimestamp(outcome.startTimestamp)}`;
+  }
+
+  return `${prefix}${summary}`;
+}
+
+function formatBucketingBase(base: {
+  kind: string;
+  attribute: string;
+}): string {
+  return `${base.kind}.${base.attribute}`;
+}
+
+function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? String(timestamp) : date.toISOString();
+}
+
+function formatItemOrder(ids: string[]): string {
+  return ids.join(` ${chalk.dim('→')} `);
+}
+
+function formatRuleTitle(
+  ruleId: string,
+  index: number,
+  ruleOrder: string[]
+): string {
+  if (ruleOrder.length === 1) {
+    return ruleId;
+  }
+  return `${ruleId} ${chalk.dim(`(position ${index + 1})`)}`;
+}
+
+function formatVariantChangeTitle(
+  before: FlagVariant,
+  after: FlagVariant
+): string {
+  const label = after.label ?? before.label;
+  return label ? `${chalk.bold(label)} (${chalk.dim(after.id)})` : after.id;
+}
+
+function formatVariantSummary(variant: FlagVariant): string {
+  const details = [
+    `${chalk.dim('id:')} ${variant.id}`,
+    `${chalk.dim('value:')} ${chalk.bold(formatVariantValue(variant.value))}`,
+  ];
+  if (variant.label) {
+    details.unshift(chalk.bold(variant.label));
+  }
+  return details.join(', ');
+}
+
+function formatScalarValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '-';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  return JSON.stringify(sortObjectKeys(value), null, 2);
+}
+
+function formatEnvironmentName(environment: string): string {
+  return environment.charAt(0).toUpperCase() + environment.slice(1);
+}
+
+function line(text: string, indent: number): string {
+  return `${' '.repeat(indent)}${text}`;
+}
+
+function diffLine(marker: DiffMarker, text: string, indent: number): string {
+  const color =
+    marker === '+' ? chalk.green : marker === '-' ? chalk.red : chalk.yellow;
+  return line(color(`${marker} ${text}`), indent);
+}
+
+function sortEnvironments(a: string, b: string): number {
+  const aIndex = ENVIRONMENT_ORDER.indexOf(a);
+  const bIndex = ENVIRONMENT_ORDER.indexOf(b);
+  if (aIndex === -1 && bIndex === -1) {
+    return a.localeCompare(b);
+  }
+  if (aIndex === -1) {
+    return 1;
+  }
+  if (bIndex === -1) {
+    return -1;
+  }
+  return aIndex - bIndex;
+}
+
+function omitKeys<T extends Record<string, unknown>>(
+  value: T,
+  keys: string[]
+): Record<string, unknown> {
+  const omitted = { ...value };
+  for (const key of keys) {
+    delete omitted[key];
+  }
+  return omitted;
+}
+
+function diffValues(
+  before: unknown,
+  after: unknown,
+  path = ''
+): VersionDiffChange[] {
+  if (deepEqual(before, after)) {
+    return [];
+  }
+
+  if (isPlainObject(before) && isPlainObject(after)) {
+    const keys = Array.from(
+      new Set([...Object.keys(before), ...Object.keys(after)])
+    ).sort();
+    return keys.flatMap(key =>
+      diffValues(before[key], after[key], joinPath(path, key))
+    );
+  }
+
+  return [
+    {
+      path,
+      action:
+        before === undefined
+          ? 'added'
+          : after === undefined
+            ? 'removed'
+            : 'changed',
+      before,
+      after,
+    },
+  ];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function joinPath(path: string, key: string): string {
+  if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)) {
+    return path ? `${path}.${key}` : key;
+  }
+  return `${path}[${JSON.stringify(key)}]`;
+}
+
+function sortObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortObjectKeys);
+  }
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map(key => [key, sortObjectKeys(value[key])])
+    );
+  }
+  return value;
+}

--- a/packages/cli/src/util/flags/get-flags.ts
+++ b/packages/cli/src/util/flags/get-flags.ts
@@ -1,5 +1,11 @@
 import type Client from '../client';
-import type { Flag, FlagsListResponse, FlagSettings } from './types';
+import type {
+  Flag,
+  FlagsListResponse,
+  FlagSettings,
+  FlagVersion,
+  FlagVersionsResponse,
+} from './types';
 import output from '../../output-manager';
 
 export interface GetFlagsOptions {
@@ -26,9 +32,21 @@ export interface GetFlagsResult {
   next: string | null;
 }
 
+export interface GetFlagVersionsOptions {
+  environment?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface GetFlagVersionsResult {
+  versions: FlagVersion[];
+  next: string | null;
+}
+
 // The v2 endpoint caps the page size at 100, so request that much when
 // fetching the full list to minimize round-trips.
 export const MAX_FLAGS_PAGE_LIMIT = 100;
+export const MAX_FLAG_VERSIONS_PAGE_LIMIT = 100;
 
 export async function getFlags(
   client: Client,
@@ -117,4 +135,39 @@ export async function getFlagSettings(
   const response = await client.fetch<FlagSettings>(url);
 
   return response;
+}
+
+export async function getFlagVersions(
+  client: Client,
+  projectId: string,
+  flagIdOrSlug: string,
+  options: GetFlagVersionsOptions = {}
+): Promise<GetFlagVersionsResult> {
+  output.debug(
+    `Fetching feature flag versions for ${flagIdOrSlug} in project ${projectId}`
+  );
+
+  const query = new URLSearchParams();
+  query.set('withMetadata', 'true');
+  if (options.environment) {
+    query.set('environment', options.environment);
+  }
+  if (options.limit !== undefined) {
+    query.set('limit', String(options.limit));
+  }
+  if (options.cursor) {
+    query.set('cursor', options.cursor);
+  }
+
+  const url = `/v1/projects/${encodeURIComponent(projectId)}/feature-flags/flags/${encodeURIComponent(flagIdOrSlug)}/versions?${query.toString()}`;
+  const response = await client.fetch<FlagVersionsResponse>(url);
+  const next =
+    response.pagination?.next ??
+    (response.pagination?.hasNext ? response.pagination.cursor : null) ??
+    null;
+
+  return {
+    versions: response.versions,
+    next,
+  };
 }

--- a/packages/cli/src/util/flags/print-flag-details.ts
+++ b/packages/cli/src/util/flags/print-flag-details.ts
@@ -1,8 +1,11 @@
 import chalk from 'chalk';
 import output from '../../output-manager';
 import formatDate from '../format-date';
-import { formatFlagConditionComparator } from './comparators';
 import { getFlagDashboardUrl } from './dashboard-url';
+import {
+  formatFlagCondition,
+  resolveTargetingLabel,
+} from './format-flag-details';
 import {
   formatFlagOutcome,
   formatFlagSplitWeights,
@@ -11,7 +14,6 @@ import {
 import { formatVariantValue } from './resolve-variant';
 import type {
   Flag,
-  FlagCondition,
   FlagEnvironmentConfig,
   FlagSettings,
   FlagVariant,
@@ -130,7 +132,10 @@ export function printFlagEnvironmentDetails(
           const outcome = formatFlagOutcome(rule.outcome, flag.variants);
           output.print(`        ${chalk.dim('→')} ${outcome}\n`);
           for (const condition of rule.conditions) {
-            const { text, listItems } = formatCondition(condition, settings);
+            const { text, listItems } = formatFlagCondition(
+              condition,
+              settings
+            );
             output.print(`          ${chalk.dim('if')} ${text}\n`);
             if (listItems && listItems.length > 0) {
               for (const item of listItems) {
@@ -209,30 +214,6 @@ function getSortedEnvironmentEntries(
       return aIndex - bIndex;
     });
 }
-function resolveTargetingLabel(
-  settings: FlagSettings | undefined,
-  entityKind: string,
-  attribute: string,
-  value: string
-): string | undefined {
-  if (!settings) {
-    return undefined;
-  }
-
-  const entity = settings.entities.find(e => e.kind === entityKind);
-  if (!entity) {
-    return undefined;
-  }
-
-  const attr = entity.attributes.find(a => a.key === attribute);
-  if (!attr?.labels) {
-    return undefined;
-  }
-
-  const labelEntry = attr.labels.find(l => l.value === value);
-  return labelEntry?.label;
-}
-
 function hasCustomConfigurationEnabled(
   envConfig: FlagEnvironmentConfig
 ): boolean {
@@ -251,71 +232,4 @@ function formatVariantListSummary(variant: FlagVariant): string {
   }
 
   return `${value}: ${chalk.gray(variant.label)}`;
-}
-
-function formatCondition(
-  condition: FlagCondition,
-  settings: FlagSettings | undefined
-): { text: string; listItems?: string[] } {
-  let lhs: string;
-  if (condition.lhs.type === 'segment') {
-    lhs = 'segment';
-  } else {
-    lhs = `${condition.lhs.kind}.${condition.lhs.attribute}`;
-  }
-
-  const cmp = chalk.dim(
-    formatFlagConditionComparator(condition.cmp, condition.cmpOptions)
-  );
-
-  if (condition.rhs === undefined || condition.rhs === null) {
-    return { text: `${lhs} ${cmp}` };
-  }
-
-  if (typeof condition.rhs === 'object') {
-    if (
-      (condition.rhs.type === 'list' || condition.rhs.type === 'list/inline') &&
-      Array.isArray(condition.rhs.items)
-    ) {
-      const items = condition.rhs.items.map(item => {
-        const itemValue =
-          typeof item === 'object' && item !== null && 'value' in item
-            ? String((item as { value: unknown }).value)
-            : String(item);
-
-        if (condition.lhs.type === 'entity') {
-          const label = resolveTargetingLabel(
-            settings,
-            condition.lhs.kind,
-            condition.lhs.attribute,
-            itemValue
-          );
-          return label ? `${itemValue} ${chalk.gray(label)}` : itemValue;
-        }
-
-        return itemValue;
-      });
-
-      return { text: `${lhs} ${cmp}`, listItems: items };
-    }
-
-    return { text: `${lhs} ${cmp} ${JSON.stringify(condition.rhs)}` };
-  }
-
-  let rhs: string;
-  if (condition.lhs.type === 'entity') {
-    const label = resolveTargetingLabel(
-      settings,
-      condition.lhs.kind,
-      condition.lhs.attribute,
-      String(condition.rhs)
-    );
-    rhs = label
-      ? `${condition.rhs} ${chalk.gray(label)}`
-      : String(condition.rhs);
-  } else {
-    rhs = String(condition.rhs);
-  }
-
-  return { text: `${lhs} ${cmp} ${rhs}` };
 }

--- a/packages/cli/src/util/flags/quote-arg.ts
+++ b/packages/cli/src/util/flags/quote-arg.ts
@@ -1,0 +1,8 @@
+// Wrap a value in single quotes only when it contains characters the shell
+// would otherwise interpret, so printed next-page commands stay copy-pasteable.
+export function quoteArg(value: string): string {
+  if (/^[A-Za-z0-9_./@:-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/cli/src/util/flags/types.ts
+++ b/packages/cli/src/util/flags/types.ts
@@ -113,19 +113,37 @@ export interface FlagsListResponse {
 
 export interface FlagVersion {
   id: string;
+  flagId: string;
   revision: number;
   createdAt: number;
-  createdBy: string;
+  createdBy?: string;
   message?: string;
+  changedEnvironments: string[];
+  metadata?: {
+    creator?: {
+      id: string;
+      name: string;
+    };
+  };
   data: {
     description?: string;
+    maintainerIds?: string[];
+    permanent?: boolean;
+    tags?: string[];
     variants: FlagVariant[];
     environments: Record<string, FlagEnvironmentConfig>;
+    seed?: number;
+    state?: 'active' | 'archived';
   };
 }
 
 export interface FlagVersionsResponse {
   versions: FlagVersion[];
+  pagination?: {
+    next?: string | null;
+    cursor?: string | null;
+    hasNext?: boolean;
+  };
 }
 
 export interface SdkKey {

--- a/packages/cli/src/util/telemetry/commands/flags/index.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/index.ts
@@ -20,6 +20,13 @@ export class FlagsTelemetryClient
     });
   }
 
+  trackCliSubcommandVersions(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'versions',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandOpen(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'open',

--- a/packages/cli/src/util/telemetry/commands/flags/versions.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/versions.ts
@@ -1,0 +1,87 @@
+import { TelemetryClient } from '../..';
+import { STANDARD_ENVIRONMENTS } from '../../../target/standard-environments';
+import type {
+  versionsDiffSubcommand,
+  versionsListSubcommand,
+  versionsSubcommand,
+} from '../../../../commands/flags/command';
+import type { TelemetryMethods } from '../../types';
+
+type StandardEnvironment = (typeof STANDARD_ENVIRONMENTS)[number];
+
+export class FlagsVersionsTelemetryClient
+  extends TelemetryClient
+  implements
+    TelemetryMethods<typeof versionsSubcommand>,
+    TelemetryMethods<typeof versionsListSubcommand>,
+    TelemetryMethods<typeof versionsDiffSubcommand>
+{
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandDiff(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'diff',
+      value: actual,
+    });
+  }
+
+  trackCliArgumentFlag(flag: string | undefined) {
+    if (flag) {
+      this.trackCliArgument({
+        arg: 'flag',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEnvironment(environment: string | undefined) {
+    if (environment) {
+      this.trackCliOption({
+        option: 'environment',
+        value: STANDARD_ENVIRONMENTS.includes(
+          environment as StandardEnvironment
+        )
+          ? environment
+          : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionLimit(limit: number | undefined) {
+    if (limit !== undefined) {
+      this.trackCliOption({
+        option: 'limit',
+        value: String(limit),
+      });
+    }
+  }
+
+  trackCliOptionCursor(cursor: string | undefined) {
+    if (cursor) {
+      this.trackCliOption({
+        option: 'cursor',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionRevision(revision: number | undefined) {
+    if (revision !== undefined) {
+      this.trackCliOption({
+        option: 'revision',
+        value: String(revision),
+      });
+    }
+  }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/test/mocks/flags.ts
+++ b/packages/cli/test/mocks/flags.ts
@@ -4,6 +4,7 @@ import type {
   SdkKey,
   CreatedSdkKey,
   FlagSettings,
+  FlagVersion,
   Segment,
   SegmentMembershipOperation,
   UpdateFlagRequest,
@@ -167,6 +168,97 @@ export const defaultSdkKeys: SdkKey[] = [
   },
 ];
 
+export const defaultFlagVersions: FlagVersion[] = [
+  {
+    id: 'flag_version_3',
+    flagId: 'flag_abc123',
+    revision: 3,
+    createdAt: Date.now() - 3600000,
+    createdBy: 'user_456',
+    message: 'Enabled production rollout',
+    changedEnvironments: ['production'],
+    metadata: {
+      creator: {
+        id: 'user_456',
+        name: 'Ada Lovelace',
+      },
+    },
+    data: {
+      description: defaultFlags[0].description,
+      variants: defaultFlags[0].variants,
+      environments: defaultFlags[0].environments,
+      seed: defaultFlags[0].seed,
+      state: defaultFlags[0].state,
+    },
+  },
+  {
+    id: 'flag_version_2',
+    flagId: 'flag_abc123',
+    revision: 2,
+    createdAt: Date.now() - 7200000,
+    createdBy: 'user_123',
+    message: 'Updated preview defaults',
+    changedEnvironments: ['preview'],
+    metadata: {
+      creator: {
+        id: 'user_123',
+        name: 'Grace Hopper',
+      },
+    },
+    data: {
+      description: defaultFlags[0].description,
+      variants: defaultFlags[0].variants,
+      environments: defaultFlags[0].environments,
+      seed: defaultFlags[0].seed,
+      state: defaultFlags[0].state,
+    },
+  },
+  {
+    id: 'flag_version_1',
+    flagId: 'flag_abc123',
+    revision: 1,
+    createdAt: Date.now() - 86400000,
+    createdBy: 'user_123',
+    message: 'Created flag',
+    changedEnvironments: ['production', 'preview', 'development'],
+    metadata: {
+      creator: {
+        id: 'user_123',
+        name: 'Grace Hopper',
+      },
+    },
+    data: {
+      description: defaultFlags[0].description,
+      variants: defaultFlags[0].variants,
+      environments: defaultFlags[0].environments,
+      seed: defaultFlags[0].seed,
+      state: defaultFlags[0].state,
+    },
+  },
+  {
+    id: 'flag_version_4',
+    flagId: 'flag_def456',
+    revision: 2,
+    createdAt: Date.now() - 7200000,
+    createdBy: 'user_123',
+    message: 'Created string flag',
+    changedEnvironments: ['production', 'preview', 'development'],
+    metadata: {
+      creator: {
+        id: 'user_123',
+        name: 'Grace Hopper',
+      },
+    },
+    data: {
+      description: defaultFlags[1].description,
+      variants: defaultFlags[1].variants,
+      environments: defaultFlags[1].environments,
+      seed: defaultFlags[1].seed,
+      state: defaultFlags[1].state,
+    },
+  },
+];
+
 export const defaultSegments: Segment[] = [
   {
     id: 'seg_beta123',
@@ -233,7 +325,8 @@ export function useFlags(
   settings: FlagSettings = defaultFlagSettings,
   segmentsList: Segment[] = defaultSegments,
   onUpdateFlag?: (request: UpdateFlagRequest) => void,
-  onGetSettings?: () => void
+  onGetSettings?: () => void,
+  versionsList: FlagVersion[] = defaultFlagVersions
 ) {
   // Get flag settings
   client.scenario.get(
@@ -279,6 +372,46 @@ export function useFlags(
         nextOffset < filteredFlags.length ? String(nextOffset) : null;
 
       res.json({ data: page, pagination: { next } });
+    }
+  );
+
+  // List flag versions
+  client.scenario.get(
+    '/v1/projects/:projectId/feature-flags/flags/:flagIdOrSlug/versions',
+    (req, res) => {
+      const { flagIdOrSlug } = req.params;
+      const flag = flagsList.find(
+        f => f.id === flagIdOrSlug || f.slug === flagIdOrSlug
+      );
+      if (!flag) {
+        res.status(404).json({ error: { message: 'Flag not found' } });
+        return;
+      }
+
+      const environment = req.query.environment as string | undefined;
+      let filteredVersions = versionsList.filter(
+        version => version.flagId === flag.id
+      );
+      if (environment) {
+        filteredVersions = filteredVersions.filter(version =>
+          version.changedEnvironments.includes(environment)
+        );
+      }
+
+      const limit = req.query.limit ? Number(req.query.limit) : 20;
+      const offset = req.query.cursor ? Number(req.query.cursor) : 0;
+      const page = filteredVersions.slice(offset, offset + limit);
+      const nextOffset = offset + limit;
+      const next =
+        nextOffset < filteredVersions.length ? String(nextOffset) : null;
+
+      res.json({
+        versions: page,
+        pagination: {
+          cursor: next,
+          hasNext: next !== null,
+        },
+      });
     }
   );
 

--- a/packages/cli/test/unit/commands/flags/index.test.ts
+++ b/packages/cli/test/unit/commands/flags/index.test.ts
@@ -6,6 +6,7 @@ import * as rolloutFlag from '../../../../src/commands/flags/rollout';
 import * as segmentsFlag from '../../../../src/commands/flags/segments';
 import * as splitFlag from '../../../../src/commands/flags/split';
 import * as updateFlag from '../../../../src/commands/flags/update';
+import * as versionsFlag from '../../../../src/commands/flags/versions';
 import { client } from '../../../mocks/client';
 
 describe('flags', () => {
@@ -15,6 +16,7 @@ describe('flags', () => {
   const segmentsSpy = vi.spyOn(segmentsFlag, 'segments').mockResolvedValue(0);
   const splitSpy = vi.spyOn(splitFlag, 'default').mockResolvedValue(0);
   const updateSpy = vi.spyOn(updateFlag, 'default').mockResolvedValue(0);
+  const versionsSpy = vi.spyOn(versionsFlag, 'default').mockResolvedValue(0);
 
   afterEach(() => {
     lsSpy.mockClear();
@@ -23,6 +25,7 @@ describe('flags', () => {
     segmentsSpy.mockClear();
     splitSpy.mockClear();
     updateSpy.mockClear();
+    versionsSpy.mockClear();
   });
 
   describe('--help', () => {
@@ -80,6 +83,14 @@ describe('flags', () => {
     client.setArgv('flags', 'update', ...args);
     await flags(client);
     expect(updateSpy).toHaveBeenCalledWith(client, args);
+  });
+
+  it('routes to versions subcommand', async () => {
+    const args: string[] = ['my-feature', '--limit', '10'];
+
+    client.setArgv('flags', 'versions', ...args);
+    await flags(client);
+    expect(versionsSpy).toHaveBeenCalledWith(client, args);
   });
 
   it('routes to rollout subcommand', async () => {

--- a/packages/cli/test/unit/commands/flags/versions.test.ts
+++ b/packages/cli/test/unit/commands/flags/versions.test.ts
@@ -1,0 +1,569 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import stripAnsi from 'strip-ansi';
+import flags from '../../../../src/commands/flags';
+import {
+  removeProjectLink,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
+import { client } from '../../../mocks/client';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+import {
+  defaultFlagVersions,
+  defaultFlags,
+  useFlags,
+} from '../../../mocks/flags';
+import type { Flag, FlagVersion } from '../../../../src/util/flags/types';
+
+describe('flags versions', () => {
+  let flagsList: Flag[];
+  let versionsList: FlagVersion[];
+
+  beforeEach(() => {
+    flagsList = JSON.parse(JSON.stringify(defaultFlags)) as Flag[];
+    versionsList = JSON.parse(
+      JSON.stringify(defaultFlagVersions)
+    ) as FlagVersion[];
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-flags-test',
+      name: 'vercel-flags-test',
+      accountId: 'team_dummy',
+    });
+    useFlags(
+      flagsList,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      versionsList
+    );
+    const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+    client.cwd = cwd;
+  });
+
+  it('prints help for the versions diff subcommand', async () => {
+    client.setArgv('flags', 'versions', 'diff', '--help');
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(2);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain(
+      'Show changes introduced by a feature flag version'
+    );
+    expect(output).toContain('--revision <NUMBER>');
+    expect(output).not.toContain('Missing required argument');
+  });
+
+  it('tracks versions subcommand and options', async () => {
+    client.setArgv(
+      'flags',
+      'versions',
+      'my-feature',
+      '--environment',
+      'production',
+      '--limit',
+      '1',
+      '--cursor',
+      '1',
+      '--json'
+    );
+    await flags(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:versions', value: 'versions' },
+      { key: 'subcommand:list', value: 'default' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:environment', value: 'production' },
+      { key: 'option:limit', value: '1' },
+      { key: 'option:cursor', value: '[REDACTED]' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+
+  it('tracks versions diff subcommand and options', async () => {
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '3',
+      '--json'
+    );
+    await flags(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:versions', value: 'versions' },
+      { key: 'subcommand:diff', value: 'diff' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:revision', value: '3' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+
+  it('prints version history in a table', async () => {
+    client.setArgv('flags', 'versions', 'my-feature', '--limit', '1');
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('Revision');
+    expect(output).toContain('Author');
+    expect(output).toContain('Message');
+    expect(output).toContain('Timestamp');
+    expect(output).toContain('Changed Environments');
+    expect(output).toContain('Ada Lovelace');
+    expect(output).toContain('Enabled production rollout');
+    expect(output).toContain('production');
+    expect(output).toContain('flags versions my-feature --limit 1 --cursor 1');
+  });
+
+  it('quotes values with shell metacharacters in the next-page command', async () => {
+    flagsList[0].slug = 'my feature';
+    versionsList.unshift({
+      ...JSON.parse(JSON.stringify(versionsList[0])),
+      id: 'flag_version_custom_env',
+      revision: 4,
+      changedEnvironments: ['custom preview'],
+    });
+    versionsList.unshift({
+      ...JSON.parse(JSON.stringify(versionsList[0])),
+      id: 'flag_version_custom_env_2',
+      revision: 5,
+      changedEnvironments: ['custom preview'],
+    });
+
+    client.setArgv(
+      'flags',
+      'versions',
+      'my feature',
+      '--environment',
+      'custom preview',
+      '--limit',
+      '1'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain(
+      "flags versions 'my feature' --limit 1 --environment 'custom preview' --cursor 1"
+    );
+  });
+
+  it('outputs version history as JSON', async () => {
+    client.setArgv('flags', 'versions', 'my-feature', '--json');
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.versions).toHaveLength(3);
+    expect(parsed.versions[0]).toMatchObject({
+      id: 'flag_version_3',
+      flagId: 'flag_abc123',
+      revision: 3,
+      author: 'Ada Lovelace',
+      createdBy: 'user_456',
+      message: 'Enabled production rollout',
+      changedEnvironments: ['production'],
+      data: {
+        variants: defaultFlags[0].variants,
+        environments: defaultFlags[0].environments,
+      },
+    });
+    expect(parsed.pagination.next).toBeNull();
+  });
+
+  it('prints Flag created for revision 0 without a message', async () => {
+    const revision0 = JSON.parse(
+      JSON.stringify(versionsList.find(version => version.revision === 1))
+    ) as FlagVersion;
+    revision0.id = 'flag_version_0';
+    revision0.revision = 0;
+    revision0.changedEnvironments = [];
+    delete revision0.message;
+    versionsList.push(revision0);
+
+    client.setArgv('flags', 'versions', 'my-feature');
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(stripAnsi(client.stderr.getFullOutput())).toContain('Flag created');
+  });
+
+  it('outputs Flag created for revision 0 JSON message', async () => {
+    const revision0 = JSON.parse(
+      JSON.stringify(versionsList.find(version => version.revision === 1))
+    ) as FlagVersion;
+    revision0.id = 'flag_version_0';
+    revision0.revision = 0;
+    revision0.changedEnvironments = [];
+    delete revision0.message;
+    versionsList.push(revision0);
+
+    client.setArgv('flags', 'versions', 'my-feature', '--json');
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(
+      parsed.versions.find(
+        (version: { revision: number }) => version.revision === 0
+      ).message
+    ).toEqual('Flag created');
+  });
+
+  it('prints a version diff', async () => {
+    const version = versionsList.find(version => version.revision === 3);
+    const previousVersion = versionsList.find(
+      version => version.revision === 2
+    );
+    expect(version).toBeDefined();
+    expect(previousVersion).toBeDefined();
+    version!.data.environments.production.revision = 3;
+    previousVersion!.data.environments.production.revision = 2;
+    previousVersion!.data.environments.production.rules = [];
+
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '3'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain('Changes in revision 3');
+    expect(output).toContain('compared with revision 2');
+    expect(output).toContain('Changed environments: production');
+    expect(output).not.toContain('environments.production.revision');
+    expect(output).not.toContain('environments.production.rules');
+    expect(output).not.toContain('+ [');
+    expect(output).toContain('Production');
+    expect(output).toContain('Rules');
+    expect(output).toContain('+ rule_1');
+    expect(output).toContain('→ On');
+    expect(output).toContain('if user.plan is pro');
+    expect(output).toContain('rule_1');
+  });
+
+  it('compares revision 1 with creation revision 0', async () => {
+    const revision1 = versionsList.find(version => version.revision === 1);
+    expect(revision1).toBeDefined();
+    const revision0 = JSON.parse(JSON.stringify(revision1)) as FlagVersion;
+    revision0.id = 'flag_version_0';
+    revision0.revision = 0;
+    revision0.message = undefined;
+    revision0.changedEnvironments = [];
+    revision0.data.description = 'Created description';
+    delete revision0.data.permanent;
+    revision1!.data.description = 'Updated description';
+    revision1!.data.permanent = false;
+    versionsList.push(revision0);
+
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '1'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain('compared with revision 0');
+    expect(output).toContain('Created description');
+    expect(output).toContain('Updated description');
+    expect(output).not.toContain('Permanent');
+  });
+
+  it('finds a revision pair split across pagination pages', async () => {
+    replaceWithVersionHistory(versionsList, 201);
+    const version = versionsList.find(candidate => candidate.revision === 101);
+    const previousVersion = versionsList.find(
+      candidate => candidate.revision === 100
+    );
+    expect(version).toBeDefined();
+    expect(previousVersion).toBeDefined();
+    version!.data.description = 'After page boundary';
+    previousVersion!.data.description = 'Before page boundary';
+
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '101'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain('compared with revision 100');
+    expect(output).toContain('Before page boundary');
+    expect(output).toContain('After page boundary');
+  });
+
+  it('reports no semantic changes instead of printing an empty diff', async () => {
+    const version = versionsList.find(candidate => candidate.revision === 3);
+    const previousVersion = versionsList.find(
+      candidate => candidate.revision === 2
+    );
+    expect(version).toBeDefined();
+    expect(previousVersion).toBeDefined();
+    version!.data.tags = ['checkout', 'experiment'];
+    previousVersion!.data.tags = ['experiment', 'checkout'];
+
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '3'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(stripAnsi(client.stderr.getFullOutput())).toContain(
+      'No changes detected.'
+    );
+  });
+
+  it('outputs a version diff as JSON', async () => {
+    const previousVersion = versionsList.find(
+      version => version.revision === 2
+    );
+    expect(previousVersion).toBeDefined();
+    previousVersion!.data.environments.production.rules = [];
+
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '3',
+      '--json'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed).toMatchObject({
+      flag: 'my-feature',
+      revision: 3,
+      previousRevision: 2,
+    });
+    expect(parsed.changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'environments.production.rules',
+          action: 'changed',
+          before: [],
+          after: expect.arrayContaining([
+            expect.objectContaining({ id: 'rule_1' }),
+          ]),
+        }),
+      ])
+    );
+  });
+
+  it('filters versions by changed environment', async () => {
+    client.setArgv(
+      'flags',
+      'versions',
+      'my-feature',
+      '--environment',
+      'preview',
+      '--json'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(
+      parsed.versions.map((version: { revision: number }) => version.revision)
+    ).toEqual([2, 1]);
+  });
+
+  it('resumes from a cursor', async () => {
+    client.setArgv(
+      'flags',
+      'versions',
+      'my-feature',
+      '--limit',
+      '1',
+      '--cursor',
+      '1',
+      '--json'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.versions).toHaveLength(1);
+    expect(parsed.versions[0].revision).toEqual(2);
+    expect(parsed.pagination.next).toEqual('2');
+  });
+
+  it('lists versions with --project when the cwd is not linked', async () => {
+    const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+    removeProjectLink(cwd);
+    client.cwd = cwd;
+
+    client.setArgv(
+      'flags',
+      'versions',
+      'my-feature',
+      '--project',
+      'vercel-flags-test',
+      '--json'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(JSON.parse(client.stdout.getFullOutput()).versions).toHaveLength(3);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:versions', value: 'versions' },
+      { key: 'subcommand:list', value: 'default' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+
+  it('returns an error when the flag argument is missing', async () => {
+    client.setArgv('flags', 'versions');
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing required argument: flag'
+    );
+  });
+
+  it('rejects a --limit below 1', async () => {
+    client.setArgv('flags', 'versions', 'my-feature', '--limit', '0');
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'The --limit option must be an integer between 1 and 100.'
+    );
+  });
+
+  it('rejects versions diff without a revision', async () => {
+    client.setArgv('flags', 'versions', 'diff', 'my-feature');
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'The --revision option must be a non-negative integer.'
+    );
+  });
+
+  it('rejects versions diff for revision 0', async () => {
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '0'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Revision 0 has no previous revision to compare.'
+    );
+  });
+
+  it('mentions available revision count when the requested revision is missing', async () => {
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '99'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain(
+      'Only 3 revisions are available. Revision 99 was not found for my-feature'
+    );
+  });
+
+  it('uses singular wording for one available revision', async () => {
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'another-feature',
+      '--revision',
+      '99'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain(
+      'Only 1 revision is available. Revision 99 was not found'
+    );
+  });
+
+  it('counts available revisions across pagination pages', async () => {
+    replaceWithVersionHistory(versionsList, 201);
+
+    client.setArgv(
+      'flags',
+      'versions',
+      'diff',
+      'my-feature',
+      '--revision',
+      '999'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain(
+      'Only 201 revisions are available. Revision 999 was not found'
+    );
+  });
+});
+
+function replaceWithVersionHistory(
+  versions: FlagVersion[],
+  revisionCount: number
+) {
+  const template = versions.find(version => version.flagId === 'flag_abc123');
+  expect(template).toBeDefined();
+
+  const history = Array.from({ length: revisionCount }, (_, index) => {
+    const revision = revisionCount - index - 1;
+    const version = JSON.parse(JSON.stringify(template)) as FlagVersion;
+    version.id = `flag_version_${revision}`;
+    version.revision = revision;
+    version.createdAt = revision;
+    version.message = revision === 0 ? undefined : `Revision ${revision}`;
+    return version;
+  });
+
+  versions.splice(0, versions.length, ...history);
+}

--- a/packages/cli/test/unit/commands/flags/versions.test.ts
+++ b/packages/cli/test/unit/commands/flags/versions.test.ts
@@ -46,7 +46,7 @@ describe('flags versions', () => {
     client.cwd = cwd;
   });
 
-  it('prints help for the versions diff subcommand', async () => {
+  it('prints help for the versions diff subcommand and tracks telemetry', async () => {
     client.setArgv('flags', 'versions', 'diff', '--help');
     const exitCode = await flags(client);
 
@@ -57,9 +57,13 @@ describe('flags versions', () => {
     );
     expect(output).toContain('--revision <NUMBER>');
     expect(output).not.toContain('Missing required argument');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:versions', value: 'versions' },
+      { key: 'flag:help', value: 'flags versions:diff' },
+    ]);
   });
 
-  it('tracks versions subcommand and options', async () => {
+  it('tracks the default versions list subcommand and options', async () => {
     client.setArgv(
       'flags',
       'versions',
@@ -85,6 +89,46 @@ describe('flags versions', () => {
     ]);
   });
 
+  it.each([
+    'list',
+    'ls',
+  ])('tracks the explicit versions %s subcommand', async subcommand => {
+    client.setArgv(
+      'flags',
+      'versions',
+      subcommand,
+      'my-feature',
+      '--limit',
+      '1'
+    );
+    await flags(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:versions', value: 'versions' },
+      { key: 'subcommand:list', value: subcommand },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:limit', value: '1' },
+    ]);
+  });
+
+  it('redacts custom environments in telemetry', async () => {
+    client.setArgv(
+      'flags',
+      'versions',
+      'my-feature',
+      '--environment',
+      'customer-preview'
+    );
+    await flags(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:versions', value: 'versions' },
+      { key: 'subcommand:list', value: 'default' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:environment', value: '[REDACTED]' },
+    ]);
+  });
+
   it('tracks versions diff subcommand and options', async () => {
     client.setArgv(
       'flags',
@@ -93,6 +137,8 @@ describe('flags versions', () => {
       'my-feature',
       '--revision',
       '3',
+      '--project',
+      'vercel-flags-test',
       '--json'
     );
     await flags(client);
@@ -101,6 +147,7 @@ describe('flags versions', () => {
       { key: 'subcommand:versions', value: 'versions' },
       { key: 'subcommand:diff', value: 'diff' },
       { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:project', value: '[REDACTED]' },
       { key: 'option:revision', value: '3' },
       { key: 'flag:json', value: 'TRUE' },
     ]);

--- a/packages/cli/test/unit/util/flags/format-version-diff.test.ts
+++ b/packages/cli/test/unit/util/flags/format-version-diff.test.ts
@@ -1,0 +1,737 @@
+import { describe, expect, it } from 'vitest';
+import chalk from 'chalk';
+import stripAnsi from 'strip-ansi';
+import {
+  diffVersionData,
+  formatVersionDataDiff,
+} from '../../../../src/util/flags/format-version-diff';
+import type {
+  FlagEnvironmentConfig,
+  FlagVersion,
+} from '../../../../src/util/flags/types';
+import { defaultFlags } from '../../../mocks/flags';
+
+describe('formatVersionDataDiff', () => {
+  it('renders a combined semantic diff', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.description = 'Old checkout rollout';
+    after.description = 'New checkout rollout';
+    before.tags = ['checkout'];
+    after.tags = ['checkout', 'experiment'];
+    before.variants[1].label = 'Enabled';
+    after.variants[1].label = 'On';
+    after.variants.push({
+      id: 'beta',
+      value: 'beta',
+      label: 'Beta',
+    });
+
+    before.environments.production.fallthrough = {
+      type: 'variant',
+      variantId: 'off',
+    };
+    after.environments.production.fallthrough = {
+      type: 'variant',
+      variantId: 'on',
+    };
+    before.environments.production.rules = [];
+    after.environments.production.rules = [
+      {
+        id: 'rule_country',
+        conditions: [
+          {
+            lhs: { type: 'entity', kind: 'user', attribute: 'country' },
+            cmp: 'oneOf',
+            rhs: {
+              type: 'list',
+              items: [{ value: 'DE' }, { value: 'FR' }, { value: 'ES' }],
+            },
+          },
+        ],
+        outcome: { type: 'variant', variantId: 'on' },
+      },
+    ];
+    after.environments.production.targets = {
+      on: {
+        user: {
+          id: [{ value: 'user_123', note: 'QA' }],
+        },
+      },
+    };
+
+    before.environments.preview.active = true;
+    after.environments.preview.active = false;
+    after.environments.preview.pausedOutcome = {
+      type: 'variant',
+      variantId: 'off',
+    };
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  General
+          Description
+            - Old checkout rollout
+            + New checkout rollout
+          Tags
+            + experiment
+          Variants
+            + Beta, id: beta, value: "beta"
+            ~ On (on)
+              Label
+                - Enabled
+                + On
+
+        Production
+          Fallthrough
+            - Serve Off
+            + Serve On
+          Rules
+            + rule_country
+              → On
+                if user.country is in
+                   - DE
+                   - FR
+                   - ES
+          Targeting
+            + user.id: user_123 (QA) → On
+
+        Preview
+          Status
+            - active
+            + paused, serving Off"
+    `);
+  });
+
+  it('renders general metadata changes', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.state = 'active';
+    after.state = 'archived';
+    before.permanent = false;
+    after.permanent = true;
+    before.tags = ['checkout', 'legacy'];
+    after.tags = ['checkout', 'experiment'];
+    before.maintainerIds = ['user_old', 'user_shared'];
+    after.maintainerIds = ['user_new', 'user_shared'];
+    before.seed = 100;
+    after.seed = 200;
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  General
+          State
+            - active
+            + archived
+          Permanent
+            - false
+            + true
+          Tags
+            - legacy
+            + experiment
+          Maintainers
+            - user_old
+            + user_new
+          Seed
+            - 100
+            + 200"
+    `);
+  });
+
+  it('does not render default permanent materialization as a change', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    delete before.permanent;
+    after.permanent = false;
+
+    expect(diffVersionData(before, after)).toEqual([]);
+    expect(render(before, after)).toEqual('');
+  });
+
+  it('renders variant removals and field changes', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.variants = [
+      { id: 'off', value: false, label: 'Off' },
+      {
+        id: 'on',
+        value: true,
+        label: 'Enabled',
+        description: 'Old enabled variant',
+      },
+      { id: 'legacy', value: 'legacy', label: 'Legacy' },
+    ];
+    after.variants = [
+      { id: 'off', value: false, label: 'Off' },
+      {
+        id: 'on',
+        value: false,
+        description: 'New disabled variant',
+      },
+    ];
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  General
+          Variants
+            - Legacy, id: legacy, value: "legacy"
+            ~ Enabled (on)
+              Value
+                - true
+                + false
+              Label
+                - Enabled
+                + -
+              Description
+                - Old enabled variant
+                + New disabled variant"
+    `);
+  });
+
+  it('renders changes to variant order', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    after.variants = [...after.variants].reverse();
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  General
+          Variants
+            Order
+              - off → on
+              + on → off"
+    `);
+  });
+
+  it('renders rule removals and modifications', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.environments.production.rules = [
+      {
+        id: 'rule_plan',
+        conditions: [
+          {
+            lhs: { type: 'entity', kind: 'user', attribute: 'plan' },
+            cmp: 'eq',
+            rhs: 'pro',
+          },
+        ],
+        outcome: { type: 'variant', variantId: 'off' },
+      },
+      {
+        id: 'rule_legacy',
+        conditions: [
+          {
+            lhs: { type: 'segment' },
+            cmp: 'eq',
+            rhs: 'legacy-users',
+          },
+        ],
+        outcome: { type: 'variant', variantId: 'on' },
+      },
+    ];
+    after.environments.production.rules = [
+      {
+        id: 'rule_plan',
+        conditions: [
+          {
+            lhs: { type: 'entity', kind: 'user', attribute: 'plan' },
+            cmp: 'eq',
+            rhs: 'enterprise',
+          },
+        ],
+        outcome: { type: 'variant', variantId: 'on' },
+      },
+    ];
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Rules
+            - rule_legacy (position 2)
+              → On
+                if segment is legacy-users
+            ~ rule_plan
+              Conditions
+                - if user.plan is pro
+                + if user.plan is enterprise
+              Serve
+                - Off
+                + On"
+    `);
+  });
+
+  it('renders changes to rule evaluation order', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+    const firstRule = {
+      id: 'rule_first',
+      conditions: [
+        {
+          lhs: { type: 'entity' as const, kind: 'user', attribute: 'plan' },
+          cmp: 'eq',
+          rhs: 'pro',
+        },
+      ],
+      outcome: { type: 'variant' as const, variantId: 'on' },
+    };
+    const secondRule = {
+      id: 'rule_second',
+      conditions: [
+        {
+          lhs: { type: 'entity' as const, kind: 'user', attribute: 'country' },
+          cmp: 'eq',
+          rhs: 'DE',
+        },
+      ],
+      outcome: { type: 'variant' as const, variantId: 'off' },
+    };
+
+    before.environments.production.rules = [firstRule, secondRule];
+    after.environments.production.rules = [secondRule, firstRule];
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Rules
+            Order
+              - rule_first → rule_second
+              + rule_second → rule_first"
+    `);
+  });
+
+  it('renders condition changes with inspect-style list bullets', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.environments.production.rules = [
+      {
+        id: 'rule_attrs',
+        conditions: [
+          {
+            lhs: { type: 'entity', kind: 'user', attribute: 'email' },
+            cmp: 'ex',
+          },
+        ],
+        outcome: { type: 'variant', variantId: 'on' },
+      },
+    ];
+    after.environments.production.rules = [
+      {
+        id: 'rule_attrs',
+        conditions: [
+          {
+            lhs: { type: 'entity', kind: 'user', attribute: 'country' },
+            cmp: 'oneOf',
+            rhs: {
+              type: 'list',
+              items: [{ value: 'DE' }, { value: 'FR' }],
+            },
+          },
+        ],
+        outcome: { type: 'variant', variantId: 'on' },
+      },
+    ];
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Rules
+            ~ rule_attrs
+              Conditions
+                - if user.email has any value
+                + if user.country is in
+                   - DE
+                   - FR"
+    `);
+  });
+
+  it('renders targets, reuse, and paused outcome changes', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.environments.preview.reuse = {
+      active: true,
+      environment: 'production',
+    };
+    after.environments.preview.reuse = {
+      active: false,
+      environment: 'production',
+    };
+    before.environments.preview.targets = {
+      off: {
+        user: {
+          id: [{ value: 'user_001' }],
+        },
+      },
+    };
+    after.environments.preview.targets = {
+      on: {
+        account: {
+          id: [{ value: 'acct_123' }],
+        },
+      },
+    };
+    before.environments.development.active = false;
+    before.environments.development.pausedOutcome = {
+      type: 'variant',
+      variantId: 'off',
+    };
+    after.environments.development.active = false;
+    after.environments.development.pausedOutcome = {
+      type: 'variant',
+      variantId: 'on',
+    };
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Preview
+          Reuse
+            - reusing Production
+            + none
+          Targeting
+            - user.id: user_001 → Off
+            + account.id: acct_123 → On
+
+        Development
+          Status
+            - paused, serving Off
+            + paused, serving On
+          Paused outcome
+            - Serve Off
+            + Serve On"
+    `);
+  });
+
+  it('uses variant IDs when labels would make targets ambiguous', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.variants.push({ id: 'also-on', value: true, label: 'On' });
+    after.variants.push({ id: 'also-on', value: true, label: 'On' });
+    before.environments.production.targets = {
+      on: { user: { id: [{ value: 'user_001' }] } },
+    };
+    after.environments.production.targets = {
+      'also-on': { user: { id: [{ value: 'user_001' }] } },
+    };
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Targeting
+            - user.id: user_001 → On (on)
+            + user.id: user_001 → On (also-on)"
+    `);
+  });
+
+  it('renders environment summaries for reuse, paused, and configured additions', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    after.environments['custom-paused'] = createEnvironment({
+      active: false,
+      pausedOutcome: { type: 'variant', variantId: 'on' },
+    });
+    after.environments['custom-reuse'] = createEnvironment({
+      reuse: {
+        active: true,
+        environment: 'production',
+      },
+    });
+    after.environments['custom-targeted'] = createEnvironment({
+      rules: [
+        {
+          id: 'rule_target',
+          conditions: [
+            {
+              lhs: { type: 'entity', kind: 'user', attribute: 'plan' },
+              cmp: 'eq',
+              rhs: 'pro',
+            },
+          ],
+          outcome: { type: 'variant', variantId: 'on' },
+        },
+      ],
+      targets: {
+        on: {
+          user: {
+            id: [{ value: 'user_001' }],
+          },
+        },
+      },
+    });
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Custom-paused
+          + Environment added
+            Status: paused, serving On
+            Paused outcome: Serve On
+
+        Custom-reuse
+          + Environment added
+            Status: active
+            Reuse: reusing Production
+
+        Custom-targeted
+          + Environment added
+            Status: active
+            Fallthrough: Serve Off
+            Rules: 1
+            Targets: 1"
+    `);
+  });
+
+  it('renders split and rollout outcomes', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.environments.production.fallthrough = {
+      type: 'split',
+      base: { type: 'entity', kind: 'user', attribute: 'id' },
+      weights: { off: 50_000, on: 50_000 },
+      defaultVariantId: 'off',
+    };
+    after.environments.production.fallthrough = {
+      type: 'rollout',
+      base: { type: 'entity', kind: 'user', attribute: 'id' },
+      startTimestamp: 0,
+      rollFromVariantId: 'off',
+      rollToVariantId: 'on',
+      defaultVariantId: 'off',
+      slots: [
+        { promille: 5_000, durationMs: 60 * 60 * 1000 },
+        { promille: 50_000, durationMs: 24 * 60 * 60 * 1000 },
+      ],
+    };
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Fallthrough
+            - Serve split (Off: 50%, On: 50%); by user.id; Fallback: Off
+            + Serve Off -> On; 5% for 1 hour, 50% for 1 day; then 100%; Fallback: Off; by user.id; Starts: 1970-01-01T00:00:00.000Z"
+    `);
+  });
+
+  it('renders split bucketing and fallback changes', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.environments.production.fallthrough = {
+      type: 'split',
+      base: { type: 'entity', kind: 'user', attribute: 'id' },
+      weights: { off: 50_000, on: 50_000 },
+      defaultVariantId: 'off',
+    };
+    after.environments.production.fallthrough = {
+      type: 'split',
+      base: { type: 'entity', kind: 'account', attribute: 'id' },
+      weights: { off: 50_000, on: 50_000 },
+      defaultVariantId: 'on',
+    };
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Fallthrough
+            - Serve split (Off: 50%, On: 50%); by user.id; Fallback: Off
+            + Serve split (Off: 50%, On: 50%); by account.id; Fallback: On"
+    `);
+  });
+
+  it('renders rollout bucketing and start changes', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+    const slots = [{ promille: 10_000, durationMs: 60 * 60 * 1000 }];
+
+    before.environments.production.fallthrough = {
+      type: 'rollout',
+      base: { type: 'entity', kind: 'user', attribute: 'id' },
+      startTimestamp: 0,
+      rollFromVariantId: 'off',
+      rollToVariantId: 'on',
+      defaultVariantId: 'off',
+      slots,
+    };
+    after.environments.production.fallthrough = {
+      type: 'rollout',
+      base: { type: 'entity', kind: 'account', attribute: 'id' },
+      startTimestamp: 60 * 60 * 1000,
+      rollFromVariantId: 'off',
+      rollToVariantId: 'on',
+      defaultVariantId: 'off',
+      slots,
+    };
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Fallthrough
+            - Serve Off -> On; 10% for 1 hour; then 100%; Fallback: Off; by user.id; Starts: 1970-01-01T00:00:00.000Z
+            + Serve Off -> On; 10% for 1 hour; then 100%; Fallback: Off; by account.id; Starts: 1970-01-01T01:00:00.000Z"
+    `);
+  });
+
+  it('uses variant IDs when labels would make outcomes ambiguous', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.variants.push({ id: 'also-on', value: true, label: 'On' });
+    after.variants.push({ id: 'also-on', value: true, label: 'On' });
+    before.environments.production.fallthrough = {
+      type: 'variant',
+      variantId: 'on',
+    };
+    after.environments.production.fallthrough = {
+      type: 'variant',
+      variantId: 'also-on',
+    };
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Fallthrough
+            - Serve On (on)
+            + Serve On (also-on)"
+    `);
+  });
+
+  it('renders environment additions and removals', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    delete before.environments['custom-preview'];
+    after.environments['custom-preview'] = createEnvironment({
+      fallthrough: { type: 'variant', variantId: 'on' },
+    });
+    delete after.environments.development;
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Development
+          - Environment removed
+            Status: active
+            Fallthrough: Serve On
+
+        Custom-preview
+          + Environment added
+            Status: active
+            Fallthrough: Serve On"
+    `);
+  });
+
+  it('falls back for unknown future fields without hiding them', () => {
+    const before = createVersionData() as FlagVersion['data'] & {
+      removedUnknown?: string;
+      unknown?: { nested?: string };
+    };
+    const after = createVersionData() as FlagVersion['data'] & {
+      addedUnknown?: string;
+      unknown?: { nested?: string };
+    };
+
+    before.removedUnknown = 'removed';
+    before.unknown = { nested: 'old' };
+    after.addedUnknown = 'added';
+    after.unknown = { nested: 'new' };
+    (
+      before.environments.production as FlagEnvironmentConfig & {
+        sampling?: string;
+      }
+    ).sampling = 'low';
+    (
+      after.environments.production as FlagEnvironmentConfig & {
+        sampling?: string;
+      }
+    ).sampling = 'high';
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Production
+          Other
+            sampling
+              - low
+              + high
+
+        Other
+          addedUnknown
+            + added
+          removedUnknown
+            - removed
+          unknown.nested
+            - old
+            + new"
+    `);
+  });
+
+  it('omits environment revision metadata from structural diffs', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+
+    before.environments.production.revision = 1;
+    after.environments.production.revision = 2;
+
+    expect(diffVersionData(before, after)).toEqual([]);
+    expect(render(before, after)).toEqual('');
+  });
+
+  it('adds subtle emphasis to semantic rule details', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+    const previousChalkLevel = chalk.level;
+
+    before.environments.production.rules = [];
+    after.environments.production.rules = [
+      {
+        id: 'rule_country',
+        conditions: [
+          {
+            lhs: { type: 'entity', kind: 'user', attribute: 'country' },
+            cmp: 'oneOf',
+            rhs: {
+              type: 'list',
+              items: [{ value: 'DE' }, { value: 'FR' }],
+            },
+          },
+        ],
+        outcome: { type: 'variant', variantId: 'on' },
+      },
+    ];
+
+    chalk.level = 1;
+    try {
+      const diff = formatVersionDataDiff(before, after);
+
+      expect(diff).toContain(chalk.dim('→'));
+      expect(diff).toContain(chalk.dim('if'));
+      expect(diff).toContain(chalk.dim('is in'));
+      expect(diff).toContain(`${chalk.dim('-')} DE`);
+      expect(diff).toContain(`${chalk.dim('→')} ${chalk.bold('On')}`);
+    } finally {
+      chalk.level = previousChalkLevel;
+    }
+  });
+});
+
+function render(before: FlagVersion['data'], after: FlagVersion['data']) {
+  return stripAnsi(formatVersionDataDiff(before, after)).trimEnd();
+}
+
+function createVersionData(): FlagVersion['data'] {
+  return JSON.parse(
+    JSON.stringify({
+      description: defaultFlags[0].description,
+      variants: defaultFlags[0].variants,
+      environments: defaultFlags[0].environments,
+      seed: defaultFlags[0].seed,
+      state: defaultFlags[0].state,
+      tags: defaultFlags[0].tags ?? [],
+      maintainerIds: defaultFlags[0].maintainerIds ?? [],
+      permanent: false,
+    })
+  );
+}
+
+function createEnvironment(
+  overrides: Partial<FlagEnvironmentConfig> = {}
+): FlagEnvironmentConfig {
+  return {
+    active: true,
+    fallthrough: { type: 'variant', variantId: 'off' },
+    pausedOutcome: { type: 'variant', variantId: 'off' },
+    rules: [],
+    ...overrides,
+  };
+}

--- a/packages/cli/test/unit/util/flags/format-version-diff.test.ts
+++ b/packages/cli/test/unit/util/flags/format-version-diff.test.ts
@@ -613,6 +613,32 @@ describe('formatVersionDataDiff', () => {
     `);
   });
 
+  it('tolerates legacy added and removed environments without rules', () => {
+    const before = createVersionData();
+    const after = createVersionData();
+    const addedEnvironment = createEnvironment({
+      fallthrough: { type: 'variant', variantId: 'on' },
+    });
+
+    delete (before.environments.development as Partial<FlagEnvironmentConfig>)
+      .rules;
+    delete (addedEnvironment as Partial<FlagEnvironmentConfig>).rules;
+    after.environments['custom-preview'] = addedEnvironment;
+    delete after.environments.development;
+
+    expect(render(before, after)).toMatchInlineSnapshot(`
+      "  Development
+          - Environment removed
+            Status: active
+            Fallthrough: Serve On
+
+        Custom-preview
+          + Environment added
+            Status: active
+            Fallthrough: Serve On"
+    `);
+  });
+
   it('falls back for unknown future fields without hiding them', () => {
     const before = createVersionData() as FlagVersion['data'] & {
       removedUnknown?: string;


### PR DESCRIPTION
Add `vercel flags versions <flag>` and `vercel flags versions diff <flag> --revision <number>` to inspect feature flag version history and changes.

Examples:

```bash
vercel flags versions my-flag
vercel flags versions my-flag --environment production
vercel flags versions diff my-flag --revision 4
```