### PR TITLE
[cli] Add `vercel ask` command for querying Vercel Agent

### DIFF
--- a/.changeset/spotty-hands-ask.md
+++ b/.changeset/spotty-hands-ask.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel ask` command for asking Vercel Agent questions from the command line. Supports streaming answers, follow-up prompts with `--session`, fire-and-forget dispatch with `--no-wait`, reasoning/tool output with `--verbose`, and JSON Lines output with `--json`.

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -12,6 +12,7 @@ export { default as aiGateway } from './commands/ai-gateway';
 export { default as alerts } from './commands/alerts';
 export { default as alias } from './commands/alias';
 export { default as api } from './commands/api';
+export { default as ask } from './commands/ask';
 export { default as bisect } from './commands/bisect';
 export { default as blob } from './commands/blob';
 export { default as buy } from './commands/buy';

--- a/packages/cli/src/commands/ask/ask.ts
+++ b/packages/cli/src/commands/ask/ask.ts
@@ -110,7 +110,9 @@ async function sendPrompt(
   if (mode === 'json') {
     client.stdout.write(`${JSON.stringify({ type: 'session', sessionId })}\n`);
   } else {
-    output.spinner('Waiting for Vercel Agent…');
+    output.spinner(
+      opts.noWait ? 'Dispatching to Vercel Agent…' : 'Waiting for Vercel Agent…'
+    );
   }
 
   const response = await api.startTurn(sessionId, {

--- a/packages/cli/src/commands/ask/ask.ts
+++ b/packages/cli/src/commands/ask/ask.ts
@@ -1,0 +1,225 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import cmd from '../../util/output/cmd';
+import getScope from '../../util/get-scope';
+import sleep from '../../util/sleep';
+import { printError } from '../../util/error';
+import {
+  OmniagentApi,
+  OmniagentApiError,
+  type SessionSnapshot,
+} from './omniagent-api';
+import { consumeTurnStream, type AskOutputMode } from './stream';
+
+const POLL_INTERVAL_MS = 2000;
+const PENDING_TURN_STATES = new Set(['queued', 'running']);
+
+export interface AskOptions {
+  prompt: string | undefined;
+  sessionId: string | undefined;
+  noWait: boolean;
+  verbose: boolean;
+  json: boolean;
+}
+
+export default async function ask(
+  client: Client,
+  options: AskOptions
+): Promise<number> {
+  const { prompt, sessionId, noWait } = options;
+
+  if (options.verbose && options.json) {
+    output.error('The `--verbose` and `--json` options cannot be combined.');
+    return 1;
+  }
+  if (!prompt && !sessionId) {
+    output.error(
+      `Provide a prompt, for example ${cmd('vercel ask "Why did my last deployment fail?"')}.`
+    );
+    return 1;
+  }
+  if (noWait && !prompt) {
+    output.error('The `--no-wait` option requires a prompt.');
+    return 1;
+  }
+
+  const mode: AskOutputMode = options.json
+    ? 'json'
+    : options.verbose
+      ? 'verbose'
+      : 'text';
+
+  const api = new OmniagentApi(client);
+
+  try {
+    if (!prompt && sessionId) {
+      return await checkSession(client, api, { sessionId, mode });
+    }
+
+    return await sendPrompt(client, api, {
+      prompt: prompt as string,
+      sessionId,
+      noWait,
+      mode,
+    });
+  } catch (error) {
+    output.stopSpinner();
+    if (error instanceof OmniagentApiError) {
+      output.error(error.message);
+      return 1;
+    }
+    printError(error);
+    return 1;
+  }
+}
+
+async function sendPrompt(
+  client: Client,
+  api: OmniagentApi,
+  opts: {
+    prompt: string;
+    sessionId: string | undefined;
+    noWait: boolean;
+    mode: AskOutputMode;
+  }
+): Promise<number> {
+  const { mode } = opts;
+  let sessionId = opts.sessionId;
+  let teamId: string | undefined;
+
+  if (!sessionId) {
+    // A team scope is required to create a session. This also refreshes the
+    // CLI access token before it is used against the agent API.
+    const { team } = await getScope(client);
+    if (!team) {
+      output.error(
+        `Vercel Agent sessions require a team scope. Run ${cmd('vercel switch')} or pass ${cmd('--scope <team>')}.`
+      );
+      return 1;
+    }
+    teamId = team.id;
+
+    if (mode !== 'json') {
+      output.spinner('Creating agent session…');
+    }
+    const created = await api.createSession(teamId);
+    sessionId = created.sessionId;
+  }
+
+  if (mode === 'json') {
+    client.stdout.write(`${JSON.stringify({ type: 'session', sessionId })}\n`);
+  } else {
+    output.spinner('Waiting for Vercel Agent…');
+  }
+
+  const response = await api.startTurn(sessionId, {
+    prompt: opts.prompt,
+    // Only needed when the turn creates the session envelope.
+    teamId,
+  });
+
+  const result = await consumeTurnStream(response, {
+    client,
+    mode,
+    stopAfterStart: opts.noWait,
+  });
+
+  if (result.status === 'dispatched') {
+    if (mode === 'json') {
+      client.stdout.write(
+        `${JSON.stringify({ type: 'dispatched', sessionId })}\n`
+      );
+    } else {
+      client.stdout.write(`${sessionId}\n`);
+      output.log(`Dispatched to Vercel Agent.`);
+      output.log(
+        `Check the answer: ${cmd(`vercel ask --session ${sessionId}`)}`
+      );
+    }
+    return 0;
+  }
+
+  if (result.status === 'error' || result.status === 'incomplete') {
+    output.error(result.errorText ?? 'The agent turn failed.');
+    printSessionHint(sessionId);
+    return 1;
+  }
+
+  printSessionHint(sessionId);
+  return 0;
+}
+
+async function checkSession(
+  client: Client,
+  api: OmniagentApi,
+  opts: { sessionId: string; mode: AskOutputMode }
+): Promise<number> {
+  const { sessionId, mode } = opts;
+
+  if (mode !== 'json') {
+    output.spinner('Waiting for Vercel Agent…');
+  }
+
+  let snapshot = await api.getSession(sessionId);
+  while (
+    snapshot.lastTurn &&
+    PENDING_TURN_STATES.has(snapshot.lastTurn.state)
+  ) {
+    await sleep(POLL_INTERVAL_MS);
+    snapshot = await api.getSession(sessionId);
+  }
+  output.stopSpinner();
+
+  if (mode === 'json') {
+    client.stdout.write(`${JSON.stringify(snapshot)}\n`);
+    return snapshot.lastTurn?.state === 'failed' ? 1 : 0;
+  }
+
+  const answerText = getLastAssistantText(snapshot);
+  if (!snapshot.lastTurn && !answerText) {
+    output.log('The agent has not responded in this session yet.');
+    printSessionHint(sessionId);
+    return 0;
+  }
+
+  if (answerText) {
+    client.stdout.write(
+      answerText.endsWith('\n') ? answerText : `${answerText}\n`
+    );
+  }
+
+  if (snapshot.lastTurn?.state === 'failed') {
+    output.error('The agent turn failed.');
+    printSessionHint(sessionId);
+    return 1;
+  }
+  if (snapshot.lastTurn?.state === 'interrupted') {
+    output.warn('The agent turn was interrupted.');
+  }
+
+  printSessionHint(sessionId);
+  return 0;
+}
+
+function getLastAssistantText(snapshot: SessionSnapshot): string {
+  for (let i = snapshot.messages.length - 1; i >= 0; i--) {
+    const message = snapshot.messages[i];
+    if (message.role !== 'assistant') {
+      continue;
+    }
+    return message.parts
+      .filter(part => part.type === 'text' && typeof part.text === 'string')
+      .map(part => part.text)
+      .join('\n\n');
+  }
+  return '';
+}
+
+function printSessionHint(sessionId: string): void {
+  output.print('\n');
+  output.log(`Session ${chalk.bold(sessionId)}`);
+  output.log(
+    `Continue: ${cmd(`vercel ask --session ${sessionId} "<prompt>"`)}`
+  );
+}

--- a/packages/cli/src/commands/ask/command.ts
+++ b/packages/cli/src/commands/ask/command.ts
@@ -1,0 +1,68 @@
+import { packageName } from '../../util/pkg-name';
+
+export const askCommand = {
+  name: 'ask',
+  aliases: [],
+  description: 'Ask Vercel Agent a question and wait for the answer',
+  arguments: [
+    {
+      name: 'prompt',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'session',
+      shorthand: null,
+      type: String,
+      argument: 'ID',
+      deprecated: false,
+      description: 'Send the prompt into an existing agent session',
+    },
+    {
+      name: 'no-wait',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Dispatch the prompt and exit immediately without waiting for the answer',
+    },
+    {
+      name: 'verbose',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Render the agent reasoning and tool activity while it works',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output the agent turn as a JSON Lines stream of parts',
+    },
+  ],
+  examples: [
+    {
+      name: 'Ask the agent a question and wait for the answer',
+      value: `${packageName} ask "Why did my last deployment fail?"`,
+    },
+    {
+      name: 'Send a follow-up prompt into an existing session',
+      value: `${packageName} ask --session <id> "Can you fix it?"`,
+    },
+    {
+      name: 'Dispatch a prompt without waiting for the answer',
+      value: `${packageName} ask --no-wait "Audit my project for slow functions"`,
+    },
+    {
+      name: 'Wait for and print the answer of a dispatched session',
+      value: `${packageName} ask --session <id>`,
+    },
+    {
+      name: 'Stream every part of the agent turn as JSON Lines',
+      value: `${packageName} ask --json "What changed in my last deployment?"`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/ask/index.ts
+++ b/packages/cli/src/commands/ask/index.ts
@@ -1,0 +1,51 @@
+import { help } from '../help';
+import { askCommand } from './command';
+import ask from './ask';
+import { parseArguments } from '../../util/get-args';
+import type Client from '../../util/client';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import output from '../../output-manager';
+import { AskTelemetryClient } from '../../util/telemetry/commands/ask';
+
+export default async function askEntrypoint(client: Client): Promise<number> {
+  const telemetry = new AskTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(askCommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    telemetry.trackCliFlagHelp('ask');
+    output.print(help(askCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  const prompt = parsedArgs.args.slice(1).join(' ').trim() || undefined;
+  const sessionId = parsedArgs.flags['--session'];
+  const noWait = parsedArgs.flags['--no-wait'] ?? false;
+  const verbose = parsedArgs.flags['--verbose'] ?? false;
+  const json = parsedArgs.flags['--json'] ?? false;
+
+  telemetry.trackCliArgumentPrompt(prompt);
+  telemetry.trackCliOptionSession(sessionId);
+  telemetry.trackCliFlagNoWait(noWait);
+  telemetry.trackCliFlagVerbose(verbose);
+  telemetry.trackCliFlagJson(json);
+
+  try {
+    return await ask(client, { prompt, sessionId, noWait, verbose, json });
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/ask/omniagent-api.ts
+++ b/packages/cli/src/commands/ask/omniagent-api.ts
@@ -1,0 +1,242 @@
+import { createHash } from 'node:crypto';
+import type Client from '../../util/client';
+import fetch, { Headers, type Response } from '../../util/fetch';
+import output from '../../output-manager';
+import ua from '../../util/ua';
+
+/**
+ * The deployment of the Omniagent HTTP API that `vercel ask` talks to.
+ *
+ * This currently targets the preview build of the Omniagent sessions API
+ * (vercel/agents#2125) until the API ships to production.
+ */
+const DEFAULT_OMNIAGENT_URL =
+  'https://omniagent-git-adriancooney-omniagent-api-pr4-async-polling.vercel.sh';
+
+/**
+ * The vercel.com endpoint that exchanges a Vercel session for a deployment
+ * protection JWT (`_vercel_jwt`).
+ */
+const SSO_API_URL = 'https://vercel.com/sso-api';
+
+export function getOmniagentBaseUrl(): string {
+  return process.env.VERCEL_OMNIAGENT_URL || DEFAULT_OMNIAGENT_URL;
+}
+
+export class OmniagentApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'OmniagentApiError';
+    this.status = status;
+  }
+}
+
+export interface SessionUIMessagePart {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+export interface SessionUIMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  parts: SessionUIMessagePart[];
+}
+
+export interface SessionSnapshot {
+  id: string;
+  lastTurn: {
+    assistantMessageId: string;
+    state: string;
+  } | null;
+  messages: SessionUIMessage[];
+  streamingMessageId: string | null;
+  title: string | null;
+}
+
+interface RequestOptions {
+  method: 'GET' | 'POST';
+  body?: unknown;
+}
+
+/**
+ * Minimal HTTP client for the Omniagent sessions API. Authenticates with the
+ * CLI bearer token and transparently completes the Vercel deployment
+ * protection SSO handshake when the target deployment is protected.
+ */
+export class OmniagentApi {
+  private client: Client;
+  private baseUrl: string;
+  private protectionCookie: string | undefined;
+
+  constructor(client: Client) {
+    this.client = client;
+    this.baseUrl = getOmniagentBaseUrl();
+  }
+
+  async createSession(teamId: string): Promise<{ sessionId: string }> {
+    const response = await this.request('/api/sessions', {
+      method: 'POST',
+      body: { teamId, surface: 'dashboard' },
+    });
+    const data = (await response.json()) as { sessionId: string };
+    return { sessionId: data.sessionId };
+  }
+
+  async getSession(sessionId: string): Promise<SessionSnapshot> {
+    const response = await this.request(
+      `/api/sessions/${encodeURIComponent(sessionId)}`,
+      { method: 'GET' }
+    );
+    return (await response.json()) as SessionSnapshot;
+  }
+
+  /**
+   * Starts a turn and returns the raw UI message SSE response so the caller
+   * can consume (or abandon) the stream.
+   */
+  async startTurn(
+    sessionId: string,
+    opts: { prompt: string; teamId?: string }
+  ): Promise<Response> {
+    return this.request(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+      method: 'POST',
+      body: {
+        type: 'message',
+        message: opts.prompt,
+        ...(opts.teamId ? { teamId: opts.teamId } : {}),
+      },
+    });
+  }
+
+  private async request(path: string, opts: RequestOptions): Promise<Response> {
+    const url = new URL(path, this.baseUrl).href;
+
+    let response = await this.fetchOnce(url, opts);
+
+    if (isProtectionRedirect(response)) {
+      await this.resolveProtectionCookie(response, url);
+      response = await this.fetchOnce(url, opts);
+    }
+
+    if (!response.ok) {
+      throw await createApiError(response);
+    }
+
+    return response;
+  }
+
+  private async fetchOnce(
+    url: string,
+    opts: RequestOptions
+  ): Promise<Response> {
+    const token = this.client.authConfig.token;
+    const headers = new Headers();
+    headers.set('user-agent', ua);
+    if (token) {
+      headers.set('authorization', `Bearer ${token}`);
+    }
+    if (this.protectionCookie) {
+      headers.set('cookie', this.protectionCookie);
+    }
+    if (opts.body !== undefined) {
+      headers.set('content-type', 'application/json');
+    }
+
+    return fetch(url, {
+      method: opts.method,
+      headers,
+      body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+      redirect: 'manual',
+    });
+  }
+
+  /**
+   * Completes the same SSO handshake the browser uses to access deployments
+   * protected by Vercel Authentication, using the current CLI token. Populates
+   * `this.protectionCookie` on success.
+   */
+  private async resolveProtectionCookie(
+    redirectResponse: Response,
+    requestUrl: string
+  ): Promise<void> {
+    const nonce = getSetCookieValue(redirectResponse, '_vercel_sso_nonce');
+    const token = this.client.authConfig.token;
+    if (!nonce || !token) {
+      throw new OmniagentApiError(
+        'The Vercel Agent API deployment requires authentication. Run `vercel login` and try again.',
+        401
+      );
+    }
+
+    const hashedNonce = createHash('sha256').update(nonce).digest('hex');
+    const ssoUrl = `${SSO_API_URL}?url=${encodeURIComponent(
+      requestUrl
+    )}&nonce=${hashedNonce}`;
+    const sso = await fetch(ssoUrl, {
+      redirect: 'manual',
+      headers: {
+        cookie: `authorization=${encodeURIComponent(`Bearer ${token}`)}; isLoggedIn=1`,
+        'user-agent': ua,
+      },
+    });
+
+    const location = sso.headers.get('location');
+    const jwt = location ? getUrlParam(location, '_vercel_jwt') : null;
+    if (!jwt) {
+      output.debug(
+        `Vercel Agent SSO handshake failed with status ${sso.status}`
+      );
+      throw new OmniagentApiError(
+        'You do not have access to the Vercel Agent API deployment.',
+        403
+      );
+    }
+
+    this.protectionCookie = `_vercel_sso_nonce=${nonce}; _vercel_jwt=${jwt}`;
+  }
+}
+
+function isProtectionRedirect(response: Response): boolean {
+  return (
+    response.status >= 300 &&
+    response.status < 400 &&
+    getSetCookieValue(response, '_vercel_sso_nonce') !== null
+  );
+}
+
+function getSetCookieValue(response: Response, name: string): string | null {
+  const header = response.headers.get('set-cookie');
+  if (!header) {
+    return null;
+  }
+  const match = header.match(new RegExp(`${name}=([^;,\\s]+)`));
+  return match ? match[1] : null;
+}
+
+function getUrlParam(url: string, name: string): string | null {
+  try {
+    return new URL(url).searchParams.get(name);
+  } catch {
+    return null;
+  }
+}
+
+async function createApiError(response: Response): Promise<OmniagentApiError> {
+  let message = `Vercel Agent request failed with status ${response.status}`;
+  try {
+    const body: unknown = await response.json();
+    if (
+      body &&
+      typeof body === 'object' &&
+      'error' in body &&
+      typeof body.error === 'string'
+    ) {
+      message = body.error;
+    }
+  } catch {
+    // Non-JSON error body; keep the generic message.
+  }
+  return new OmniagentApiError(message, response.status);
+}

--- a/packages/cli/src/commands/ask/omniagent-api.ts
+++ b/packages/cli/src/commands/ask/omniagent-api.ts
@@ -23,6 +23,10 @@ export function getOmniagentBaseUrl(): string {
   return process.env.VERCEL_OMNIAGENT_URL || DEFAULT_OMNIAGENT_URL;
 }
 
+function getSsoApiUrl(): string {
+  return process.env.VERCEL_SSO_API_URL || SSO_API_URL;
+}
+
 export class OmniagentApiError extends Error {
   status: number;
   constructor(message: string, status: number) {
@@ -115,7 +119,7 @@ export class OmniagentApi {
 
     let response = await this.fetchOnce(url, opts);
 
-    if (isProtectionRedirect(response)) {
+    if (isProtectionChallenge(response)) {
       await this.resolveProtectionCookie(response, url);
       response = await this.fetchOnce(url, opts);
     }
@@ -171,7 +175,7 @@ export class OmniagentApi {
     }
 
     const hashedNonce = createHash('sha256').update(nonce).digest('hex');
-    const ssoUrl = `${SSO_API_URL}?url=${encodeURIComponent(
+    const ssoUrl = `${getSsoApiUrl()}?url=${encodeURIComponent(
       requestUrl
     )}&nonce=${hashedNonce}`;
     const sso = await fetch(ssoUrl, {
@@ -198,10 +202,18 @@ export class OmniagentApi {
   }
 }
 
-function isProtectionRedirect(response: Response): boolean {
+/**
+ * Detects the Vercel deployment protection challenge. Protection answers
+ * browser-style GET requests with a 302 redirect to the SSO endpoint, but
+ * requests carrying an `Authorization` header (like ours) receive a 401.
+ * Both variants set the `_vercel_sso_nonce` cookie used by the handshake.
+ */
+function isProtectionChallenge(response: Response): boolean {
+  const isChallengeStatus =
+    response.status === 401 ||
+    (response.status >= 300 && response.status < 400);
   return (
-    response.status >= 300 &&
-    response.status < 400 &&
+    isChallengeStatus &&
     getSetCookieValue(response, '_vercel_sso_nonce') !== null
   );
 }

--- a/packages/cli/src/commands/ask/stream.ts
+++ b/packages/cli/src/commands/ask/stream.ts
@@ -1,0 +1,289 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import type { Response } from '../../util/fetch';
+import output from '../../output-manager';
+
+export interface StreamPart {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type AskOutputMode = 'text' | 'verbose' | 'json';
+
+export interface TurnStreamResult {
+  status: 'finished' | 'error' | 'dispatched' | 'incomplete';
+  errorText?: string;
+  answerText: string;
+}
+
+const MAX_TOOL_PREVIEW_LENGTH = 120;
+
+/**
+ * Parses the AI SDK UI message SSE stream (`data: <json>` events terminated
+ * by `data: [DONE]`) into individual stream parts.
+ */
+export async function* parseUIMessageStream(
+  response: Response
+): AsyncGenerator<StreamPart> {
+  const body = response.body;
+  if (!body) {
+    return;
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex = buffer.indexOf('\n');
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex).replace(/\r$/, '');
+        buffer = buffer.slice(newlineIndex + 1);
+        newlineIndex = buffer.indexOf('\n');
+
+        if (!line.startsWith('data:')) {
+          continue;
+        }
+        const data = line.slice(5).trim();
+        if (!data || data === '[DONE]') {
+          continue;
+        }
+        let part: StreamPart;
+        try {
+          part = JSON.parse(data) as StreamPart;
+        } catch {
+          output.debug(`Skipping unparseable stream part: ${data}`);
+          continue;
+        }
+        yield part;
+      }
+    }
+  } finally {
+    // Releases the connection when the caller stops consuming early
+    // (e.g. --no-wait). The agent turn continues server-side.
+    reader.cancel().catch(() => undefined);
+  }
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
+}
+
+function formatToolInput(input: unknown): string {
+  if (input === undefined || input === null) {
+    return '';
+  }
+  try {
+    return truncate(JSON.stringify(input), MAX_TOOL_PREVIEW_LENGTH);
+  } catch {
+    return '';
+  }
+}
+
+function readString(part: StreamPart, key: string): string | undefined {
+  const value = part[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function formatStatusData(data: unknown): string | undefined {
+  if (typeof data === 'string') {
+    return data;
+  }
+  if (data && typeof data === 'object') {
+    const record = data as Record<string, unknown>;
+    for (const key of ['title', 'text', 'status', 'message']) {
+      if (typeof record[key] === 'string') {
+        return record[key];
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Consumes an agent turn stream and renders it according to the output mode:
+ *
+ * - `text`: the answer text streams to stdout; everything else is hidden
+ *   behind a spinner on stderr.
+ * - `verbose`: like `text`, but reasoning and tool activity render to stderr.
+ * - `json`: every stream part is emitted as a JSON line on stdout.
+ */
+export async function consumeTurnStream(
+  response: Response,
+  opts: {
+    client: Client;
+    mode: AskOutputMode;
+    /** Stop consuming once the turn has started (used by --no-wait). */
+    stopAfterStart?: boolean;
+  }
+): Promise<TurnStreamResult> {
+  const { client, mode } = opts;
+
+  let answerText = '';
+  let errorText: string | undefined;
+  let sawFinish = false;
+  let sawAbort = false;
+  let stoppedAfterStart = false;
+  /** Set when the last stderr write did not end with a newline. */
+  let openStderrLine = false;
+  const toolNamesByCallId = new Map<string, string>();
+
+  const writeAnswer = (text: string) => {
+    output.stopSpinner();
+    client.stdout.write(text);
+  };
+
+  const endOpenStderrLine = () => {
+    if (openStderrLine) {
+      output.print('\n');
+      openStderrLine = false;
+    }
+  };
+
+  try {
+    for await (const part of parseUIMessageStream(response)) {
+      if (mode === 'json') {
+        client.stdout.write(`${JSON.stringify(part)}\n`);
+      }
+
+      switch (part.type) {
+        case 'start': {
+          if (opts.stopAfterStart) {
+            stoppedAfterStart = true;
+          }
+          break;
+        }
+        case 'text-start': {
+          if (mode !== 'json') {
+            endOpenStderrLine();
+            if (answerText.length > 0) {
+              writeAnswer('\n\n');
+              answerText += '\n\n';
+            }
+          }
+          break;
+        }
+        case 'text-delta': {
+          const delta = readString(part, 'delta') ?? '';
+          if (delta && mode !== 'json') {
+            writeAnswer(delta);
+          }
+          answerText += delta;
+          break;
+        }
+        case 'reasoning-delta': {
+          if (mode === 'verbose') {
+            const delta = readString(part, 'delta') ?? '';
+            if (delta) {
+              output.print(chalk.dim(delta));
+              openStderrLine = !delta.endsWith('\n');
+            }
+          }
+          break;
+        }
+        case 'reasoning-end': {
+          if (mode === 'verbose') {
+            endOpenStderrLine();
+          }
+          break;
+        }
+        case 'tool-input-available': {
+          const toolCallId = readString(part, 'toolCallId');
+          const toolName = readString(part, 'toolName') ?? 'tool';
+          if (toolCallId) {
+            toolNamesByCallId.set(toolCallId, toolName);
+          }
+          if (mode === 'verbose') {
+            endOpenStderrLine();
+            output.log(
+              `${chalk.cyan(toolName)} ${chalk.gray(formatToolInput(part.input))}`
+            );
+          }
+          break;
+        }
+        case 'tool-output-error': {
+          if (mode === 'verbose') {
+            const toolCallId = readString(part, 'toolCallId');
+            const toolName =
+              (toolCallId && toolNamesByCallId.get(toolCallId)) || 'tool';
+            endOpenStderrLine();
+            output.log(
+              chalk.red(
+                `${toolName} failed: ${readString(part, 'errorText') ?? 'unknown error'}`
+              )
+            );
+          }
+          break;
+        }
+        case 'error': {
+          errorText = readString(part, 'errorText') ?? 'The agent turn failed';
+          break;
+        }
+        case 'abort': {
+          sawAbort = true;
+          break;
+        }
+        case 'finish': {
+          sawFinish = true;
+          break;
+        }
+        default: {
+          if (mode === 'verbose' && part.type.startsWith('data-')) {
+            const status = formatStatusData(part.data);
+            if (status) {
+              endOpenStderrLine();
+              output.log(chalk.gray(status));
+            }
+          }
+          break;
+        }
+      }
+
+      if (stoppedAfterStart) {
+        break;
+      }
+    }
+  } catch (error) {
+    output.stopSpinner();
+    return {
+      status: 'incomplete',
+      errorText: error instanceof Error ? error.message : String(error),
+      answerText,
+    };
+  }
+
+  output.stopSpinner();
+  if (mode !== 'json' && answerText.length > 0 && !answerText.endsWith('\n')) {
+    client.stdout.write('\n');
+  }
+
+  if (stoppedAfterStart) {
+    return { status: 'dispatched', answerText };
+  }
+  if (errorText) {
+    return { status: 'error', errorText, answerText };
+  }
+  if (sawAbort) {
+    return {
+      status: 'error',
+      errorText: 'The agent turn was interrupted',
+      answerText,
+    };
+  }
+  if (sawFinish) {
+    return { status: 'finished', answerText };
+  }
+  return {
+    status: 'incomplete',
+    errorText: 'The agent stream ended unexpectedly',
+    answerText,
+  };
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -5,6 +5,7 @@ import { aiGatewayCommand } from './ai-gateway/command';
 import { alertsCommand } from './alerts/command';
 import { aliasCommand } from './alias/command';
 import { apiCommand } from './api/command';
+import { askCommand } from './ask/command';
 import { bisectCommand } from './bisect/command';
 import { buildCommand } from './build/command';
 import { buyCommand } from './buy/command';
@@ -74,6 +75,7 @@ const commandsStructs = [
   aliasCommand,
   activityCommand,
   apiCommand,
+  askCommand,
   blobCommand,
   bisectCommand,
   buildCommand,

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -47,6 +47,7 @@ export const help = () => `
       alerts                           List alerts for a project or team
       alias                [cmd]       Manages your domain aliases
       api                  [endpoint]  Make authenticated HTTP requests to the Vercel API [beta]
+      ask                  [prompt]    Ask Vercel Agent a question and wait for the answer [beta]
       bisect                           Use binary search to find the deployment that introduced a bug
       blob                 [cmd]       Manages your Blob stores and files
       buy                  [cmd]       Purchase Vercel products for your team

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -989,6 +989,10 @@ const main = async () => {
           telemetry.trackCliCommandApi(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).api;
           break;
+        case 'ask':
+          telemetry.trackCliCommandAsk(userSuppliedSubCommand);
+          func = (await import('./commands-bulk.js')).ask;
+          break;
         case 'bisect':
           telemetry.trackCliCommandBisect(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).bisect;

--- a/packages/cli/src/util/telemetry/commands/ask/index.ts
+++ b/packages/cli/src/util/telemetry/commands/ask/index.ts
@@ -1,0 +1,44 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { askCommand } from '../../../../commands/ask/command';
+
+export class AskTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof askCommand>
+{
+  trackCliArgumentPrompt(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({
+        arg: 'prompt',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSession(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'session',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagNoWait(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('no-wait');
+    }
+  }
+
+  trackCliFlagVerbose(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('verbose');
+    }
+  }
+
+  trackCliFlagJson(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -61,6 +61,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandAsk(actual: string) {
+    this.trackCliCommand({
+      command: 'ask',
+      value: actual,
+    });
+  }
+
   trackCliCommandBisect(actual: string) {
     this.trackCliCommand({
       command: 'bisect',

--- a/packages/cli/test/unit/commands/ask/ask.test.ts
+++ b/packages/cli/test/unit/commands/ask/ask.test.ts
@@ -1,0 +1,397 @@
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
+import type { Request, Response } from 'express';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+import ask from '../../../../src/commands/ask';
+
+const SESSION_ID = 'f1e2d3c4-0000-0000-0000-000000000000';
+
+function useTeamScope() {
+  useUser();
+  useTeams('team_dummy');
+  client.config.currentTeam = 'team_dummy';
+}
+
+function useCreateSession() {
+  const requests: Array<Record<string, unknown>> = [];
+  client.scenario.post('/api/sessions', (req: Request, res: Response) => {
+    requests.push(req.body);
+    res.json({ sessionId: SESSION_ID, url: `/sessions/${SESSION_ID}` });
+  });
+  return requests;
+}
+
+function useTurnStream(
+  parts: Array<Record<string, unknown>>,
+  opts: { holdOpen?: boolean } = {}
+) {
+  const requests: Array<Record<string, unknown>> = [];
+  client.scenario.post(
+    `/api/sessions/${SESSION_ID}`,
+    (req: Request, res: Response) => {
+      requests.push(req.body);
+      res.setHeader('content-type', 'text/event-stream');
+      for (const part of parts) {
+        res.write(`data: ${JSON.stringify(part)}\n\n`);
+      }
+      if (opts.holdOpen) {
+        // Keep the connection open until the client cancels the stream
+        // (exercises the --no-wait early exit).
+        req.on('close', () => res.end());
+      } else {
+        res.write('data: [DONE]\n\n');
+        res.end();
+      }
+    }
+  );
+  return requests;
+}
+
+function useSessionSnapshot(
+  snapshots: Array<Record<string, unknown>>
+): Array<Record<string, unknown>> {
+  const remaining = [...snapshots];
+  client.scenario.get(
+    `/api/sessions/${SESSION_ID}`,
+    (_req: Request, res: Response) => {
+      const snapshot = remaining.length > 1 ? remaining.shift() : remaining[0];
+      res.json(snapshot);
+    }
+  );
+  return remaining;
+}
+
+const answerParts = [
+  { type: 'start', messageId: 'msg_1' },
+  { type: 'start-step' },
+  { type: 'text-start', id: 'txt_1' },
+  { type: 'text-delta', id: 'txt_1', delta: 'Your deployment failed ' },
+  { type: 'text-delta', id: 'txt_1', delta: 'because of a build error.' },
+  { type: 'text-end', id: 'txt_1' },
+  { type: 'finish-step' },
+  { type: 'finish' },
+];
+
+describe('ask', () => {
+  beforeEach(() => {
+    client.reset();
+    process.env.VERCEL_OMNIAGENT_URL = client.apiUrl;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_OMNIAGENT_URL;
+  });
+
+  it('creates a session, streams the answer, and prints a continuation hint', async () => {
+    useTeamScope();
+    const sessionRequests = useCreateSession();
+    const turnRequests = useTurnStream(answerParts);
+
+    client.setArgv('ask', 'Why did my last deployment fail?');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    expect(sessionRequests).toEqual([
+      { teamId: 'team_dummy', surface: 'dashboard' },
+    ]);
+    expect(turnRequests).toEqual([
+      {
+        type: 'message',
+        message: 'Why did my last deployment fail?',
+        teamId: 'team_dummy',
+      },
+    ]);
+    expect(client.stdout.getFullOutput()).toBe(
+      'Your deployment failed because of a build error.\n'
+    );
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain(`Session ${SESSION_ID}`);
+    expect(stderr).toContain(`vercel ask --session ${SESSION_ID}`);
+  });
+
+  it('outputs the turn as JSON Lines with --json', async () => {
+    useTeamScope();
+    useCreateSession();
+    useTurnStream(answerParts);
+
+    client.setArgv('ask', '--json', 'What happened?');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    const lines = client.stdout
+      .getFullOutput()
+      .split('\n')
+      .filter(Boolean)
+      .map(line => JSON.parse(line));
+    expect(lines[0]).toEqual({ type: 'session', sessionId: SESSION_ID });
+    expect(lines.slice(1)).toEqual(answerParts);
+  });
+
+  it('renders reasoning and tool activity with --verbose', async () => {
+    useTeamScope();
+    useCreateSession();
+    useTurnStream([
+      { type: 'start', messageId: 'msg_1' },
+      { type: 'reasoning-start', id: 'r_1' },
+      { type: 'reasoning-delta', id: 'r_1', delta: 'Inspecting the build…' },
+      { type: 'reasoning-end', id: 'r_1' },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'call_1',
+        toolName: 'getDeploymentLogs',
+        input: { deploymentId: 'dpl_123' },
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call_1',
+        output: { ok: true },
+      },
+      { type: 'text-start', id: 'txt_1' },
+      { type: 'text-delta', id: 'txt_1', delta: 'All good.' },
+      { type: 'text-end', id: 'txt_1' },
+      { type: 'finish' },
+    ]);
+
+    client.setArgv('ask', '--verbose', 'Check my logs');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe('All good.\n');
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Inspecting the build…');
+    expect(stderr).toContain('getDeploymentLogs');
+    expect(stderr).toContain('dpl_123');
+  });
+
+  it('sends the prompt into an existing session with --session', async () => {
+    useTeamScope();
+    const sessionRequests = useCreateSession();
+    const turnRequests = useTurnStream(answerParts);
+
+    client.setArgv('ask', '--session', SESSION_ID, 'Can you fix it?');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    expect(sessionRequests).toEqual([]);
+    expect(turnRequests).toEqual([
+      { type: 'message', message: 'Can you fix it?' },
+    ]);
+    expect(client.stdout.getFullOutput()).toBe(
+      'Your deployment failed because of a build error.\n'
+    );
+  });
+
+  it('dispatches without waiting with --no-wait', async () => {
+    useTeamScope();
+    useCreateSession();
+    useTurnStream([{ type: 'start', messageId: 'msg_1' }], {
+      holdOpen: true,
+    });
+
+    client.setArgv('ask', '--no-wait', 'Audit my project');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe(`${SESSION_ID}\n`);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Dispatched to Vercel Agent.');
+    expect(stderr).toContain(`vercel ask --session ${SESSION_ID}`);
+  });
+
+  it('emits a dispatched JSON line with --no-wait --json', async () => {
+    useTeamScope();
+    useCreateSession();
+    useTurnStream([{ type: 'start', messageId: 'msg_1' }], {
+      holdOpen: true,
+    });
+
+    client.setArgv('ask', '--no-wait', '--json', 'Audit my project');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    const lines = client.stdout
+      .getFullOutput()
+      .split('\n')
+      .filter(Boolean)
+      .map(line => JSON.parse(line));
+    expect(lines[0]).toEqual({ type: 'session', sessionId: SESSION_ID });
+    expect(lines[lines.length - 1]).toEqual({
+      type: 'dispatched',
+      sessionId: SESSION_ID,
+    });
+  });
+
+  it('returns 1 when the turn stream reports an error', async () => {
+    useTeamScope();
+    useCreateSession();
+    useTurnStream([
+      { type: 'start', messageId: 'msg_1' },
+      { type: 'error', errorText: 'The agent exploded' },
+      { type: 'finish' },
+    ]);
+
+    client.setArgv('ask', 'Trigger an error');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('The agent exploded');
+  });
+
+  it('returns 1 and prints the API error when the turn request fails', async () => {
+    useTeamScope();
+    useCreateSession();
+    client.scenario.post(
+      `/api/sessions/${SESSION_ID}`,
+      (_req: Request, res: Response) => {
+        res.status(403).json({ error: 'Access denied to this team' });
+      }
+    );
+
+    client.setArgv('ask', 'Hello');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Access denied to this team'
+    );
+  });
+
+  it('prints the latest answer for a settled session with --session and no prompt', async () => {
+    useTeamScope();
+    useSessionSnapshot([
+      {
+        id: SESSION_ID,
+        lastTurn: { assistantMessageId: 'msg_2', state: 'completed' },
+        messages: [
+          { id: 'msg_1', role: 'user', parts: [{ type: 'text', text: 'Q' }] },
+          {
+            id: 'msg_2',
+            role: 'assistant',
+            parts: [
+              { type: 'reasoning', text: 'hidden' },
+              { type: 'text', text: 'The answer is 42.' },
+            ],
+          },
+        ],
+        streamingMessageId: null,
+        title: null,
+      },
+    ]);
+
+    client.setArgv('ask', '--session', SESSION_ID);
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe('The answer is 42.\n');
+  });
+
+  it('polls until a running turn settles with --session and no prompt', async () => {
+    useTeamScope();
+    const runningSnapshot = {
+      id: SESSION_ID,
+      lastTurn: { assistantMessageId: 'msg_2', state: 'running' },
+      messages: [],
+      streamingMessageId: 'msg_2',
+      title: null,
+    };
+    const completedSnapshot = {
+      id: SESSION_ID,
+      lastTurn: { assistantMessageId: 'msg_2', state: 'completed' },
+      messages: [
+        {
+          id: 'msg_2',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Done after polling.' }],
+        },
+      ],
+      streamingMessageId: null,
+      title: null,
+    };
+    useSessionSnapshot([runningSnapshot, completedSnapshot]);
+
+    client.setArgv('ask', '--session', SESSION_ID);
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toBe('Done after polling.\n');
+  }, 15000);
+
+  it('returns 1 when checking a session whose last turn failed', async () => {
+    useTeamScope();
+    useSessionSnapshot([
+      {
+        id: SESSION_ID,
+        lastTurn: { assistantMessageId: 'msg_2', state: 'failed' },
+        messages: [],
+        streamingMessageId: null,
+        title: null,
+      },
+    ]);
+
+    client.setArgv('ask', '--session', SESSION_ID);
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('The agent turn failed.');
+  });
+
+  it('errors when no prompt and no session are provided', async () => {
+    client.setArgv('ask');
+    const exitCode = await ask(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Provide a prompt');
+  });
+
+  it('errors when --no-wait is used without a prompt', async () => {
+    client.setArgv('ask', '--no-wait', '--session', SESSION_ID);
+    const exitCode = await ask(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--no-wait` option requires a prompt'
+    );
+  });
+
+  it('errors when --verbose and --json are combined', async () => {
+    client.setArgv('ask', '--verbose', '--json', 'Hello');
+    const exitCode = await ask(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '`--verbose` and `--json` options cannot be combined'
+    );
+  });
+
+  it('errors when there is no team scope', async () => {
+    useUser();
+    client.setArgv('ask', 'Hello');
+    const exitCode = await ask(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Vercel Agent sessions require a team scope'
+    );
+  });
+
+  it('prints help with --help', async () => {
+    client.setArgv('ask', '--help');
+    const exitCode = await ask(client);
+    expect(exitCode).toBe(2);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'flag:help', value: 'ask' },
+    ]);
+  });
+
+  it('tracks telemetry for the prompt and flags', async () => {
+    useTeamScope();
+    useCreateSession();
+    useTurnStream(answerParts);
+
+    client.setArgv('ask', '--json', 'What happened?');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'argument:prompt', value: '[REDACTED]' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/ask/ask.test.ts
+++ b/packages/cli/test/unit/commands/ask/ask.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, beforeEach, afterEach, expect, it } from 'vitest';
 import type { Request, Response } from 'express';
 import { client } from '../../../mocks/client';
@@ -81,6 +82,57 @@ describe('ask', () => {
 
   afterEach(() => {
     delete process.env.VERCEL_OMNIAGENT_URL;
+    delete process.env.VERCEL_SSO_API_URL;
+  });
+
+  it('completes the deployment protection SSO handshake on a 401 challenge', async () => {
+    useTeamScope();
+    process.env.VERCEL_SSO_API_URL = `${client.apiUrl}/sso-api`;
+
+    const NONCE = 'nonce123';
+    const JWT = 'jwt456';
+    const protectionCookie = `_vercel_sso_nonce=${NONCE}; _vercel_jwt=${JWT}`;
+    const seenCookies: Array<string | undefined> = [];
+    let ssoRequest: { url?: string; nonce?: string; cookie?: string } = {};
+
+    client.scenario.post('/api/sessions', (req: Request, res: Response) => {
+      seenCookies.push(req.headers.cookie);
+      if (req.headers.cookie !== protectionCookie) {
+        // Vercel deployment protection answers requests with an
+        // Authorization header using a 401 challenge (not a 302).
+        res.setHeader(
+          'set-cookie',
+          `_vercel_sso_nonce=${NONCE}; Max-Age=3600; Path=/; Secure; HttpOnly`
+        );
+        res.status(401).send('Authentication Required');
+        return;
+      }
+      res.json({ sessionId: SESSION_ID, url: `/sessions/${SESSION_ID}` });
+    });
+    client.scenario.get('/sso-api', (req: Request, res: Response) => {
+      ssoRequest = {
+        url: req.query.url as string,
+        nonce: req.query.nonce as string,
+        cookie: req.headers.cookie as string,
+      };
+      res.redirect(302, `${client.apiUrl}/api/sessions?_vercel_jwt=${JWT}`);
+    });
+    useTurnStream(answerParts);
+
+    client.setArgv('ask', 'Hello through protection');
+    const exitCode = await ask(client);
+
+    expect(exitCode).toBe(0);
+    // First request is challenged, the retry carries the handshake cookies.
+    expect(seenCookies).toEqual([undefined, protectionCookie]);
+    expect(ssoRequest.url).toBe(`${client.apiUrl}/api/sessions`);
+    expect(ssoRequest.nonce).toBe(
+      createHash('sha256').update(NONCE).digest('hex')
+    );
+    expect(ssoRequest.cookie).toContain('authorization=Bearer%20token_dummy');
+    expect(client.stdout.getFullOutput()).toBe(
+      'Your deployment failed because of a build error.\n'
+    );
   });
 
   it('creates a session, streams the answer, and prints a continuation hint', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new `vercel ask` command that sends a prompt to Vercel Agent (Omniagent) and streams the answer back to the terminal.

```
vercel ask "Why did my last deployment fail?"
```

- `vercel ask "<prompt>"` creates a session on the current team scope, streams the answer text to **stdout**, and prints the session id plus a continuation command on stderr
- `vercel ask --session <id> "<prompt>"` sends a follow-up prompt into an existing session and waits for the answer
- `vercel ask --session <id>` (no prompt) waits for the latest turn to settle and prints the answer — pairs with `--no-wait`
- `--no-wait` dispatches the prompt and exits as soon as the turn starts (sub-agent style); prints the session id on stdout and the check command on stderr
- `--verbose` renders the agent's reasoning and tool activity on stderr while the answer still streams to stdout
- `--json` emits the turn as a JSON Lines stream of AI SDK UI message parts on stdout

## How it talks to Omniagent

Targets the Omniagent sessions API from the stacked API PRs (vercel/agents#2122 → vercel/agents#2125), specifically the **preview deployment** of the top of the stack (`omniagent-git-adriancooney-omniagent-api-pr4-async-polling.vercel.sh`) until the API ships. The base URL is overridable via `VERCEL_OMNIAGENT_URL`.

- Authenticates with the CLI bearer token (Omniagent's `Credential.fromRequest` bearer path)
- Handles Vercel deployment protection transparently via the same `vercel.com/sso-api` handshake the CLI already uses for OpenAPI spec fetching. Protection answers requests carrying an `Authorization` header with a **401 challenge** rather than a 302 redirect, so both variants are detected (the 401 path initially shipped broken and surfaced a raw `Vercel Agent request failed with status 401`; fixed and unit-tested)
- `POST /api/sessions` creates the session (surface `dashboard`, so sessions also show up in the dashboard sidebar), then `POST /api/sessions/:id` starts the streaming turn; `--no-wait`/`--session` checking uses `GET /api/sessions/:id` and the `lastTurn` state added in vercel/agents#2125

## Demo (real built CLI against a local mock of the Omniagent API)

[vercel_ask_demo_transcript.log](https://cursor.com/agents/bc-42f4d09a-800a-4bd9-9d52-beaedc1fa37a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvercel_ask_demo_transcript.log)

## Validation

- 18 unit tests covering session creation, streaming, `--json`, `--verbose`, `--session` continuation and checking, polling, `--no-wait`, the deployment-protection 401 challenge + SSO handshake, error paths, arg validation, and telemetry
- End-to-end run of the built CLI (`node dist/vc.js ask …`) against a local mock Omniagent server exercising all five flows (see transcript artifact)
- Against the real preview deployment, verified the 401 protection challenge now triggers the SSO handshake on `POST` (previously surfaced a raw 401); a full live turn couldn't be exercised because no valid Vercel token is available in this environment
- One open question worth verifying with a valid token: whether an agent turn reliably continues server-side after `--no-wait` drops the SSE connection (the resumable-stream tee + `after()` consumption suggests it does)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42f4d09a-800a-4bd9-9d52-beaedc1fa37a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42f4d09a-800a-4bd9-9d52-beaedc1fa37a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

