### PR TITLE
[cli] DO NOT MERGE: verify incomplete endpoints declarations block merges

### DIFF
--- a/packages/cli/src/commands/coverage-demo/command.ts
+++ b/packages/cli/src/commands/coverage-demo/command.ts
@@ -1,0 +1,25 @@
+import { packageName } from '../../util/pkg-name';
+
+/**
+ * DO NOT MERGE — demonstrates that declaring only public endpoints while
+ * calling a private API fails the static fetch coverage check in
+ * `test/unit/util/api-endpoint-policy.test.ts`.
+ *
+ * `endpoints` lists the public `GET /v2/user`, but `index.ts` also calls
+ * the private `GET /v1/oauth-apps/installations`.
+ */
+export const coverageDemoCommand = {
+  name: 'coverage-demo',
+  aliases: [],
+  description: 'Demonstrates incomplete endpoint declarations (do not merge)',
+  hidden: true,
+  arguments: [],
+  options: [],
+  examples: [
+    {
+      name: 'Trigger the coverage check',
+      value: `${packageName} coverage-demo`,
+    },
+  ],
+  endpoints: [{ method: 'GET', path: '/v2/user' }],
+} as const;

--- a/packages/cli/src/commands/coverage-demo/index.ts
+++ b/packages/cli/src/commands/coverage-demo/index.ts
@@ -1,0 +1,13 @@
+import type Client from '../../util/client';
+import { coverageDemoCommand } from './command';
+
+/**
+ * Intentionally calls a private endpoint that is not listed in
+ * `coverageDemoCommand.endpoints` (which only declares `GET /v2/user`).
+ */
+export default async function coverageDemo(client: Client): Promise<number> {
+  await client.fetch('/v2/user');
+  await client.fetch('/v1/oauth-apps/installations', { method: 'GET' });
+  void coverageDemoCommand;
+  return 0;
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -40,6 +40,7 @@ import { mcpCommand } from './mcp/command';
 import { metricsCommand } from './metrics/command';
 import { microfrontendsCommand } from './microfrontends/command';
 import { openCommand } from './open/command';
+import { coverageDemoCommand } from './coverage-demo/command';
 import { projectCommand } from './project/command';
 import { promoteCommand } from './promote/command';
 import { pullCommand } from './pull/command';
@@ -106,6 +107,7 @@ const commandsStructs: Command[] = [
   mcpCommand,
   microfrontendsCommand,
   openCommand,
+  coverageDemoCommand,
   projectCommand,
   promoteCommand,
   pullCommand,


### PR DESCRIPTION
## Summary

**Do not merge.** Stacked on #17071 to verify the new static `client.fetch` coverage check.

Adds a hidden `coverage-demo` command that:

- Declares only a **public** endpoint: `GET /v2/user`
- Actually also calls a **private** endpoint: `GET /v1/oauth-apps/installations` in `index.ts`

Expected CI failure from `test/unit/util/api-endpoint-policy.test.ts`:

```
- "coverage-demo" calls API endpoints that are not listed in its `endpoints` declaration (GET /v1/oauth-apps/installations (commands/coverage-demo/index.ts:10)). Add them to the declaration (and mark `beta: true` if any are private). See packages/cli/docs/api-endpoint-policy.md
```

This is the bypass the coverage check was meant to catch: listing only public endpoints while using a private API (without marking `beta`).

Base is `cli-endpoint-policy` (#17071). Close without merging after verifying the Unit / CLI (and Summary) checks fail.

## Test plan

- [x] Locally: `pnpm vitest run test/unit/util/api-endpoint-policy.test.ts` fails with the coverage violation above
- [ ] CI: confirm Unit / CLI shards fail and the PR is unmergeable

<!-- commands-to-test:start -->
### Commands To Test
- None — demo command must not merge.
<!-- commands-to-test:end -->

Made with [Cursor](https://cursor.com)