### PR TITLE
refactor(cli): use options for linked project resolution

### DIFF
--- a/.changeset/calm-project-options.md
+++ b/.changeset/calm-project-options.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Refactor linked project resolution to use named options.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -339,12 +339,11 @@ export default async function main(client: Client): Promise<number> {
   // No local link matched `--project`; resolve via API before the
   // settings-pull prompt would silently re-link to the wrong project.
   if (projectNameOrId && !link) {
-    const linkedFromApi = await getLinkedProject(
-      client,
+    const linkedFromApi = await getLinkedProject(client, {
       cwd,
-      projectNameOrId,
-      true
-    );
+      projectName: projectNameOrId,
+      apiFallback: true,
+    });
     if (linkedFromApi.status === 'linked') {
       link = {
         projectId: linkedFromApi.project.id,

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -484,7 +484,7 @@ export async function getDeploymentUrlAndToken(
 
   const { project } = link;
 
-  const linkedProject = await getLinkedProject(client, client.cwd);
+  const linkedProject = await getLinkedProject(client, { cwd: client.cwd });
 
   if (linkedProject.status !== 'linked') {
     output.error('This command requires a linked project. Please run:');

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -52,12 +52,11 @@ export default async function dev(
   const projectNameOrId = opts['--project'];
 
   // retrieve dev command
-  let link = await getLinkedProject(
-    client,
+  let link = await getLinkedProject(client, {
     cwd,
-    projectNameOrId,
-    !!projectNameOrId
-  );
+    projectName: projectNameOrId,
+    apiFallback: Boolean(projectNameOrId),
+  });
 
   if (link.status === 'not_linked' && !process.env.__VERCEL_SKIP_DEV_CMD) {
     if (opts['--local']) {

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -214,7 +214,7 @@ export default async function list(client: Client) {
     showAllProjects = true;
   } else {
     // No app argument and no --all flag: try to get linked project
-    const link = await getLinkedProject(client, client.cwd);
+    const link = await getLinkedProject(client, { cwd: client.cwd });
     if (link.status === 'error') {
       return link.exitCode;
     }

--- a/packages/cli/src/commands/microfrontends/create-group.ts
+++ b/packages/cli/src/commands/microfrontends/create-group.ts
@@ -459,7 +459,7 @@ export default async function createGroup(client: Client): Promise<number> {
   );
 
   // If the default app is the linked project, offer to create microfrontends.json
-  const link = await getLinkedProject(client, client.cwd);
+  const link = await getLinkedProject(client, { cwd: client.cwd });
   const linkedProject = link.status === 'linked' ? link.project : undefined;
   if (linkedProject && linkedProject.id === defaultApp.id) {
     const repoRoot = link.status === 'linked' ? link.repoRoot : undefined;

--- a/packages/cli/src/commands/microfrontends/delete-group.ts
+++ b/packages/cli/src/commands/microfrontends/delete-group.ts
@@ -92,7 +92,7 @@ export default async function deleteGroup(client: Client): Promise<number> {
     selectedGroup = found;
   } else {
     // If the linked project is the default app for a group, suggest that group first
-    const link = await getLinkedProject(client, client.cwd);
+    const link = await getLinkedProject(client, { cwd: client.cwd });
     const linkedProject = link.status === 'linked' ? link.project : undefined;
     const linkedGroup = linkedProject
       ? groups.find(g =>

--- a/packages/cli/src/commands/microfrontends/inspect-group.ts
+++ b/packages/cli/src/commands/microfrontends/inspect-group.ts
@@ -339,7 +339,7 @@ async function enrichGroupProject(
 
 async function getLocalRepoContext(client: Client): Promise<LocalRepoContext> {
   try {
-    const link = await getLinkedProject(client, client.cwd);
+    const link = await getLinkedProject(client, { cwd: client.cwd });
     // link is discriminated union, need to make TS happy
     if (link.status !== 'linked') {
       return {

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -54,12 +54,11 @@ export async function ensureLink(
       // `failIfNotFound` doubles as the opt-in for API-based name/ID
       // resolution: both behaviors only apply when `projectName` came from
       // an explicit user flag.
-      link = await getLinkedProject(
-        client,
+      link = await getLinkedProject(client, {
         cwd,
-        opts.projectName,
-        opts.failIfNotFound
-      );
+        projectName: opts.projectName,
+        apiFallback: opts.failIfNotFound,
+      });
     }
     opts.link = link;
   }

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -301,7 +301,7 @@ export default async function setupAndLink(
     return { status: 'error', exitCode: 1, reason: 'PATH_IS_FILE' };
   }
   if (!link) {
-    link = await getLinkedProject(client, path);
+    link = await getLinkedProject(client, { cwd: path });
   }
   const isTTY = client.stdin.isTTY;
   let rootDirectory: string | null = null;
@@ -317,7 +317,7 @@ export default async function setupAndLink(
   // without requiring `--yes`). The env link itself is what makes commands
   // work here, so leave local link files untouched.
   if (getPlatformEnv('ORG_ID') && getPlatformEnv('PROJECT_ID')) {
-    const envLink = await getLinkedProject(client, path);
+    const envLink = await getLinkedProject(client, { cwd: path });
     if (envLink.status === 'error') {
       return envLink;
     }

--- a/packages/cli/src/util/projects/get-linked-project-or-fail.ts
+++ b/packages/cli/src/util/projects/get-linked-project-or-fail.ts
@@ -35,12 +35,11 @@ export async function getLinkedProjectOrFail(
   client: Client,
   projectName?: string
 ): Promise<ProjectLinkResult> {
-  const link = await getLinkedProject(
-    client,
-    client.cwd,
+  const link = await getLinkedProject(client, {
+    cwd: client.cwd,
     projectName,
-    Boolean(projectName)
-  );
+    apiFallback: Boolean(projectName),
+  });
 
   if (link.status === 'not_linked' && projectName) {
     await printProjectNotFoundError(

--- a/packages/cli/src/util/projects/get-project-by-cwd-or-link.ts
+++ b/packages/cli/src/util/projects/get-project-by-cwd-or-link.ts
@@ -44,7 +44,7 @@ export default async function getProjectByCwdOrLink({
 
   if (forReadOnlyCommand && effectiveNonInteractive) {
     const resolvedCwd = await resolveProjectCwd(cwd ?? client.cwd);
-    const link = await getLinkedProject(client, resolvedCwd);
+    const link = await getLinkedProject(client, { cwd: resolvedCwd });
     if (link.status === 'linked' && link.project) {
       return link.project;
     }

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -284,18 +284,24 @@ async function hasProjectLink(
   return false;
 }
 
-export async function getLinkedProject(
-  client: Client,
-  path = client.cwd,
-  projectName?: string,
+export interface GetLinkedProjectOptions {
+  cwd?: string;
+  projectName?: string;
   /**
    * When `true`, resolve `projectName` via the API if no local link matches.
    * Only enable for explicit user-supplied names (e.g. `--project`) so that
    * implicit `projectName` defaults (like a directory basename) keep their
    * existing `not_linked` → `setupAndLink` flow.
    */
-  apiFallback?: boolean
+  apiFallback?: boolean;
+}
+
+export async function getLinkedProject(
+  client: Client,
+  options: GetLinkedProjectOptions = {}
 ): Promise<ProjectLinkResult> {
+  let path = options.cwd ?? client.cwd;
+  const { projectName, apiFallback } = options;
   path = await resolveProjectCwd(path);
 
   const VERCEL_ORG_ID = getPlatformEnv('ORG_ID');

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -14,6 +14,7 @@ import { useUser } from '../../../mocks/user';
 import { execSync } from 'child_process';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { vi } from 'vitest';
+import * as linkModule from '../../../../src/util/projects/link';
 import {
   detectBuilders,
   REGEX_NON_VERCEL_PLATFORM_FILES,
@@ -3555,6 +3556,7 @@ writeFileSync(
 
     it('fails fast with a clean error when the project does not exist anywhere', async () => {
       const cwd = await getWriteableDirectory();
+      const getLinkedProjectSpy = vi.spyOn(linkModule, 'getLinkedProject');
       useUser();
       useTeams('team_dummy');
       // No useProject() — every API lookup will 404.
@@ -3568,6 +3570,12 @@ writeFileSync(
       );
       const exitCode = await exitCodePromise;
       expect(exitCode, 'exit code for "build"').toEqual(1);
+      expect(getLinkedProjectSpy).toHaveBeenCalledWith(client, {
+        cwd: await fs.realpath(cwd),
+        projectName: 'does-not-exist',
+        apiFallback: true,
+      });
+      getLinkedProjectSpy.mockRestore();
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/crons/ls.test.ts
+++ b/packages/cli/test/unit/commands/crons/ls.test.ts
@@ -299,12 +299,11 @@ describe('crons ls', () => {
       const exitCode = await crons(client);
 
       expect(exitCode).toEqual(0);
-      expect(mockedGetLinkedProject).toHaveBeenCalledWith(
-        client,
-        client.cwd,
-        'crons-project',
-        true
-      );
+      expect(mockedGetLinkedProject).toHaveBeenCalledWith(client, {
+        cwd: client.cwd,
+        projectName: 'crons-project',
+        apiFallback: true,
+      });
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'subcommand:list', value: 'ls' },
         { key: 'option:project', value: '[REDACTED]' },

--- a/packages/cli/test/unit/commands/crons/run.test.ts
+++ b/packages/cli/test/unit/commands/crons/run.test.ts
@@ -275,12 +275,11 @@ describe('crons run', () => {
       const exitCode = await crons(client);
 
       expect(exitCode).toEqual(0);
-      expect(mockedGetLinkedProject).toHaveBeenCalledWith(
-        client,
-        client.cwd,
-        'crons-project',
-        true
-      );
+      expect(mockedGetLinkedProject).toHaveBeenCalledWith(client, {
+        cwd: client.cwd,
+        projectName: 'crons-project',
+        apiFallback: true,
+      });
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'subcommand:run', value: 'run' },
         { key: 'option:project', value: '[REDACTED]' },

--- a/packages/cli/test/unit/commands/curl/index.test.ts
+++ b/packages/cli/test/unit/commands/curl/index.test.ts
@@ -10,6 +10,7 @@ import { useUser } from '../../../mocks/user';
 import { useProject } from '../../../mocks/project';
 import { useTeams, createTeam } from '../../../mocks/team';
 import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import * as linkModule from '../../../../src/util/projects/link';
 
 const MOCK_ACCOUNT_ID = 'team_test123';
 
@@ -130,11 +131,16 @@ describe('curl', () => {
 
     it('should accept / as a valid path', async () => {
       await setupLinkedProject();
+      const getLinkedProjectSpy = vi.spyOn(linkModule, 'getLinkedProject');
 
       client.setArgv('curl', '/', '--protection-bypass', 'test-secret');
       const exitCode = await curl(client);
 
       expect(exitCode).toEqual(0);
+      expect(getLinkedProjectSpy).toHaveBeenCalledWith(client, {
+        cwd: client.cwd,
+      });
+      getLinkedProjectSpy.mockRestore();
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -13,6 +13,8 @@ import { type fs, vol } from 'memfs';
 import { useUser } from '../../../mocks/user';
 import { useTeams } from '../../../mocks/team';
 import { useProject } from '../../../mocks/project';
+import * as linkModule from '../../../../src/util/projects/link';
+import { normalize } from 'path';
 
 const { mockStart, devServerInstances, mockedRepoRoots } = vi.hoisted(() => ({
   mockStart: vi.fn<() => void>(),
@@ -409,12 +411,19 @@ describe('dev', () => {
 
   describe('project/org IDs', () => {
     it('passes the linked project and org IDs to DevServer', async () => {
+      const getLinkedProjectSpy = vi.spyOn(linkModule, 'getLinkedProject');
       client.setArgv('dev', projectPath);
       const exitCodePromise = dev(client);
 
       await expect(exitCodePromise).resolves.toEqual(undefined);
       expect(devServerInstances).toHaveLength(1);
       expect(devServerInstances[0]).toMatchObject({ projectId, orgId });
+      expect(getLinkedProjectSpy).toHaveBeenCalledWith(client, {
+        cwd: normalize(projectPath),
+        projectName: undefined,
+        apiFallback: false,
+      });
+      getLinkedProjectSpy.mockRestore();
     });
 
     it('omits the IDs for unlinked projects in --local mode', async () => {

--- a/packages/cli/test/unit/commands/list/index.test.ts
+++ b/packages/cli/test/unit/commands/list/index.test.ts
@@ -21,6 +21,7 @@ import {
   pluckIdentifiersFromDeploymentList,
 } from '../../../helpers/parse-table';
 import output from '../../../../src/output-manager';
+import * as linkModule from '../../../../src/util/projects/link';
 
 const fixture = (name: string) =>
   join(__dirname, '../../../fixtures/unit/commands/list', name);
@@ -463,6 +464,7 @@ describe('list', () => {
   });
 
   it('should get deployments from a project linked by a directory', async () => {
+    const getLinkedProjectSpy = vi.spyOn(linkModule, 'getLinkedProject');
     const user = useUser();
     const teams = useTeams('team_dummy');
     assert(Array.isArray(teams));
@@ -475,6 +477,10 @@ describe('list', () => {
 
     client.cwd = fixture('with-team');
     await list(client);
+    expect(getLinkedProjectSpy).toHaveBeenCalledWith(client, {
+      cwd: client.cwd,
+    });
+    getLinkedProjectSpy.mockRestore();
 
     const lines = createLineIterator(client.stderr);
 

--- a/packages/cli/test/unit/commands/microfrontends/create-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/create-group.test.ts
@@ -177,6 +177,9 @@ describe('microfrontends create-group', () => {
       client.stdin.write('n\n');
 
       expect(await exitCodePromise).toBe(0);
+      expect(mockedGetLinkedProject).toHaveBeenCalledWith(client, {
+        cwd: client.cwd,
+      });
       expect(mocks.getPostCalled()).toBe(true);
       expect(mocks.getPostBody()).toEqual({
         groupName: 'My Group',

--- a/packages/cli/test/unit/commands/microfrontends/delete-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/delete-group.test.ts
@@ -229,6 +229,9 @@ describe('microfrontends delete-group', () => {
       client.stdin.write('My Group\n');
 
       expect(await exitCodePromise).toBe(0);
+      expect(mockedGetLinkedProject).toHaveBeenCalledWith(client, {
+        cwd: client.cwd,
+      });
       expect(mocks.getDeleteCalled()).toBe(true);
       expect(mocks.getDeleteGroupId()).toBe('group_1');
     });

--- a/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/inspect-group.test.ts
@@ -1,6 +1,7 @@
-import { describe, beforeEach, expect, it } from 'vitest';
+import { describe, beforeEach, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import microfrontends from '../../../../src/commands/microfrontends';
+import * as linkModule from '../../../../src/util/projects/link';
 import { teamCache } from '../../../../src/util/teams/get-team-by-id';
 import type { MicrofrontendsGroupsResponse } from '../../../../src/commands/microfrontends/types';
 
@@ -152,6 +153,7 @@ describe('microfrontends inspect-group', () => {
   });
 
   it('outputs JSON when --format=json is provided', async () => {
+    const getLinkedProjectSpy = vi.spyOn(linkModule, 'getLinkedProject');
     client.setArgv(
       'microfrontends',
       'inspect-group',
@@ -162,6 +164,10 @@ describe('microfrontends inspect-group', () => {
     const exitCode = await microfrontends(client);
 
     expect(exitCode).toBe(0);
+    expect(getLinkedProjectSpy).toHaveBeenCalledWith(client, {
+      cwd: client.cwd,
+    });
+    getLinkedProjectSpy.mockRestore();
     const stdout = client.stdout.getFullOutput().trim();
     const parsed = JSON.parse(stdout);
 

--- a/packages/cli/test/unit/commands/rolling-release/configure.test.ts
+++ b/packages/cli/test/unit/commands/rolling-release/configure.test.ts
@@ -103,12 +103,11 @@ describe('rolling-release configure', () => {
 
     expect(exitCode).toBe(0);
     expect(patchBody).toEqual({ enabled: false });
-    expect(mockedGetLinkedProject).toHaveBeenCalledWith(
-      client,
-      client.cwd,
-      'my-project',
-      true
-    );
+    expect(mockedGetLinkedProject).toHaveBeenCalledWith(client, {
+      cwd: client.cwd,
+      projectName: 'my-project',
+      apiFallback: true,
+    });
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'option:project', value: '[REDACTED]' },
       { key: 'flag:disable', value: 'TRUE' },

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -65,7 +65,7 @@ describe('getLinkedProject', () => {
     let link: UnPromisify<ReturnType<typeof getLinkedProject>> | undefined;
     let error: Error | undefined;
     try {
-      link = await getLinkedProject(client, cwd);
+      link = await getLinkedProject(client, { cwd });
     } catch (err) {
       error = err as Error;
     }
@@ -94,7 +94,7 @@ describe('getLinkedProject', () => {
     let link: UnPromisify<ReturnType<typeof getLinkedProject>> | undefined;
     let error: Error | undefined;
     try {
-      link = await getLinkedProject(client, cwd);
+      link = await getLinkedProject(client, { cwd });
     } catch (err) {
       error = err as Error;
     }
@@ -123,7 +123,7 @@ describe('getLinkedProject', () => {
     let link: UnPromisify<ReturnType<typeof getLinkedProject>> | undefined;
     let error: Error | undefined;
     try {
-      link = await getLinkedProject(client, cwd);
+      link = await getLinkedProject(client, { cwd });
     } catch (err) {
       error = err as Error;
     }
@@ -152,7 +152,7 @@ describe('getLinkedProject', () => {
     let link: UnPromisify<ReturnType<typeof getLinkedProject>> | undefined;
     let error: Error | undefined;
     try {
-      link = await getLinkedProject(client, cwd);
+      link = await getLinkedProject(client, { cwd });
     } catch (err) {
       error = err as Error;
     }
@@ -178,7 +178,7 @@ describe('getLinkedProject', () => {
       name: 'vercel-pull-next',
     });
 
-    const link = await getLinkedProject(client, cwd);
+    const link = await getLinkedProject(client, { cwd });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -200,7 +200,9 @@ describe('getLinkedProject', () => {
       id: 'QmbKpqpiUqbcke',
       name: 'monorepo-dashboard',
     });
-    let link = await getLinkedProject(client, join(cwd, 'dashboard'));
+    let link = await getLinkedProject(client, {
+      cwd: join(cwd, 'dashboard'),
+    });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -215,7 +217,9 @@ describe('getLinkedProject', () => {
       id: 'QmX6P93ChNDoZP',
       name: 'monorepo-marketing',
     });
-    link = await getLinkedProject(client, join(cwd, 'marketing/subdir'));
+    link = await getLinkedProject(client, {
+      cwd: join(cwd, 'marketing/subdir'),
+    });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -230,7 +234,7 @@ describe('getLinkedProject', () => {
       id: 'QmScb7GPQt6gsS',
       name: 'monorepo-blog',
     });
-    link = await getLinkedProject(client, join(cwd, 'blog'));
+    link = await getLinkedProject(client, { cwd: join(cwd, 'blog') });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -281,7 +285,7 @@ describe('getLinkedProject', () => {
     });
 
     const selectSpy = vi.spyOn(client.input, 'select');
-    const link = await getLinkedProject(client, cwd);
+    const link = await getLinkedProject(client, { cwd });
 
     // If repo.json was consulted, we'd have prompted to disambiguate.
     expect(selectSpy).not.toHaveBeenCalled();
@@ -313,7 +317,11 @@ describe('getLinkedProject', () => {
       accountId: 'team_dummy',
     });
 
-    const link = await getLinkedProject(client, cwd, 'explicit-project', true);
+    const link = await getLinkedProject(client, {
+      cwd,
+      projectName: 'explicit-project',
+      apiFallback: true,
+    });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -332,12 +340,11 @@ describe('getLinkedProject', () => {
       name: 'monorepo-marketing',
     });
 
-    const link = await getLinkedProject(
-      client,
-      join(cwd, 'dashboard'),
-      'monorepo-marketing',
-      true
-    );
+    const link = await getLinkedProject(client, {
+      cwd: join(cwd, 'dashboard'),
+      projectName: 'monorepo-marketing',
+      apiFallback: true,
+    });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -356,7 +363,9 @@ describe('getLinkedProject', () => {
       id: 'QmbKpqpiUqbcke',
       name: 'monorepo-dashboard',
     });
-    const link = await getLinkedProject(client, join(cwd, 'dashboard'));
+    const link = await getLinkedProject(client, {
+      cwd: join(cwd, 'dashboard'),
+    });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -378,7 +387,7 @@ describe('getLinkedProject', () => {
       name: 'monorepo-dashboard',
     });
 
-    const linkPromise = getLinkedProject(client, cwd);
+    const linkPromise = getLinkedProject(client, { cwd });
 
     // wait for prompt
     await expect(client.stderr).toOutput('Please select a Project:');
@@ -408,7 +417,10 @@ describe('getLinkedProject', () => {
     });
 
     // When projectName is provided, it should auto-select without prompting
-    const link = await getLinkedProject(client, cwd, 'monorepo-marketing');
+    const link = await getLinkedProject(client, {
+      cwd,
+      projectName: 'monorepo-marketing',
+    });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -430,7 +442,10 @@ describe('getLinkedProject', () => {
     });
 
     // When projectName is provided, it should auto-select without prompting
-    const link = await getLinkedProject(client, cwd, 'monorepo-blog');
+    const link = await getLinkedProject(client, {
+      cwd,
+      projectName: 'monorepo-blog',
+    });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -452,7 +467,10 @@ describe('getLinkedProject', () => {
     });
 
     const selectSpy = vi.spyOn(client.input, 'select');
-    const link = await getLinkedProject(client, cwd, 'QmX6P93ChNDoZP');
+    const link = await getLinkedProject(client, {
+      cwd,
+      projectName: 'QmX6P93ChNDoZP',
+    });
     expect(selectSpy).not.toHaveBeenCalled();
     selectSpy.mockRestore();
 
@@ -475,12 +493,11 @@ describe('getLinkedProject', () => {
       accountId: 'team_dummy',
     });
 
-    const link = await getLinkedProject(
-      client,
+    const link = await getLinkedProject(client, {
       cwd,
-      'api-fallback-project',
-      true
-    );
+      projectName: 'api-fallback-project',
+      apiFallback: true,
+    });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
@@ -497,12 +514,11 @@ describe('getLinkedProject', () => {
     useTeams('team_dummy');
     // Intentionally no useProject — every API lookup 404s.
 
-    const link = await getLinkedProject(
-      client,
+    const link = await getLinkedProject(client, {
       cwd,
-      'definitely-missing',
-      true
-    );
+      projectName: 'definitely-missing',
+      apiFallback: true,
+    });
     expect(link.status).toEqual('not_linked');
   });
 
@@ -512,7 +528,7 @@ describe('getLinkedProject', () => {
     useUser();
     useTeams('team_dummy');
 
-    const link = await getLinkedProject(client, cwd);
+    const link = await getLinkedProject(client, { cwd });
     expect(link.status).toEqual('not_linked');
   });
 
@@ -530,7 +546,10 @@ describe('getLinkedProject', () => {
 
     // Protects callers like `vercel deploy` that pass a directory-derived
     // `projectName` and rely on `setupAndLink` running interactively.
-    const link = await getLinkedProject(client, cwd, 'no-link-implicit-name');
+    const link = await getLinkedProject(client, {
+      cwd,
+      projectName: 'no-link-implicit-name',
+    });
     expect(link.status).toEqual('not_linked');
   });
 });


### PR DESCRIPTION
## Why

`getLinkedProject()` has accumulated several positional arguments with different meanings. Call sites such as `getLinkedProject(client, cwd, name, true)` are difficult to review and easy to misuse.

## Changes

- Replace positional arguments with a named options object.
- Migrate existing callers mechanically.
- Preserve current resolution behavior.

## Review notes

This is intentionally a signature-only refactor. The existing `apiFallback` behavior is documented but unchanged; selector precedence is handled in the next PR.

## Validation
- See PR 5 for testing matrix for avoiding regressions

Stack: 1 of 5. Next: #17081.


