### PR TITLE
feat(cli): vc git passthrough with push-aware deployment tracking

### DIFF
--- a/.changeset/git-passthrough-push.md
+++ b/.changeset/git-passthrough-push.md
@@ -1,0 +1,12 @@
+---
+'@vercel/cli': minor
+---
+
+Add `vc git` passthrough with push-aware deployment tracking.
+
+- `vc git <any git args>` now runs git as passthrough from the CLI, preserving exit code and stdio.
+- `vc git push` (and variants) detects the push, resolves all Vercel projects linked via `.vercel/repo.json` (repo-root discovery works from any subdir), and polls for new git-triggered deployments.
+- Shows deployment links for all projects that started a deployment; shows "no new deployment" for those ignored by git config.
+- Streams build logs only for the project whose `rootDirectory` contains the current cwd (deepest match), matching `vc deploy` output via `printDeploymentStatus` and `displayBuildLogs`. Other projects only show links.
+- Adds wrapper flags: `--no-attach` to skip polling, `--logs`/`-l` to force logs for cwd project, `--no-logs` to disable.
+- Updates telemetry and help snapshots, and adapts git command tests for passthrough behavior.

--- a/packages/cli/src/commands/git/command.ts
+++ b/packages/cli/src/commands/git/command.ts
@@ -43,7 +43,7 @@ export const gitCommand = {
   name: 'git',
   aliases: [],
   description:
-    'Manage your Git repository connection to the current Project. Also acts as a Git passthrough: `vc git push` (and other git commands) runs Git and, on push, tracks Vercel deployments for linked projects.',
+    'Manage your Git repository connection to the current Project. Also acts as a Git passthrough: `vc git push` runs Git and tracks Vercel deployments for linked projects; `vc git status` shows Git status plus latest Vercel deployments for the current branch.',
   arguments: [
     {
       name: 'git-args',
@@ -73,10 +73,15 @@ export const gitCommand = {
       shorthand: null,
       type: Boolean,
       deprecated: false,
-      description: 'Do not stream build logs even when attached to a deployment',
+      description:
+        'Do not stream build logs even when attached to a deployment',
     },
   ],
   examples: [
+    {
+      name: 'Show Git status with Vercel deployments for this branch',
+      value: `${packageName} git status`,
+    },
     {
       name: 'Push and watch linked Vercel deployments',
       value: `${packageName} git push`,
@@ -87,7 +92,7 @@ export const gitCommand = {
     },
     {
       name: 'Run any Git command through Vercel CLI',
-      value: `${packageName} git status`,
+      value: `${packageName} git log --oneline -n 10`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/git/command.ts
+++ b/packages/cli/src/commands/git/command.ts
@@ -42,9 +42,52 @@ export const disconnectSubcommand = {
 export const gitCommand = {
   name: 'git',
   aliases: [],
-  description: 'Manage your Git repository connection to the current Project',
-  arguments: [],
+  description:
+    'Manage your Git repository connection to the current Project. Also acts as a Git passthrough: `vc git push` (and other git commands) runs Git and, on push, tracks Vercel deployments for linked projects.',
+  arguments: [
+    {
+      name: 'git-args',
+      required: false,
+    },
+  ],
   subcommands: [connectSubcommand, disconnectSubcommand],
-  options: [],
-  examples: [],
+  options: [
+    {
+      name: 'no-attach',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Do not poll or attach to deployments after `git push`; just run Git and exit',
+    },
+    {
+      name: 'logs',
+      shorthand: 'l',
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Stream build logs for the current-directory project after `git push` (default: auto when cwd is inside a linked project rootDirectory)',
+    },
+    {
+      name: 'no-logs',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Do not stream build logs even when attached to a deployment',
+    },
+  ],
+  examples: [
+    {
+      name: 'Push and watch linked Vercel deployments',
+      value: `${packageName} git push`,
+    },
+    {
+      name: 'Push without attaching to deployments',
+      value: `${packageName} git push --no-attach`,
+    },
+    {
+      name: 'Run any Git command through Vercel CLI',
+      value: `${packageName} git status`,
+    },
+  ],
 } as const;

--- a/packages/cli/src/commands/git/index.ts
+++ b/packages/cli/src/commands/git/index.ts
@@ -3,6 +3,7 @@ import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import { printError } from '../../util/error';
 import connect from './connect';
 import disconnect from './disconnect';
+import passthrough from './passthrough';
 import { help } from '../help';
 import { gitCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -33,15 +34,36 @@ export default async function main(client: Client) {
     },
   });
 
+  // Slice past `git` – parseArguments args includes "git" as first positional when permissive
+  // e.g. argv = ['vc','git','push'] => parsedArgs.args = ['git','push']
+  const rawAfterGit =
+    parsedArgs.args[0] === 'git' ? parsedArgs.args.slice(1) : parsedArgs.args;
+
+  // If no args at all => show help
+  if (rawAfterGit.length === 0) {
+    if (parsedArgs.flags['--help']) {
+      telemetry.trackCliFlagHelp('git', undefined);
+    }
+    output.print(help(gitCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
   const { subcommand, args, subcommandOriginal } = getSubcommand(
     parsedArgs.args.slice(1),
     COMMAND_CONFIG
   );
 
   if (parsedArgs.flags['--help']) {
-    telemetry.trackCliFlagHelp('git', subcommand);
-    output.print(help(gitCommand, { columns: client.stderr.columns }));
-    return 2;
+    // `vc git --help` or `vc git connect --help` etc – keep explicit help for subcommands
+    // If user did `vc git push --help`, we should pass through to git, not intercept.
+    // Only intercept help when subcommand is known or no git passthrough intent.
+    const isPassthrough = subcommand === undefined;
+    if (!isPassthrough) {
+      telemetry.trackCliFlagHelp('git', subcommand);
+      output.print(help(gitCommand, { columns: client.stderr.columns }));
+      return 2;
+    }
+    // else fall through to passthrough – it will run `git push --help` natively
   }
 
   switch (subcommand) {
@@ -51,9 +73,37 @@ export default async function main(client: Client) {
     case 'disconnect':
       telemetry.trackCliSubcommandDisconnect(subcommandOriginal);
       return disconnect(client, args);
-    default:
-      output.error(getInvalidSubcommand(COMMAND_CONFIG));
-      output.print(help(gitCommand, { columns: client.stderr.columns }));
-      return 2;
+    default: {
+      // Not a known subcommand: treat as git passthrough
+      // rawAfterGit is pure git args (wrapper flags like --no-attach already
+      // extracted into parsedArgs.flags by parseArguments because they are defined
+      // in gitCommand.options).
+      const isPush = rawAfterGit[0] === 'push';
+
+      // Track passthrough telemetry
+      try {
+        (telemetry as any).trackCliSubcommandPassthrough?.(
+          rawAfterGit[0] || 'unknown'
+        );
+      } catch {}
+      if (isPush) {
+        telemetry.trackCliFlagNoAttach(
+          Boolean(parsedArgs.flags['--no-attach'])
+        );
+        telemetry.trackCliFlagLogs(Boolean(parsedArgs.flags['--logs']));
+        telemetry.trackCliFlagNoLogs(Boolean(parsedArgs.flags['--no-logs']));
+      }
+
+      const wrapperOpts = {
+        noAttach: Boolean(parsedArgs.flags['--no-attach']),
+        logs: Boolean(parsedArgs.flags['--logs']),
+        noLogs: Boolean(parsedArgs.flags['--no-logs']),
+      };
+
+      const result = await passthrough(client, rawAfterGit as string[], wrapperOpts);
+
+      // Return git's exit code directly to preserve plumbing expectations
+      return result;
+    }
   }
 }

--- a/packages/cli/src/commands/git/passthrough.ts
+++ b/packages/cli/src/commands/git/passthrough.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import chalk from 'chalk';
+import ms from 'ms';
 import { relative } from 'path';
 import type Client from '../../util/client';
 import { getRepoLink, findProjectsFromPath } from '../../util/link/repo';
@@ -109,16 +110,17 @@ async function spawnGit(
   return { exitCode, usedShas };
 }
 
-async function tryGetRefShas(
-  cwd: string
-): Promise<Map<string, string>> {
+async function tryGetRefShas(cwd: string): Promise<Map<string, string>> {
   const { execSync } = await import('child_process');
   try {
-    const out = execSync('git for-each-ref --format="%(refname) %(objectname)" refs/heads', {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
+    const out = execSync(
+      'git for-each-ref --format="%(refname) %(objectname)" refs/heads',
+      {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }
+    );
     const map = new Map<string, string>();
     for (const line of out.trim().split('\n')) {
       if (!line.trim()) continue;
@@ -160,9 +162,7 @@ async function tryGetCurrentBranch(cwd: string): Promise<string | undefined> {
   }
 }
 
-async function resolveAllLinkedProjects(
-  client: Client
-): Promise<{
+async function resolveAllLinkedProjects(client: Client): Promise<{
   repoRoot: string;
   projects: ProjectWithMeta[];
   cwdRelativePath: string;
@@ -292,7 +292,12 @@ async function findLatestGitDeploymentForProject(
           continue;
         }
         // Only consider git-triggered deployments, unless user manually triggered but with same sha
-        if (dep.source && dep.source !== 'git' && dep.source !== 'import/repo' && dep.source !== 'clone/repo') {
+        if (
+          dep.source &&
+          dep.source !== 'git' &&
+          dep.source !== 'import/repo' &&
+          dep.source !== 'clone/repo'
+        ) {
           // allow if sha matches anyway (e.g., cli deployment from same sha? we still want to show)
           // but prefer git
         }
@@ -341,7 +346,9 @@ async function pollForProjectsDeployments(opts: {
   const found = new Map<string, Deployment>();
 
   // initial banner
-  output.log(`Triggered git push. Polling ${projects.length} linked project${projects.length === 1 ? '' : 's'} for new deployments...`);
+  output.log(
+    `Triggered git push. Polling ${projects.length} linked project${projects.length === 1 ? '' : 's'} for new deployments...`
+  );
 
   // Determine "current" project(s) based on cwd match using findProjectsFromPath logic
   const cwdMatchedIds = new Set(
@@ -352,8 +359,9 @@ async function pollForProjectsDeployments(opts: {
   while (Date.now() < deadline && pending.size > 0) {
     const checks = Array.from(pending.values()).map(async proj => {
       // Ensure team context for fetch
-      client.config.currentTeam =
-        proj.orgIdResolved.startsWith('team_') ? proj.orgIdResolved : undefined;
+      client.config.currentTeam = proj.orgIdResolved.startsWith('team_')
+        ? proj.orgIdResolved
+        : undefined;
       const dep = await findLatestGitDeploymentForProject(
         client,
         proj,
@@ -371,7 +379,8 @@ async function pollForProjectsDeployments(opts: {
         found.set(proj.id, dep);
         pending.delete(proj.id);
         const url = dep.url ? `https://${dep.url}` : dep.id;
-        const targetLabel = dep.target === 'production' ? 'Production' : dep.target || 'Preview';
+        const targetLabel =
+          dep.target === 'production' ? 'Production' : dep.target || 'Preview';
         const orgSlug = proj.orgSlug ? `${proj.orgSlug}/` : '';
         output.print(
           `${prependEmoji(
@@ -413,6 +422,202 @@ async function pollForProjectsDeployments(opts: {
   return { found, cwdMatchedIds };
 }
 
+function formatAge(createdAt?: number): string {
+  if (!createdAt) return '';
+  const age = Date.now() - createdAt;
+  if (age < 0) return 'now';
+  if (age < 1000) return 'just now';
+  return ms(age) + ' ago';
+}
+
+function deploymentStateIcon(state?: string): {
+  icon: string;
+  color: (s: string) => string;
+} {
+  switch (state) {
+    case 'READY':
+      return { icon: '●', color: chalk.green };
+    case 'ERROR':
+      return { icon: '●', color: chalk.red };
+    case 'BUILDING':
+    case 'INITIALIZING':
+    case 'QUEUED':
+      return { icon: '●', color: chalk.yellow };
+    case 'CANCELED':
+      return { icon: '○', color: chalk.gray };
+    default:
+      return { icon: '○', color: chalk.gray };
+  }
+}
+
+function getBranchFromDeployment(dep: Deployment): string | undefined {
+  // gitSource.ref is often like "refs/heads/<branch>" or just "<branch>"
+  // gitSource.slug is usually branch name for PRs; sourceRef branch in some APIs
+  const raw =
+    dep.gitSource?.ref ||
+    dep.gitSource?.slug ||
+    (dep as any)?.sourceCommit?.ref ||
+    dep.meta?.githubCommitRef ||
+    dep.meta?.gitlabCommitRef;
+  if (!raw) return undefined;
+  return raw.replace(/^refs\/heads\//, '');
+}
+
+async function fetchLatestDeploymentsForBranch(
+  client: Client,
+  project: ProjectWithMeta,
+  branch: string | undefined,
+  limit = 5
+): Promise<Deployment[]> {
+  const query = new URLSearchParams({
+    projectId: project.id,
+    limit: String(limit),
+  });
+  try {
+    for await (const chunk of client.fetchPaginated<{
+      deployments: Deployment[];
+    }>(`/v6/deployments?${query}`, {
+      accountId: project.orgIdResolved,
+    })) {
+      if (!branch) {
+        // No branch filter, return whatever we got (newest first)
+        return chunk.deployments;
+      }
+      const filtered = chunk.deployments.filter(d => {
+        const b = getBranchFromDeployment(d);
+        if (!b) {
+          // If no branch info but source=git and we have no other heuristic,
+          // include it if it's very recent? For status summary we prefer branch match.
+          // Still include if source !== 'git' is false? Simpler: exclude when branch requested.
+          return false;
+        }
+        return b === branch;
+      });
+      if (filtered.length > 0) {
+        return filtered;
+      }
+      // If first page had zero matches for this branch, try one more page before giving up
+      // (keep loop by returning [] and letting caller decide, but we break after 2 pages anyway)
+      // Fall back to unfiltered if nothing matched at all after scanning?
+      // For UX we show nothing rather than wrong branch.
+      // Continue to next chunk only if we explicitly want deeper scan – we keep to 2 pages.
+      // So break here to avoid unnecessary fetching when likely no deployment.
+      const hasBranchInChunk = chunk.deployments.some(d =>
+        Boolean(getBranchFromDeployment(d))
+      );
+      if (!hasBranchInChunk) {
+        // chunk had no branch info at all – likely API shape change, return raw
+        return chunk.deployments;
+      }
+      // else chunk had branch info but none matched → try one more page
+      // by fetching again outside loop we already break after 1 iteration in current paginated impl,
+      // so just return filtered (empty).
+      return filtered;
+    }
+  } catch (err) {
+    output.debug(
+      `failed to fetch branch deployments for ${project.name}: ${err}`
+    );
+  }
+  return [];
+}
+
+async function showBranchDeploymentSummary(opts: {
+  client: Client;
+  projects: ProjectWithMeta[];
+  cwdRelativePath: string;
+  branch: string | undefined;
+  headSha?: string;
+}) {
+  const { client, projects, cwdRelativePath, branch, headSha } = opts;
+
+  // Determine cwd-matched projects (deepest)
+  const cwdMatched = findProjectsFromPath(projects, cwdRelativePath);
+  // If cwd is repo root and projects are all in subdirs with directory '.'? Then findProjects returns all '.'?
+  // findProjectsFromPath returns matches for '.' as any path, so root will match all root-dir projects.
+  // That's fine: we show summary for all when at root, or filtered when inside subdir.
+
+  const projectsToShow = cwdMatched.length > 0 ? cwdMatched : projects;
+
+  if (projectsToShow.length === 0) return;
+
+  const titleBranch = branch ? chalk.bold(branch) : chalk.dim('current branch');
+  output.print(`\n${chalk.bold('Vercel Deployments')} for ${titleBranch}`);
+  if (headSha) {
+    output.print(` ${chalk.dim(headSha.slice(0, 7))}`);
+  }
+  output.print(`\n`);
+
+  // Sort by directory depth for stable display (shallow first, then alpha)
+  const sorted = [...projectsToShow].sort((a, b) => {
+    const da = a.directory.split('/').length;
+    const db = b.directory.split('/').length;
+    if (da !== db) return da - db;
+    return a.name.localeCompare(b.name);
+  });
+
+  const results = await Promise.all(
+    sorted.map(async proj => {
+      client.config.currentTeam = proj.orgIdResolved.startsWith('team_')
+        ? proj.orgIdResolved
+        : undefined;
+      const deps = await fetchLatestDeploymentsForBranch(
+        client,
+        proj,
+        branch,
+        5
+      );
+      return { proj, deps };
+    })
+  );
+
+  let anyDeploys = false;
+  for (const { proj, deps } of results) {
+    const orgSlug = proj.orgSlug ? `${proj.orgSlug}/` : '';
+    const header = `${chalk.bold(orgSlug + proj.name)} ${chalk.dim(`(${proj.directory})`)}`;
+    if (deps.length === 0) {
+      output.print(
+        `  ${chalk.dim('–')} ${header} ${chalk.dim(branch ? `no deployments for ${branch}` : 'no deployments')}\n`
+      );
+      continue;
+    }
+    anyDeploys = true;
+    output.print(`  ${header}\n`);
+    for (const dep of deps) {
+      const { icon, color } = deploymentStateIcon(dep.readyState);
+      const target =
+        dep.target === 'production' ? 'Production' : dep.target || 'Preview';
+      const url = dep.url ? `https://${dep.url}` : dep.id;
+      const shaShort =
+        dep.gitSource?.sha?.slice(0, 7) ||
+        dep.meta?.githubCommitSha?.slice(0, 7) ||
+        '';
+      const isHead = Boolean(
+        headSha && shaShort && headSha.startsWith(shaShort)
+      );
+      const age = formatAge(dep.createdAt);
+      output.print(
+        `    ${color(icon)} ${chalk.dim(`[${dep.readyState || 'UNKNOWN'}]`)} ${chalk.cyan(url)} ${chalk.dim(target)}${shaShort ? ` ${chalk.dim(shaShort)}` : ''}${isHead ? chalk.green(' ← HEAD') : ''} ${chalk.dim(age)}\n`
+      );
+      if (dep.inspectorUrl) {
+        output.print(
+          `      ${chalk.dim('Inspect:')} ${chalk.cyan(dep.inspectorUrl)}\n`
+        );
+      }
+    }
+  }
+
+  if (!anyDeploys) {
+    output.print(
+      `\n  ${chalk.dim(`No deployments found. Push to trigger one, or run ${chalk.cyan('vc deploy')} for manual.`)}\n`
+    );
+  } else {
+    output.print(
+      `\n  ${chalk.dim(`Run ${chalk.cyan('vc ls')} or ${chalk.cyan('vc inspect <url>')} for more details.`)}\n`
+    );
+  }
+}
+
 async function streamDeploymentUntilReady(
   client: Client,
   deployment: Deployment,
@@ -445,7 +650,6 @@ async function streamDeploymentUntilReady(
   }
 
   // Poll readyState
-  const contextName = project.orgSlug || project.orgIdResolved;
   while (true) {
     // We need getDeployment utility; avoid import cycle by fetching directly
     try {
@@ -550,7 +754,9 @@ export default async function gitPassthrough(
 
   if (gitArgs.length === 0) {
     // show help if bare `vc git`
-    output.print(`Usage: vc git <git-args>  (passthrough) or vc git connect|disconnect\n`);
+    output.print(
+      `Usage: vc git <git-args>  (passthrough) or vc git connect|disconnect\n`
+    );
     return 2;
   }
 
@@ -577,14 +783,39 @@ export default async function gitPassthrough(
     return 1;
   }
 
-  // If not push, or git failed, or --no-attach, just return git exit code
-  if (!push || gitExit !== 0 || wrapperFlags.noAttach) {
-    if (!push && gitExit === 0) {
-      // optionally hint
-      if (gitArgs[0] !== 'push') {
-        output.debug(`git ${gitArgs.join(' ')} completed (exit ${gitExit}), no deployment polling`);
+  const isStatus = gitArgs[0] === 'status';
+
+  // If not push, handle status summary before returning
+  if (!push) {
+    if (gitExit === 0 && isStatus) {
+      // Don't block on summary errors — always preserve git exit code
+      try {
+        const branch = await tryGetCurrentBranch(client.cwd).catch(
+          () => undefined
+        );
+        const headSha = await tryGetHeadSha(client.cwd).catch(() => undefined);
+        const repoInfo = await resolveAllLinkedProjects(client);
+        if (repoInfo) {
+          await showBranchDeploymentSummary({
+            client,
+            projects: repoInfo.projects,
+            cwdRelativePath: repoInfo.cwdRelativePath,
+            branch,
+            headSha,
+          });
+        }
+      } catch (e) {
+        output.debug(`status deployment summary failed: ${e}`);
       }
+    } else if (gitExit === 0) {
+      output.debug(
+        `git ${gitArgs.join(' ')} completed (exit ${gitExit}), no deployment polling`
+      );
     }
+    return gitExit;
+  }
+
+  if (gitExit !== 0 || wrapperFlags.noAttach) {
     return gitExit;
   }
 
@@ -636,7 +867,9 @@ export default async function gitPassthrough(
     const candidates = Array.from(cwdMatchedIds)
       .map(id => projects.find(p => p.id === id)!)
       .filter(Boolean)
-      .sort((a, b) => b.directory.split('/').length - a.directory.split('/').length);
+      .sort(
+        (a, b) => b.directory.split('/').length - a.directory.split('/').length
+      );
     for (const c of candidates) {
       if (found.has(c.id)) {
         primaryProjectId = c.id;

--- a/packages/cli/src/commands/git/passthrough.ts
+++ b/packages/cli/src/commands/git/passthrough.ts
@@ -1,0 +1,706 @@
+import { spawn } from 'child_process';
+import chalk from 'chalk';
+import { relative } from 'path';
+import type Client from '../../util/client';
+import { getRepoLink, findProjectsFromPath } from '../../util/link/repo';
+import type { RepoProjectConfig } from '../../util/link/repo';
+import { normalizePath } from '@vercel/build-utils';
+import type { Deployment } from '@vercel-internals/types';
+import getOrgById from '../../util/projects/get-org-by-id';
+import output from '../../output-manager';
+import { printDeploymentStatus } from '../../util/deploy/print-deployment-status';
+import { displayBuildLogs } from '../../util/logs';
+import stamp from '../../util/output/stamp';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import link from '../../util/output/link';
+import sleepLib from '../../util/sleep';
+import { prependEmoji } from '../../util/emoji';
+
+const GIT_TRIGGER_TIMEOUT_MS = 120_000; // 2 minutes to notice new git deployment
+const GIT_POLL_INTERVAL_MS = 3_000;
+const READY_POLL_INTERVAL_MS = 3_000;
+
+interface ProjectWithMeta extends RepoProjectConfig {
+  orgIdResolved: string;
+  orgSlug?: string;
+}
+
+interface PushInfo {
+  targetBranch?: string;
+  targetSha?: string;
+  remoteName?: string;
+}
+
+function isPushArgs(args: string[]): boolean {
+  if (args.length === 0) return false;
+  // first non-flag arg should be "push" or implicit if first arg starts with flag? We support `vc git push ...`
+  // args arriving here are already sliced past `git` subcommand routing — i.e. original cli argv past `... git`
+  // Examples: ["push"], ["push","origin","main"], ["push","--force"]
+  // Ignore if it starts with known subcommands that we handle explicitly.
+  const knownSub = new Set(['connect', 'disconnect']);
+  if (knownSub.has(args[0])) return false;
+  return args[0] === 'push';
+}
+
+function parsePushInfo(args: string[]): PushInfo {
+  // very lightweight: try to extract remote and branch from `git push [remote] [branch]`
+  // ignores most flags
+  const info: PushInfo = {};
+  const positional: string[] = [];
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith('-')) {
+      // --set-upstream, -u takes next arg
+      if (a === '-u' || a === '--set-upstream') {
+        i++; // skip remote
+        if (i < args.length) positional.push(args[i]);
+        i++;
+        if (i < args.length) positional.push(args[i]);
+        i--;
+        continue;
+      }
+      if (a.includes('=')) continue;
+      // flags with no value or single dash combined
+      continue;
+    }
+    positional.push(a);
+  }
+  if (positional[0]) info.remoteName = positional[0];
+  if (positional[1]) {
+    // could be refspec like HEAD:main or main or refs/heads/main:refs/heads/main
+    const branch = positional[1].split(':').pop() || positional[1];
+    info.targetBranch = branch.replace(/^refs\/heads\//, '');
+  }
+  return info;
+}
+
+async function spawnGit(
+  client: Client,
+  gitArgs: string[]
+): Promise<{ exitCode: number; usedShas: Set<string> }> {
+  // We attempt to pre-capture SHAs before and after to diff, but primary flow uses rev-parse
+  const beforeShas = await tryGetRefShas(client.cwd).catch(() => new Map());
+  const exitCode = await new Promise<number>((resolveExit, reject) => {
+    const child = spawn('git', gitArgs, {
+      cwd: client.cwd,
+      stdio: 'inherit',
+      env: process.env,
+    });
+    child.on('error', err => {
+      reject(err);
+    });
+    child.on('close', code => {
+      resolveExit(code ?? 0);
+    });
+  });
+  const afterShas = await tryGetRefShas(client.cwd).catch(() => new Map());
+  const usedShas = new Set<string>();
+  for (const [ref, sha] of afterShas) {
+    const before = beforeShas.get(ref);
+    if (before !== sha) {
+      usedShas.add(sha);
+    }
+  }
+  // If we couldn't diff, fall back to HEAD
+  if (usedShas.size === 0) {
+    const head = await tryGetHeadSha(client.cwd).catch(() => undefined);
+    if (head) usedShas.add(head);
+  }
+  return { exitCode, usedShas };
+}
+
+async function tryGetRefShas(
+  cwd: string
+): Promise<Map<string, string>> {
+  const { execSync } = await import('child_process');
+  try {
+    const out = execSync('git for-each-ref --format="%(refname) %(objectname)" refs/heads', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const map = new Map<string, string>();
+    for (const line of out.trim().split('\n')) {
+      if (!line.trim()) continue;
+      const [ref, sha] = line.trim().split(' ');
+      if (ref && sha) map.set(ref, sha);
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+async function tryGetHeadSha(cwd: string): Promise<string | undefined> {
+  const { execSync } = await import('child_process');
+  try {
+    const sha = execSync('git rev-parse HEAD', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return sha || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function tryGetCurrentBranch(cwd: string): Promise<string | undefined> {
+  const { execSync } = await import('child_process');
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!branch || branch === 'HEAD') return undefined;
+    return branch;
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveAllLinkedProjects(
+  client: Client
+): Promise<{
+  repoRoot: string;
+  projects: ProjectWithMeta[];
+  cwdRelativePath: string;
+} | null> {
+  const repoLink = await getRepoLink(client, client.cwd);
+  if (repoLink?.repoConfig?.projects?.length) {
+    const cwdRelative = normalizePath(
+      relative(repoLink.rootPath, client.cwd) || '.'
+    );
+
+    const allProjects: ProjectWithMeta[] = [];
+    for (const p of repoLink.repoConfig.projects) {
+      const orgId = p.orgId ?? repoLink.repoConfig.orgId;
+      if (!orgId) continue;
+      allProjects.push({
+        ...p,
+        orgIdResolved: orgId,
+      });
+    }
+
+    // resolve org slugs in parallel (best-effort)
+    await Promise.all(
+      allProjects.map(async proj => {
+        try {
+          const org = await getOrgById(client, proj.orgIdResolved);
+          if (org) proj.orgSlug = org.slug;
+        } catch {
+          // ignore
+        }
+      })
+    );
+
+    return {
+      repoRoot: repoLink.rootPath,
+      projects: allProjects,
+      cwdRelativePath: cwdRelative,
+    };
+  }
+
+  // Fallback: single project linked via .vercel/project.json (no repo.json yet)
+  // This still "works from anywhere in this repo" because we traverse up for .vercel
+  try {
+    const { getLinkedProject } = await import('../../util/projects/link');
+    const { findRepoRoot } = await import('../../util/link/repo');
+    const linked = await getLinkedProject(client, client.cwd);
+    if (linked.status === 'linked') {
+      const { org, project } = linked;
+      const repoRoot = (await findRepoRoot(client.cwd)) || client.cwd;
+      const cwdRelative = normalizePath(relative(repoRoot, client.cwd) || '.');
+      const dir = normalizePath(project.rootDirectory || '.');
+      const meta: ProjectWithMeta = {
+        id: project.id,
+        name: project.name,
+        directory: dir,
+        orgId: org.id,
+        orgIdResolved: org.id,
+        orgSlug: org.slug,
+      };
+      return {
+        repoRoot,
+        projects: [meta],
+        cwdRelativePath: cwdRelative,
+      };
+    }
+  } catch (e) {
+    output.debug(`fallback linked project resolve failed: ${e}`);
+  }
+
+  return null;
+}
+
+function isMatchingDeploymentForSha(
+  dep: Deployment,
+  shas: Set<string>,
+  branchHint?: string
+): boolean {
+  // Git deployments from Vercel have source='git', gitSource.sha, gitSource.ref
+  // Some deployments may not populate gitSource immediately, so we also check meta/githubCommitSha.
+  const gitSha =
+    dep.gitSource?.sha ||
+    (dep.meta as any)?.githubCommitSha ||
+    (dep.meta as any)?.gitlabCommitSha ||
+    (dep.meta as any)?.bitbucketCommitSha;
+  const gitRef = dep.gitSource?.ref || dep.gitSource?.slug;
+
+  if (gitSha && shas.has(gitSha)) return true;
+
+  // If we have branch hint but no sha yet, accept any git source deployment on that branch recently created
+  if (branchHint && gitRef && dep.source === 'git') {
+    if (gitRef === branchHint) return true;
+    // some refs are full like refs/heads/main
+    if (gitRef.endsWith(`/${branchHint}`)) return true;
+  }
+
+  // Fallback: accept any deployment with source === 'git' created very recently (within polling window)
+  // We filter by recency outside
+  return false;
+}
+
+async function findLatestGitDeploymentForProject(
+  client: Client,
+  project: ProjectWithMeta,
+  shas: Set<string>,
+  branchHint: string | undefined,
+  since: number
+): Promise<Deployment | null> {
+  // Fetch recent deployments for project; rely on /v6/deployments?projectId=
+  const query = new URLSearchParams({
+    projectId: project.id,
+    limit: '20',
+  });
+  // We keep team context via currentTeam set by caller, but also pass accountId to client if needed
+  // fetchPaginated will include teamId automatically via client
+  try {
+    for await (const chunk of client.fetchPaginated<{
+      deployments: Deployment[];
+    }>(`/v6/deployments?${query}`, {
+      accountId: project.orgIdResolved,
+    })) {
+      for (const dep of chunk.deployments) {
+        if (!dep.createdAt || dep.createdAt < since - 10_000) {
+          // deployments sorted newest first; if we pass the window we can stop scanning chunk likely
+          // but continue a bit for safety
+        }
+        if (dep.createdAt && dep.createdAt < since - 600_000) {
+          // older than 10 min before push -> ignore
+          continue;
+        }
+        // Only consider git-triggered deployments, unless user manually triggered but with same sha
+        if (dep.source && dep.source !== 'git' && dep.source !== 'import/repo' && dep.source !== 'clone/repo') {
+          // allow if sha matches anyway (e.g., cli deployment from same sha? we still want to show)
+          // but prefer git
+        }
+
+        if (isMatchingDeploymentForSha(dep, shas, branchHint)) {
+          return dep;
+        }
+
+        // Heuristic: if deployment is extremely recent (<2m) and git source and branch matches hint, take it even without sha match
+        if (
+          branchHint &&
+          dep.source === 'git' &&
+          dep.createdAt >= since - 5_000 &&
+          dep.gitSource?.ref
+        ) {
+          const ref = dep.gitSource.ref;
+          if (ref === branchHint || ref.endsWith(`/${branchHint}`)) {
+            // If we haven't seen sha yet due to race, allow
+            if (shas.size === 0 || !dep.gitSource?.sha) return dep;
+          }
+        }
+      }
+      // only first page needed typically; but allow 2 pages
+      break;
+    }
+  } catch (err) {
+    output.debug(`failed to fetch deployments for ${project.name}: ${err}`);
+  }
+  return null;
+}
+
+async function pollForProjectsDeployments(opts: {
+  client: Client;
+  projects: ProjectWithMeta[];
+  shas: Set<string>;
+  branchHint?: string;
+  cwdRelativePath: string;
+}) {
+  const { client, projects, shas, branchHint, cwdRelativePath } = opts;
+  const since = Date.now();
+  const deadline = since + GIT_TRIGGER_TIMEOUT_MS;
+
+  const pending = new Map<string, ProjectWithMeta>(
+    projects.map(p => [p.id, p])
+  );
+  const found = new Map<string, Deployment>();
+
+  // initial banner
+  output.log(`Triggered git push. Polling ${projects.length} linked project${projects.length === 1 ? '' : 's'} for new deployments...`);
+
+  // Determine "current" project(s) based on cwd match using findProjectsFromPath logic
+  const cwdMatchedIds = new Set(
+    findProjectsFromPath(projects, cwdRelativePath).map(p => p.id)
+  );
+
+  // Poll loop
+  while (Date.now() < deadline && pending.size > 0) {
+    const checks = Array.from(pending.values()).map(async proj => {
+      // Ensure team context for fetch
+      client.config.currentTeam =
+        proj.orgIdResolved.startsWith('team_') ? proj.orgIdResolved : undefined;
+      const dep = await findLatestGitDeploymentForProject(
+        client,
+        proj,
+        shas,
+        branchHint,
+        since
+      );
+      return { proj, dep };
+    });
+
+    const results = await Promise.all(checks);
+
+    for (const { proj, dep } of results) {
+      if (dep) {
+        found.set(proj.id, dep);
+        pending.delete(proj.id);
+        const url = dep.url ? `https://${dep.url}` : dep.id;
+        const targetLabel = dep.target === 'production' ? 'Production' : dep.target || 'Preview';
+        const orgSlug = proj.orgSlug ? `${proj.orgSlug}/` : '';
+        output.print(
+          `${prependEmoji(
+            `${chalk.bold(orgSlug + proj.name)} (${proj.directory}) → ${targetLabel}: ${chalk.cyan(url)} ${chalk.dim(`[${dep.readyState}]`)}`,
+            dep.readyState === 'READY' ? 'success' : 'notice'
+          )}\n`
+        );
+        if (dep.inspectorUrl) {
+          printAlignedLabel('Inspect', chalk.cyan(dep.inspectorUrl));
+        }
+        // Link print
+        if (dep.url) {
+          const nice = `https://${dep.url}`;
+          output.debug(`deployment link: ${nice}`);
+        }
+      }
+    }
+
+    if (pending.size === 0) break;
+
+    await sleepLib(GIT_POLL_INTERVAL_MS);
+  }
+
+  if (pending.size > 0) {
+    for (const proj of pending.values()) {
+      output.print(
+        `${chalk.dim('–')} ${chalk.bold(proj.name)} (${proj.directory}) ${chalk.dim('no new deployment detected (may be ignored by git config / no changes)')}\n`
+      );
+    }
+  }
+
+  // Now decide logs
+  // Logic: only stream logs if cwd is inside a given project, and that project has a deployment found and is building.
+  // If multiple cwdMatched, pick the deepest.
+  if (found.size === 0) {
+    return { found, cwdMatchedIds };
+  }
+
+  return { found, cwdMatchedIds };
+}
+
+async function streamDeploymentUntilReady(
+  client: Client,
+  deployment: Deployment,
+  project: ProjectWithMeta,
+  shouldStreamLogs: boolean
+): Promise<Deployment> {
+  let current = deployment;
+  const deployStamp = stamp();
+  // set currentTeam appropriately
+  client.config.currentTeam = project.orgIdResolved.startsWith('team_')
+    ? project.orgIdResolved
+    : undefined;
+
+  let abortController: AbortController | undefined;
+  if (shouldStreamLogs) {
+    try {
+      const { promise, abortController: ac } = displayBuildLogs(
+        client,
+        current,
+        true
+      );
+      abortController = ac;
+      // don't await yet – we will poll status alongside
+      promise.catch(e => {
+        output.debug(`log stream error for ${project.name}: ${e}`);
+      });
+    } catch (e) {
+      output.debug(`failed to start log stream: ${e}`);
+    }
+  }
+
+  // Poll readyState
+  const contextName = project.orgSlug || project.orgIdResolved;
+  while (true) {
+    // We need getDeployment utility; avoid import cycle by fetching directly
+    try {
+      const fresh = await client.fetch<Deployment>(
+        `/v13/deployments/${encodeURIComponent(current.id)}`,
+        { accountId: project.orgIdResolved }
+      );
+      current = fresh;
+      const state = current.readyState;
+      if (state === 'READY' || state === 'ERROR' || state === 'CANCELED') {
+        break;
+      }
+      // update spinner-like line? reuse printAlignedLabel? Instead just debug spinner
+      output.spinner(
+        `Building ${chalk.bold(project.name)} ${chalk.dim(`[${state}]`)}`
+      );
+    } catch (e) {
+      output.debug(`failed to poll deployment ${current.id}: ${e}`);
+    }
+    await sleepLib(READY_POLL_INTERVAL_MS);
+  }
+
+  if (abortController) {
+    try {
+      abortController.abort();
+    } catch {}
+    output.stopSpinner();
+  } else {
+    output.stopSpinner();
+  }
+
+  // print final status similar to vc deploy output
+  try {
+    await printDeploymentStatus(
+      client,
+      {
+        readyState: current.readyState,
+        alias: (current as any).alias || [],
+        aliasError: (current as any).aliasError,
+        target: current.target || 'preview',
+        indications: [],
+        url: current.url,
+        aliasWarning: (current as any).aliasWarning,
+      },
+      deployStamp,
+      false,
+      false,
+      false
+    );
+  } catch {
+    // fallback minimal
+    output.print(
+      `\n${current.readyState === 'READY' ? chalk.green('✓') : chalk.red('✗')} ${chalk.bold(
+        project.name
+      )} ${chalk.dim(current.readyState)} ${chalk.cyan(
+        `https://${current.url}`
+      )}\n`
+    );
+  }
+
+  // Inspector link already printed by printDeploymentStatus? Print anyway
+  if (current.inspectorUrl) {
+    output.print(`  Inspect: ${link(current.inspectorUrl)}\n`);
+  }
+
+  return current;
+}
+
+export default async function gitPassthrough(
+  client: Client,
+  rawArgs: string[],
+  wrapperOpts?: { noAttach?: boolean; logs?: boolean; noLogs?: boolean }
+): Promise<number> {
+  // rawArgs = argv sliced after `git`, e.g. ["push"] or ["status"] etc.
+  // Wrapper flags (--no-attach, --logs, --no-logs) are parsed by the parent
+  // command (git/index.ts) via getFlagsSpecification. For backwards compat,
+  // also support manual extraction if caller passes them in rawArgs.
+  const wrapperFlags = {
+    noAttach: Boolean(wrapperOpts?.noAttach),
+    logs: Boolean(wrapperOpts?.logs),
+    noLogs: Boolean(wrapperOpts?.noLogs),
+  };
+  const gitArgs: string[] = [];
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    if (!wrapperOpts) {
+      if (arg === '--no-attach') {
+        wrapperFlags.noAttach = true;
+        continue;
+      }
+      if (arg === '--logs' || arg === '-l') {
+        wrapperFlags.logs = true;
+        continue;
+      }
+      if (arg === '--no-logs') {
+        wrapperFlags.noLogs = true;
+        continue;
+      }
+    }
+    gitArgs.push(arg);
+  }
+
+  if (gitArgs.length === 0) {
+    // show help if bare `vc git`
+    output.print(`Usage: vc git <git-args>  (passthrough) or vc git connect|disconnect\n`);
+    return 2;
+  }
+
+  const push = isPushArgs(gitArgs);
+  const pushInfo = push ? parsePushInfo(gitArgs) : {};
+  let branchHint = pushInfo.targetBranch;
+  if (push && !branchHint) {
+    branchHint = await tryGetCurrentBranch(client.cwd).catch(() => undefined);
+  }
+
+  // Run git
+  let shas = new Set<string>();
+  let gitExit: number;
+  try {
+    const res = await spawnGit(client, gitArgs);
+    gitExit = res.exitCode;
+    shas = res.usedShas;
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') {
+      output.error('Git is not installed or not found in PATH.');
+      return 1;
+    }
+    output.error(`Failed to run git: ${err?.message || String(err)}`);
+    return 1;
+  }
+
+  // If not push, or git failed, or --no-attach, just return git exit code
+  if (!push || gitExit !== 0 || wrapperFlags.noAttach) {
+    if (!push && gitExit === 0) {
+      // optionally hint
+      if (gitArgs[0] !== 'push') {
+        output.debug(`git ${gitArgs.join(' ')} completed (exit ${gitExit}), no deployment polling`);
+      }
+    }
+    return gitExit;
+  }
+
+  // Push succeeded: now find linked projects
+  const repoInfo = await resolveAllLinkedProjects(client);
+  if (!repoInfo) {
+    output.log(
+      chalk.dim(
+        `No linked Vercel projects found for this repository. Run ${chalk.cyan(
+          'vc link'
+        )} to link projects, or use ${chalk.cyan('vc deploy')} for manual deploys.`
+      )
+    );
+    return gitExit;
+  }
+
+  const { projects, cwdRelativePath } = repoInfo;
+
+  // Poll
+  const { found, cwdMatchedIds } = await pollForProjectsDeployments({
+    client,
+    projects,
+    shas,
+    branchHint,
+    cwdRelativePath,
+  });
+
+  if (found.size === 0) {
+    return gitExit;
+  }
+
+  // Show links already printed. Now handle log streaming.
+  // Determine if we should stream logs.
+  // Rules: show logs only if cwd is inside a linked project (cwdMatchedIds non-empty)
+  // AND that project's deployment is building/queued.
+  // --logs forces it for cwd-matched project even if maybe not building? we still stream if building.
+  // --no-logs disables.
+  const shouldAutoLog = cwdMatchedIds.size > 0 && !wrapperFlags.noLogs;
+  const shouldForceLog = wrapperFlags.logs && cwdMatchedIds.size > 0;
+
+  if (wrapperFlags.noLogs) {
+    return gitExit;
+  }
+
+  // Pick project to stream: deepest matching cwd project that has deployment
+  let primaryProjectId: string | undefined;
+  if (cwdMatchedIds.size > 0) {
+    // sort by directory depth desc
+    const candidates = Array.from(cwdMatchedIds)
+      .map(id => projects.find(p => p.id === id)!)
+      .filter(Boolean)
+      .sort((a, b) => b.directory.split('/').length - a.directory.split('/').length);
+    for (const c of candidates) {
+      if (found.has(c.id)) {
+        primaryProjectId = c.id;
+        break;
+      }
+    }
+    // If --logs forced but no deployment yet for cwd project, we already would have shown no deployment message.
+    // No extra work.
+  }
+
+  // If no cwd match but --logs was passed explicitly, warn?
+  if (wrapperFlags.logs && !primaryProjectId) {
+    output.warn(
+      `No deployment is attached to the current directory (cwd: ${chalk.dim(
+        cwdRelativePath
+      )}). Build logs are only shown when cwd is inside a linked project directory.`
+    );
+    return gitExit;
+  }
+
+  if (!primaryProjectId) {
+    // No cwd-matched deployment to tail, just exit. Links already shown.
+    return gitExit;
+  }
+
+  const primaryProj = projects.find(p => p.id === primaryProjectId)!;
+  const primaryDep = found.get(primaryProjectId)!;
+
+  // If deployment is already done and user didn't force logs, skip streaming
+  if (
+    (primaryDep.readyState === 'READY' ||
+      primaryDep.readyState === 'ERROR' ||
+      primaryDep.readyState === 'CANCELED') &&
+    !shouldForceLog
+  ) {
+    // short-circuit still prints final status already done via pollFor...? It printed initial line but not full status. Print final.
+    if (primaryDep.readyState !== 'READY') {
+      output.print(
+        `${chalk.yellow('⚠')} ${chalk.bold(primaryProj.name)} deployment finished with ${primaryDep.readyState}\n`
+      );
+    }
+    return gitExit;
+  }
+
+  output.print('\n');
+  output.log(
+    `Attaching to deployment for ${chalk.bold(primaryProj.name)} ${chalk.dim(
+      `(${primaryProj.directory})`
+    )} — streaming build logs. ${chalk.dim('Ctrl+C to detach, deployment continues.')}`
+  );
+
+  try {
+    await streamDeploymentUntilReady(
+      client,
+      primaryDep,
+      primaryProj,
+      shouldAutoLog || shouldForceLog
+    );
+  } catch (err: any) {
+    output.debug(`stream failed: ${err?.stack || err}`);
+    // don't fail the git push exit code because deployment continues server-side
+  }
+
+  // For other projects, we already showed links; we don't stream them.
+
+  return gitExit;
+}

--- a/packages/cli/src/commands/git/passthrough.ts
+++ b/packages/cli/src/commands/git/passthrough.ts
@@ -15,15 +15,41 @@ import stamp from '../../util/output/stamp';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
 import link from '../../util/output/link';
 import sleepLib from '../../util/sleep';
-import { prependEmoji } from '../../util/emoji';
 
 const GIT_TRIGGER_TIMEOUT_MS = 120_000; // 2 minutes to notice new git deployment
 const GIT_POLL_INTERVAL_MS = 3_000;
 const READY_POLL_INTERVAL_MS = 3_000;
 
+// Keep API pressure bounded when a monorepo links dozens of projects.
+// 6 concurrent fetches is a good tradeoff: fast enough for 30 projects (~5 waves),
+// low enough to avoid 429s when every poll iteration fans out.
+const GIT_PROJECT_FETCH_CONCURRENCY = 6;
+const GIT_ORG_FETCH_CONCURRENCY = 6;
+
 interface ProjectWithMeta extends RepoProjectConfig {
   orgIdResolved: string;
   orgSlug?: string;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  fn: (item: T, index: number) => Promise<R>,
+  concurrency: number
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array(Math.min(concurrency, items.length))
+    .fill(0)
+    .map(async () => {
+      while (true) {
+        const i = next++;
+        if (i >= items.length) break;
+        results[i] = await fn(items[i], i);
+      }
+    });
+  await Promise.all(workers);
+  return results;
 }
 
 interface PushInfo {
@@ -183,21 +209,31 @@ async function resolveAllLinkedProjects(client: Client): Promise<{
       });
     }
 
-    // resolve org slugs in parallel (best-effort)
-    await Promise.all(
-      allProjects.map(async proj => {
+    // resolve org slugs with limited concurrency (best-effort) so 30 projects doesn't slam /v2/teams.
+    await mapWithConcurrency(
+      allProjects,
+      async proj => {
         try {
           const org = await getOrgById(client, proj.orgIdResolved);
           if (org) proj.orgSlug = org.slug;
         } catch {
           // ignore
         }
-      })
+      },
+      GIT_ORG_FETCH_CONCURRENCY
     );
+
+    // De-dupe by project id in case repo.json has duplicates; keep first occurrence.
+    const seen = new Set<string>();
+    const deduped = allProjects.filter(p => {
+      if (seen.has(p.id)) return false;
+      seen.add(p.id);
+      return true;
+    });
 
     return {
       repoRoot: repoLink.rootPath,
-      projects: allProjects,
+      projects: deduped,
       cwdRelativePath: cwdRelative,
     };
   }
@@ -345,59 +381,117 @@ async function pollForProjectsDeployments(opts: {
   );
   const found = new Map<string, Deployment>();
 
-  // initial banner
   output.log(
     `Triggered git push. Polling ${projects.length} linked project${projects.length === 1 ? '' : 's'} for new deployments...`
   );
 
-  // Determine "current" project(s) based on cwd match using findProjectsFromPath logic
   const cwdMatchedIds = new Set(
-    findProjectsFromPath(projects, cwdRelativePath).map(p => p.id)
+    (
+      findProjectsFromPath(
+        projects as unknown as RepoProjectConfig[],
+        cwdRelativePath
+      ) as unknown as ProjectWithMeta[]
+    ).map(p => p.id)
   );
 
-  // Poll loop
-  while (Date.now() < deadline && pending.size > 0) {
-    const checks = Array.from(pending.values()).map(async proj => {
-      // Ensure team context for fetch
-      client.config.currentTeam = proj.orgIdResolved.startsWith('team_')
-        ? proj.orgIdResolved
-        : undefined;
-      const dep = await findLatestGitDeploymentForProject(
-        client,
-        proj,
-        shas,
-        branchHint,
-        since
-      );
-      return { proj, dep };
-    });
+  const noticeTruncated = (n: number) => {
+    if (n <= 10) return;
+    // Don't spam: once up front is enough for 30-project case
+    output.print(
+      `  ${chalk.dim(`Tracking ${n} projects; showing links as they appear. Full list in Vercel dashboard.`)}\n`
+    );
+  };
+  noticeTruncated(projects.length);
 
-    const results = await Promise.all(checks);
+  // Poll loop: bounded concurrency so 30 projects doesn't 429.
+  // Also cap banner lines so 30 finds doesn't flood terminal.
+  let linesPrinted = 0;
+  const MAX_INLINE_PROJECTS = 12;
+  let deferredOverflow = 0;
 
-    for (const { proj, dep } of results) {
-      if (dep) {
-        found.set(proj.id, dep);
-        pending.delete(proj.id);
-        const url = dep.url ? `https://${dep.url}` : dep.id;
-        const targetLabel =
-          dep.target === 'production' ? 'Production' : dep.target || 'Preview';
-        const orgSlug = proj.orgSlug ? `${proj.orgSlug}/` : '';
+  const flushFound = (
+    items: Array<{ proj: ProjectWithMeta; dep: Deployment }>
+  ) => {
+    for (const { proj, dep } of items) {
+      found.set(proj.id, dep);
+      pending.delete(proj.id);
+      const url = dep.url ? `https://${dep.url}` : dep.id;
+      const targetLabel =
+        dep.target === 'production' ? 'Production' : dep.target || 'Preview';
+      const orgSlug = proj.orgSlug ? `${proj.orgSlug}/` : '';
+
+      const isProd = dep.target === 'production';
+      if (linesPrinted < MAX_INLINE_PROJECTS) {
+        if (isProd) {
+          printAlignedLabel(
+            'Production',
+            chalk.cyan(`https://${url.replace(/^https?:\/\//, '')}`),
+            { gutter: '▲' }
+          );
+        } else {
+          printAlignedLabel('Preview', chalk.cyan(url));
+        }
         output.print(
-          `${prependEmoji(
-            `${chalk.bold(orgSlug + proj.name)} (${proj.directory}) → ${targetLabel}: ${chalk.cyan(url)} ${chalk.dim(`[${dep.readyState}]`)}`,
-            dep.readyState === 'READY' ? 'success' : 'notice'
-          )}\n`
+          `  ${chalk.dim(`${orgSlug}${proj.name} (${proj.directory}) ${targetLabel} [${dep.readyState}]`)}\n`
         );
         if (dep.inspectorUrl) {
           printAlignedLabel('Inspect', chalk.cyan(dep.inspectorUrl));
         }
-        // Link print
-        if (dep.url) {
-          const nice = `https://${dep.url}`;
-          output.debug(`deployment link: ${nice}`);
-        }
+        linesPrinted++;
+      } else {
+        deferredOverflow++;
       }
+      output.debug(`deployment link: ${url}`);
     }
+    if (deferredOverflow > 0 && pending.size === 0) {
+      // Final overflow summary
+      output.print(
+        `  ${chalk.dim(`… +${deferredOverflow} more deployments (run ${chalk.cyan('vc ls')} or open dashboard to see all)`)}\n`
+      );
+      deferredOverflow = -1; // don't print again
+    }
+  };
+
+  while (Date.now() < deadline && pending.size > 0) {
+    const pendingArr = Array.from(pending.values());
+
+    // Capture per-project team context ahead of concurrency (client.config.currentTeam is mutable)
+    // so each fetch uses the right account scoping.
+    const checks: Array<{ proj: ProjectWithMeta; dep: Deployment | null }> =
+      await mapWithConcurrency(
+        pendingArr,
+        async proj => {
+          const teamId = proj.orgIdResolved.startsWith('team_')
+            ? proj.orgIdResolved
+            : undefined;
+          // We don't rely on global client.config.currentTeam here; we pass accountId
+          // explicitly. But set currentTeam too for any downstream that still reads it,
+          // behind a tiny critical section using a cloned view.
+          // Since client isn't thread-safe for currentTeam, we save/restore.
+          const prevTeam = client.config.currentTeam;
+          try {
+            if (teamId) client.config.currentTeam = teamId;
+            else client.config.currentTeam = undefined;
+            const dep = await findLatestGitDeploymentForProject(
+              client,
+              proj,
+              shas,
+              branchHint,
+              since
+            );
+            return { proj, dep };
+          } finally {
+            client.config.currentTeam = prevTeam;
+          }
+        },
+        GIT_PROJECT_FETCH_CONCURRENCY
+      );
+
+    const newlyFound: Array<{ proj: ProjectWithMeta; dep: Deployment }> = [];
+    for (const { proj, dep } of checks) {
+      if (dep) newlyFound.push({ proj, dep });
+    }
+    if (newlyFound.length > 0) flushFound(newlyFound);
 
     if (pending.size === 0) break;
 
@@ -405,16 +499,33 @@ async function pollForProjectsDeployments(opts: {
   }
 
   if (pending.size > 0) {
-    for (const proj of pending.values()) {
+    // For large monorepos, collapse the "no deployment" tail so 30 lines doesn't become 30 warnings.
+    if (pending.size > 8) {
       output.print(
-        `${chalk.dim('–')} ${chalk.bold(proj.name)} (${proj.directory}) ${chalk.dim('no new deployment detected (may be ignored by git config / no changes)')}\n`
+        `  ${chalk.dim('–')} ${chalk.dim(`${pending.size} projects`)} ${chalk.dim('had no new deployment detected (may be ignored by git config / no changes, or still queuing).')}\n`
       );
+      output.print(
+        `  ${chalk.dim(
+          `Those projects: ${Array.from(pending.values())
+            .slice(0, 8)
+            .map(p => p.name)
+            .join(', ')}${pending.size > 8 ? ', …' : ''}`
+        )}\n`
+      );
+      if (output.isDebugEnabled()) {
+        for (const proj of pending.values()) {
+          output.debug(`no deployment for ${proj.name} (${proj.directory})`);
+        }
+      }
+    } else {
+      for (const proj of pending.values()) {
+        output.print(
+          `  ${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('no new deployment detected (may be ignored by git config / no changes)')}\n`
+        );
+      }
     }
   }
 
-  // Now decide logs
-  // Logic: only stream logs if cwd is inside a given project, and that project has a deployment found and is building.
-  // If multiple cwdMatched, pick the deepest.
   if (found.size === 0) {
     return { found, cwdMatchedIds };
   }
@@ -531,24 +642,25 @@ async function showBranchDeploymentSummary(opts: {
 }) {
   const { client, projects, cwdRelativePath, branch, headSha } = opts;
 
-  // Determine cwd-matched projects (deepest)
-  const cwdMatched = findProjectsFromPath(projects, cwdRelativePath);
-  // If cwd is repo root and projects are all in subdirs with directory '.'? Then findProjects returns all '.'?
-  // findProjectsFromPath returns matches for '.' as any path, so root will match all root-dir projects.
-  // That's fine: we show summary for all when at root, or filtered when inside subdir.
-
-  const projectsToShow = cwdMatched.length > 0 ? cwdMatched : projects;
+  // findProjectsFromPath is typed for RepoProjectConfig, but ProjectWithMeta extends it
+  // so casting via unknown is safe here – we only read extra fields for org routing.
+  const cwdMatched = findProjectsFromPath(
+    projects as unknown as RepoProjectConfig[],
+    cwdRelativePath
+  ) as unknown as ProjectWithMeta[];
+  const projectsToShow: ProjectWithMeta[] =
+    cwdMatched.length > 0 ? cwdMatched : projects;
 
   if (projectsToShow.length === 0) return;
 
   const titleBranch = branch ? chalk.bold(branch) : chalk.dim('current branch');
+  // Blank line separator from git output, then section heading using cli-ux pattern: no gutter for section, bold title
   output.print(`\n${chalk.bold('Vercel Deployments')} for ${titleBranch}`);
   if (headSha) {
     output.print(` ${chalk.dim(headSha.slice(0, 7))}`);
   }
   output.print(`\n`);
 
-  // Sort by directory depth for stable display (shallow first, then alpha)
   const sorted = [...projectsToShow].sort((a, b) => {
     const da = a.directory.split('/').length;
     const db = b.directory.split('/').length;
@@ -556,55 +668,79 @@ async function showBranchDeploymentSummary(opts: {
     return a.name.localeCompare(b.name);
   });
 
-  const results = await Promise.all(
-    sorted.map(async proj => {
-      client.config.currentTeam = proj.orgIdResolved.startsWith('team_')
-        ? proj.orgIdResolved
-        : undefined;
-      const deps = await fetchLatestDeploymentsForBranch(
-        client,
-        proj,
-        branch,
-        5
-      );
-      return { proj, deps };
-    })
+  // Also cap status fetch concurrency for big monorepos (git status path)
+  const results = await mapWithConcurrency(
+    sorted,
+    async proj => {
+      const prevTeam = client.config.currentTeam;
+      try {
+        client.config.currentTeam = proj.orgIdResolved.startsWith('team_')
+          ? proj.orgIdResolved
+          : undefined;
+        const deps = await fetchLatestDeploymentsForBranch(
+          client,
+          proj,
+          branch,
+          5
+        );
+        return { proj, deps };
+      } finally {
+        client.config.currentTeam = prevTeam;
+      }
+    },
+    GIT_PROJECT_FETCH_CONCURRENCY
   );
 
+  const MAX_STATUS_INLINE = 10;
   let anyDeploys = false;
+  let inlineShown = 0;
+  let overflow = 0;
   for (const { proj, deps } of results) {
     const orgSlug = proj.orgSlug ? `${proj.orgSlug}/` : '';
     const header = `${chalk.bold(orgSlug + proj.name)} ${chalk.dim(`(${proj.directory})`)}`;
     if (deps.length === 0) {
-      output.print(
-        `  ${chalk.dim('–')} ${header} ${chalk.dim(branch ? `no deployments for ${branch}` : 'no deployments')}\n`
-      );
+      if (inlineShown < MAX_STATUS_INLINE) {
+        output.print(
+          `  ${chalk.dim('–')} ${header} ${chalk.dim(branch ? `no deployments for ${branch}` : 'no deployments')}\n`
+        );
+      }
+      inlineShown++;
       continue;
     }
     anyDeploys = true;
-    output.print(`  ${header}\n`);
-    for (const dep of deps) {
-      const { icon, color } = deploymentStateIcon(dep.readyState);
-      const target =
-        dep.target === 'production' ? 'Production' : dep.target || 'Preview';
-      const url = dep.url ? `https://${dep.url}` : dep.id;
-      const shaShort =
-        dep.gitSource?.sha?.slice(0, 7) ||
-        dep.meta?.githubCommitSha?.slice(0, 7) ||
-        '';
-      const isHead = Boolean(
-        headSha && shaShort && headSha.startsWith(shaShort)
-      );
-      const age = formatAge(dep.createdAt);
-      output.print(
-        `    ${color(icon)} ${chalk.dim(`[${dep.readyState || 'UNKNOWN'}]`)} ${chalk.cyan(url)} ${chalk.dim(target)}${shaShort ? ` ${chalk.dim(shaShort)}` : ''}${isHead ? chalk.green(' ← HEAD') : ''} ${chalk.dim(age)}\n`
-      );
-      if (dep.inspectorUrl) {
-        output.print(
-          `      ${chalk.dim('Inspect:')} ${chalk.cyan(dep.inspectorUrl)}\n`
+    if (inlineShown < MAX_STATUS_INLINE) {
+      output.print(`  ${header}\n`);
+      for (const dep of deps) {
+        const { icon, color } = deploymentStateIcon(dep.readyState);
+        const target =
+          dep.target === 'production' ? 'Production' : dep.target || 'Preview';
+        const url = dep.url ? `https://${dep.url}` : dep.id;
+        const shaShort =
+          dep.gitSource?.sha?.slice(0, 7) ||
+          dep.meta?.githubCommitSha?.slice(0, 7) ||
+          '';
+        const isHead = Boolean(
+          headSha && shaShort && headSha.startsWith(shaShort)
         );
+        const age = formatAge(dep.createdAt);
+        output.print(
+          `    ${color(icon)} ${chalk.dim(`[${dep.readyState || 'UNKNOWN'}]`)} ${chalk.cyan(url)} ${chalk.dim(target)}${shaShort ? ` ${chalk.dim(shaShort)}` : ''}${isHead ? chalk.green(' ← HEAD') : ''} ${chalk.dim(age)}\n`
+        );
+        if (dep.inspectorUrl) {
+          output.print(
+            `      ${chalk.dim('Inspect:')} ${link(dep.inspectorUrl)}\n`
+          );
+        }
       }
+      inlineShown++;
+    } else {
+      overflow++;
     }
+  }
+  if (overflow > 0) {
+    output.print(
+      `  ${chalk.dim(`… +${overflow} more projects not shown (run ${chalk.cyan('vc ls')} for full list)`)}\n`
+    );
   }
 
   if (!anyDeploys) {
@@ -618,6 +754,30 @@ async function showBranchDeploymentSummary(opts: {
   }
 }
 
+async function fetchDeploymentByIdWithFallback(
+  client: Client,
+  id: string,
+  accountId: string
+): Promise<Deployment> {
+  try {
+    return await client.fetch<Deployment>(
+      `/v13/deployments/${encodeURIComponent(id)}`,
+      { accountId }
+    );
+  } catch (firstErr: any) {
+    const status = (firstErr && (firstErr.status || firstErr.statusCode)) || 0;
+    const msg = String(firstErr?.message || '');
+    if (status === 404 || msg.includes('404')) {
+      output.debug(`v13 fetch 404 for ${id}, falling back to v6: ${msg}`);
+      return await client.fetch<Deployment>(
+        `/v6/deployments/${encodeURIComponent(id)}`,
+        { accountId }
+      );
+    }
+    throw firstErr;
+  }
+}
+
 async function streamDeploymentUntilReady(
   client: Client,
   deployment: Deployment,
@@ -626,50 +786,158 @@ async function streamDeploymentUntilReady(
 ): Promise<Deployment> {
   let current = deployment;
   const deployStamp = stamp();
-  // set currentTeam appropriately
-  client.config.currentTeam = project.orgIdResolved.startsWith('team_')
-    ? project.orgIdResolved
-    : undefined;
+  const isTeam = project.orgIdResolved.startsWith('team_');
+  client.config.currentTeam = isTeam ? project.orgIdResolved : undefined;
 
   let abortController: AbortController | undefined;
-  if (shouldStreamLogs) {
+  let logPromise: Promise<void> | undefined;
+  let logRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  let logAttempt = 0;
+  let awaitingReady = true;
+
+  const MAX_LOG_RETRIES_BEFORE_READY = 6; // covers ~ 24s of 404 warmup
+
+  const startLogTail = (dep: Deployment) => {
+    if (abortController) {
+      // Clean previous controller before reattaching
+      try {
+        abortController.abort();
+      } catch {}
+      abortController = undefined;
+    }
+    logAttempt++;
     try {
       const { promise, abortController: ac } = displayBuildLogs(
         client,
-        current,
+        dep,
         true
       );
       abortController = ac;
-      // don't await yet – we will poll status alongside
-      promise.catch(e => {
-        output.debug(`log stream error for ${project.name}: ${e}`);
+      logPromise = promise;
+      promise.catch(err => {
+        const msg = String((err as any)?.message || err || '');
+        const is404 =
+          msg.includes('404') && msg.toLowerCase().includes('deployment');
+        if (
+          is404 &&
+          awaitingReady &&
+          logAttempt <= MAX_LOG_RETRIES_BEFORE_READY
+        ) {
+          output.debug(
+            `log stream 404 for ${project.name} ${dep.id} attempt ${logAttempt}/${MAX_LOG_RETRIES_BEFORE_READY}, retrying in background`
+          );
+          // Schedule background retry — don't surface to user yet
+          if (!logRetryTimer) {
+            logRetryTimer = setTimeout(() => {
+              logRetryTimer = undefined;
+              if (!awaitingReady) return;
+              startLogTail(current);
+            }, 4000);
+          }
+          return;
+        }
+        if (is404) {
+          output.debug(
+            `log stream giving up after ${logAttempt} attempts for ${project.name} ${dep.id}: ${msg}`
+          );
+          // Don't warn — readyState polling still continues and we have inspect fallback
+          return;
+        }
+        output.warn(`Failed to read build logs: ${msg}`);
+        output.debug(`log stream error for ${project.name}: ${err}`);
       });
     } catch (e) {
       output.debug(`failed to start log stream: ${e}`);
+      if (awaitingReady && logAttempt < MAX_LOG_RETRIES_BEFORE_READY) {
+        if (!logRetryTimer) {
+          logRetryTimer = setTimeout(() => {
+            logRetryTimer = undefined;
+            startLogTail(current);
+          }, 3000);
+        }
+      }
     }
+  };
+
+  if (shouldStreamLogs) {
+    // Git deploys: events endpoint may not be indexed immediately.
+    // Start right away — printEvents will stream if available, 404-catch above will schedule retries.
+    // Don't await delay: start immediately so we don't miss early build lines.
+    startLogTail(current);
   }
 
   // Poll readyState
+  let consecutive404 = 0;
   while (true) {
-    // We need getDeployment utility; avoid import cycle by fetching directly
     try {
-      const fresh = await client.fetch<Deployment>(
-        `/v13/deployments/${encodeURIComponent(current.id)}`,
-        { accountId: project.orgIdResolved }
+      const fresh = await fetchDeploymentByIdWithFallback(
+        client,
+        current.id,
+        project.orgIdResolved
       );
       current = fresh;
+      consecutive404 = 0;
+
+      // If initial log tail 404'd, re-attach as soon as BUILDING
+      if (
+        shouldStreamLogs &&
+        !abortController &&
+        (current.readyState === 'BUILDING' ||
+          current.readyState === 'INITIALIZING' ||
+          current.readyState === 'QUEUED')
+      ) {
+        startLogTail(current);
+      }
+
       const state = current.readyState;
       if (state === 'READY' || state === 'ERROR' || state === 'CANCELED') {
         break;
       }
-      // update spinner-like line? reuse printAlignedLabel? Instead just debug spinner
-      output.spinner(
-        `Building ${chalk.bold(project.name)} ${chalk.dim(`[${state}]`)}`
-      );
-    } catch (e) {
+      if (!shouldStreamLogs) {
+        output.spinner(
+          `Building ${chalk.bold(project.name)} ${chalk.dim(`[${state}]`)}`
+        );
+      }
+    } catch (e: any) {
+      const msg = String(e?.message || e || '');
+      const is404 = msg.includes('404');
+      if (is404) {
+        consecutive404++;
+        // Also try to re-attach log tail during 404 warmup — events may still be absent but ready
+        // poll will recover. Don't spam but keep one retry in flight.
+        if (shouldStreamLogs && !abortController && !logRetryTimer) {
+          logRetryTimer = setTimeout(() => {
+            logRetryTimer = undefined;
+            if (!awaitingReady) return;
+            startLogTail(current);
+          }, 4000);
+        }
+        if (consecutive404 >= 5) {
+          output.debug(
+            `giving up polling deployment ${current.id} after ${consecutive404} consecutive 404s`
+          );
+          output.warn(
+            `Deployment ${chalk.bold(current.id)} not found (404). It may still be building — try ${chalk.cyan(
+              'vc inspect ' + current.id + ' --logs'
+            )} or ${link(
+              current.inspectorUrl ||
+                `https://vercel.com/${project.orgSlug || ''}/${project.name}/${current.id}`
+            )}`
+          );
+          break;
+        }
+      } else {
+        consecutive404 = 0;
+      }
       output.debug(`failed to poll deployment ${current.id}: ${e}`);
     }
     await sleepLib(READY_POLL_INTERVAL_MS);
+  }
+
+  awaitingReady = false;
+  if (logRetryTimer) {
+    clearTimeout(logRetryTimer);
+    logRetryTimer = undefined;
   }
 
   if (abortController) {
@@ -677,11 +945,27 @@ async function streamDeploymentUntilReady(
       abortController.abort();
     } catch {}
     output.stopSpinner();
+    if (logPromise) {
+      try {
+        await Promise.race([logPromise.catch(() => {}), sleepLib(800)]);
+      } catch {}
+    }
   } else {
     output.stopSpinner();
+    if (shouldStreamLogs) {
+      // Only warn when we truly never attached — user-facing hint with inspect fallback
+      output.print(
+        `${chalk.dim('Build logs unavailable via events stream (may be warming up).')}\n`
+      );
+      output.print(
+        `  ${chalk.dim('Inspect:')} ${link(
+          current.inspectorUrl ||
+            `https://vercel.com/${project.orgSlug || ''}/${project.name}/${current.id}`
+        )}  ${chalk.dim(`or ${chalk.cyan('vc inspect ' + current.id + ' --logs')}`)}\n`
+      );
+    }
   }
 
-  // print final status similar to vc deploy output
   try {
     await printDeploymentStatus(
       client,
@@ -700,7 +984,6 @@ async function streamDeploymentUntilReady(
       false
     );
   } catch {
-    // fallback minimal
     output.print(
       `\n${current.readyState === 'READY' ? chalk.green('✓') : chalk.red('✗')} ${chalk.bold(
         project.name
@@ -710,9 +993,8 @@ async function streamDeploymentUntilReady(
     );
   }
 
-  // Inspector link already printed by printDeploymentStatus? Print anyway
   if (current.inspectorUrl) {
-    output.print(`  Inspect: ${link(current.inspectorUrl)}\n`);
+    printAlignedLabel('Inspect', link(current.inspectorUrl));
   }
 
   return current;
@@ -847,51 +1129,94 @@ export default async function gitPassthrough(
     return gitExit;
   }
 
-  // Show links already printed. Now handle log streaming.
-  // Determine if we should stream logs.
-  // Rules: show logs only if cwd is inside a linked project (cwdMatchedIds non-empty)
-  // AND that project's deployment is building/queued.
-  // --logs forces it for cwd-matched project even if maybe not building? we still stream if building.
-  // --no-logs disables.
-  const shouldAutoLog = cwdMatchedIds.size > 0 && !wrapperFlags.noLogs;
-  const shouldForceLog = wrapperFlags.logs && cwdMatchedIds.size > 0;
-
   if (wrapperFlags.noLogs) {
     return gitExit;
   }
 
-  // Pick project to stream: deepest matching cwd project that has deployment
+  // Determine if we should stream logs.
+  // Rules (cli-ux):
+  //  - default: stream if cwd is inside a linked project (cwdMatchedIds non-empty)
+  //  - --logs forces stream for cwd-matched, even if READY/ERROR (will show what we have + inspect fallback)
+  //  - --no-logs disables entirely, handled above
+  const shouldAutoLog = !wrapperFlags.noLogs;
+  const shouldForceLog = wrapperFlags.logs;
+
+  // Pick project to stream: deepest matching cwd project that has deployment.
+  // Fallbacks when cwd is repo root:
+  //   - if cwdRelativePath === '.' or cwdMatchedIds empty but exactly one deployment found, attach to that one
+  //   - if cwdMatchedIds empty and multiple found but one project has directory '.' (common single-root repo), attach to that
   let primaryProjectId: string | undefined;
-  if (cwdMatchedIds.size > 0) {
-    // sort by directory depth desc
-    const candidates = Array.from(cwdMatchedIds)
+
+  const pickDeepest = (ids: Iterable<string>) => {
+    const candidates = Array.from(ids)
       .map(id => projects.find(p => p.id === id)!)
       .filter(Boolean)
       .sort(
         (a, b) => b.directory.split('/').length - a.directory.split('/').length
       );
     for (const c of candidates) {
-      if (found.has(c.id)) {
-        primaryProjectId = c.id;
-        break;
-      }
+      if (found.has(c.id)) return c.id;
     }
-    // If --logs forced but no deployment yet for cwd project, we already would have shown no deployment message.
-    // No extra work.
+    return undefined;
+  };
+
+  if (cwdMatchedIds.size > 0) {
+    primaryProjectId = pickDeepest(cwdMatchedIds);
   }
 
-  // If no cwd match but --logs was passed explicitly, warn?
+  if (!primaryProjectId) {
+    // repo root / un-nested monorepo cwd: try smart defaults so "never picked up log stream" doesn't happen
+    const isRootCwd =
+      cwdRelativePath === '.' ||
+      cwdRelativePath === '' ||
+      cwdRelativePath === '/';
+    if (isRootCwd) {
+      if (found.size === 1) {
+        primaryProjectId = Array.from(found.keys())[0];
+      } else {
+        // Prefer projects with directory '.' or '' (root projects)
+        const rootDirCandidates = projects.filter(
+          p =>
+            (p.directory === '.' ||
+              p.directory === '' ||
+              p.directory === '/') &&
+            found.has(p.id)
+        );
+        if (rootDirCandidates.length === 1) {
+          primaryProjectId = rootDirCandidates[0].id;
+        } else if (rootDirCandidates.length === 0) {
+          // No root project — pick the most recently updated found deployment by primacy?
+          // Deepest found is still the best guess for typical usage.
+          primaryProjectId = pickDeepest(found.keys());
+        } else {
+          // Multiple root candidates — pick deepest (they're all same depth 0, so first alphabetical wins deterministically)
+          primaryProjectId = pickDeepest(rootDirCandidates.map(p => p.id));
+        }
+      }
+    }
+  }
+
   if (wrapperFlags.logs && !primaryProjectId) {
     output.warn(
       `No deployment is attached to the current directory (cwd: ${chalk.dim(
         cwdRelativePath
-      )}). Build logs are only shown when cwd is inside a linked project directory.`
+      )}). Build logs are only shown when cwd is inside a linked project directory — or at repo root when a single project matches.`
     );
     return gitExit;
   }
 
   if (!primaryProjectId) {
-    // No cwd-matched deployment to tail, just exit. Links already shown.
+    // No cwd-matched deployment to tail, and no safe root fallback — links already shown.
+    // Preserve git exit code. Hint user how to get logs explicitly.
+    if (found.size === 1) {
+      const onlyId = Array.from(found.keys())[0];
+      const onlyDep = found.get(onlyId)!;
+      output.print(
+        `\n  ${chalk.dim(`→ Build logs not auto-attached (cwd outside project root). Try:`)} ${chalk.cyan(
+          `vc inspect ${onlyDep.id} --logs`
+        )}\n`
+      );
+    }
     return gitExit;
   }
 
@@ -915,6 +1240,7 @@ export default async function gitPassthrough(
   }
 
   output.print('\n');
+  // Use log() which already emits "> …" at col 0 — don't add another ">" manually; cli-ux forbids double gutters.
   output.log(
     `Attaching to deployment for ${chalk.bold(primaryProj.name)} ${chalk.dim(
       `(${primaryProj.directory})`

--- a/packages/cli/src/commands/git/passthrough.ts
+++ b/packages/cli/src/commands/git/passthrough.ts
@@ -16,19 +16,62 @@ import { printAlignedLabel } from '../../util/output/print-aligned-label';
 import link from '../../util/output/link';
 import sleepLib from '../../util/sleep';
 
-const GIT_TRIGGER_TIMEOUT_MS = 120_000; // 2 minutes to notice new git deployment
-const GIT_POLL_INTERVAL_MS = 3_000;
+/**
+ * Trigger wait budgets.
+ *
+ * Long blocking after `git push` feels wrong, especially in non-TTY / CI.
+ * Platform typically creates git-triggered Deployments in 5-15s but can take
+ * 30-60s for borderline-large monorepos (30+ links) where webhook fanout is slow.
+ *
+ * Rules:
+ *  - single project  → give server a little more time since log tail is the main value
+ *  - multi project   → shorter, because the user just wants a summary; grace window
+ *                      covers staggered triggers without holding the terminal for 2m.
+ *  - non-TTY / CI / nonInteractive → never block for logs; shortest poll so `vc git push`
+ *                      still returns fast and preserves `git push` semantics.
+ */
+const GIT_TRIGGER_TIMEOUT_SINGLE_TTY_MS = 60_000;
+const GIT_TRIGGER_TIMEOUT_MULTI_TTY_MS = 35_000;
+const GIT_TRIGGER_TIMEOUT_NON_TTY_MS = 12_000;
+
+const GIT_POLL_INTERVAL_MS = 2_500;
+const GIT_POLL_BACKOFF_AFTER_MS = 14_000;
+const GIT_POLL_BACKOFF_INTERVAL_MS = 5_000;
 const READY_POLL_INTERVAL_MS = 3_000;
 
-// Keep API pressure bounded when a monorepo links dozens of projects.
-// 6 concurrent fetches is a good tradeoff: fast enough for 30 projects (~5 waves),
-// low enough to avoid 429s when every poll iteration fans out.
+// Grace window after first find: covers "1 deploy started right away, 1 took a bit longer".
+// Capped at small values so multi-project TTY doesn't feel like 2 extra minutes.
+const GRACE_EXTRA_SINGLE_MS = 12_000;
+const GRACE_EXTRA_MULTI_MS = 18_000;
+const GRACE_EXTRA_NON_TTY_MS = 5_000;
+
+// Concurrency caps stay low — with many fewer waves now (12-35s rather than 120s),
+// a small concurrency prevents 429s when 30 projects each request /v6/deployments + /v9/projects.
 const GIT_PROJECT_FETCH_CONCURRENCY = 6;
-const GIT_ORG_FETCH_CONCURRENCY = 6;
+const GIT_ORG_FETCH_CONCURRENCY = 4;
+
+type DeployDecisionReason =
+  | 'gitDisabled' // git.deploymentEnabled = false (or per-branch false)
+  | 'ignoredByGitConfig' // explicit per-branch mapping disables
+  | 'ignoreCommand' // vercel.json / ProjectSettings.commandForIgnoringBuildStep exited 0
+  | 'ignoreCommandMissing' // undecidable locally — server decided to skip via ignoreCommand
+  | 'rootDirectoryNoChange' // monorepo heuristic: no change in rootDirectory (best effort)
+  | 'sourceless' // project.link.sourceless
+  | 'noGitLink' // project has no link at all (manual only)
+  | 'unknown';
+
+interface DeployDecision {
+  shouldDeploy: boolean;
+  reason: DeployDecisionReason;
+  detail?: string; // human hint: e.g. "git.deploymentEnabled[main]=false"
+}
 
 interface ProjectWithMeta extends RepoProjectConfig {
   orgIdResolved: string;
   orgSlug?: string;
+  // enriched after we fetch /v9/projects/{id} once — optional so we don't have to fetch for every flow
+  _project?: import('@vercel-internals/types').Project;
+  _decision?: DeployDecision | undefined;
 }
 
 async function mapWithConcurrency<T, R>(
@@ -270,6 +313,149 @@ async function resolveAllLinkedProjects(client: Client): Promise<{
   return null;
 }
 
+/**
+ * Heuristic evaluation of whether a project _elected_ not to deploy for this push.
+ *
+ * Today the platform has no "negative deployment" record — when a push is ignored
+ * because of `git.deploymentEnabled=false`, per-branch mapping, `ignoreCommand`
+ * exiting 0, `rootDirectory` with no changes, or a `sourceless` project, the API
+ * simply creates no Deployment. So we can only infer locally. The logic:
+ *  - fetch `/v9/projects/{id}` to get `link`, `rootDirectory`, `commandForIgnoringBuildStep`, git config
+ *  - apply rules that are stable across Dashboard / vercel.json
+ *  - when we can't evaluate (ignoreCommand needs server-side shell, root dir diff needs server file list),
+ *    return `unknown` — caller should phrase as "no new deployment detected (may be ignored …)"
+ *
+ * This is intentionally best-effort: if the server ever surfaces a decision endpoint
+ * (`…/should-deploy` / `…/git-decision`), `pollForProjectsDeployments` can promote
+ * this to that endpoint without changing the UI contract.
+ */
+async function evaluateDeployDecision(
+  client: Client,
+  project: ProjectWithMeta,
+  branchHint?: string
+): Promise<DeployDecision | undefined> {
+  if (project._decision) return project._decision;
+
+  let full: any;
+  try {
+    full = project._project;
+    if (!full) {
+      const { default: getProjectByNameOrId } = await import(
+        '../../util/projects/get-project-by-id-or-name'
+      );
+      full = await getProjectByNameOrId(
+        client,
+        project.id,
+        project.orgIdResolved
+      );
+      if (full && typeof full === 'object' && 'id' in full) {
+        project._project = full;
+      } else {
+        return undefined;
+      }
+    }
+  } catch (e) {
+    output.debug(
+      `evaluateDeployDecision: fetch project ${project.id} failed: ${e}`
+    );
+    return undefined;
+  }
+
+  const link = full?.link as any;
+  const git = (full?.git ?? full?.gitConfig ?? full?.link?.git) as any;
+  const vercelJson = (full?.vercelJson ?? {}) as any;
+
+  // No git wiring ⇒ project never auto-deploys on git push (manual/cli only)
+  if (!link) {
+    return {
+      shouldDeploy: false,
+      reason: 'noGitLink',
+      detail: 'project is not connected to a Git repo (no link)',
+    };
+  }
+  if (link.sourceless) {
+    return {
+      shouldDeploy: false,
+      reason: 'sourceless',
+      detail: 'project is sourceless / template-only',
+    };
+  }
+
+  // git.deploymentEnabled may live in:
+  // - project.link.deploymentEnabled (some API shapes)
+  // - vercel.json `git.deploymentEnabled`
+  // - Dashboard Project Settings → Git → Deployments
+  // Normalize: boolean | Record<branch, boolean>
+  const rawDeploymentEnabled =
+    (git?.deploymentEnabled as boolean | Record<string, boolean> | undefined) ??
+    (vercelJson?.git?.deploymentEnabled as
+      | boolean
+      | Record<string, boolean>
+      | undefined);
+
+  if (rawDeploymentEnabled === false) {
+    return {
+      shouldDeploy: false,
+      reason: 'gitDisabled',
+      detail: 'git.deploymentEnabled=false',
+    };
+  }
+  if (
+    rawDeploymentEnabled &&
+    typeof rawDeploymentEnabled === 'object' &&
+    branchHint
+  ) {
+    const v = (rawDeploymentEnabled as Record<string, boolean>)[branchHint];
+    if (v === false) {
+      return {
+        shouldDeploy: false,
+        reason: 'ignoredByGitConfig',
+        detail: `git.deploymentEnabled[${branchHint}]=false`,
+      };
+    }
+  }
+
+  // ignoreCommand — if defined, server will skip deploy when it exits 0 or with matched code.
+  // We can't evaluate the command locally without reproducing the full FS, so mark as
+  // "maybe ignored by ignoreCommand" via `ignoreCommandMissing`, preserving the existing generic text
+  // but letting caller label it: "skipped locally? unknown; dashboard may say ignored by Ignore Build Step".
+  const ignoreCommand =
+    full?.commandForIgnoringBuildStep ??
+    vercelJson?.ignoreCommand ??
+    git?.ignoreCommand ??
+    null;
+  if (ignoreCommand) {
+    // We deliberately do not return a hard false here — if a deployment _did_ occur we don't
+    // want to claim it was skipped. For the pending remainder set (no deployment found after timeout),
+    // caller will surface this as the most likely explanation.
+    // Store as soft hint; poller still keeps polling until deadline unless we switch to per-project
+    // "shouldDeploy=false" hard-skip (which we only do for gitDisabled / sourceless).
+    // So mark via detail but keep shouldDeploy true-ish → converted to soft reason in caller's render.
+    return {
+      shouldDeploy: true, // allow polling to continue; render layer will show soft reason
+      reason: 'ignoreCommandMissing',
+      detail: `project has ignoreCommand (${typeof ignoreCommand === 'string' ? ignoreCommand.slice(0, 60) : 'configured'}) — may have elected not to deploy`,
+    };
+  }
+
+  // rootDirectory: if monorepo and this push touched only other dirs, server may skip.
+  // We can't compute file diff server-side without asking for changed files list.
+  // Report as unknown — caller will phrase as "no changes in rootDirectory?"
+  if (
+    full?.rootDirectory &&
+    full.rootDirectory !== '.' &&
+    full.rootDirectory !== ''
+  ) {
+    return {
+      shouldDeploy: true,
+      reason: 'rootDirectoryNoChange',
+      detail: `rootDirectory=${full.rootDirectory} — server may have skipped due to no file changes`,
+    };
+  }
+
+  return { shouldDeploy: true, reason: 'unknown' };
+}
+
 function isMatchingDeploymentForSha(
   dep: Deployment,
   shas: Set<string>,
@@ -371,15 +557,81 @@ async function pollForProjectsDeployments(opts: {
   shas: Set<string>;
   branchHint?: string;
   cwdRelativePath: string;
+  isSingleProject?: boolean;
+  ttyMode?: 'tty' | 'non-tty';
 }) {
-  const { client, projects, shas, branchHint, cwdRelativePath } = opts;
+  const {
+    client,
+    projects,
+    shas,
+    branchHint,
+    cwdRelativePath,
+    isSingleProject,
+    ttyMode,
+  } = opts;
   const since = Date.now();
-  const deadline = since + GIT_TRIGGER_TIMEOUT_MS;
+  const effectiveTty = ttyMode ?? 'tty';
+  const timeoutMs =
+    effectiveTty === 'non-tty'
+      ? GIT_TRIGGER_TIMEOUT_NON_TTY_MS
+      : isSingleProject
+        ? GIT_TRIGGER_TIMEOUT_SINGLE_TTY_MS
+        : GIT_TRIGGER_TIMEOUT_MULTI_TTY_MS;
+  const deadline = since + timeoutMs;
+  const graceExtraMs =
+    effectiveTty === 'non-tty'
+      ? GRACE_EXTRA_NON_TTY_MS
+      : isSingleProject
+        ? GRACE_EXTRA_SINGLE_MS
+        : GRACE_EXTRA_MULTI_MS;
+
+  // We want to distinguish "will never deploy" from "still queuing".
+  // The platform has no negative-deployment record, so we do a best-effort local evaluation:
+  // fetch /v9/projects/{id} in the background (concurrency-capped) and compute DeployDecision.
+  // Projects whose decision is a hard "shouldDeploy=false" (gitDisabled, sourceless, noGitLink, per-branch false)
+  // are moved out of `pending` early with a precise reason, instead of waiting 2 minutes.
+  const decisionsEvaluated = new Map<string, DeployDecision>();
+  let decisionsInFlight: Promise<void> | undefined;
+
+  const evaluateDecisionsInBackground = () => {
+    if (decisionsInFlight) return decisionsInFlight;
+    decisionsInFlight = (async () => {
+      await mapWithConcurrency(
+        projects,
+        async proj => {
+          const prevTeam = client.config.currentTeam;
+          try {
+            const teamId = proj.orgIdResolved.startsWith('team_')
+              ? proj.orgIdResolved
+              : undefined;
+            if (teamId) client.config.currentTeam = teamId;
+            else client.config.currentTeam = undefined;
+            const d = await evaluateDeployDecision(client, proj, branchHint);
+            if (d) decisionsEvaluated.set(proj.id, d);
+          } catch {
+          } finally {
+            client.config.currentTeam = prevTeam;
+          }
+        },
+        GIT_PROJECT_FETCH_CONCURRENCY
+      );
+    })();
+    return decisionsInFlight;
+  };
+  // kick off without awaiting — poll loop starts right away and uses whatever we already know
+  void evaluateDecisionsInBackground();
 
   const pending = new Map<string, ProjectWithMeta>(
     projects.map(p => [p.id, p])
   );
   const found = new Map<string, Deployment>();
+  const skippedHard = new Map<string, DeployDecision>(); // decided won't deploy (precise)
+  const skippedSoft = new Map<string, DeployDecision>(); // may have skipped via ignoreCommand / rootDir heuristics
+
+  // See comment block at top of file: grace window after first find accounts for
+  // "one deploy started right away, another took a bit longer" without holding the
+  // terminal for the full trigger timeout. Duration varies by TTY / single distinction.
+  let firstFoundAt = 0;
 
   output.log(
     `Triggered git push. Polling ${projects.length} linked project${projects.length === 1 ? '' : 's'} for new deployments...`
@@ -396,18 +648,35 @@ async function pollForProjectsDeployments(opts: {
 
   const noticeTruncated = (n: number) => {
     if (n <= 10) return;
-    // Don't spam: once up front is enough for 30-project case
     output.print(
       `  ${chalk.dim(`Tracking ${n} projects; showing links as they appear. Full list in Vercel dashboard.`)}\n`
     );
   };
   noticeTruncated(projects.length);
 
-  // Poll loop: bounded concurrency so 30 projects doesn't 429.
-  // Also cap banner lines so 30 finds doesn't flood terminal.
   let linesPrinted = 0;
   const MAX_INLINE_PROJECTS = 12;
   let deferredOverflow = 0;
+
+  const formatDecisionLine = (proj: ProjectWithMeta, d: DeployDecision) => {
+    switch (d.reason) {
+      case 'gitDisabled':
+        return `${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('skipped — git.deploymentEnabled=false')}`;
+      case 'ignoredByGitConfig':
+        return `${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim(`skipped — ${d.detail || 'disabled for this branch'}`)}`;
+      case 'noGitLink':
+        return `${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('not connected to git (manual deploys only)')}`;
+      case 'sourceless':
+        return `${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('sourceless project — no git deploys')}`;
+      case 'ignoreCommandMissing':
+        // soft: only shown after polling exhausted
+        return `${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('no new deployment (likely ignoreCommand — check dashboard Build settings)')}`;
+      case 'rootDirectoryNoChange':
+        return `${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('no new deployment (no changes in rootDirectory?)')}`;
+      default:
+        return `${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim(d.detail || 'no new deployment detected')}`;
+    }
+  };
 
   const flushFound = (
     items: Array<{ proj: ProjectWithMeta; dep: Deployment }>
@@ -415,6 +684,7 @@ async function pollForProjectsDeployments(opts: {
     for (const { proj, dep } of items) {
       found.set(proj.id, dep);
       pending.delete(proj.id);
+      if (firstFoundAt === 0) firstFoundAt = Date.now();
       const url = dep.url ? `https://${dep.url}` : dep.id;
       const targetLabel =
         dep.target === 'production' ? 'Production' : dep.target || 'Preview';
@@ -444,19 +714,75 @@ async function pollForProjectsDeployments(opts: {
       output.debug(`deployment link: ${url}`);
     }
     if (deferredOverflow > 0 && pending.size === 0) {
-      // Final overflow summary
       output.print(
         `  ${chalk.dim(`… +${deferredOverflow} more deployments (run ${chalk.cyan('vc ls')} or open dashboard to see all)`)}\n`
       );
-      deferredOverflow = -1; // don't print again
+      deferredOverflow = -1;
     }
   };
 
+  const flushSkippedHard = (
+    items: Array<{ proj: ProjectWithMeta; decision: DeployDecision }>
+  ) => {
+    for (const { proj, decision } of items) {
+      if (pending.has(proj.id)) {
+        pending.delete(proj.id);
+        skippedHard.set(proj.id, decision);
+        if (linesPrinted < MAX_INLINE_PROJECTS) {
+          output.print(`  ${formatDecisionLine(proj, decision)}\n`);
+          linesPrinted++;
+        } else {
+          deferredOverflow++;
+        }
+      }
+    }
+  };
+
+  let iteration = 0;
   while (Date.now() < deadline && pending.size > 0) {
+    iteration++;
+    // Grace window: once at least one deployment landed, allow a short extra window for
+    // stragglers — shorter in single-project TTY (logs matter more than other projects)
+    // and non-TTY (return fast). Uses the precomputed graceExtraMs which already varies by mode.
+    if (found.size > 0 && firstFoundAt > 0) {
+      const graceDeadline = Math.min(deadline, firstFoundAt + graceExtraMs);
+      if (
+        Date.now() >= graceDeadline &&
+        pending.size > 0 &&
+        projects.length > 1
+      ) {
+        // Collect soft reasons before bailing
+        // Wait briefly for decision fetch to finish to give better messages
+        if (decisionsInFlight) {
+          try {
+            await Promise.race([decisionsInFlight, sleepLib(1500)]);
+          } catch {}
+        }
+        for (const proj of pending.values()) {
+          const d = decisionsEvaluated.get(proj.id);
+          if (d) {
+            if (
+              !d.shouldDeploy &&
+              (d.reason === 'gitDisabled' ||
+                d.reason === 'ignoredByGitConfig' ||
+                d.reason === 'noGitLink' ||
+                d.reason === 'sourceless')
+            ) {
+              skippedHard.set(proj.id, d);
+            } else if (
+              d.reason === 'ignoreCommandMissing' ||
+              d.reason === 'rootDirectoryNoChange'
+            ) {
+              skippedSoft.set(proj.id, d);
+            }
+          }
+        }
+        break; // stop ticking, fall through to tail rendering
+      }
+    }
+
     const pendingArr = Array.from(pending.values());
 
-    // Capture per-project team context ahead of concurrency (client.config.currentTeam is mutable)
-    // so each fetch uses the right account scoping.
     const checks: Array<{ proj: ProjectWithMeta; dep: Deployment | null }> =
       await mapWithConcurrency(
         pendingArr,
@@ -464,10 +790,6 @@ async function pollForProjectsDeployments(opts: {
           const teamId = proj.orgIdResolved.startsWith('team_')
             ? proj.orgIdResolved
             : undefined;
-          // We don't rely on global client.config.currentTeam here; we pass accountId
-          // explicitly. But set currentTeam too for any downstream that still reads it,
-          // behind a tiny critical section using a cloned view.
-          // Since client isn't thread-safe for currentTeam, we save/restore.
           const prevTeam = client.config.currentTeam;
           try {
             if (teamId) client.config.currentTeam = teamId;
@@ -493,44 +815,161 @@ async function pollForProjectsDeployments(opts: {
     }
     if (newlyFound.length > 0) flushFound(newlyFound);
 
-    if (pending.size === 0) break;
-
-    await sleepLib(GIT_POLL_INTERVAL_MS);
-  }
-
-  if (pending.size > 0) {
-    // For large monorepos, collapse the "no deployment" tail so 30 lines doesn't become 30 warnings.
-    if (pending.size > 8) {
-      output.print(
-        `  ${chalk.dim('–')} ${chalk.dim(`${pending.size} projects`)} ${chalk.dim('had no new deployment detected (may be ignored by git config / no changes, or still queuing).')}\n`
-      );
-      output.print(
-        `  ${chalk.dim(
-          `Those projects: ${Array.from(pending.values())
-            .slice(0, 8)
-            .map(p => p.name)
-            .join(', ')}${pending.size > 8 ? ', …' : ''}`
-        )}\n`
-      );
-      if (output.isDebugEnabled()) {
-        for (const proj of pending.values()) {
-          output.debug(`no deployment for ${proj.name} (${proj.directory})`);
+    // After first tick, allow hard-skipped projects to drop out early with a precise reason,
+    // so 30-project monorepo doesn't wait 2m for 25 projects that elected not to deploy.
+    if (iteration >= 1 && decisionsEvaluated.size > 0) {
+      const toSkip: Array<{ proj: ProjectWithMeta; decision: DeployDecision }> =
+        [];
+      for (const proj of pending.values()) {
+        const d = decisionsEvaluated.get(proj.id);
+        if (!d) continue;
+        if (
+          !d.shouldDeploy &&
+          (d.reason === 'gitDisabled' ||
+            d.reason === 'ignoredByGitConfig' ||
+            d.reason === 'noGitLink' ||
+            d.reason === 'sourceless')
+        ) {
+          toSkip.push({ proj, decision: d });
         }
       }
-    } else {
-      for (const proj of pending.values()) {
-        output.print(
-          `  ${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('no new deployment detected (may be ignored by git config / no changes)')}\n`
-        );
+      if (toSkip.length > 0) flushSkippedHard(toSkip);
+    }
+
+    if (pending.size === 0) break;
+
+    const elapsed = Date.now() - since;
+    const sleepMs =
+      elapsed >= GIT_POLL_BACKOFF_AFTER_MS
+        ? GIT_POLL_BACKOFF_INTERVAL_MS
+        : GIT_POLL_INTERVAL_MS;
+    await sleepLib(sleepMs);
+  }
+
+  // Make sure decision fetch finishes before we render the tail, so we can give precise reasons
+  if (decisionsInFlight && (pending.size > 0 || skippedSoft.size === 0)) {
+    try {
+      await Promise.race([decisionsInFlight, sleepLib(1200)]);
+    } catch {}
+    // re-bin any remaining pending via newly available decisions
+    for (const proj of pending.values()) {
+      const d = decisionsEvaluated.get(proj.id);
+      if (!d) continue;
+      if (!d.shouldDeploy) skippedHard.set(proj.id, d);
+      else if (
+        d.reason === 'ignoreCommandMissing' ||
+        d.reason === 'rootDirectoryNoChange'
+      ) {
+        skippedSoft.set(proj.id, d);
       }
     }
   }
 
-  if (found.size === 0) {
-    return { found, cwdMatchedIds };
+  if (pending.size > 0 || skippedHard.size > 0 || skippedSoft.size > 0) {
+    const allRemaining = [...pending.values()];
+    const allReasonsMap = new Map<string, DeployDecision>();
+    for (const [id, d] of skippedHard) allReasonsMap.set(id, d);
+    for (const [id, d] of skippedSoft) allReasonsMap.set(id, d);
+    // also attach any evaluated decision for plain pending so we can label it
+    for (const proj of allRemaining) {
+      const d = decisionsEvaluated.get(proj.id) ?? allReasonsMap.get(proj.id);
+      if (d) allReasonsMap.set(proj.id, d);
+    }
+
+    if (allRemaining.length + skippedHard.size > 8) {
+      // Large remaining set — collapse + show a few sampled reasons
+      const total = allRemaining.length + skippedHard.size;
+      const reasonCounts = new Map<DeployDecisionReason, number>();
+      for (const d of allReasonsMap.values()) {
+        reasonCounts.set(d.reason, (reasonCounts.get(d.reason) ?? 0) + 1);
+      }
+      const sortedReasons = Array.from(reasonCounts.entries())
+        .filter(([r]) => r !== 'unknown')
+        .sort((a, b) => b[1] - a[1]);
+
+      // Compact tail
+      const sample = [
+        ...allRemaining,
+        ...Array.from(skippedHard.keys())
+          .map(id => projects.find(p => p.id === id)!)
+          .filter(Boolean),
+      ].slice(0, 8);
+
+      if (skippedHard.size === 0) {
+        output.print(
+          `  ${chalk.dim('–')} ${chalk.dim(`${total} projects`)} ${chalk.dim('had no new deployment detected')}${sortedReasons.length ? chalk.dim(` (${sortedReasons.map(([r, n]) => `${r}:${n}`).join(', ')})`) : ''}. ${chalk.dim('Likely: ignored by git config / ignoreCommand / rootDirectory no changes, or still queuing.')}\n`
+        );
+      } else {
+        output.print(
+          `  ${chalk.dim('–')} ${chalk.dim(`${total} projects`)} ${chalk.dim('did not produce a new deployment')}${sortedReasons.length ? chalk.dim(` — ${sortedReasons.map(([r, n]) => `${r}×${n}`).join(', ')}`) : ''}\n`
+        );
+      }
+      output.print(
+        `  ${chalk.dim(
+          `Sample: ${sample.map(p => p.name).join(', ')}${total > 8 ? ', …' : ''}`
+        )}\n`
+      );
+      if (sortedReasons.length > 0) {
+        // One more line hinting most common
+        const [topReason] = sortedReasons[0];
+        if (topReason === 'gitDisabled') {
+          output.print(
+            `  ${chalk.dim(`Tip: many projects have ${chalk.bold('git.deploymentEnabled=false')} — enable in vercel.json or Dashboard Git settings.`)}\n`
+          );
+        } else if (topReason === 'ignoreCommandMissing') {
+          output.print(
+            `  ${chalk.dim(`Tip: projects with an ${chalk.bold('Ignore Build Step')} may be intentionally skipping — check Dashboard → Build Settings.`)}\n`
+          );
+        } else if (topReason === 'ignoredByGitConfig') {
+          output.print(
+            `  ${chalk.dim(`Tip: per-branch git config disabled deploys for ${chalk.bold(branchHint || 'this branch')} — check ${chalk.bold('vercel.json → git.deploymentEnabled')} mapping.`)}\n`
+          );
+        }
+      }
+      if (output.isDebugEnabled()) {
+        for (const proj of allRemaining) {
+          const d = decisionsEvaluated.get(proj.id);
+          output.debug(
+            `no deployment for ${proj.name} (${proj.directory}) decision=${d?.reason ?? 'unknown'} detail=${d?.detail ?? ''}`
+          );
+        }
+      }
+    } else {
+      // Small tail — line per project with precise reason when available
+      for (const proj of allRemaining) {
+        const d = decisionsEvaluated.get(proj.id) ?? allReasonsMap.get(proj.id);
+        if (d && d.reason !== 'unknown') {
+          output.print(`  ${formatDecisionLine(proj, d)}\n`);
+        } else if (d) {
+          output.print(
+            `  ${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('no new deployment detected (may be ignored by git config / no changes)')}\n`
+          );
+        } else {
+          output.print(
+            `  ${chalk.dim('–')} ${chalk.bold(proj.name)} ${chalk.dim(`(${proj.directory})`)} ${chalk.dim('no new deployment detected (may be ignored by git config / no changes)')}\n`
+          );
+        }
+      }
+      for (const [id, d] of skippedHard) {
+        const proj = projects.find(p => p.id === id);
+        if (!proj) continue;
+        output.print(`  ${formatDecisionLine(proj, d)}\n`);
+      }
+      for (const [id, d] of skippedSoft) {
+        const proj = projects.find(p => p.id === id);
+        if (!proj) continue;
+        // soft only shown when we truly have no deploy — avoids noisy lines during grace window
+        if (pending.has(id)) continue; // already printed via generic tail above
+        output.print(`  ${formatDecisionLine(proj, d)}\n`);
+      }
+    }
   }
 
-  return { found, cwdMatchedIds };
+  return {
+    found,
+    cwdMatchedIds,
+    skipped: skippedHard as Map<string, DeployDecision> & Map<string, any>,
+  };
 }
 
 function formatAge(createdAt?: number): string {
@@ -1116,13 +1555,59 @@ export default async function gitPassthrough(
 
   const { projects, cwdRelativePath } = repoInfo;
 
-  // Poll
+  // Infer TTY / non-TTY semantics for timeout & log policy.
+  // - client.nonInteractive may be true inside CI / `vc --yes`
+  // - stdout/stderr !isTTY happens when `vc git push | tee` or when caller is a program
+  // Behavior matrix:
+  //   single + tty         → up to 60s trigger, 12s grace, auto-logs
+  //   single + non-tty     → 12s trigger, 5s grace, NO log streaming (programmatic must use --logs to opt-in)
+  //   multi + tty          → 35s trigger, 18s grace after first find (staggered monorepo), no auto log streaming
+  //   multi + non-tty      → 12s trigger, 5s grace, summary-only
+  const isStdoutTTY = Boolean(client.stdout?.isTTY ?? process.stdout.isTTY);
+  const isStderrTTY =
+    typeof process.stderr.isTTY === 'boolean' ? process.stderr.isTTY : true;
+  const effectiveNonInteractive =
+    Boolean((client as any).nonInteractive) || !isStdoutTTY;
+  const ttyMode: 'tty' | 'non-tty' = effectiveNonInteractive
+    ? 'non-tty'
+    : 'tty';
+
+  // Heuristically decide single vs multi *before* polling so we can pick the right budget
+  // and avoid blocking 60s when this is really a 30-project monorepo.
+  // If cwdRelativePath maps to exactly one project via findProjectsFromPath, treat as single UX
+  // even if repo.json has many entries — user's intent is "I am in one project".
+  let isSingleProjectHeuristic = repoInfo.projects.length === 1;
+  let cwdMatchedIdsHint: Set<string> | undefined;
+  if (!isSingleProjectHeuristic) {
+    try {
+      const matched = findProjectsFromPath(
+        repoInfo.projects as unknown as RepoProjectConfig[],
+        cwdRelativePath
+      );
+      if (matched.length === 1) {
+        isSingleProjectHeuristic = true;
+        cwdMatchedIdsHint = new Set(matched.map(p => p.id));
+      }
+    } catch {
+      // never block push UX
+    }
+  }
+
+  if (ttyMode === 'non-tty') {
+    output.debug(
+      `git push detected but stdout !isTTY (or nonInteractive); using short timeouts: ${!isStdoutTTY ? 'stdout!isTTY' : 'nonInteractive'} ${!isStderrTTY ? '+ stderr!isTTY' : ''}`
+    );
+  }
+
+  // Poll — with grace window and skip-reason detection handled inside.
   const { found, cwdMatchedIds } = await pollForProjectsDeployments({
     client,
     projects,
     shas,
     branchHint,
     cwdRelativePath,
+    isSingleProject: isSingleProjectHeuristic,
+    ttyMode,
   });
 
   if (found.size === 0) {
@@ -1133,19 +1618,36 @@ export default async function gitPassthrough(
     return gitExit;
   }
 
-  // Determine if we should stream logs.
-  // Rules (cli-ux):
-  //  - default: stream if cwd is inside a linked project (cwdMatchedIds non-empty)
-  //  - --logs forces stream for cwd-matched, even if READY/ERROR (will show what we have + inspect fallback)
-  //  - --no-logs disables entirely, handled above
-  const shouldAutoLog = !wrapperFlags.noLogs;
+  // ── TTY-aware log policy ───────────────────────────────────────────────
+  // - non-TTY (piped, CI, --yes, programmatic): NEVER auto-stream logs — blocks don't compose well with pipes.
+  //   `vc git push` in that mode preserves plain `git push` exit code and returns quickly; caller can
+  //   explicitly opt in with --logs if they really want streamed logs in non-TTY (we still stream if --logs).
+  // - tty: single repo → stream logs; multi → summary only (as requested), unless --logs forces cwd-matched.
+  const shouldAutoLogBase = !wrapperFlags.noLogs;
   const shouldForceLog = wrapperFlags.logs;
+  const shouldAutoLog =
+    ttyMode === 'non-tty'
+      ? shouldForceLog /* only when user forced */
+      : shouldAutoLogBase;
 
-  // Pick project to stream: deepest matching cwd project that has deployment.
-  // Fallbacks when cwd is repo root:
-  //   - if cwdRelativePath === '.' or cwdMatchedIds empty but exactly one deployment found, attach to that one
-  //   - if cwdMatchedIds empty and multiple found but one project has directory '.' (common single-root repo), attach to that
-  let primaryProjectId: string | undefined;
+  if (ttyMode === 'non-tty' && shouldAutoLogBase && !shouldForceLog) {
+    // In non-TTY we suppress the implicit "Attaching to deployment ..." line entirely —
+    // machine consumers don't want spinner/logs. Still show deployment URLs (already printed by poller).
+    output.debug(
+      'non-TTY detected: skipping auto log attach (use --logs to force)'
+    );
+  }
+
+  // ── single vs multi UX (your request) ──────────────────────────────────
+  // isSingleProjectHeuristic already computed before poll for timeout reasons;
+  // recompute definitive version now that we know `found` (same logic, but prefer found evidence).
+  const isSingleProjectRepo =
+    isSingleProjectHeuristic ||
+    // repo.json may list 30 but cwd matched only one deepest — still single UX for that cwd.
+    // Use hint if poll returned a definitive cwdMatchedIds that differs from early estimate.
+    (cwdMatchedIds.size === 1 &&
+      projects.length > 1 &&
+      Array.from(cwdMatchedIds).some(id => found.has(id)));
 
   const pickDeepest = (ids: Iterable<string>) => {
     const candidates = Array.from(ids)
@@ -1160,12 +1662,132 @@ export default async function gitPassthrough(
     return undefined;
   };
 
+  if (!isSingleProjectRepo) {
+    // Multi-project path: summary table, no log streaming by default.
+    // In non-TTY, this is the *only* path (single repo in non-TTY is also summarized below
+    // before log logic). Here we own the full table — even for overflow-hidden items,
+    // re-render a compact complete list so callers in CI get deterministic parsable output.
+    const foundEntries = Array.from(found.entries());
+    const sortedFound = foundEntries
+      .map(([id, dep]) => ({ proj: projects.find(p => p.id === id)!, dep }))
+      .filter(x => x.proj)
+      .sort((a, b) => {
+        const aProd = a.dep.target === 'production' ? 0 : 1;
+        const bProd = b.dep.target === 'production' ? 0 : 1;
+        if (aProd !== bProd) return aProd - bProd;
+        const depth = (p: ProjectWithMeta) => p.directory.split('/').length;
+        const dd = depth(a.proj) - depth(b.proj);
+        if (dd !== 0) return dd;
+        return a.proj.name.localeCompare(b.proj.name);
+      });
+
+    // In non-TTY / piped we still print, but avoid chalk.bold where possible for machine readers?
+    // Keep visual but parsable: state icon + url is stable.
+    if (ttyMode !== 'non-tty') {
+      output.print(
+        `\n${chalk.bold('Deployments for')} ${chalk.bold(branchHint || 'this push')}\n`
+      );
+    } else {
+      output.print(
+        `\nDeployments for ${branchHint || 'this push'} (${found.size}):\n`
+      );
+    }
+    const maxName = Math.min(
+      32,
+      Math.max(...sortedFound.map(({ proj }) => proj.name.length), 10)
+    );
+    for (const { proj, dep } of sortedFound) {
+      const { icon, color } = deploymentStateIcon(dep.readyState);
+      const orgSlug = proj.orgSlug ? `${proj.orgSlug}/` : '';
+      const url = dep.url ? `https://${dep.url}` : dep.id;
+      const target =
+        dep.target === 'production' ? 'Production' : dep.target || 'Preview';
+      const namePadded =
+        ttyMode === 'non-tty' ? proj.name : proj.name.padEnd(maxName);
+      if (ttyMode === 'non-tty') {
+        // Plain, machine-friendly: name <url> [state] target
+        output.print(
+          `${namePadded} ${url} [${dep.readyState || 'UNKNOWN'}] ${target}\n`
+        );
+        if (dep.inspectorUrl) {
+          output.print(`  Inspect: ${dep.inspectorUrl}\n`);
+        }
+      } else {
+        output.print(
+          `  ${color(icon)} ${chalk.bold(namePadded)} ${chalk.dim(`(${proj.directory})`)}  ${chalk.cyan(url)} ${chalk.dim(`· ${target} · [${dep.readyState || 'UNKNOWN'}]`)}\n`
+        );
+        if (dep.inspectorUrl) {
+          output.print(
+            `    ${chalk.dim(`${orgSlug}${proj.name} Inspect:`)} ${link(dep.inspectorUrl)}\n`
+          );
+        }
+      }
+    }
+
+    // Only hint about logs in TTY — non-TTY caller piped vc git push
+    if (ttyMode === 'non-tty') {
+      output.print(
+        `\n${found.size} deployment(s) triggered. In non-interactive mode, logs are not streamed. Run with ${chalk.cyan('vc git push --logs')} or ${chalk.cyan('vc inspect <url> --logs')}.\n`
+      );
+    } else {
+      output.print(
+        `\n  ${chalk.dim(`All ${found.size} deployment(s) triggered. Logs not streamed for multi-project push.`)} ${chalk.dim(`Use:`)} ${chalk.cyan('vc inspect <url> --logs')} ${chalk.dim('or rerun from inside a project directory to stream that project. Or:')} ${chalk.cyan(`vc git push --logs`)} ${chalk.dim('(forces streaming for cwd-matched project).')}\n`
+      );
+    }
+
+    if (shouldForceLog) {
+      // Explicit opt-in from vc git push --logs even in multi-project repo:
+      // stream logs for the cwd-matched deepest project only (if any). This respects
+      // the "don't spam one project's logs across 30 lines" rule by picking one.
+      const forcedId = pickDeepest(cwdMatchedIdsHint ?? cwdMatchedIds);
+      if (forcedId) {
+        const forcedProj = projects.find(p => p.id === forcedId);
+        const forcedDep = found.get(forcedId);
+        if (forcedProj && forcedDep) {
+          output.print('\n');
+          output.log(
+            `--logs: streaming build logs for ${chalk.bold(forcedProj.name)} ${chalk.dim(`(${forcedProj.directory})`)} ${chalk.dim('(other projects continue server-side)')}`
+          );
+          try {
+            await streamDeploymentUntilReady(
+              client,
+              forcedDep,
+              forcedProj,
+              true
+            );
+          } catch (err: any) {
+            output.debug(`forced stream failed: ${err?.stack || err}`);
+          }
+        }
+      }
+    }
+
+    return gitExit;
+  }
+
+  // ── Single-project path: normal output plus logs (TTY-only by default) ──────
+  // Non-TTY: short-circuit to summary line — don't block on log tail, preserve git exit semantics.
+  if (ttyMode === 'non-tty' && !shouldForceLog) {
+    const onlyId = Array.from(found.keys())[0];
+    const onlyDep = onlyId ? found.get(onlyId) : undefined;
+    if (onlyDep) {
+      const url = onlyDep.url ? `https://${onlyDep.url}` : onlyDep.id;
+      output.print(
+        `Deployment triggered: ${url} [${onlyDep.readyState}] ${onlyDep.inspectorUrl ? `Inspect: ${onlyDep.inspectorUrl}` : ''}\n`
+      );
+    }
+    // Don't attach logs in non-TTY unless --logs — return quickly.
+    return gitExit;
+  }
+
+  let primaryProjectId: string | undefined;
   if (cwdMatchedIds.size > 0) {
     primaryProjectId = pickDeepest(cwdMatchedIds);
+  } else if (cwdMatchedIdsHint && cwdMatchedIdsHint.size > 0) {
+    primaryProjectId = pickDeepest(cwdMatchedIdsHint);
   }
 
   if (!primaryProjectId) {
-    // repo root / un-nested monorepo cwd: try smart defaults so "never picked up log stream" doesn't happen
     const isRootCwd =
       cwdRelativePath === '.' ||
       cwdRelativePath === '' ||
@@ -1174,7 +1796,6 @@ export default async function gitPassthrough(
       if (found.size === 1) {
         primaryProjectId = Array.from(found.keys())[0];
       } else {
-        // Prefer projects with directory '.' or '' (root projects)
         const rootDirCandidates = projects.filter(
           p =>
             (p.directory === '.' ||
@@ -1185,11 +1806,8 @@ export default async function gitPassthrough(
         if (rootDirCandidates.length === 1) {
           primaryProjectId = rootDirCandidates[0].id;
         } else if (rootDirCandidates.length === 0) {
-          // No root project — pick the most recently updated found deployment by primacy?
-          // Deepest found is still the best guess for typical usage.
           primaryProjectId = pickDeepest(found.keys());
         } else {
-          // Multiple root candidates — pick deepest (they're all same depth 0, so first alphabetical wins deterministically)
           primaryProjectId = pickDeepest(rootDirCandidates.map(p => p.id));
         }
       }
@@ -1206,8 +1824,6 @@ export default async function gitPassthrough(
   }
 
   if (!primaryProjectId) {
-    // No cwd-matched deployment to tail, and no safe root fallback — links already shown.
-    // Preserve git exit code. Hint user how to get logs explicitly.
     if (found.size === 1) {
       const onlyId = Array.from(found.keys())[0];
       const onlyDep = found.get(onlyId)!;
@@ -1223,14 +1839,12 @@ export default async function gitPassthrough(
   const primaryProj = projects.find(p => p.id === primaryProjectId)!;
   const primaryDep = found.get(primaryProjectId)!;
 
-  // If deployment is already done and user didn't force logs, skip streaming
   if (
     (primaryDep.readyState === 'READY' ||
       primaryDep.readyState === 'ERROR' ||
       primaryDep.readyState === 'CANCELED') &&
     !shouldForceLog
   ) {
-    // short-circuit still prints final status already done via pollFor...? It printed initial line but not full status. Print final.
     if (primaryDep.readyState !== 'READY') {
       output.print(
         `${chalk.yellow('⚠')} ${chalk.bold(primaryProj.name)} deployment finished with ${primaryDep.readyState}\n`
@@ -1240,7 +1854,6 @@ export default async function gitPassthrough(
   }
 
   output.print('\n');
-  // Use log() which already emits "> …" at col 0 — don't add another ">" manually; cli-ux forbids double gutters.
   output.log(
     `Attaching to deployment for ${chalk.bold(primaryProj.name)} ${chalk.dim(
       `(${primaryProj.directory})`
@@ -1256,10 +1869,7 @@ export default async function gitPassthrough(
     );
   } catch (err: any) {
     output.debug(`stream failed: ${err?.stack || err}`);
-    // don't fail the git push exit code because deployment continues server-side
   }
-
-  // For other projects, we already showed links; we don't stream them.
 
   return gitExit;
 }

--- a/packages/cli/src/util/events.ts
+++ b/packages/cli/src/util/events.ts
@@ -219,6 +219,16 @@ async function printEvents(
           o = 0;
         }
 
+        const msg = String((err as any)?.message || err || '');
+        // Suppress noisy repeated 404 while events endpoint warms up for a new
+        // git-triggered deployment. readyState polling still progresses and
+        // deploy will eventually be READY; log as debug instead of user-visible.
+        // The caller (git push passthrough) will retry the tail once BUILDING.
+        if (msg.includes('404') && msg.toLowerCase().includes('deployment')) {
+          debug(`Deployment events transient 404 (will retry): ${msg}`);
+          return;
+        }
+
         log(`Deployment events polling error: ${err.message}`);
       },
     }

--- a/packages/cli/src/util/telemetry/commands/git/index.ts
+++ b/packages/cli/src/util/telemetry/commands/git/index.ts
@@ -19,4 +19,43 @@ export class GitTelemetryClient
       value: actual,
     });
   }
+
+  // TelemetryMethods generates required keys based on arguments+options:
+  // - git-args argument -> trackCliArgumentGitArgs
+  // - --no-attach -> trackCliFlagNoAttach etc.
+  // We also expose a passthrough helper not modeled in command.ts (dynamic).
+
+  trackCliArgumentGitArgs(_value: string | undefined) {
+    // Intentionally do not record raw git args (may contain sensitive info)
+    // but satisfy type checker for TelemetryMethods.
+    this.trackCliArgument({
+      arg: 'git-args',
+      value: this.redactedValue,
+    } as any);
+  }
+
+  trackCliSubcommandPassthrough(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'passthrough',
+      value: actual,
+    });
+  }
+
+  trackCliFlagNoAttach(noAttach: boolean | undefined) {
+    if (noAttach) {
+      this.trackCliFlag('no-attach');
+    }
+  }
+
+  trackCliFlagLogs(logs: boolean | undefined) {
+    if (logs) {
+      this.trackCliFlag('logs');
+    }
+  }
+
+  trackCliFlagNoLogs(noLogs: boolean | undefined) {
+    if (noLogs) {
+      this.trackCliFlag('no-logs');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3117,10 +3117,14 @@ exports[`help command > git help output snapshots > git disconnect help output s
 
 exports[`help command > git help output snapshots > git help column width 40 1`] = `
 "
-  ▲ vercel git command
+  ▲ vercel git [git-args] [options]
 
   Manage your Git repository connection 
-  to the current Project                
+  to the current Project. Also acts as  
+  a Git passthrough: \`vc git push\` (and 
+  other git commands) runs Git and, on  
+  push, tracks Vercel deployments for   
+  linked projects.                      
 
   Commands:
 
@@ -3141,6 +3145,23 @@ exports[`help command > git help output snapshots > git help column width 40 1`]
                          from your 
                          Vercel    
                          Project   
+
+
+  Options:
+
+  -l,  --logs       Stream build logs for the
+                    current-directory project
+                    after \`git push\`         
+                    (default: auto when cwd  
+                    is inside a linked       
+                    project rootDirectory)   
+       --no-attach  Do not poll or attach to 
+                    deployments after \`git   
+                    push\`; just run Git and  
+                    exit                     
+       --no-logs    Do not stream build logs 
+                    even when attached to a  
+                    deployment               
 
 
   Global Options:
@@ -3191,14 +3212,30 @@ exports[`help command > git help output snapshots > git help column width 40 1`]
                               number    
 
 
+  Examples:
+
+  - Push and watch linked Vercel deployments
+
+    $ vercel git push
+
+  - Push without attaching to deployments
+
+    $ vercel git push --no-attach
+
+  - Run any Git command through Vercel CLI
+
+    $ vercel git status
+
 "
 `;
 
 exports[`help command > git help output snapshots > git help column width 80 1`] = `
 "
-  ▲ vercel git command
+  ▲ vercel git [git-args] [options]
 
-  Manage your Git repository connection to the current Project                  
+  Manage your Git repository connection to the current Project. Also acts as a  
+  Git passthrough: \`vc git push\` (and other git commands) runs Git and, on      
+  push, tracks Vercel deployments for linked projects.                          
 
   Commands:
 
@@ -3206,6 +3243,16 @@ exports[`help command > git help output snapshots > git help column width 80 1`]
                          or provide the remote URL to your Git repository  
   disconnect             Disconnect the Git repository from your Vercel    
                          Project                                           
+
+
+  Options:
+
+  -l,  --logs       Stream build logs for the current-directory project after \`git   
+                    push\` (default: auto when cwd is inside a linked project         
+                    rootDirectory)                                                   
+       --no-attach  Do not poll or attach to deployments after \`git push\`; just run  
+                    Git and exit                                                     
+       --no-logs    Do not stream build logs even when attached to a deployment      
 
 
   Global Options:
@@ -3224,20 +3271,43 @@ exports[`help command > git help output snapshots > git help column width 80 1`]
   -v,  --version              Output the version number                         
 
 
+  Examples:
+
+  - Push and watch linked Vercel deployments
+
+    $ vercel git push
+
+  - Push without attaching to deployments
+
+    $ vercel git push --no-attach
+
+  - Run any Git command through Vercel CLI
+
+    $ vercel git status
+
 "
 `;
 
 exports[`help command > git help output snapshots > git help column width 120 1`] = `
 "
-  ▲ vercel git command
+  ▲ vercel git [git-args] [options]
 
-  Manage your Git repository connection to the current Project                                                          
+  Manage your Git repository connection to the current Project. Also acts as a Git passthrough: \`vc git push\` (and      
+  other git commands) runs Git and, on push, tracks Vercel deployments for linked projects.                             
 
   Commands:
 
   connect     [git-url]  Connect your Vercel Project to your Git repository or provide the remote URL to your Git  
                          repository                                                                                
   disconnect             Disconnect the Git repository from your Vercel Project                                    
+
+
+  Options:
+
+  -l,  --logs       Stream build logs for the current-directory project after \`git push\` (default: auto when cwd is inside a 
+                    linked project rootDirectory)                                                                            
+       --no-attach  Do not poll or attach to deployments after \`git push\`; just run Git and exit                             
+       --no-logs    Do not stream build logs even when attached to a deployment                                              
 
 
   Global Options:
@@ -3253,6 +3323,20 @@ exports[`help command > git help output snapshots > git help column width 120 1`
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
 
+
+  Examples:
+
+  - Push and watch linked Vercel deployments
+
+    $ vercel git push
+
+  - Push without attaching to deployments
+
+    $ vercel git push --no-attach
+
+  - Run any Git command through Vercel CLI
+
+    $ vercel git status
 
 "
 `;

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3121,10 +3121,11 @@ exports[`help command > git help output snapshots > git help column width 40 1`]
 
   Manage your Git repository connection 
   to the current Project. Also acts as  
-  a Git passthrough: \`vc git push\` (and 
-  other git commands) runs Git and, on  
-  push, tracks Vercel deployments for   
-  linked projects.                      
+  a Git passthrough: \`vc git push\` runs 
+  Git and tracks Vercel deployments for 
+  linked projects; \`vc git status\`      
+  shows Git status plus latest Vercel   
+  deployments for the current branch.   
 
   Commands:
 
@@ -3214,6 +3215,10 @@ exports[`help command > git help output snapshots > git help column width 40 1`]
 
   Examples:
 
+  - Show Git status with Vercel deployments for this branch
+
+    $ vercel git status
+
   - Push and watch linked Vercel deployments
 
     $ vercel git push
@@ -3224,7 +3229,7 @@ exports[`help command > git help output snapshots > git help column width 40 1`]
 
   - Run any Git command through Vercel CLI
 
-    $ vercel git status
+    $ vercel git log --oneline -n 10
 
 "
 `;
@@ -3234,8 +3239,9 @@ exports[`help command > git help output snapshots > git help column width 80 1`]
   ▲ vercel git [git-args] [options]
 
   Manage your Git repository connection to the current Project. Also acts as a  
-  Git passthrough: \`vc git push\` (and other git commands) runs Git and, on      
-  push, tracks Vercel deployments for linked projects.                          
+  Git passthrough: \`vc git push\` runs Git and tracks Vercel deployments for     
+  linked projects; \`vc git status\` shows Git status plus latest Vercel          
+  deployments for the current branch.                                           
 
   Commands:
 
@@ -3273,6 +3279,10 @@ exports[`help command > git help output snapshots > git help column width 80 1`]
 
   Examples:
 
+  - Show Git status with Vercel deployments for this branch
+
+    $ vercel git status
+
   - Push and watch linked Vercel deployments
 
     $ vercel git push
@@ -3283,7 +3293,7 @@ exports[`help command > git help output snapshots > git help column width 80 1`]
 
   - Run any Git command through Vercel CLI
 
-    $ vercel git status
+    $ vercel git log --oneline -n 10
 
 "
 `;
@@ -3292,8 +3302,9 @@ exports[`help command > git help output snapshots > git help column width 120 1`
 "
   ▲ vercel git [git-args] [options]
 
-  Manage your Git repository connection to the current Project. Also acts as a Git passthrough: \`vc git push\` (and      
-  other git commands) runs Git and, on push, tracks Vercel deployments for linked projects.                             
+  Manage your Git repository connection to the current Project. Also acts as a Git passthrough: \`vc git push\` runs Git  
+  and tracks Vercel deployments for linked projects; \`vc git status\` shows Git status plus latest Vercel deployments    
+  for the current branch.                                                                                               
 
   Commands:
 
@@ -3326,6 +3337,10 @@ exports[`help command > git help output snapshots > git help column width 120 1`
 
   Examples:
 
+  - Show Git status with Vercel deployments for this branch
+
+    $ vercel git status
+
   - Push and watch linked Vercel deployments
 
     $ vercel git push
@@ -3336,7 +3351,7 @@ exports[`help command > git help output snapshots > git help column width 120 1`
 
   - Run any Git command through Vercel CLI
 
-    $ vercel git status
+    $ vercel git log --oneline -n 10
 
 "
 `;

--- a/packages/cli/test/unit/commands/git/index.test.ts
+++ b/packages/cli/test/unit/commands/git/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import git from '../../../../src/commands/git';
 import { client } from '../../../mocks/client';
 
@@ -27,7 +27,6 @@ describe('git', () => {
   });
 
   describe('passthrough', () => {
-
     it('passes through unknown args to git and returns its exit code', async () => {
       // We can't easily mock the already-imported spawn without vi.mock hoisting,
       // so test the routing: unknown subcommand should not return 2 (help) anymore.
@@ -64,8 +63,44 @@ describe('git', () => {
       await git(client);
 
       const events = client.telemetryEventStore.readonlyEvents;
-      const hasPassthrough = events.some(e => e.key === 'subcommand:passthrough');
+      const hasPassthrough = events.some(
+        e => e.key === 'subcommand:passthrough'
+      );
       expect(hasPassthrough).toBe(true);
+    });
+
+    it('shows deployment summary after git status without changing exit code', async () => {
+      // Exercise the new branch deployment summary path. We don't have a linked
+      // .vercel/repo.json in the temp repo, so summary should gracefully skip
+      // and exit code should still equal git's.
+      const { mkdtempSync } = await import('fs');
+      const { tmpdir } = await import('os');
+      const { execSync } = await import('child_process');
+      const { join } = await import('path');
+      const dir = mkdtempSync(join(tmpdir(), 'vc-git-test-status-'));
+      execSync('git init -q', { cwd: dir });
+      execSync('git checkout -b feature-branch -q', { cwd: dir });
+      client.cwd = dir;
+
+      client.setArgv('git', 'status');
+      const exitCode = await git(client);
+
+      expect(exitCode).toBe(0);
+      // Should not throw even without link config
+    });
+
+    it('preserves git status exit code for non-zero git failure', async () => {
+      const { mkdtempSync } = await import('fs');
+      const { tmpdir } = await import('os');
+      const { join } = await import('path');
+      const dir = mkdtempSync(join(tmpdir(), 'vc-git-test-fail-'));
+      // Intentionally NOT init git, so `git status` fails with 128
+      client.cwd = dir;
+
+      client.setArgv('git', 'status');
+      const exitCode = await git(client);
+
+      expect([128, 1]).toContain(exitCode);
     });
   });
 });

--- a/packages/cli/test/unit/commands/git/index.test.ts
+++ b/packages/cli/test/unit/commands/git/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import git from '../../../../src/commands/git';
 import { client } from '../../../mocks/client';
 
@@ -26,11 +26,46 @@ describe('git', () => {
     expect(exitCode, 'exit code for git').toBe(2);
   });
 
-  describe('unrecognized subcommand', () => {
-    it('shows help', async () => {
-      client.setArgv('git', 'not-a-command');
+  describe('passthrough', () => {
+
+    it('passes through unknown args to git and returns its exit code', async () => {
+      // We can't easily mock the already-imported spawn without vi.mock hoisting,
+      // so test the routing: unknown subcommand should not return 2 (help) anymore.
+      // Instead it attempts git passthrough. Since we didn't mock spawn here (it would be real git),
+      // we verify that the new behavior does NOT return help exit code 2 for a real git subcommand like `status`.
+      // `git status` will either succeed (0) if inside a repo or fail (128) if not, but never 2 from CLI help.
+
+      // Setup a temp cwd that is a git repo to get deterministic 0
+      const { mkdtempSync } = await import('fs');
+      const { tmpdir } = await import('os');
+      const { execSync } = await import('child_process');
+      const { join } = await import('path');
+      const dir = mkdtempSync(join(tmpdir(), 'vc-git-test-'));
+      execSync('git init -q', { cwd: dir });
+      client.cwd = dir;
+
+      client.setArgv('git', 'status', '--short');
       const exitCode = await git(client);
-      expect(exitCode).toEqual(2);
+      // git status --short in empty repo should be 0
+      expect([0, 128]).toContain(exitCode);
+      expect(exitCode).not.toEqual(2);
+    });
+
+    it('tracks passthrough telemetry', async () => {
+      const { mkdtempSync } = await import('fs');
+      const { tmpdir } = await import('os');
+      const { execSync } = await import('child_process');
+      const { join } = await import('path');
+      const dir = mkdtempSync(join(tmpdir(), 'vc-git-test-'));
+      execSync('git init -q', { cwd: dir });
+      client.cwd = dir;
+
+      client.setArgv('git', 'status');
+      await git(client);
+
+      const events = client.telemetryEventStore.readonlyEvents;
+      const hasPassthrough = events.some(e => e.key === 'subcommand:passthrough');
+      expect(hasPassthrough).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `vc git` – a transparent git passthrough that keeps Vercel aware of what you pushed, without replacing git.

`vc git <any git args>` runs the real `git` binary via `spawn` with inherited stdio, preserving exit codes and TTY behavior. When the command is a `push`, it tracks the resulting Vercel deployments.

## Why

Some teams lock deployments to be git-only — direct `vercel deploy` from CLI is no longer allowed for those projects. That creates a gap: developers lose the instant feedback they used to get from `vercel deploy` (deployment link, status, streaming build logs).

`vc git` closes that gap. It preserves existing `git` muscle memory — `vc git push` behaves identically to `git push` — while adding Vercel-aware feedback: which projects deployed, which were skipped and why, and optional log tailing like `vc deploy` does. For git-only teams, `vc git push` becomes the natural replacement for `vercel deploy`.

> Note: git-only deployment guarding is not yet announced; this PR is fine to mention it at a high level.

## Behavior

- `vc git status` → normal `git status`, plus a Vercel section with the latest deployments for the current branch.
- `vc git push` (and `push --force`, `push origin branch`, etc) → runs `git push`, captures branch + SHAs, polls `/v6/deployments` for new git-triggered deployments.
- Non-push commands → pure passthrough, zero Vercel API calls.

### Timing / TTY-awareness

- **Single project linked** (TTY): 60s trigger wait + 12s grace after first deploy seen, then streams build logs for that project.
- **Monorepo (30 projects)** (TTY): 35s + 18s grace, summary table only (no log flood). `vc git push --logs` streams cwd-matched deepest project.
- **Non-TTY / CI / `| tee` / `--yes`**: 12s + 5s grace, no log tail, machine-friendly one-liners. Opt-in with `--logs`.
- Poll backoff 2.5s → 5s, concurrency capped to avoid 429s.

### Skipped deployments explained

When a push doesn't yield a deployment, we fetch `/v9/projects/{id}` and surface the reason instead of hanging the full budget:

- `git.deploymentEnabled=false` or per-branch `false`
- `sourceless` / not connected to git
- `ignoreCommand` / `rootDirectory` heuristic (soft reason)

## Output examples

### `vc git status`

```sh
$ vc git status
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean

── Vercel ──
Branch main – 2 projects linked from .vercel/repo.json

  • my-site (acme/my-site) — READY  abcd123… — https://my-site.vercel.app (32s ago)
      $ vercel inspect my-site-f7hs9abc…  /  vercel logs my-site-f7hs9abc…
  • docs (acme/docs) — no deployment on main yet
    Tip: push this branch or run `vercel deploy` inside apps/docs.
```

### `vc git push` – single project, logs streamed

```sh
$ vc git push
Enumerating objects: 9, done.
...
To github.com:acme/my-site.git
   a1b2c3d..f7e8d9c  main -> main

✓ Pushed main (f7e8d9c) — checking Vercel…

Found 1 deployment for f7e8d9c on main

  my-site (acme/my-site)
    ⏳ BUILDING — https://my-site-f7hs9abc…vercel.app
       Inspect: https://vercel.com/acme/my-site/f7hs9abc…

[build logs stream here — same as `vercel logs --follow`]

✓ my-site READY — https://my-site-f7hs9abc….vercel.app (18s)
```

### `vc git push` – monorepo with mixed results

```sh
$ vc git push
...
✓ Pushed main (f7e8d9c)

Found 6 deployments for f7e8d9c on main (12 still pending)

  ✓ my-site     READY      https://my-site-f7h….vercel.app      acme/my-site
  ⏳ docs        BUILDING   https://docs-4k2j….vercel.app       acme/docs
  ✓ api         READY      https://api-g9a1….vercel.app        acme/api
  – marketing   skipped — git.deploymentEnabled=false
  – internal    not connected to git (manual deploys only)
  – legacy      no new deployment (likely ignoreCommand — check dashboard Build settings)
  …and 12 more still waiting (use --logs to stream)

Tip: `vercel git status` to re-check pending deployments.
```

### `vc git push | tee` / CI (non-TTY)

```sh
$ vc git push | tee /tmp/push.log
...
my-site https://my-site-f7hs9….vercel.app [READY] Production
docs    https://docs-4k2j….vercel.app [BUILDING] Preview

# no log tail, exits fast (~12s). Add --logs to force streaming.
```

## Wrapper flags

```
--no-attach   skip polling after push, return immediately after git exits
--logs, -l    force log tail (cwd-matched project in monorepo, or single project)
--no-logs     never tail, summary only even in TTY
```

## Notes

- `vc git` is pure passthrough: same args, same stdout/stderr, same exit code as `git`.
- Ctrl+C during log tail detaches (deployment continues server-side).
- Telemetry: `gitArgsCount`, `isPush`, `pushExitCode`, `noAttach`, `forceLogs`.