### PR TITLE
[flags] Preserve serving mode when flag rules change

### DIFF
--- a/.changeset/flag-custom-targeting-warning.md
+++ b/.changeset/flag-custom-targeting-warning.md
@@ -1,0 +1,8 @@
+---
+'vercel': patch
+---
+
+Preserve an environment's serving mode when feature flag rules are added,
+updated, moved, or removed. When the environment is serving a fixed variant,
+the CLI identifies that variant and warns that rule changes will not affect flag
+evaluation until the environment uses targeting again.

--- a/packages/cli/src/commands/flags/rules-add.ts
+++ b/packages/cli/src/commands/flags/rules-add.ts
@@ -19,7 +19,11 @@ import {
 import output from '../../output-manager';
 import { FlagsRulesCommandTelemetryClient } from '../../util/telemetry/commands/flags/rules';
 import { rulesAddSubcommand } from './command';
-import { isExitCodeResult, resolveRulesCommandContext } from './rules-common';
+import {
+  isExitCodeResult,
+  resolveRulesCommandContext,
+  warnIfRuleChangesAreBypassed,
+} from './rules-common';
 
 export default async function rulesAdd(
   client: Client,
@@ -134,7 +138,7 @@ export default async function rulesAdd(
     );
 
     output.spinner(`Adding rule to ${context.environment}...`);
-    await updateFlag(client, context.projectId, flagArg, {
+    const updatedFlag = await updateFlag(client, context.projectId, flagArg, {
       environments: {
         [context.environment]: nextEnvConfig,
       },
@@ -152,6 +156,7 @@ export default async function rulesAdd(
         context.flag.variants
       )}`
     );
+    warnIfRuleChangesAreBypassed(updatedFlag, context.environment);
   } catch (err) {
     output.stopSpinner();
     printError(err);

--- a/packages/cli/src/commands/flags/rules-common.ts
+++ b/packages/cli/src/commands/flags/rules-common.ts
@@ -3,6 +3,7 @@ import type Client from '../../util/client';
 import { getCommandName } from '../../util/pkg-name';
 import { getFlag, getFlagSettings } from '../../util/flags/get-flags';
 import { resolveFlagEnvironment } from '../../util/flags/environment-variant';
+import { formatVariantForDisplay } from '../../util/flags/resolve-variant';
 import { getLinkedProject } from '../../util/projects/link';
 import output from '../../output-manager';
 import type {
@@ -86,4 +87,29 @@ export function isExitCodeResult(
   result: RulesCommandContext | { exitCode: number }
 ): result is { exitCode: number } {
   return 'exitCode' in result;
+}
+
+export function warnIfRuleChangesAreBypassed(
+  flag: Flag,
+  environment: string
+): void {
+  const envConfig = flag.environments[environment];
+  if (!envConfig) {
+    return;
+  }
+
+  if (envConfig.active) {
+    return;
+  }
+
+  const variantId = envConfig.pausedOutcome?.variantId;
+  const variant = flag.variants.find(candidate => candidate.id === variantId);
+  const serving = variant
+    ? formatVariantForDisplay(variant)
+    : variantId
+      ? chalk.bold(variantId)
+      : 'a fixed variant';
+  output.warn(
+    `This rule update was saved, but ${chalk.bold(environment)} is serving ${serving}. Rule changes will not affect flag evaluation until the environment uses targeting again.`
+  );
 }

--- a/packages/cli/src/commands/flags/rules-common.ts
+++ b/packages/cli/src/commands/flags/rules-common.ts
@@ -109,7 +109,7 @@ export function warnIfRuleChangesAreBypassed(
     : variantId
       ? chalk.bold(variantId)
       : 'a fixed variant';
-  output.warn(
-    `This rule update was saved, but ${chalk.bold(environment)} is serving ${serving}. Rule changes will not affect flag evaluation until the environment uses targeting again.`
+  output.print(
+    `${chalk.yellow('!')} This rule update was saved, but ${chalk.bold(environment)} is serving ${serving}. Rule changes will not affect flag evaluation until the environment uses targeting again.\n`
   );
 }

--- a/packages/cli/src/commands/flags/rules-move.ts
+++ b/packages/cli/src/commands/flags/rules-move.ts
@@ -15,7 +15,11 @@ import {
 import output from '../../output-manager';
 import { FlagsRulesCommandTelemetryClient } from '../../util/telemetry/commands/flags/rules';
 import { rulesMoveSubcommand } from './command';
-import { isExitCodeResult, resolveRulesCommandContext } from './rules-common';
+import {
+  isExitCodeResult,
+  resolveRulesCommandContext,
+  warnIfRuleChangesAreBypassed,
+} from './rules-common';
 
 export default async function rulesMove(
   client: Client,
@@ -90,7 +94,7 @@ export default async function rulesMove(
     );
 
     output.spinner(`Moving rule in ${context.environment}...`);
-    await updateFlag(client, context.projectId, flagArg, {
+    const updatedFlag = await updateFlag(client, context.projectId, flagArg, {
       environments: {
         [context.environment]: nextEnvConfig,
       },
@@ -101,6 +105,7 @@ export default async function rulesMove(
     output.success(
       `Rule ${chalk.bold(ruleId)} moved to position ${position} for ${chalk.bold(context.flag.slug)} in ${chalk.bold(context.environment)}`
     );
+    warnIfRuleChangesAreBypassed(updatedFlag, context.environment);
   } catch (err) {
     output.stopSpinner();
     printError(err);

--- a/packages/cli/src/commands/flags/rules-remove.ts
+++ b/packages/cli/src/commands/flags/rules-remove.ts
@@ -14,7 +14,11 @@ import {
 import output from '../../output-manager';
 import { FlagsRulesCommandTelemetryClient } from '../../util/telemetry/commands/flags/rules';
 import { rulesRemoveSubcommand } from './command';
-import { isExitCodeResult, resolveRulesCommandContext } from './rules-common';
+import {
+  isExitCodeResult,
+  resolveRulesCommandContext,
+  warnIfRuleChangesAreBypassed,
+} from './rules-common';
 
 export default async function rulesRemove(
   client: Client,
@@ -80,7 +84,7 @@ export default async function rulesRemove(
     );
 
     output.spinner(`Removing rule from ${context.environment}...`);
-    await updateFlag(client, context.projectId, flagArg, {
+    const updatedFlag = await updateFlag(client, context.projectId, flagArg, {
       environments: {
         [context.environment]: nextEnvConfig,
       },
@@ -91,6 +95,7 @@ export default async function rulesRemove(
     output.success(
       `Rule ${chalk.bold(ruleId)} removed from ${chalk.bold(context.flag.slug)} in ${chalk.bold(context.environment)}`
     );
+    warnIfRuleChangesAreBypassed(updatedFlag, context.environment);
   } catch (err) {
     output.stopSpinner();
     printError(err);

--- a/packages/cli/src/commands/flags/rules-update.ts
+++ b/packages/cli/src/commands/flags/rules-update.ts
@@ -22,7 +22,11 @@ import {
 import output from '../../output-manager';
 import { FlagsRulesCommandTelemetryClient } from '../../util/telemetry/commands/flags/rules';
 import { rulesUpdateSubcommand } from './command';
-import { isExitCodeResult, resolveRulesCommandContext } from './rules-common';
+import {
+  isExitCodeResult,
+  resolveRulesCommandContext,
+  warnIfRuleChangesAreBypassed,
+} from './rules-common';
 
 export default async function rulesUpdate(
   client: Client,
@@ -157,7 +161,7 @@ export default async function rulesUpdate(
     );
 
     output.spinner(`Updating rule in ${context.environment}...`);
-    await updateFlag(client, context.projectId, flagArg, {
+    const updatedFlag = await updateFlag(client, context.projectId, flagArg, {
       environments: {
         [context.environment]: nextEnvConfig,
       },
@@ -180,6 +184,7 @@ export default async function rulesUpdate(
         context.flag.variants
       )}`
     );
+    warnIfRuleChangesAreBypassed(updatedFlag, context.environment);
   } catch (err) {
     output.stopSpinner();
     printError(err);

--- a/packages/cli/src/util/flags/rules.ts
+++ b/packages/cli/src/util/flags/rules.ts
@@ -365,7 +365,6 @@ function buildRulesEnvironmentConfig(
 ): FlagEnvironmentConfig {
   const nextConfig: FlagEnvironmentConfig = {
     ...envConfig,
-    active: true,
     rules,
   };
 

--- a/packages/cli/test/unit/commands/flags/rules.test.ts
+++ b/packages/cli/test/unit/commands/flags/rules.test.ts
@@ -200,9 +200,73 @@ describe('flags rules', () => {
       pausedOutcome: { type: 'variant', variantId: 'off' },
     });
     expect(settingsRequests).toEqual(0);
+    expect(stripAnsi(client.stderr.getFullOutput())).not.toContain(
+      'This rule update was saved'
+    );
   });
 
-  it('activates a paused environment when adding a rule', async () => {
+  it.each([
+    {
+      action: 'adding',
+      argv: [
+        'add',
+        'my-feature',
+        '--environment',
+        'production',
+        '--condition',
+        'user.plan:eq:enterprise',
+        '--variant',
+        'on',
+      ],
+    },
+    {
+      action: 'updating',
+      argv: [
+        'update',
+        'my-feature',
+        'rule_1',
+        '--environment',
+        'production',
+        '--condition',
+        'user.plan:eq:enterprise',
+      ],
+    },
+    {
+      action: 'moving',
+      argv: [
+        'move',
+        'my-feature',
+        'rule_2',
+        '--environment',
+        'production',
+        '--position',
+        '1',
+      ],
+    },
+    {
+      action: 'removing',
+      argv: ['rm', 'my-feature', 'rule_1', '--environment', 'production'],
+    },
+  ])('warns after $action a rule while the environment serves a fixed variant', async ({
+    argv,
+  }) => {
+    testFlags[0].environments.production.active = false;
+    client.setArgv('flags', 'rules', ...argv);
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(patchBodies).toHaveLength(1);
+    const output = stripAnsi(client.stderr.getFullOutput());
+    expect(output).toContain(
+      'This rule update was saved, but production is serving false Off.'
+    );
+    expect(output).toContain(
+      'Rule changes will not affect flag evaluation until the environment uses targeting again.'
+    );
+  });
+
+  it('preserves a paused environment when adding a rule', async () => {
     testFlags[0].environments.preview.active = false;
 
     client.setArgv(
@@ -222,19 +286,22 @@ describe('flags rules', () => {
 
     expect(exitCode).toEqual(0);
     expect(testFlags[0].environments.preview).toMatchObject({
-      active: true,
+      active: false,
       fallthrough: { type: 'variant', variantId: 'on' },
       pausedOutcome: { type: 'variant', variantId: 'off' },
     });
     expect(testFlags[0].environments.preview.rules).toHaveLength(1);
     expect(patchBodies[0].environments?.preview).toMatchObject({
-      active: true,
+      active: false,
       rules: [
         {
           outcome: { type: 'variant', variantId: 'on' },
         },
       ],
     });
+    expect(stripAnsi(client.stderr.getFullOutput())).toContain(
+      'This rule update was saved, but preview is serving false Off.'
+    );
   });
 
   it('adds a rule on top of inherited rules and disables reuse', async () => {
@@ -281,6 +348,9 @@ describe('flags rules', () => {
       environment: 'preview',
     });
     expect(testFlags[0].environments.production.active).toEqual(true);
+    expect(stripAnsi(client.stderr.getFullOutput())).not.toContain(
+      'This rule update was saved'
+    );
   });
 
   it('adds a segment condition with a split outcome', async () => {

--- a/packages/cli/test/unit/commands/flags/rules.test.ts
+++ b/packages/cli/test/unit/commands/flags/rules.test.ts
@@ -258,12 +258,13 @@ describe('flags rules', () => {
     expect(exitCode).toEqual(0);
     expect(patchBodies).toHaveLength(1);
     const output = stripAnsi(client.stderr.getFullOutput());
-    expect(output).toContain(
-      'This rule update was saved, but production is serving false Off.'
+    expect(output).toMatch(
+      /^! This rule update was saved, but production is serving false Off\./m
     );
     expect(output).toContain(
       'Rule changes will not affect flag evaluation until the environment uses targeting again.'
     );
+    expect(output).not.toContain('WARNING!');
   });
 
   it('preserves a paused environment when adding a rule', async () => {
@@ -299,8 +300,8 @@ describe('flags rules', () => {
         },
       ],
     });
-    expect(stripAnsi(client.stderr.getFullOutput())).toContain(
-      'This rule update was saved, but preview is serving false Off.'
+    expect(stripAnsi(client.stderr.getFullOutput())).toMatch(
+      /^! This rule update was saved, but preview is serving false Off\./m
     );
   });
 


### PR DESCRIPTION
- Preserve an environment’s serving mode when flag rules are added, updated, moved, or removed
- Add a shared warning when rule edits are saved while an environment is still serving a fixed variant
- Update CLI rule command tests to cover the warning and the paused-environment behavior