### PR TITLE
Add support for project-only tokens to `vercel deploy`

### DIFF
--- a/.changeset/cli-project-scoped-token-deploy.md
+++ b/.changeset/cli-project-scoped-token-deploy.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Support linked-project deploys with project-scoped tokens that cannot fetch owner user/team resources.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -90,6 +90,7 @@ import parseTarget from '../../util/parse-target';
 import { DeployTelemetryClient } from '../../util/telemetry/commands/deploy';
 import output from '../../output-manager';
 import { ensureLink } from '../../util/link/ensure-link';
+import { isOwnerLookupUnavailableLink } from '../../util/projects/link';
 import { UploadErrorMissingArchive } from '../../util/deploy/process-deployment';
 import { displayBuildLogsUntilFinalError } from '../../util/logs';
 import { determineAgent } from '@vercel/detect-agent';
@@ -1128,6 +1129,7 @@ async function handleDefaultDeploy(
       projectNameOrId ?? parsedArguments.flags['--name'] ?? localConfig?.name,
     failIfNotFound: !!projectNameOrId,
     requireExistingLink: parsedArguments.flags['--dry'],
+    allowOwnerLookupFallback: true,
     v0: isV0,
   });
   if (typeof link === 'number') {
@@ -1200,7 +1202,17 @@ async function handleDefaultDeploy(
   // #endregion
 
   const contextName = org.slug;
-  client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+  const ownerLookupUnavailable = isOwnerLookupUnavailableLink(link);
+  const currentTeam = ownerLookupUnavailable
+    ? undefined
+    : org.type === 'team'
+      ? org.id
+      : undefined;
+  if (currentTeam) {
+    client.config.currentTeam = currentTeam;
+  } else {
+    delete client.config.currentTeam;
+  }
 
   if (
     rootDirectory &&
@@ -1350,7 +1362,6 @@ async function handleDefaultDeploy(
   const regions = regionFlag.length > 0 ? regionFlag : localConfig.regions;
   // #endregion
 
-  const currentTeam = org.type === 'team' ? org.id : undefined;
   const now = new Now({
     client,
     currentTeam,

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -1202,17 +1202,11 @@ async function handleDefaultDeploy(
   // #endregion
 
   const contextName = org.slug;
-  const ownerLookupUnavailable = isOwnerLookupUnavailableLink(link);
-  const currentTeam = ownerLookupUnavailable
-    ? undefined
-    : org.type === 'team'
-      ? org.id
-      : undefined;
-  if (currentTeam) {
-    client.config.currentTeam = currentTeam;
-  } else {
-    delete client.config.currentTeam;
-  }
+  const currentTeam =
+    isOwnerLookupUnavailableLink(link) || org.type !== 'team'
+      ? undefined
+      : org.id;
+  client.config.currentTeam = currentTeam;
 
   if (
     rootDirectory &&

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -104,7 +104,7 @@ export default async function processDeployment({
   };
 
   const clientOptions: VercelClientOptions = {
-    teamId: org.type === 'team' ? org.id : undefined,
+    teamId: now.currentTeam ?? undefined,
     apiUrl: now._apiUrl,
     token,
     debug: output.isDebugEnabled(),

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -17,6 +17,11 @@ import { detectExplicitScope } from '../get-scope';
 interface EnsureLinkOptions extends SetupAndLinkOptions {
   /** When true, fail instead of setting up a project that is not linked. */
   requireExistingLink?: boolean;
+  /**
+   * Deploy-only fallback for project-scoped tokens that can fetch the linked
+   * project but cannot fetch the owner user/team resource.
+   */
+  allowOwnerLookupFallback?: boolean;
 }
 
 /**
@@ -63,6 +68,7 @@ export async function ensureLink(
         projectName: opts.projectName,
         projectNameIsExplicit: Boolean(opts.projectName && opts.failIfNotFound),
         scopeIsExplicit: detectExplicitScope(client),
+        allowOwnerLookupFallback: opts.allowOwnerLookupFallback,
       });
     }
     opts.link = link;

--- a/packages/cli/src/util/projects/get-project-by-id-or-name.ts
+++ b/packages/cli/src/util/projects/get-project-by-id-or-name.ts
@@ -6,14 +6,13 @@ export default async function getProjectByNameOrId(
   client: Client,
   projectNameOrId: string,
   accountId?: string,
-  includeRollbackInfo?: boolean,
-  options: { useCurrentTeam?: boolean } = {}
+  includeRollbackInfo?: boolean
 ) {
   try {
     const qs = includeRollbackInfo ? '?rollbackInfo=true' : '';
     const project = await client.fetch<Project>(
       `/v9/projects/${encodeURIComponent(projectNameOrId)}${qs}`,
-      { accountId, ...options }
+      { accountId }
     );
     return project;
   } catch (err: unknown) {

--- a/packages/cli/src/util/projects/get-project-by-id-or-name.ts
+++ b/packages/cli/src/util/projects/get-project-by-id-or-name.ts
@@ -6,13 +6,14 @@ export default async function getProjectByNameOrId(
   client: Client,
   projectNameOrId: string,
   accountId?: string,
-  includeRollbackInfo?: boolean
+  includeRollbackInfo?: boolean,
+  options: { useCurrentTeam?: boolean } = {}
 ) {
   try {
     const qs = includeRollbackInfo ? '?rollbackInfo=true' : '';
     const project = await client.fetch<Project>(
       `/v9/projects/${encodeURIComponent(projectNameOrId)}${qs}`,
-      { accountId }
+      { accountId, ...options }
     );
     return project;
   } catch (err: unknown) {

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -10,6 +10,7 @@ import type Client from '../client';
 import { InvalidToken, isAPIError, ProjectNotFound } from '../errors-ts';
 import type {
   Project,
+  ProjectLinked,
   ProjectLinkResult,
   Org,
   ProjectLink,
@@ -35,6 +36,18 @@ export const VERCEL_DIR_FALLBACK = '.now';
 export const VERCEL_DIR_README = 'README.txt';
 export const VERCEL_DIR_PROJECT = 'project.json';
 export const VERCEL_DIR_REPO = 'repo.json';
+
+export interface OwnerLookupUnavailableProjectLinked extends ProjectLinked {
+  ownerLookupUnavailable: true;
+}
+
+export function isOwnerLookupUnavailableLink(
+  link: ProjectLinked
+): link is OwnerLookupUnavailableProjectLinked {
+  return (
+    'ownerLookupUnavailable' in link && link.ownerLookupUnavailable === true
+  );
+}
 
 const linkSchema = {
   type: 'object',
@@ -289,6 +302,11 @@ export interface GetLinkedProjectOptions {
   projectName?: string;
   projectNameIsExplicit?: boolean;
   scopeIsExplicit?: boolean;
+  /**
+   * Allows default deploy to continue when a project-scoped token can fetch the
+   * linked project but cannot fetch the owner user/team resource.
+   */
+  allowOwnerLookupFallback?: boolean;
 }
 
 export type ProjectLinkResultWithOrgId = ProjectLinkResult & {
@@ -402,6 +420,7 @@ export async function getLinkedProject(
   output.spinner('Retrieving project…', 1000);
   let org: Org | null = null;
   let project: Project | ProjectNotFound | null = null;
+  let ownerLookupUnavailable = false;
   try {
     const [orgResult, projectResult] = await Promise.allSettled([
       getOrgById(client, link.orgId),
@@ -419,6 +438,17 @@ export async function getLinkedProject(
         orgResult.reason.code === 'mock_unimplemented')
     ) {
       org = null;
+    } else if (
+      options.allowOwnerLookupFallback &&
+      (orgResult.reason instanceof InvalidToken ||
+        (isAPIError(orgResult.reason) &&
+          orgResult.reason.status === 403 &&
+          (orgResult.reason.missingToken ||
+            orgResult.reason.invalidToken ||
+            orgResult.reason.code === 'forbidden' ||
+            orgResult.reason.code === 'team_unauthorized')))
+    ) {
+      ownerLookupUnavailable = true;
     } else {
       throw orgResult.reason;
     }
@@ -456,6 +486,24 @@ export async function getLinkedProject(
     throw err;
   } finally {
     output.stopSpinner();
+  }
+
+  if (ownerLookupUnavailable) {
+    if (project && !(project instanceof ProjectNotFound)) {
+      const ownerId = project.accountId || link.orgId;
+      const ownerLookupUnavailableLink: OwnerLookupUnavailableProjectLinked = {
+        status: 'linked',
+        org: {
+          type: ownerId.startsWith('team_') ? 'team' : 'user',
+          id: ownerId,
+          slug: ownerId,
+        },
+        project,
+        repoRoot: link.repoRoot,
+        ownerLookupUnavailable: true,
+      };
+      return ownerLookupUnavailableLink;
+    }
   }
 
   if (!org || !project || project instanceof ProjectNotFound) {

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -38,7 +38,9 @@ export const VERCEL_DIR_PROJECT = 'project.json';
 export const VERCEL_DIR_REPO = 'repo.json';
 
 export interface OwnerLookupUnavailableProjectLinked extends ProjectLinked {
+  orgId?: string;
   ownerLookupUnavailable: true;
+  projectRootDirectory?: string;
 }
 
 export function isOwnerLookupUnavailableLink(
@@ -46,6 +48,14 @@ export function isOwnerLookupUnavailableLink(
 ): link is OwnerLookupUnavailableProjectLinked {
   return (
     'ownerLookupUnavailable' in link && link.ownerLookupUnavailable === true
+  );
+}
+
+function isOwnerLookupUnavailableError(error: unknown): boolean {
+  return (
+    isAPIError(error) &&
+    error.status === 403 &&
+    error.code === 'team_unauthorized'
   );
 }
 
@@ -303,8 +313,8 @@ export interface GetLinkedProjectOptions {
   projectNameIsExplicit?: boolean;
   scopeIsExplicit?: boolean;
   /**
-   * Allows default deploy to continue when a project-scoped token can fetch the
-   * linked project but cannot fetch the owner user/team resource.
+   * Allows deploying with a project-scoped token, which can fetch the
+   * linked project, but cannot fetch the owning user/team.
    */
   allowOwnerLookupFallback?: boolean;
 }
@@ -440,13 +450,7 @@ export async function getLinkedProject(
       org = null;
     } else if (
       options.allowOwnerLookupFallback &&
-      (orgResult.reason instanceof InvalidToken ||
-        (isAPIError(orgResult.reason) &&
-          orgResult.reason.status === 403 &&
-          (orgResult.reason.missingToken ||
-            orgResult.reason.invalidToken ||
-            orgResult.reason.code === 'forbidden' ||
-            orgResult.reason.code === 'team_unauthorized')))
+      isOwnerLookupUnavailableError(orgResult.reason)
     ) {
       ownerLookupUnavailable = true;
     } else {
@@ -500,6 +504,8 @@ export async function getLinkedProject(
         },
         project,
         repoRoot: link.repoRoot,
+        projectRootDirectory: link.projectRootDirectory,
+        orgId: link.orgId,
         ownerLookupUnavailable: true,
       };
       return ownerLookupUnavailableLink;

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -854,6 +854,127 @@ describe('deploy', () => {
     ).toEqual(true);
   });
 
+  it('should keep passing teamId for normal linked team deploys', async () => {
+    const originalVercelTeamId = process.env.VERCEL_TEAM_ID;
+    delete process.env.VERCEL_TEAM_ID;
+
+    try {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      let createTeamId: unknown;
+      client.scenario.post(`/v13/deployments`, (req, res) => {
+        createTeamId = req.query.teamId;
+        res.json({
+          creator: {
+            uid: user.id,
+            username: user.username,
+          },
+          id: 'dpl_normal_team',
+          url: 'normal-team.vercel.app',
+          readyState: 'READY',
+          aliasAssigned: true,
+          alias: [],
+          target: 'preview',
+        });
+      });
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy');
+      const exitCode = await deploy(client);
+
+      expect(exitCode).toEqual(0);
+      expect(createTeamId).toEqual('team_dummy');
+    } finally {
+      if (originalVercelTeamId === undefined) {
+        delete process.env.VERCEL_TEAM_ID;
+      } else {
+        process.env.VERCEL_TEAM_ID = originalVercelTeamId;
+      }
+    }
+  });
+
+  it('should deploy a linked project when owner lookup is unavailable', async () => {
+    const originalVercelTeamId = process.env.VERCEL_TEAM_ID;
+    delete process.env.VERCEL_TEAM_ID;
+
+    try {
+      useTeams('team_dummy', { failNoAccess: true });
+      client.config.currentTeam = 'team_dummy';
+
+      const projectLookupTeamIds: unknown[] = [];
+      client.scenario.get(`/v9/projects/static`, (req, res) => {
+        projectLookupTeamIds.push(req.query.teamId);
+        res.json({
+          ...defaultProject,
+          accountId: 'team_dummy',
+          name: 'static',
+          id: 'static',
+        });
+      });
+
+      let createTeamId: unknown;
+      const statusTeamIds: unknown[] = [];
+      client.scenario.post(`/v13/deployments`, (req, res) => {
+        createTeamId = req.query.teamId;
+        res.json({
+          creator: {
+            uid: 'user_dummy',
+            username: 'user_dummy',
+          },
+          id: 'dpl_scoped_token',
+          url: 'scoped-token.vercel.app',
+          readyState: 'BUILDING',
+          aliasAssigned: false,
+          alias: [],
+          target: 'preview',
+        });
+      });
+      client.scenario.get(`/v13/deployments/dpl_scoped_token`, (req, res) => {
+        statusTeamIds.push(req.query.teamId);
+        res.json({
+          creator: {
+            uid: 'user_dummy',
+            username: 'user_dummy',
+          },
+          id: 'dpl_scoped_token',
+          url: 'scoped-token.vercel.app',
+          readyState: 'READY',
+          aliasAssigned: true,
+          alias: [],
+          target: 'preview',
+        });
+      });
+      client.scenario.get(
+        `/v3/now/deployments/dpl_scoped_token/events`,
+        (_req, res) => {
+          res.end();
+        }
+      );
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy');
+      const exitCode = await deploy(client);
+
+      expect(exitCode).toEqual(0);
+      expect(projectLookupTeamIds).toEqual(['team_dummy']);
+      expect(createTeamId).toBeUndefined();
+      expect(statusTeamIds).toEqual([undefined]);
+      expect(client.config.currentTeam).toBeUndefined();
+    } finally {
+      if (originalVercelTeamId === undefined) {
+        delete process.env.VERCEL_TEAM_ID;
+      } else {
+        process.env.VERCEL_TEAM_ID = originalVercelTeamId;
+      }
+    }
+  });
+
   it('should deploy project linked with `repo.json`', async () => {
     const user = useUser();
     useTeams('team_dummy');

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -97,6 +97,25 @@ describe('pull', () => {
     expect(devFileHasDevEnv).toBeTruthy();
   });
 
+  it('should not use owner lookup fallback for pulling', async () => {
+    const cwd = setupUnitFixture('vercel-pull-next');
+
+    useUser();
+    useTeams('team_dummy', { failNoAccess: true });
+    useProject({
+      ...defaultProject,
+      accountId: 'team_dummy',
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+
+    client.setArgv('pull', cwd);
+
+    await expect(pull(client)).rejects.toThrow(
+      'Could not retrieve Project Settings. To link your Project, remove the `.vercel` directory and deploy again.'
+    );
+  });
+
   it('should fail with message to pull without a link and without --env', async () => {
     client.stdin.isTTY = false;
     (client as { nonInteractive: boolean }).nonInteractive = false;

--- a/packages/cli/test/unit/util/link/ensure-link.test.ts
+++ b/packages/cli/test/unit/util/link/ensure-link.test.ts
@@ -36,6 +36,42 @@ describe('ensureLink', () => {
     setupAndLink = setupAndLinkModule.default as ReturnType<typeof vi.fn>;
   });
 
+  it('does not enable owner lookup fallback by default', async () => {
+    const linked = {
+      status: 'linked' as const,
+      org: { id: 'o1', slug: 'team', type: 'team' as const },
+      project: { id: 'p1', name: 'proj' },
+    };
+    vi.mocked(getLinkedProject).mockResolvedValue(linked);
+
+    const result = await ensureLink('pull', client, '/cwd', {});
+
+    expect(result).toEqual(linked);
+    expect(getLinkedProject).toHaveBeenCalledTimes(1);
+    expect(
+      getLinkedProject.mock.calls[0][1].allowOwnerLookupFallback
+    ).toBeUndefined();
+  });
+
+  it('passes owner lookup fallback when explicitly enabled', async () => {
+    const linked = {
+      status: 'linked' as const,
+      org: { id: 'o1', slug: 'team', type: 'team' as const },
+      project: { id: 'p1', name: 'proj' },
+    };
+    vi.mocked(getLinkedProject).mockResolvedValue(linked);
+
+    const result = await ensureLink('deploy', client, '/cwd', {
+      allowOwnerLookupFallback: true,
+    });
+
+    expect(result).toEqual(linked);
+    expect(getLinkedProject).toHaveBeenCalledTimes(1);
+    expect(getLinkedProject.mock.calls[0][1].allowOwnerLookupFallback).toEqual(
+      true
+    );
+  });
+
   it('returns action_required payload when not linked and setupAndLink returns action_required', async () => {
     const actionRequiredPayload = {
       status: 'action_required' as const,

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -5,6 +5,7 @@ import { mkdirp, writeJSON } from 'fs-extra';
 import {
   getLinkFromDir,
   getLinkedProject,
+  isOwnerLookupUnavailableLink,
 } from '../../../../src/util/projects/link';
 import { client } from '../../../mocks/client';
 
@@ -170,6 +171,51 @@ describe('getLinkedProject', () => {
     expect(error.message).toBe(
       'You are not authorized to read this team. (403)'
     );
+  });
+
+  it('should return a linked project when owner lookup fallback is allowed', async () => {
+    const cwd = fixture('vercel-pull-next');
+
+    useUser();
+    useTeams('team_dummy', { failNoAccess: true });
+    useProject({
+      ...defaultProject,
+      accountId: 'team_dummy',
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+
+    const link = await getLinkedProject(client, {
+      cwd,
+      allowOwnerLookupFallback: true,
+    });
+
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.org).toEqual({
+      type: 'team',
+      id: 'team_dummy',
+      slug: 'team_dummy',
+    });
+    expect(link.project.id).toEqual('vercel-pull-next');
+    expect(link.orgId).toEqual('team_dummy');
+    expect(isOwnerLookupUnavailableLink(link)).toEqual(true);
+  });
+
+  it('should still require project lookup when owner lookup fallback is allowed', async () => {
+    const cwd = fixture('vercel-pull-next');
+
+    useUser();
+    useTeams('team_dummy', { failNoAccess: true });
+    useUnknownProject();
+
+    const link = await getLinkedProject(client, {
+      cwd,
+      allowOwnerLookupFallback: true,
+    });
+
+    expect(link.status).toEqual('not_linked');
   });
 
   it('should return link with `project.json`', async () => {

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -203,6 +203,33 @@ describe('getLinkedProject', () => {
     expect(isOwnerLookupUnavailableLink(link)).toEqual(true);
   });
 
+  it('should preserve repo link metadata when owner lookup fallback is allowed', async () => {
+    const cwd = fixture('monorepo-link');
+
+    useUser();
+    useTeams('team_dummy', { failNoAccess: true });
+    useProject({
+      ...defaultProject,
+      accountId: 'team_dummy',
+      id: 'QmX6P93ChNDoZP',
+      name: 'monorepo-marketing',
+    });
+
+    const link = await getLinkedProject(client, {
+      cwd: join(cwd, 'marketing/subdir'),
+      allowOwnerLookupFallback: true,
+    });
+
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.project.id).toEqual('QmX6P93ChNDoZP');
+    expect(link.repoRoot).toEqual(cwd);
+    expect(link.projectRootDirectory).toEqual('marketing');
+    expect(link.orgId).toEqual('team_dummy');
+    expect(isOwnerLookupUnavailableLink(link)).toEqual(true);
+  });
+
   it('should still require project lookup when owner lookup fallback is allowed', async () => {
     const cwd = fixture('vercel-pull-next');
 
@@ -216,6 +243,23 @@ describe('getLinkedProject', () => {
     });
 
     expect(link.status).toEqual('not_linked');
+  });
+
+  it('should not use owner lookup fallback for unrelated 403 errors', async () => {
+    const cwd = fixture('vercel-pull-next');
+
+    useUser();
+    useTeams('team_dummy', { failWithCustom403Code: true });
+    useProject({
+      ...defaultProject,
+      accountId: 'team_dummy',
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+
+    await expect(
+      getLinkedProject(client, { cwd, allowOwnerLookupFallback: true })
+    ).rejects.toThrow('You are not authorized to read this team. (403)');
   });
 
   it('should return link with `project.json`', async () => {


### PR DESCRIPTION
Adds support for project-scoped tokens (without user/team access) to `vercel deploy`. The API can infer the team from these tokens, so when owner lookup fails, the CLI continues and just omits the `?teamId` query param from subsequent API requests.

Context: https://vercel.slack.com/archives/C08R2K7STHD/p1782506491053839

Related: https://github.com/vercel/api/pull/79740 - will need to wait until this is deployed to test