### PR TITLE
[connect] Add Passport dual authentication

### DIFF
--- a/.changeset/shiny-cats-connect.md
+++ b/.changeset/shiny-cats-connect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Add Passport subjects and dual-authentication support to Connect token and authorization requests.

--- a/.changeset/tidy-pears-travel.md
+++ b/.changeset/tidy-pears-travel.md
@@ -1,0 +1,5 @@
+---
+'@vercel/passport': minor
+---
+
+Verify resource-bound Passport identities used by delegated development previews.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -30,6 +30,35 @@ const token = await getToken(process.env.CONNECTOR_LINEAR!, {
 });
 ```
 
+When Passport authenticates the current request, pass its verified token as a
+second credential. The project OIDC token still authenticates the calling
+Vercel project, while Passport identifies the user whose Connect grant should
+be used:
+
+```ts
+import { getToken } from '@vercel/connect';
+import { getIdentity } from '@vercel/passport';
+
+const identity = await getIdentity(undefined, { development: false });
+
+if (!identity?.verified || !identity.token) {
+  throw new Error('Passport authentication required');
+}
+
+const token = await getToken(
+  'google/calendar',
+  { subject: { type: 'passport' } },
+  {
+    passportToken: identity.token,
+    passportResource: identity.resource,
+  }
+);
+```
+
+`passportToken` and `passportResource` must come from the same verified
+`PassportIdentity`. The SDK forwards them alongside the project OIDC bearer
+and does not cache Passport-scoped token responses in process memory.
+
 ### Chat SDK
 
 Spread the helper into the matching `create*Adapter` factory. Each helper

--- a/packages/connect/src/authorization.ts
+++ b/packages/connect/src/authorization.ts
@@ -1,7 +1,9 @@
 import { getVercelOidcToken } from '@vercel/oidc';
-import type { ConnectTokenParams } from './token.js';
+import { passportAuthorizationHeaders } from './internal/passport.js';
+import type { ConnectPassportOptions, ConnectTokenParams } from './token.js';
 
-export interface ConnectAuthorizationOptions {
+export interface ConnectAuthorizationOptions
+  extends Partial<ConnectPassportOptions> {
   vercelToken?: string;
   callbackUrl?: string;
   webhook?: string;
@@ -54,6 +56,7 @@ export async function startAuthorization(
   if (options?.webhook !== undefined) {
     validateWebhookUrl(options.webhook);
   }
+  const passportHeaders = passportAuthorizationHeaders(params.subject, options);
 
   const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
   const endpoint = `https://api.vercel.com/v1/connect/authorize/${encodeURIComponent(connector)}`;
