### PR TITLE
[CLI] fixing vc env pull to not overwrite non upstream varibles

### DIFF
--- a/.changeset/tidy-plums-brush.md
+++ b/.changeset/tidy-plums-brush.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+`vercel env pull` now keeps variables that only exist in the local env file instead of deleting them. Kept variables are listed in the command output. CLI-managed variables (`VERCEL_OIDC_TOKEN` and analytics IDs) are still removed when they no longer exist upstream.

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -265,18 +265,11 @@ export async function envPullCommandLogic(
   let oldEnv;
   if (exists && !oidcTokenOnly) {
     oldEnv = await createEnvObject(fullPath);
-    if (oldEnv) {
-      // Removes any double quotes from `records`, if they exist
-      // We need this because double quotes are stripped from the local .env file,
-      // but `records` is already in the form of a JSON object that doesn't filter
-      // double quotes.
-      const newEnv = JSONparse(JSON.stringify(records).replace(/\\"/g, ''));
-      deltaString = buildDeltaString(oldEnv, newEnv);
-    }
   }
 
   let contents: string;
   let fileChanged = true;
+  const keptLocalKeys: string[] = [];
 
   if (oidcTokenOnly) {
     const existingContents = exists ? await readFile(fullPath, 'utf8') : '';
@@ -286,14 +279,35 @@ export async function envPullCommandLogic(
     );
     fileChanged = contents !== existingContents;
   } else {
+    const mergedRecords: Record<string, string | undefined> = { ...records };
+    if (oldEnv) {
+      for (const [key, value] of Object.entries(oldEnv)) {
+        if (
+          !(key in mergedRecords) &&
+          key !== VERCEL_OIDC_TOKEN &&
+          !VARIABLES_TO_IGNORE.includes(key)
+        ) {
+          mergedRecords[key] = value;
+          keptLocalKeys.push(key);
+        }
+      }
+    }
+
     contents =
       CONTENTS_PREFIX +
-      Object.keys(records)
+      Object.keys(mergedRecords)
         .sort()
         .filter(key => !VARIABLES_TO_IGNORE.includes(key))
-        .map(key => `${key}="${escapeValue(records[key])}"`)
+        .map(key => `${key}="${escapeValue(mergedRecords[key])}"`)
         .join('\n') +
       '\n';
+
+    if (oldEnv) {
+      const newEnv = JSONparse(
+        JSON.stringify(mergedRecords).replace(/\\"/g, '')
+      );
+      deltaString = buildDeltaString(oldEnv, newEnv);
+    }
   }
 
   if (fileChanged) {
@@ -304,6 +318,17 @@ export async function envPullCommandLogic(
     output.print('\n' + deltaString);
   } else if (oldEnv && exists) {
     output.log('No changes found.');
+  }
+
+  if (keptLocalKeys.length > 0) {
+    output.log(
+      `Kept ${keptLocalKeys
+        .sort()
+        .map(key => chalk.bold(key))
+        .join(', ')} (defined locally, not found in the ${chalk.cyan(
+        environment
+      )} Environment)`
+    );
   }
 
   let isGitIgnoreUpdated = false;

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -539,17 +539,45 @@ describe('env pull', () => {
         'Downloading `development` environment variables for'
       );
       await expect(client.stderr).toOutput(
-        '  Changes:\n  + SPECIAL_FLAG (Updated)\n  + NEW_VAR\n  - TEST\n'
+        '  Changes:\n  + SPECIAL_FLAG (Updated)\n  + NEW_VAR\n\n> Kept TEST (defined locally, not found in the development Environment)'
       );
       await expect(client.stderr).toOutput(
         'Updated         .env.local file and added it to .gitignore'
       );
 
       await expect(pullPromise).resolves.toEqual(0);
+
+      const rawDevEnv = await fs.readFile(path.join(cwd, '.env.local'));
+      expect(rawDevEnv.toString()).toContain('TEST="hi"');
     } finally {
       client.setArgv('env', 'rm', 'NEW_VAR', '--yes');
       await env(client);
     }
+  });
+
+  it('should keep variables that only exist locally', async () => {
+    const cwd = setupUnitFixture('vercel-env-pull-delta');
+    client.cwd = cwd;
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'env-pull-delta',
+      name: 'env-pull-delta',
+    });
+
+    client.setArgv('env', 'pull', '--yes');
+    const pullPromise = env(client);
+    await expect(client.stderr).toOutput(
+      'Kept TEST (defined locally, not found in the development Environment)'
+    );
+    await expect(pullPromise).resolves.toEqual(0);
+
+    const rawDevEnv = (
+      await fs.readFile(path.join(cwd, '.env.local'))
+    ).toString();
+    expect(rawDevEnv).toContain('TEST="hi"');
+    expect(rawDevEnv).toContain('SPECIAL_FLAG="1"');
   });
 
   it('should not show a delta string when it fails to read a file', async () => {


### PR DESCRIPTION
This pr addresses an issue in Slack where if a user has env var A and b in `.env.local` they would get over written regardless if they eexist upstream