### PR TITLE
[cli] Always surface framework mismatch warning in vercel build

### DIFF
--- a/.changeset/ten-dolls-wave.md
+++ b/.changeset/ten-dolls-wave.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Run first-deployment framework detection without requiring `VERCEL_FRAMEWORK_DETECTION`, and show mismatch warnings without `--debug`.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -848,8 +848,6 @@ async function doBuild(
     normalizePath(relative(workPath, f))
   );
 
-  // Framework detection for the end-of-build cross-check, started here so it
-  // runs concurrently with the builders instead of adding latency.
   const detectedFrameworksPromise = span
     .child('vc.detectAllFrameworks', {
       enabled: String(isFrameworkDetectionEnabled()),
@@ -866,7 +864,7 @@ async function doBuild(
         });
         return slugs;
       } catch (err) {
-        output.debug(`Framework cross-check detection failed: ${err}`);
+        output.warn(`Framework cross-check detection failed: ${err}`);
         s.setAttributes({
           error: err instanceof Error ? err.message : String(err),
         });

--- a/packages/cli/src/util/build/framework-detection.ts
+++ b/packages/cli/src/util/build/framework-detection.ts
@@ -64,6 +64,11 @@ export interface DetectedFramework {
  * On a project's first deployment, detect the framework from the source code
  * and apply it to the in-memory `projectSettings` (mutated in place so the
  * caller's subsequent `detectBuilders` call sees it).
+ *
+ * This always runs when `VERCEL_FIRST_DEPLOYMENT=1` and no framework is
+ * configured, even when `VERCEL_FRAMEWORK_DETECTION` is not set, so new
+ * projects get a framework from their first build without needing the
+ * feature flag.
  */
 export async function detectFirstDeploymentFramework(options: {
   workPath: string;
@@ -71,10 +76,8 @@ export async function detectFirstDeploymentFramework(options: {
 }): Promise<DetectedFramework> {
   const { workPath, projectSettings } = options;
 
-  if (!isFrameworkDetectionEnabled()) {
-    return { status: 'skipped' };
-  }
-
+  // First-deployment detection is not gated by VERCEL_FRAMEWORK_DETECTION;
+  // it is gated only by VERCEL_FIRST_DEPLOYMENT and absence of configured framework.
   logDebug(
     `First deployment: evaluating framework detection (workPath="${workPath}", ` +
       `configuredFramework=${

--- a/packages/cli/test/unit/util/build/framework-detection.test.ts
+++ b/packages/cli/test/unit/util/build/framework-detection.test.ts
@@ -116,7 +116,7 @@ describe('detectFirstDeploymentFramework()', () => {
     expect(projectSettings.framework).toBeNull();
   });
 
-  it('returns skipped when framework detection is not opted in', async () => {
+  it('detects even without opt-in when it is a first deployment', async () => {
     process.env.VERCEL_FIRST_DEPLOYMENT = '1';
     delete process.env.VERCEL_FRAMEWORK_DETECTION;
     const dir = await makeProjectDir({ dependencies: { next: '14.0.0' } });
@@ -129,8 +129,8 @@ describe('detectFirstDeploymentFramework()', () => {
       projectSettings,
     });
 
-    expect(result).toEqual({ status: 'skipped' });
-    expect(projectSettings.framework).toBeNull();
+    expect(result.status).toBe('detected');
+    expect(projectSettings.framework).toBe('nextjs');
   });
 
   it('returns skipped when a framework is already configured', async () => {


### PR DESCRIPTION
First-deployment detection now runs without `VERCEL_FRAMEWORK_DETECTION` when `VERCEL_FIRST_DEPLOYMENT=1` and no framework is configured. Mismatch detection stays behind the flag but warnings now surface as `warn` (not `debug`), so they show without `--debug`.