@@ -78,6 +81,7 @@ export async function startAuthorization(
       Accept: 'application/json',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${vercelToken}`,
+      ...passportHeaders,
     },
     body: JSON.stringify(body),
   });

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -9,6 +9,8 @@ export {
   ConnectorInstallationRequiredError,
   type ConnectErrorOptions,
   type ConnectOptions,
+  type ConnectPassportOptions,
+  type ConnectPassportTokenSubject,
   type ConnectTokenParams,
   type ConnectTokenResponse,
   type ConnectTokenSubject,

--- a/packages/connect/src/internal/passport.ts
+++ b/packages/connect/src/internal/passport.ts
@@ -1,0 +1,32 @@
+import type { ConnectPassportOptions, ConnectTokenSubject } from '../token.js';
+
+export const PASSPORT_TOKEN_HEADER_NAME = 'x-vercel-oidc-passport-token';
+export const PASSPORT_RESOURCE_HEADER_NAME = 'x-vercel-passport-resource';
+
+export function passportAuthorizationHeaders(
+  subject: ConnectTokenSubject,
+  options?: Partial<ConnectPassportOptions>
+): Record<string, string> {
+  if (subject.type !== 'passport') {
+    return {};
+  }
+
+  if (!options?.passportToken?.trim()) {
+    throw new Error(
+      'passportToken is required when subject.type is "passport"'
+    );
+  }
+
+  const headers = { [PASSPORT_TOKEN_HEADER_NAME]: options.passportToken };
+  if (!options.passportResource) {
+    return headers;
+  }
+  return {
+    ...headers,
+    [PASSPORT_RESOURCE_HEADER_NAME]: options.passportResource,
+  };
+}
+
+export function isPassportSubject(subject: ConnectTokenSubject): boolean {
+  return subject.type === 'passport';
+}

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -1,12 +1,17 @@
 import { getVercelOidcToken } from '@vercel/oidc';
 import type { ConnectAuthorizationDetail } from './authorization-details.js';
+import {
+  isPassportSubject,
+  passportAuthorizationHeaders,
+} from './internal/passport.js';
 
-export type ConnectSubjectType = 'app' | 'user' | 'jwt-bearer';
+export type ConnectSubjectType = 'app' | 'user' | 'jwt-bearer' | 'passport';
 
 export type ConnectTokenSubject =
   | ConnectAppTokenSubject
   | ConnectUserTokenSubject
-  | ConnectJwtBearerTokenSubject;
+  | ConnectJwtBearerTokenSubject
+  | ConnectPassportTokenSubject;
 
 export interface ConnectAppTokenSubject {
   type: 'app';
@@ -26,6 +31,25 @@ export interface ConnectJwtBearerTokenSubject {
   /** Defaults to the connector's OAuth token endpoint. */
   aud?: string;
   additionalClaims?: Record<string, unknown>;
+}
+
+/**
+ * Use the identity in the verified Passport token supplied through
+ * {@link ConnectOptions.passportToken}.
+ */
+export interface ConnectPassportTokenSubject {
+  type: 'passport';
+}
+
+export interface ConnectPassportOptions {
+  /**
+   * Raw token from a verified `PassportIdentity`. The Connect API validates
+   * the token again before using its identity.
+   */
+  passportToken: string;
+
+  /** Resource returned with a resource-bound Passport identity. */
+  passportResource?: string;
 }
 
 export interface ConnectTokenParams {
@@ -114,7 +138,7 @@ export class ConnectorInstallationRequiredError extends ConnectError {
   }
 }
 
-export interface ConnectOptions {
+export interface ConnectOptions extends Partial<ConnectPassportOptions> {
   vercelToken?: string;
 
   /**
@@ -127,6 +151,10 @@ export interface ConnectOptions {
    * needs Connect to re-validate the grant on this call — a revoked grant
    * then surfaces as `no_token` / `user_authorization_required` instead of
    * a stale bearer.
+   *
+   * Passport subjects always bypass the in-process cache, regardless of this
+   * option, because their identity lives in `passportToken` rather than in the
+   * cache-keyed request parameters.
    */
   forceRefresh?: boolean;
 }
@@ -145,20 +173,27 @@ export async function getTokenResponse(
   params: ConnectTokenParams,
   options?: ConnectOptions
 ): Promise<ConnectTokenResponse> {
+  const passportHeaders = passportAuthorizationHeaders(params.subject, options);
+  const passportSubject = isPassportSubject(params.subject);
   const bufferMs = params.validityBufferMs ?? DEFAULT_VALIDITY_BUFFER_MS;
-  const cacheKey = tokenCacheKey(connector, params);
+  let cacheKey: string | undefined;
 
-  if (options?.forceRefresh) {
-    cache.delete(cacheKey);
-  } else {
-    const cached = cache.get(cacheKey);
-    if (cached) {
-      const now = Date.now();
-      if (cached.response.expiresAt - now > bufferMs) {
-        cached.lastUsed = now;
-        return cached.response;
-      }
+  // A Passport subject is identified by the separately supplied bearer, not
+  // by `params`. Never cache its response or put the raw bearer in a key.
+  if (!passportSubject) {
+    cacheKey = tokenCacheKey(connector, params);
+    if (options?.forceRefresh) {
       cache.delete(cacheKey);
+    } else {
+      const cached = cache.get(cacheKey);
+      if (cached) {
+        const now = Date.now();
+        if (cached.response.expiresAt - now > bufferMs) {
+          cached.lastUsed = now;
+          return cached.response;
+        }
+        cache.delete(cacheKey);
+      }
     }
   }
 
@@ -172,6 +207,7 @@ export async function getTokenResponse(
       Accept: 'application/json',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${vercelToken}`,
+      ...passportHeaders,
     },
     body: JSON.stringify(params),
   });
