### PR TITLE
ci: Use OIDC for Turborepo remote cache

### DIFF
--- a/.changeset/healthy-taxis-cache.md
+++ b/.changeset/healthy-taxis-cache.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use OIDC authentication for Turborepo remote caching in GitHub Actions.

--- a/.changeset/healthy-taxis-cache.md
+++ b/.changeset/healthy-taxis-cache.md
@@ -1,4 +1,0 @@
----
----
-
-Use OIDC authentication for Turborepo remote caching in GitHub Actions.

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -7,8 +7,6 @@ on:
 
 env:
   TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'zero-conf-vtest314'
-  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -23,6 +21,11 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+
+      - name: Setup Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -16,8 +16,6 @@ permissions:
 
 env:
   TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'zero-conf-vtest314'
-  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 concurrency:
   group: release-binary-${{ inputs.tag || github.ref }}
@@ -85,6 +83,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
+
+      - name: Setup Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
 
 env:
   TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'zero-conf-vtest314'
-  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -33,6 +31,11 @@ jobs:
 
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -5,8 +5,6 @@ on:
 
 env:
   TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'zero-conf-vtest314'
-  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   NODE_VERSION: '22'
 
 concurrency:
@@ -37,11 +35,18 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.title != 'Version Packages'
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           # Check out the PR commit directly instead of a merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ permissions:
 env:
   VERCEL_TELEMETRY_DISABLED: '1'
   TURBO_REMOTE_ONLY: 'true'
-  TURBO_TEAM: 'zero-conf-vtest314'
-  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,6 +25,10 @@ jobs:
   setup:
     name: Find Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
     outputs:
       unitTests: ${{ steps['set-tests'].outputs['unitTests'] }}
       e2eTests: ${{ steps['set-tests'].outputs['e2eTests'] }}
@@ -73,6 +75,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.pr-context.outputs.headSha }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -252,6 +258,9 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{ matrix.runner }}
     name: Unit / ${{ matrix.label }}
+    permissions:
+      contents: read
+      id-token: write
     if: ${{ needs.setup.outputs['unitTests'] != '[]' }}
     needs:
       - setup
@@ -265,6 +274,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.headSha }}
+      - name: Setup Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -383,6 +396,11 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{ matrix.runner }}
     name: E2E / ${{ matrix.label }}
+    permissions:
+      contents: read
+      deployments: read
+      id-token: write
+      statuses: read
     if: ${{ needs.setup.outputs['e2eTests'] != '[]' }}
     needs:
       - setup
@@ -396,6 +414,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.headSha }}
+      - name: Setup Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}


### PR DESCRIPTION
## Why

Remote caching currently depends on a long-lived Vercel token shared with unrelated test behavior. Short-lived OIDC credentials reduce secret exposure and separate cache authentication from Vercel API access.

## What

Migrate the existing cache-enabled CI jobs to the Turborepo remote-cache setup action while retaining Vercel tokens only where tests require them. The action is pinned to its current commit because the documented `v1` tag does not exist yet.

## How

- `TURBO_TEAM` is configured as the repository variable `zero-conf-vtest314`.
- Before marking ready, confirm exactly one Turborepo CLI OIDC policy in that team matches each affected workflow.
- Validate a pull request run, a `main` canary/release run, and a binary release dispatch; each Turbo invocation should report `Remote caching enabled`.
- Verified YAML parsing, Prettier, `git diff --check`, and Zizmor 1.24.1.