### PR TITLE
[cli] Attribute marketplace skill installs in skills telemetry

### DIFF
--- a/.changeset/cli-skill-install-telemetry-metadata.md
+++ b/.changeset/cli-skill-install-telemetry-metadata.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Attribute marketplace agent-skill auto-installs in the skills CLI's install telemetry by passing `--metadata` (origin, flow, integration and product slugs) to the `npx skills add` invocation. Older skills versions (< 1.5.16) ignore the flag and install unchanged.

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -583,10 +583,22 @@ export async function addAutoProvision(
     if (!options.asJson) {
       output.spinner(`Installing agent skills for ${product.name}...`);
     }
+    // Provenance for the skills CLI's install telemetry: attributes the
+    // install to the marketplace flow and its integration/product. Everything
+    // else (agent, CI, versions) is detected by the skills CLI itself.
+    const skillsTelemetryMetadata = JSON.stringify({
+      origin: 'vercel-cli',
+      flow: 'integration-install',
+      integration: integration.slug,
+      product: product.slug,
+    });
     for (const skill of skills) {
       // Both `--yes` flags are needed in non-interactive (agent/CI) contexts:
       // the first stops `npx` from prompting to install the `skills` package,
       // the second makes `skills add` accept its defaults instead of asking.
+      // `--metadata` requires skills >= 1.5.16; older resolved versions
+      // silently ignore the flag and still install successfully (verified
+      // against 1.5.15), so no attribution is logged but nothing fails.
       const args = [
         '--yes',
         'skills',
@@ -594,6 +606,8 @@ export async function addAutoProvision(
         skill.repoUrl,
         ...(skill.skill ? ['--skill', skill.skill] : []),
         '--yes',
+        '--metadata',
+        skillsTelemetryMetadata,
       ];
       const result = await execa('npx', args, {
         cwd: client.cwd,

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -2606,6 +2606,8 @@ describe('integration add (auto-provision)', () => {
           '--skill',
           'shopify-dev',
           '--yes',
+          '--metadata',
+          '{"origin":"vercel-cli","flow":"integration-install","integration":"acme-skills","product":"acme"}',
         ],
         expect.objectContaining({ stdio: 'pipe', reject: false })
       );
@@ -2633,6 +2635,8 @@ describe('integration add (auto-provision)', () => {
           '--skill',
           'shopify-dev',
           '--yes',
+          '--metadata',
+          '{"origin":"vercel-cli","flow":"integration-install","integration":"acme-skills","product":"acme"}',
         ],
         expect.objectContaining({ stdio: 'pipe', reject: false })
       );
@@ -2670,6 +2674,8 @@ describe('integration add (auto-provision)', () => {
           '--skill',
           'shopify-dev',
           '--yes',
+          '--metadata',
+          '{"origin":"vercel-cli","flow":"integration-install","integration":"acme-skills","product":"acme"}',
         ],
         expect.objectContaining({ stdio: 'pipe', reject: false })
       );


### PR DESCRIPTION
## What

When `vercel integration add` auto-installs a marketplace product's declared agent skills (`product.agentSkills`), pass `--metadata` to the `npx skills add` invocation so the skills CLI's install telemetry can attribute the install to the marketplace flow:

```json
{"origin":"vercel-cli","flow":"integration-install","integration":"<integration.slug>","product":"<product.slug>"}
```

Today these auto-installs are indistinguishable from a user manually running `npx skills add`.

## Why these four fields only

The skills CLI already attaches the detected agent (`agent=claude-code|cursor|...`), CI flag, and its own version to the same `install` event, so none of that is duplicated here. The metadata carries only what the skills CLI cannot know: that the install was triggered by the marketplace flow, and which integration/product triggered it. `origin` and `flow` are separate fields so future skill-installing surfaces/flows can slot in without renaming.

## Compatibility

- `--metadata` is supported by skills >= 1.5.16. Older versions silently ignore the flag and install successfully (verified empirically against 1.5.15: exit 0, clean output) — no attribution is logged, nothing fails, and the population self-heals as versions roll forward.
- `JSON.stringify` + execa argv means no shell quoting is involved.
- The manual-retry command printed on install failure (from `skill-suggestion.ts`) intentionally remains metadata-free, so manual retries are not misattributed to the automated flow; existing tests enforce this.

## Verification

- End-to-end payload delivery verified against the skills telemetry backend: test installs with equivalent `--metadata` payloads were confirmed received server-side with fields intact.
- 129/129 tests pass across `add-auto-provision.test.ts` and `skill-suggestion.test.ts`; the three exact-args assertions now cover the metadata pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)