@@ -182,10 +218,12 @@ export async function getTokenResponse(
 
   const data: ConnectTokenResponse = await response.json();
 
-  if (cache.size >= MAX_CACHE_SIZE) {
-    evictLru();
+  if (cacheKey !== undefined) {
+    if (cache.size >= MAX_CACHE_SIZE) {
+      evictLru();
+    }
+    cache.set(cacheKey, { response: data, lastUsed: Date.now() });
   }
-  cache.set(cacheKey, { response: data, lastUsed: Date.now() });
 
   return data;
 }
@@ -198,6 +236,7 @@ export async function revokeToken(
   },
   options?: ConnectOptions
 ): Promise<void> {
+  const passportHeaders = passportAuthorizationHeaders(params.subject, options);
   const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
   const endpoint = `https://api.vercel.com/v1/connect/connectors/${encodeURIComponent(connector)}/tokens`;
 
@@ -207,6 +246,7 @@ export async function revokeToken(
       Accept: 'application/json',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${vercelToken}`,
+      ...passportHeaders,
     },
     body: JSON.stringify(params),
   });

--- a/packages/connect/test/authorization.test.ts
+++ b/packages/connect/test/authorization.test.ts
@@ -64,6 +64,50 @@ describe('startAuthorization', () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('requires a Passport token for a Passport subject', async () => {
+    await expect(
+      startAuthorization(CONNECTOR, { subject: { type: 'passport' } })
+    ).rejects.toThrow(
+      'passportToken is required when subject.type is "passport"'
+    );
+
+    expect(getVercelOidcToken).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends Passport identity alongside project OIDC', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        request: 'req_passport',
+        verifier: 'verifier_passport',
+        url: 'https://connect.vercel.com/authorize/req_passport',
+      })
+    );
+
+    await startAuthorization(
+      CONNECTOR,
+      { subject: { type: 'passport' } },
+      {
+        vercelToken: 'project_oidc',
+        passportToken: 'verified_passport_token',
+        passportResource: 'owner:team_1:project:prj_1:sandbox:sbx_1:host:vm',
+      }
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toEqual({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer project_oidc',
+      'x-vercel-oidc-passport-token': 'verified_passport_token',
+      'x-vercel-passport-resource':
+        'owner:team_1:project:prj_1:sandbox:sbx_1:host:vm',
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      subject: { type: 'passport' },
+    });
+  });
 });
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {

--- a/packages/connect/test/token.test.ts
+++ b/packages/connect/test/token.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ConnectError,
   deleteTokenCacheEntry,
+  getToken,
   getTokenResponse,
   revokeToken,
   UserAuthorizationRequiredError,
@@ -103,6 +104,118 @@ describe('revokeToken', () => {
       statusText: 'Forbidden',
       message: 'Missing permission to revoke tokens',
     });
+  });
+
+  it('requires and forwards Passport identity for a Passport subject', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(RESULT));
+    const params = { subject: { type: 'passport' as const } };
+
+    await expect(revokeToken(CONNECTOR, params)).rejects.toThrow(
+      'passportToken is required when subject.type is "passport"'
+    );
+
+    await revokeToken(CONNECTOR, params, {
+      vercelToken: 'project_oidc',
+      passportToken: 'verified_passport_token',
+      passportResource: 'owner:team_1:project:prj_1:sandbox:sbx_1:host:vm',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toEqual({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer project_oidc',
+      'x-vercel-oidc-passport-token': 'verified_passport_token',
+      'x-vercel-passport-resource':
+        'owner:team_1:project:prj_1:sandbox:sbx_1:host:vm',
+    });
+  });
+});
+
+describe('Passport token subjects', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getVercelOidcToken).mockResolvedValue('project_oidc');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('requires a Passport token before resolving project OIDC', async () => {
+    await expect(
+      getToken(CONNECTOR, { subject: { type: 'passport' } })
+    ).rejects.toThrow(
+      'passportToken is required when subject.type is "passport"'
+    );
+
+    expect(getVercelOidcToken).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends Passport identity alongside project OIDC', async () => {
+    fetchMock.mockResolvedValue(tokenResponse('tok_passport'));
+
+    await expect(
+      getToken(
+        CONNECTOR,
+        { subject: { type: 'passport' } },
+        { passportToken: 'verified_passport_token' }
+      )
+    ).resolves.toBe('tok_passport');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toEqual({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer project_oidc',
+      'x-vercel-oidc-passport-token': 'verified_passport_token',
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      subject: { type: 'passport' },
+    });
+  });
+
+  it('does not cache Passport-scoped results across users', async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('tok_user_a'))
+      .mockResolvedValueOnce(tokenResponse('tok_user_b'));
+    const params = { subject: { type: 'passport' as const } };
+
+    const userA = await getTokenResponse(CONNECTOR, params, {
+      passportToken: 'passport_user_a',
+    });
+    const userB = await getTokenResponse(CONNECTOR, params, {
+      passportToken: 'passport_user_b',
+    });
+
+    expect(userA.token).toBe('tok_user_a');
+    expect(userB.token).toBe('tok_user_b');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][1].headers).toMatchObject({
+      'x-vercel-oidc-passport-token': 'passport_user_a',
+    });
+    expect(fetchMock.mock.calls[1][1].headers).toMatchObject({
+      'x-vercel-oidc-passport-token': 'passport_user_b',
+    });
+  });
+
+  it('does not forward a Passport token for another subject type', async () => {
+    fetchMock.mockResolvedValue(tokenResponse('tok_user'));
+
+    await getTokenResponse(
+      CONNECTOR,
+      { subject: { type: 'user', id: 'not_passport' } },
+      { passportToken: 'must_not_be_forwarded' }
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty('x-vercel-oidc-passport-token');
   });
 });
 

--- a/packages/connect/test/token.types.test.ts
+++ b/packages/connect/test/token.types.test.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf, it } from 'vitest';
+import type {
+  ConnectPassportOptions,
+  ConnectPassportTokenSubject,
+  ConnectTokenSubject,
+} from '../src/index.js';
+
+it('exports Passport subject and credential types', () => {
+  expectTypeOf<ConnectPassportTokenSubject>().toEqualTypeOf<{
+    type: 'passport';
+  }>();
+  expectTypeOf<ConnectPassportTokenSubject>().toMatchTypeOf<ConnectTokenSubject>();
+  expectTypeOf<ConnectPassportOptions>().toEqualTypeOf<{
+    passportToken: string;
+    passportResource?: string;
+  }>();
+});

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -47,6 +47,12 @@ only accepts the dedicated `https://passport.vercel.com/{owner}` issuer. It also
 validates the Passport-specific token shape so regular Vercel OIDC tokens are
 not accepted as Passport identities.
 
+Resource-bound preview identities are verified automatically when Vercel
+supplies the trusted `x-vercel-passport-resource` request context. A token with
+a `resource` claim is rejected when that context is absent or does not match.
+Tests and non-Vercel runtimes can provide the expected value explicitly with
+`verifyOptions.resource`.
+
 ## Local development
 
 Local development usually does not have a real `_vercel_passport` cookie or

--- a/packages/passport/src/index.ts
+++ b/packages/passport/src/index.ts
@@ -2,6 +2,7 @@ import { createRemoteJWKSet, jwtVerify, type JWTVerifyOptions } from 'jose';
 
 export const PASSPORT_HEADER_NAME = 'x-vercel-oidc-passport-token';
 export const PASSPORT_COOKIE_NAME = '_vercel_passport';
+export const PASSPORT_RESOURCE_HEADER_NAME = 'x-vercel-passport-resource';
 
 export type TokenSource = 'header' | 'cookie' | 'local';
 
@@ -11,6 +12,7 @@ export interface PassportIdentityPayload {
   owner_id?: string;
   project?: string;
   project_id?: string;
+  resource?: string;
   environment?: string;
   plan?: string;
   aud?: string;
@@ -47,6 +49,7 @@ export interface PassportIdentity {
     id?: string;
     name?: string;
   };
+  resource?: string;
   environment?: string;
 }
 
@@ -179,7 +182,13 @@ export async function getIdentity(
     const shouldVerify =
       tokenSource === 'local' ? (options.verify ?? false) : true;
     if (shouldVerify) {
-      const payload = await verifyPassportToken(token, options.verifyOptions);
+      const resource =
+        options.verifyOptions?.resource ??
+        getHeader(headers, PASSPORT_RESOURCE_HEADER_NAME);
+      const payload = await verifyPassportToken(token, {
+        ...options.verifyOptions,
+        resource,
+      });
       return createIdentity(token, tokenSource, true, payload);
     }
 
@@ -224,6 +233,7 @@ function createIdentity(
       slug: stringClaim(payload.owner)!,
     },
     project: createProjectIdentity(payload),
+    resource: stringClaim(payload.resource),
     environment: stringClaim(payload.environment),
   };
 }
@@ -494,6 +504,11 @@ export type PassportVerifyOptions = {
   projectId?: string | string[] | '*';
   environment?: string | string[] | '*';
   ownerId?: string;
+  /**
+   * Resource expected for a delegated preview identity. Delegated tokens are
+   * rejected when this does not exactly match their resource claim.
+   */
+  resource?: string;
 } & JWTVerifyOptions;
 
 async function verifyPassportToken(
@@ -505,6 +520,7 @@ async function verifyPassportToken(
     environment = process.env.VERCEL_TARGET_ENV || process.env.VERCEL_ENV,
     ownerId,
     projectId = process.env.VERCEL_PROJECT_ID,
+    resource,
     ...verifyOptions
   } = options ?? {};
 
@@ -548,8 +564,36 @@ async function verifyPassportToken(
     claim: 'owner_id',
     expected: ownerId,
   });
+  validateDelegatedResource(payload.resource, resource);
 
   return payload;
+}
+
+function validateDelegatedResource(
+  actual: unknown,
+  expected: string | undefined
+): void {
+  if (actual === undefined) {
+    return;
+  }
+
+  if (typeof actual !== 'string' || actual === '') {
+    throw new TypeError(
+      'Expected Passport token resource claim to be a non-empty string.'
+    );
+  }
+
+  if (expected === undefined || expected === '') {
+    throw new TypeError(
+      `Expected ${PASSPORT_RESOURCE_HEADER_NAME} to be set or verifyOptions.resource to be provided for a resource-bound Passport token.`
+    );
+  }
+
+  if (actual !== expected) {
+    throw new TypeError(
+      `Expected Passport token resource claim to be "${expected}".`
+    );
+  }
 }
 
 function hasAudienceVerification(

--- a/packages/passport/test/unit/index.test.ts
+++ b/packages/passport/test/unit/index.test.ts
@@ -10,6 +10,7 @@ import {
   getIdentity,
   PASSPORT_COOKIE_NAME,
   PASSPORT_HEADER_NAME,
+  PASSPORT_RESOURCE_HEADER_NAME,
 } from '../../src';
 
 function createToken(payload: Record<string, unknown>): string {
@@ -129,6 +130,67 @@ describe('getIdentity', () => {
       tokenSource: 'header',
       verified: true,
     });
+  });
+
+  test('verifies a resource-bound delegated preview identity', async () => {
+    const resource =
+      'owner:team_123:project:prj_123:sandbox:sbx_123:host:preview.example';
+    const token = createToken({ ...payload, resource });
+    const identity = await getIdentity(
+      new Headers({
+        [PASSPORT_HEADER_NAME]: token,
+        [PASSPORT_RESOURCE_HEADER_NAME]: resource,
+      }),
+      { verifyOptions }
+    );
+
+    expect(identity?.resource).toBe(resource);
+    expect(identity?.verified).toBe(true);
+  });
+
+  test('rejects a resource-bound token without trusted resource context', async () => {
+    const resource =
+      'owner:team_123:project:prj_123:sandbox:sbx_123:host:preview.example';
+    const token = createToken({ ...payload, resource });
+
+    await expect(
+      getIdentity(new Headers({ [PASSPORT_HEADER_NAME]: token }), {
+        verifyOptions,
+      })
+    ).rejects.toThrow(
+      `Expected ${PASSPORT_RESOURCE_HEADER_NAME} to be set or verifyOptions.resource to be provided for a resource-bound Passport token.`
+    );
+  });
+
+  test('rejects a resource-bound token for another sandbox', async () => {
+    const resource =
+      'owner:team_123:project:prj_123:sandbox:sbx_123:host:preview.example';
+    const token = createToken({ ...payload, resource });
+
+    await expect(
+      getIdentity(
+        new Headers({
+          [PASSPORT_HEADER_NAME]: token,
+          [PASSPORT_RESOURCE_HEADER_NAME]:
+            'owner:team_123:project:prj_123:sandbox:sbx_other:host:preview.example',
+        }),
+        { verifyOptions }
+      )
+    ).rejects.toThrow(
+      'Expected Passport token resource claim to be "owner:team_123:project:prj_123:sandbox:sbx_other:host:preview.example".'
+    );
+  });
+
+  test('accepts an explicitly provided delegated preview resource', async () => {
+    const resource =
+      'owner:team_123:project:prj_123:sandbox:sbx_123:host:preview.example';
+    const token = createToken({ ...payload, resource });
+    const identity = await getIdentity(
+      new Headers({ [PASSPORT_HEADER_NAME]: token }),
+      { verifyOptions: { ...verifyOptions, resource } }
+    );
+
+    expect(identity?.resource).toBe(resource);
   });
 
   test('falls back to an explicitly provided Passport cookie', async () => {


### PR DESCRIPTION
## Summary

Add the public SDK half of Passport + Connect dual authentication while preserving resource-bound Passport verification.

- add `{ type: 'passport' }` and exported Passport option types to `@vercel/connect`
- send the verified Passport token and optional resource beside the project Vercel OIDC bearer for token, authorization, and revocation requests
- require the Passport credential at runtime and never forward it for legacy subject modes
- bypass the process token cache for Passport subjects so identities cannot collide and every request is revalidated
- keep `@vercel/passport` fail-closed when a delegated identity is replayed without its exact trusted resource

## Architecture

```mermaid
flowchart LR
  I["Verified Passport identity"] --> S["@vercel/connect"]
  O["Project Vercel OIDC"] --> S
  S --> A["Connect API dual verification"]
  A --> G["User scoped managed grant"]
```

## Example

```ts
const identity = await getIdentity(request, { development: false })
const token = await getToken(
  'google/calendar',
  { subject: { type: 'passport' } },
  {
    passportToken: identity.token,
    passportResource: identity.resource,
  },
)
```

Passport mode intentionally omits scope refinements because it reuses the exact managed Passport grant.

## Validation

- `@vercel/connect`: 80/80 tests passed
- type check passed
- build passed
- Biome/lint-staged passed
- resource matching, missing context, mismatch, cache isolation, and non-Passport header suppression covered

## Draft stack

- attestation: https://github.com/vercel/api/pull/80055
- broker and Connect API verification: https://github.com/vercel/api/pull/80063
- v0 transport and generation: https://github.com/vercel/v0/pull/26599

This PR is not independently enabled in production.
