### PR TITLE
[cli] Harden filesystem trust boundaries

### DIFF
--- a/.changeset/cli-symlink-path-hardening.md
+++ b/.changeset/cli-symlink-path-hardening.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Harden filesystem trust boundaries: `vercel init` no longer materializes symlink or hardlink entries from downloaded example archives (blocking tar link-following path traversal, CVE-2024-12905 / CVE-2025-48387, and upgrading `tar-fs` to 1.16.5), the deploy root-directory check now normalizes paths before the containment test so a sibling directory sharing the project's path prefix can no longer be selected, and `ai-gateway coding-agents setup` now flags in its plan when a target config path is a symlink so the approval prompt reflects the file the write actually lands on.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -195,7 +195,7 @@
     "split2": "4.2.0",
     "strip-ansi": "6.0.1",
     "supports-hyperlinks": "3.0.0",
-    "tar-fs": "1.16.3",
+    "tar-fs": "1.16.5",
     "title": "3.4.1",
     "tldts": "6.1.47",
     "tmp-promise": "1.0.3",

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -145,7 +145,12 @@ async function extractExample(
       }
 
       await new Promise((resolve, reject) => {
-        const extractor = tar.extract(folder);
+        const extractor = tar.extract(folder, {
+          // Drop symlink/hardlink entries: they're the tar link-following
+          // traversal vector (CVE-2024-12905 / CVE-2025-48387).
+          ignore: (_name, header) =>
+            header?.type !== 'file' && header?.type !== 'directory',
+        });
         const body = toNodeReadable(res.body);
         body.on('error', reject);
         extractor.on('error', reject);

--- a/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
@@ -5,6 +5,7 @@ import {
   backupFile,
   writeConfigFile,
   upsertManagedBlock,
+  isSymlink,
 } from './config-files';
 import { KEY_PLACEHOLDER } from './gateway';
 import { keychainLookup } from './keychain';
@@ -21,6 +22,7 @@ export interface PlannedChange {
   status: ChangeStatus;
   error?: string;
   mode?: number;
+  symlink?: boolean;
 }
 
 export interface AgentNotes {
@@ -204,6 +206,7 @@ export async function buildSetupPlan(
   const changes: PlannedChange[] = [];
   for (const [path, entry] of byPath) {
     const current = await readFileOrNull(path);
+    const symlink = await isSymlink(path);
     let next: string | null = null;
     let status: ChangeStatus;
     let error: string | undefined;
@@ -239,6 +242,7 @@ export async function buildSetupPlan(
       next,
       status,
       error,
+      symlink,
     });
   }
 

--- a/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
@@ -1,4 +1,11 @@
-import { readFile, writeFile, mkdir, copyFile, access } from 'node:fs/promises';
+import {
+  readFile,
+  writeFile,
+  mkdir,
+  copyFile,
+  access,
+  lstat,
+} from 'node:fs/promises';
 import { isDeepStrictEqual } from 'node:util';
 import { dirname } from 'node:path';
 import { parse as tomlParse, stringify as tomlStringify } from 'smol-toml';
@@ -12,6 +19,15 @@ export async function pathExists(path: string): Promise<boolean> {
   try {
     await access(path);
     return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True when `path` is a symlink — `writeConfigFile` follows it, so the plan flags it. */
+export async function isSymlink(path: string): Promise<boolean> {
+  try {
+    return (await lstat(path)).isSymbolicLink();
   } catch {
     return false;
   }

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -61,6 +61,7 @@ export async function runMachine(args: {
                 : c.status === 'update'
                   ? 'would_update'
                   : c.status,
+            ...(c.symlink ? { symlink: true } : {}),
           })),
           skipped,
           warnings: args.warnings,

--- a/packages/cli/src/util/ai-gateway/coding-agents/render.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/render.ts
@@ -85,6 +85,12 @@ export function printPlan(
     output.print(
       `  ${verb === 'create' ? chalk.green('+') : '~'} ${chalk.bold(change.label)} (${verb})  ${chalk.dim(change.path)}\n`
     );
+    // The write follows the symlink to its target; surface that before approval.
+    if (change.symlink) {
+      output.print(
+        `    ${chalk.yellow('↳ warning:')} this path is a symlink — the write will follow it to its target\n`
+      );
+    }
     // An existing file is copied to `<path>.bak` before it's overwritten;
     // surface that side effect in the preview unless backups are disabled.
     if (opts.backup && change.current !== null) {

--- a/packages/cli/src/util/validate-paths.ts
+++ b/packages/cli/src/util/validate-paths.ts
@@ -1,6 +1,7 @@
 import { lstat } from 'fs-extra';
 import chalk from 'chalk';
 import { homedir } from 'os';
+import { resolve, sep } from 'path';
 import toHumanPath from './humanize-path';
 import type Client from './client';
 import output from '../output-manager';
@@ -34,7 +35,10 @@ export async function validateRootDirectory(
     return false;
   }
 
-  if (!path.startsWith(cwd)) {
+  // Normalize first: a raw `startsWith` lets `<cwd>-evil` / `<cwd>/../x` through.
+  const base = resolve(cwd);
+  const target = resolve(path);
+  if (target !== base && !target.startsWith(base + sep)) {
     output.error(
       `The provided path ${chalk.cyan(
         `“${toHumanPath(path)}”`

--- a/packages/cli/test/unit/util/validate-paths.test.ts
+++ b/packages/cli/test/unit/util/validate-paths.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { validateRootDirectory } from '../../../src/util/validate-paths';
+
+vi.mock('../../../src/output-manager', () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+describe('validateRootDirectory', () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'vc-root-'));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+    // The sibling-prefix dir lives next to `base`, not inside it.
+    rmSync(`${base}-evil`, { recursive: true, force: true });
+  });
+
+  it('accepts the project root itself', async () => {
+    expect(await validateRootDirectory(base, base)).toBe(true);
+  });
+
+  it('accepts a directory inside the project root', async () => {
+    const sub = join(base, 'apps', 'web');
+    mkdirSync(sub, { recursive: true });
+    expect(await validateRootDirectory(base, sub)).toBe(true);
+  });
+
+  it('rejects a sibling directory that shares the root as a string prefix', async () => {
+    // A raw `startsWith(cwd)` would wrongly accept this.
+    const sibling = `${base}-evil`;
+    mkdirSync(sibling, { recursive: true });
+    expect(await validateRootDirectory(base, sibling)).toBe(false);
+  });
+
+  it('rejects a path that escapes the root via ..', async () => {
+    const outside = join(base, '..');
+    expect(await validateRootDirectory(base, outside)).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -940,8 +940,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       tar-fs:
-        specifier: 1.16.3
-        version: 1.16.3
+        specifier: 1.16.5
+        version: 1.16.5
       title:
         specifier: 3.4.1
         version: 3.4.1
@@ -6102,9 +6102,6 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
-
-  '@types/async-retry@1.2.1':
-    resolution: {integrity: sha512-yMQ6CVgICWtyFNBqJT3zqOc+TnqqEPLo4nKJNPFwcialiylil38Ie6q1ENeFTjvaLOkVim9K5LisHgAKJWidGQ==}
 
   '@types/async-retry@1.4.5':
     resolution: {integrity: sha512-YrdjSD+yQv7h6d5Ip+PMxh3H6ZxKyQk0Ts+PvaNRInxneG9PFVZjFg77ILAN+N6qYf7g4giSJ1l+ZjQ1zeegvA==}
@@ -12051,6 +12048,9 @@ packages:
   tar-fs@1.16.3:
     resolution: {integrity: sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==}
 
+  tar-fs@1.16.5:
+    resolution: {integrity: sha512-1ergVCCysmwHQNrOS+Pjm4DQ4nrGp43+Xnu4MRGjCnQu/m3hEgLNS78d5z+B8OJ1hN5EejJdCSFZE1oM6AQXAQ==}
+
   tar-fs@2.0.0:
     resolution: {integrity: sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==}
 
@@ -16443,8 +16443,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  '@types/async-retry@1.2.1': {}
 
   '@types/async-retry@1.4.5':
     dependencies:
@@ -23509,6 +23507,13 @@ snapshots:
       - typescript
 
   tar-fs@1.16.3:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp: 0.5.6
+      pump: 1.0.3
+      tar-stream: 1.6.2
+
+  tar-fs@1.16.5:
     dependencies:
       chownr: 1.1.4
       mkdirp: 0.5.6


### PR DESCRIPTION
Tightens where the CLI writes and extracts files so a target path stays where the user expects.

**Happy path**
- As a developer running `vercel init`, my example project extracts into the target folder as before.
- As a developer setting a deploy root directory, a valid folder inside my project is accepted.
- As a developer running `ai-gateway coding-agents setup`, my agent config files are written and the plan shows what will change.

**Unhappy path**
- As a developer running `vercel init`, symlink and hardlink entries in the downloaded archive are skipped instead of writing outside the target folder.
- As a developer picking a deploy root, a path that resolves outside my project (a sibling folder sharing the name prefix, or a `../` escape) is rejected instead of silently accepted.
- As a developer whose agent config path is a symlink, the setup plan warns me before I approve so I know the write follows the link.