### PR TITLE
fix(cli): respect explicit project resolution

### DIFF
--- a/.changeset/steady-project-resolution.md
+++ b/.changeset/steady-project-resolution.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Respect explicit project and scope selection when resolving project context.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -342,7 +342,7 @@ export default async function main(client: Client): Promise<number> {
     const linkedFromApi = await getLinkedProject(client, {
       cwd,
       projectName: projectNameOrId,
-      apiFallback: true,
+      projectNameIsExplicit: true,
     });
     if (linkedFromApi.status === 'linked') {
       link = {
@@ -353,7 +353,12 @@ export default async function main(client: Client): Promise<number> {
     } else if (linkedFromApi.status === 'error') {
       return linkedFromApi.exitCode;
     } else {
-      await printProjectNotFoundError(client, projectNameOrId, 'build');
+      await printProjectNotFoundError(
+        client,
+        projectNameOrId,
+        'build',
+        linkedFromApi.orgId
+      );
       return 1;
     }
   }

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -29,6 +29,7 @@ import { tryDetectServices } from '../../util/projects/detect-services';
 import { displayDetectedServices } from '../../util/input/display-services';
 import { acquireDevLock, releaseDevLock } from '../../util/dev/dev-lock';
 import { resolveProjectCwd } from '../../util/projects/find-project-root';
+import { detectExplicitScope } from '../../util/get-scope';
 
 type Options = {
   '--listen': string;
@@ -55,7 +56,8 @@ export default async function dev(
   let link = await getLinkedProject(client, {
     cwd,
     projectName: projectNameOrId,
-    apiFallback: Boolean(projectNameOrId),
+    projectNameIsExplicit: Boolean(projectNameOrId),
+    scopeIsExplicit: detectExplicitScope(client),
   });
 
   if (link.status === 'not_linked' && !process.env.__VERCEL_SKIP_DEV_CMD) {
@@ -67,7 +69,12 @@ export default async function dev(
           `To link your project, run ${getCommandName('dev')} without \`-L\` or \`--local\` or ${getCommandName('link')}.`
       );
     } else if (projectNameOrId) {
-      await printProjectNotFoundError(client, projectNameOrId, 'dev');
+      await printProjectNotFoundError(
+        client,
+        projectNameOrId,
+        'dev',
+        link.orgId
+      );
       return 1;
     } else {
       link = await setupAndLink(client, cwd, {

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -2,13 +2,17 @@ import type Client from '../client';
 import setupAndLink from '../link/setup-and-link';
 import param from '../output/param';
 import { getCommandName, getCommandNamePlain } from '../pkg-name';
-import { getLinkedProject } from '../projects/link';
+import {
+  getLinkedProject,
+  type ProjectLinkResultWithOrgId,
+} from '../projects/link';
 import { resolveProjectCwd } from '../projects/find-project-root';
 import type { SetupAndLinkOptions } from '../link/setup-and-link';
 import type { ProjectLinked } from '@vercel-internals/types';
 import output from '../../output-manager';
 import { outputActionRequired, buildCommandWithYes } from '../agent-output';
 import { printProjectNotFoundError } from '../projects/project-not-found-error';
+import { detectExplicitScope } from '../get-scope';
 
 interface EnsureLinkOptions extends SetupAndLinkOptions {
   /** When true, fail instead of setting up a project that is not linked. */
@@ -39,7 +43,7 @@ export async function ensureLink(
 ): Promise<ProjectLinked | number> {
   cwd = await resolveProjectCwd(cwd);
 
-  let { link } = opts;
+  let link: ProjectLinkResultWithOrgId | undefined = opts.link;
   // All commands respect global --non-interactive; link can override via opts
   const nonInteractive = opts.nonInteractive ?? client.nonInteractive ?? false;
   opts.nonInteractive = nonInteractive;
@@ -57,7 +61,8 @@ export async function ensureLink(
       link = await getLinkedProject(client, {
         cwd,
         projectName: opts.projectName,
-        apiFallback: opts.failIfNotFound,
+        projectNameIsExplicit: Boolean(opts.projectName && opts.failIfNotFound),
+        scopeIsExplicit: detectExplicitScope(client),
       });
     }
     opts.link = link;
@@ -74,7 +79,12 @@ export async function ensureLink(
       opts.failIfNotFound &&
       opts.projectName
     ) {
-      await printProjectNotFoundError(client, opts.projectName, commandName);
+      await printProjectNotFoundError(
+        client,
+        opts.projectName,
+        commandName,
+        link.orgId
+      );
       return 1;
     }
 

--- a/packages/cli/src/util/projects/get-linked-project-or-fail.ts
+++ b/packages/cli/src/util/projects/get-linked-project-or-fail.ts
@@ -1,27 +1,12 @@
 import type Client from '../client';
 import type { ProjectLinkResult } from '@vercel-internals/types';
-import { omitGlobalFlagsFromArgs } from '../agent-output';
-import { getLinkedProject } from './link';
-import { printProjectNotFoundError } from './project-not-found-error';
+import { resolveProjectContext } from './resolve-project-context';
 
 /**
- * Returns the invoking command path (e.g. `flags ls`) from argv: the leading
- * positional tokens once global flags are removed. Used to build a runnable
- * retry command in the "project not found" suggestion.
- */
-function getInvokingCommandFromArgv(argv: string[]): string {
-  const args = omitGlobalFlagsFromArgs(argv.slice(2));
-  const positionals: string[] = [];
-  for (const arg of args) {
-    if (arg.startsWith('-')) {
-      break;
-    }
-    positionals.push(arg);
-  }
-  return positionals.join(' ');
-}
-
-/**
+ * Compatibility entry point for commands that have not migrated to
+ * `resolveProjectContext()` yet. New project-aware commands should use the
+ * shared resolver directly.
+ *
  * Resolves the project for commands that accept `--project` outside a linked
  * directory.
  *
@@ -35,20 +20,8 @@ export async function getLinkedProjectOrFail(
   client: Client,
   projectName?: string
 ): Promise<ProjectLinkResult> {
-  const link = await getLinkedProject(client, {
-    cwd: client.cwd,
-    projectName,
-    apiFallback: Boolean(projectName),
+  return resolveProjectContext({
+    client,
+    projectNameOrId: projectName,
   });
-
-  if (link.status === 'not_linked' && projectName) {
-    await printProjectNotFoundError(
-      client,
-      projectName,
-      getInvokingCommandFromArgv(client.argv)
-    );
-    return { status: 'error', exitCode: 1 };
-  }
-
-  return link;
 }

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -287,28 +287,36 @@ async function hasProjectLink(
 export interface GetLinkedProjectOptions {
   cwd?: string;
   projectName?: string;
-  /**
-   * When `true`, resolve `projectName` via the API if no local link matches.
-   * Only enable for explicit user-supplied names (e.g. `--project`) so that
-   * implicit `projectName` defaults (like a directory basename) keep their
-   * existing `not_linked` → `setupAndLink` flow.
-   */
-  apiFallback?: boolean;
+  projectNameIsExplicit?: boolean;
+  scopeIsExplicit?: boolean;
 }
+
+export type ProjectLinkResultWithOrgId = ProjectLinkResult & {
+  orgId?: string;
+  projectRootDirectory?: string;
+};
 
 export async function getLinkedProject(
   client: Client,
   options: GetLinkedProjectOptions = {}
-): Promise<ProjectLinkResult> {
+): Promise<ProjectLinkResultWithOrgId> {
   let path = options.cwd ?? client.cwd;
-  const { projectName, apiFallback } = options;
   path = await resolveProjectCwd(path);
 
   const VERCEL_ORG_ID = getPlatformEnv('ORG_ID');
   const VERCEL_PROJECT_ID = getPlatformEnv('PROJECT_ID');
   const shouldUseEnv = Boolean(VERCEL_ORG_ID && VERCEL_PROJECT_ID);
+  const projectName = options.projectName;
+  const projectNameIsExplicit = options.projectNameIsExplicit === true;
+  const explicitProjectName = projectNameIsExplicit ? projectName : undefined;
+  const hasExplicitProject = Boolean(explicitProjectName);
+  const shouldUseEnvContext = shouldUseEnv && !hasExplicitProject;
 
-  if ((VERCEL_ORG_ID || VERCEL_PROJECT_ID) && !shouldUseEnv) {
+  if (
+    !hasExplicitProject &&
+    (VERCEL_ORG_ID || VERCEL_PROJECT_ID) &&
+    !shouldUseEnv
+  ) {
     output.error(
       `You specified ${
         VERCEL_ORG_ID ? '`VERCEL_ORG_ID`' : '`VERCEL_PROJECT_ID`'
@@ -319,29 +327,76 @@ export async function getLinkedProject(
     return { status: 'error', exitCode: 1 };
   }
 
-  let link =
-    VERCEL_ORG_ID && VERCEL_PROJECT_ID
-      ? { orgId: VERCEL_ORG_ID, projectId: VERCEL_PROJECT_ID }
-      : await getProjectLink(client, path, projectName, apiFallback);
-
-  // Resolve `projectName` via the API when no local link matches. Enables
-  // non-interactive CI use (e.g. `vercel deploy --project my-app`).
-  if (!link && projectName && apiFallback) {
-    try {
-      const apiProject = await getProjectByIdOrName(client, projectName);
-      if (!(apiProject instanceof ProjectNotFound)) {
-        link = {
-          projectId: apiProject.id,
-          orgId: apiProject.accountId,
-        };
+  let link: ProjectLink | null;
+  let explicitlyResolvedProject: Project | null = null;
+  let orgId: string | undefined;
+  if (explicitProjectName) {
+    const hasExplicitScope = options.scopeIsExplicit === true;
+    const matchingLocalLink =
+      hasExplicitScope || shouldUseEnv
+        ? null
+        : await getProjectLink(client, path, explicitProjectName, true);
+    const fallbackOrgId = shouldUseEnv
+      ? VERCEL_ORG_ID
+      : (matchingLocalLink?.orgId ?? client.config.currentTeam);
+    const lookupOrgId = hasExplicitScope
+      ? client.config.currentTeam
+      : fallbackOrgId;
+    orgId = lookupOrgId;
+    const apiProject = await getProjectByIdOrName(
+      client,
+      explicitProjectName,
+      lookupOrgId
+    );
+    explicitlyResolvedProject =
+      apiProject instanceof ProjectNotFound ? null : apiProject;
+    if (explicitlyResolvedProject === null) {
+      link = null;
+    } else {
+      const resolvedOrgId =
+        explicitlyResolvedProject.accountId ??
+        lookupOrgId ??
+        matchingLocalLink?.orgId;
+      let localLink =
+        matchingLocalLink?.projectId === explicitlyResolvedProject.id
+          ? matchingLocalLink
+          : null;
+      if (!localLink) {
+        try {
+          localLink = await getProjectLink(
+            client,
+            path,
+            explicitlyResolvedProject.id,
+            true
+          );
+        } catch (err) {
+          output.debug(
+            `Ignoring local project metadata after explicit project resolution: ${err}`
+          );
+        }
       }
-    } catch {
-      // Swallow; caller handles `not_linked` below.
+      link = resolvedOrgId
+        ? {
+            ...(localLink?.projectId === explicitlyResolvedProject.id &&
+            localLink.orgId === resolvedOrgId
+              ? localLink
+              : {}),
+            projectId: explicitlyResolvedProject.id,
+            orgId: resolvedOrgId,
+          }
+        : null;
+    }
+  } else {
+    link = shouldUseEnvContext
+      ? { orgId: VERCEL_ORG_ID!, projectId: VERCEL_PROJECT_ID! }
+      : await getProjectLink(client, path, projectName, projectNameIsExplicit);
+    if (link) {
+      orgId = link.orgId;
     }
   }
 
   if (!link) {
-    return { status: 'not_linked', org: null, project: null };
+    return { status: 'not_linked', org: null, project: null, orgId };
   }
 
   output.spinner('Retrieving project…', 1000);
@@ -350,7 +405,9 @@ export async function getLinkedProject(
   try {
     const [orgResult, projectResult] = await Promise.allSettled([
       getOrgById(client, link.orgId),
-      getProjectByIdOrName(client, link.projectId, link.orgId),
+      explicitlyResolvedProject
+        ? Promise.resolve(explicitlyResolvedProject)
+        : getProjectByIdOrName(client, link.projectId, link.orgId),
     ]);
 
     if (orgResult.status === 'fulfilled') {
@@ -402,14 +459,14 @@ export async function getLinkedProject(
   }
 
   if (!org || !project || project instanceof ProjectNotFound) {
-    if (shouldUseEnv) {
+    if (shouldUseEnvContext) {
       output.error(
         `Project not found (${JSON.stringify({
           VERCEL_PROJECT_ID,
           VERCEL_ORG_ID,
         })})\n`
       );
-      return { status: 'error', exitCode: 1 };
+      return { status: 'error', exitCode: 1, orgId };
     }
 
     output.print(
@@ -418,10 +475,22 @@ export async function getLinkedProject(
         emoji('warning')
       )
     );
-    return { status: 'not_linked', org: null, project: null };
+    return {
+      status: 'not_linked',
+      org: null,
+      project: null,
+      orgId: link.orgId,
+    };
   }
 
-  return { status: 'linked', org, project, repoRoot: link.repoRoot };
+  return {
+    status: 'linked',
+    org,
+    project,
+    repoRoot: link.repoRoot,
+    projectRootDirectory: link.projectRootDirectory,
+    orgId: link.orgId,
+  };
 }
 
 const VERCEL_DIR_README_CONTENT = `> Why do I have a folder named ".vercel" in my project?

--- a/packages/cli/src/util/projects/project-not-found-error.ts
+++ b/packages/cli/src/util/projects/project-not-found-error.ts
@@ -7,6 +7,7 @@ import {
   shouldEmitNonInteractiveCommandError,
 } from '../agent-output';
 import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
+import getOrgById from './get-org-by-id';
 
 /**
  * Emits a consistent "Project <x> was not found" error that names the scope
@@ -17,14 +18,21 @@ import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
 export async function printProjectNotFoundError(
   client: Client,
   projectNameOrId: string,
-  commandName: string
+  commandName: string,
+  orgId?: string
 ): Promise<void> {
   let contextName: string | undefined;
   try {
-    const scope = await getScope(client);
-    contextName = scope.contextName;
+    if (orgId) {
+      const org = await getOrgById(client, orgId);
+      contextName = org?.slug ?? orgId;
+    } else {
+      const scope = await getScope(client);
+      contextName = scope.contextName;
+    }
   } catch (err) {
-    output.debug(`getScope failed during error reporting: ${err}`);
+    contextName = orgId;
+    output.debug(`Scope lookup failed during error reporting: ${err}`);
   }
 
   const scopeClause = contextName ? ` (${contextName})` : '';

--- a/packages/cli/src/util/projects/resolve-project-context.ts
+++ b/packages/cli/src/util/projects/resolve-project-context.ts
@@ -1,0 +1,53 @@
+import type Client from '../client';
+import { omitGlobalFlagsFromArgs } from '../agent-output';
+import { detectExplicitScope } from '../get-scope';
+import { getLinkedProject, type ProjectLinkResultWithOrgId } from './link';
+import { printProjectNotFoundError } from './project-not-found-error';
+
+export interface ResolveProjectContextOptions {
+  client: Client;
+  cwd?: string;
+  projectNameOrId?: string;
+  commandName?: string;
+}
+
+function getInvokingCommandFromArgv(argv: string[]): string {
+  const args = omitGlobalFlagsFromArgs(argv.slice(2));
+  const positionals: string[] = [];
+  for (const arg of args) {
+    if (arg.startsWith('-')) {
+      break;
+    }
+    positionals.push(arg);
+  }
+  return positionals.join(' ');
+}
+
+/**
+ * Resolves project context without linking the directory or creating a project.
+ */
+export async function resolveProjectContext({
+  client,
+  cwd = client.cwd,
+  projectNameOrId,
+  commandName = '',
+}: ResolveProjectContextOptions): Promise<ProjectLinkResultWithOrgId> {
+  const context = await getLinkedProject(client, {
+    cwd,
+    projectName: projectNameOrId,
+    projectNameIsExplicit: Boolean(projectNameOrId),
+    scopeIsExplicit: detectExplicitScope(client),
+  });
+
+  if (context.status === 'not_linked' && projectNameOrId) {
+    await printProjectNotFoundError(
+      client,
+      projectNameOrId,
+      commandName || getInvokingCommandFromArgv(client.argv),
+      context.orgId
+    );
+    return { status: 'error', exitCode: 1, orgId: context.orgId };
+  }
+
+  return context;
+}

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -8,7 +8,11 @@ import {
 import build from '../../../../src/commands/build';
 import cliPkg from '../../../../src/util/pkg';
 import { client } from '../../../mocks/client';
-import { defaultProject, useProject } from '../../../mocks/project';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 import { execSync } from 'child_process';
@@ -3559,7 +3563,7 @@ writeFileSync(
       const getLinkedProjectSpy = vi.spyOn(linkModule, 'getLinkedProject');
       useUser();
       useTeams('team_dummy');
-      // No useProject() — every API lookup will 404.
+      useUnknownProject();
 
       client.cwd = cwd;
       client.setArgv('build', '--project=does-not-exist');
@@ -3573,7 +3577,7 @@ writeFileSync(
       expect(getLinkedProjectSpy).toHaveBeenCalledWith(client, {
         cwd: await fs.realpath(cwd),
         projectName: 'does-not-exist',
-        apiFallback: true,
+        projectNameIsExplicit: true,
       });
       getLinkedProjectSpy.mockRestore();
 
@@ -3589,6 +3593,7 @@ writeFileSync(
       const cwd = await getWriteableDirectory();
       useUser();
       useTeams('team_dummy');
+      useUnknownProject();
 
       client.cwd = cwd;
       client.setArgv('build', '--project=my-app');

--- a/packages/cli/test/unit/commands/crons/ls.test.ts
+++ b/packages/cli/test/unit/commands/crons/ls.test.ts
@@ -302,7 +302,8 @@ describe('crons ls', () => {
       expect(mockedGetLinkedProject).toHaveBeenCalledWith(client, {
         cwd: client.cwd,
         projectName: 'crons-project',
-        apiFallback: true,
+        projectNameIsExplicit: true,
+        scopeIsExplicit: false,
       });
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'subcommand:list', value: 'ls' },

--- a/packages/cli/test/unit/commands/crons/run.test.ts
+++ b/packages/cli/test/unit/commands/crons/run.test.ts
@@ -278,7 +278,8 @@ describe('crons run', () => {
       expect(mockedGetLinkedProject).toHaveBeenCalledWith(client, {
         cwd: client.cwd,
         projectName: 'crons-project',
-        apiFallback: true,
+        projectNameIsExplicit: true,
+        scopeIsExplicit: false,
       });
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         { key: 'subcommand:run', value: 'run' },

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -11,7 +11,11 @@ import {
   setupUnitFixture,
   setupTmpDir,
 } from '../../../helpers/setup-unit-fixture';
-import { defaultProject, useProject } from '../../../mocks/project';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
 import { useDeployment, useBuildLogs } from '../../../mocks/deployment';
 import { useTeams, createTeam } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
@@ -3212,7 +3216,7 @@ describe('deploy', () => {
       const cwd = setupTmpDir();
       useUser();
       useTeams('team_dummy');
-      // Intentionally no useProject() — every API lookup will 404.
+      useUnknownProject();
 
       client.cwd = cwd;
       client.setArgv('deploy', '--yes', '--project=does-not-exist');

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -421,7 +421,8 @@ describe('dev', () => {
       expect(getLinkedProjectSpy).toHaveBeenCalledWith(client, {
         cwd: normalize(projectPath),
         projectName: undefined,
-        apiFallback: false,
+        projectNameIsExplicit: false,
+        scopeIsExplicit: false,
       });
       getLinkedProjectSpy.mockRestore();
     });

--- a/packages/cli/test/unit/commands/pull/index.test.ts
+++ b/packages/cli/test/unit/commands/pull/index.test.ts
@@ -5,7 +5,11 @@ import path from 'path';
 import pull from '../../../../src/commands/pull';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
-import { defaultProject, useProject } from '../../../mocks/project';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
 import { useTeams, createTeam } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
@@ -477,7 +481,7 @@ describe('pull', () => {
       const cwd = setupUnitFixture('vercel-pull-unlinked');
       useUser();
       useTeams('team_dummy');
-      // No useProject() — every GET /v9/projects/* will 404.
+      useUnknownProject();
 
       client.setArgv('pull', '--yes', '--project=does-not-exist', cwd);
       const exitCodePromise = pull(client);

--- a/packages/cli/test/unit/commands/rolling-release/configure.test.ts
+++ b/packages/cli/test/unit/commands/rolling-release/configure.test.ts
@@ -106,7 +106,8 @@ describe('rolling-release configure', () => {
     expect(mockedGetLinkedProject).toHaveBeenCalledWith(client, {
       cwd: client.cwd,
       projectName: 'my-project',
-      apiFallback: true,
+      projectNameIsExplicit: true,
+      scopeIsExplicit: false,
     });
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'option:project', value: '[REDACTED]' },

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { join } from 'path';
+import { writeFile } from 'fs/promises';
 import { mkdirp, writeJSON } from 'fs-extra';
 import {
   getLinkFromDir,
@@ -7,7 +8,11 @@ import {
 } from '../../../../src/util/projects/link';
 import { client } from '../../../mocks/client';
 
-import { defaultProject, useProject } from '../../../mocks/project';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
@@ -317,16 +322,53 @@ describe('getLinkedProject', () => {
       accountId: 'team_dummy',
     });
 
-    const link = await getLinkedProject(client, {
-      cwd,
-      projectName: 'explicit-project',
-      apiFallback: true,
-    });
-    if (link.status !== 'linked') {
-      throw new Error('Expected to be linked');
+    process.env.VERCEL_ORG_ID = 'team_dummy';
+    process.env.VERCEL_PROJECT_ID = 'stale-project';
+    try {
+      const link = await getLinkedProject(client, {
+        cwd,
+        projectName: 'explicit-project',
+        projectNameIsExplicit: true,
+      });
+      if (link.status !== 'linked') {
+        throw new Error('Expected to be linked');
+      }
+      expect(link.project.id).toEqual('explicit-project');
+      expect(link.repoRoot).toBeUndefined();
+    } finally {
+      delete process.env.VERCEL_ORG_ID;
+      delete process.env.VERCEL_PROJECT_ID;
     }
-    expect(link.project.id).toEqual('explicit-project');
-    expect(link.repoRoot).toBeUndefined();
+  });
+
+  it('should ignore malformed local metadata when environment IDs provide the scope', async () => {
+    const cwd = setupTmpDir('env-scope-malformed-project-json');
+    const vercelDir = join(cwd, '.vercel');
+    await mkdirp(vercelDir);
+    await writeFile(join(vercelDir, 'project.json'), '{ malformed');
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'explicit-project',
+      name: 'explicit-project',
+      accountId: 'team_dummy',
+    });
+
+    process.env.VERCEL_ORG_ID = 'team_dummy';
+    process.env.VERCEL_PROJECT_ID = 'stale-project';
+    try {
+      const link = await getLinkedProject(client, {
+        cwd,
+        projectName: 'explicit-project',
+        projectNameIsExplicit: true,
+      });
+      expect(link.status).toEqual('linked');
+    } finally {
+      delete process.env.VERCEL_ORG_ID;
+      delete process.env.VERCEL_PROJECT_ID;
+    }
   });
 
   it('should let explicit projectName override repo path auto-selection', async () => {
@@ -334,22 +376,86 @@ describe('getLinkedProject', () => {
 
     useUser();
     useTeams('team_dummy');
-    useProject({
+    client.config.currentTeam = 'team_default';
+    let requestedTeamId: unknown;
+    const project = {
       ...defaultProject,
       id: 'QmX6P93ChNDoZP',
       name: 'monorepo-marketing',
+      accountId: 'team_dummy',
+    };
+    client.scenario.get('/v9/projects/monorepo-marketing', (req, res) => {
+      requestedTeamId = req.query.teamId;
+      res.json(project);
     });
 
     const link = await getLinkedProject(client, {
       cwd: join(cwd, 'dashboard'),
       projectName: 'monorepo-marketing',
-      apiFallback: true,
+      projectNameIsExplicit: true,
     });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
     }
     expect(link.project.id).toEqual('QmX6P93ChNDoZP');
     expect(link.repoRoot).toEqual(cwd);
+    expect(link.projectRootDirectory).toEqual('marketing');
+    expect(requestedTeamId).toEqual('team_dummy');
+  });
+
+  it('should constrain explicit project lookup to the selected scope', async () => {
+    const cwd = setupTmpDir('explicit-project-scope');
+    const project = {
+      ...defaultProject,
+      id: 'prj_scoped',
+      name: 'scoped-project',
+      accountId: 'team_scope',
+    };
+    let requestedTeamId: unknown;
+
+    useUser();
+    useTeams('team_scope');
+    client.config.currentTeam = 'team_scope';
+    client.scenario.get('/v9/projects/scoped-project', (req, res) => {
+      requestedTeamId = req.query.teamId;
+      res.json(project);
+    });
+
+    const link = await getLinkedProject(client, {
+      cwd,
+      projectName: 'scoped-project',
+      projectNameIsExplicit: true,
+      scopeIsExplicit: true,
+    });
+
+    expect(requestedTeamId).toEqual('team_scope');
+    expect(link.status).toEqual('linked');
+  });
+
+  it('should ignore conflicting local metadata when scope is explicit', async () => {
+    const cwd = setupTmpDir('explicit-scope-conflicting-metadata');
+    await mkdirp(join(cwd, '.vercel'));
+    await mkdirp(join(cwd, '.now'));
+    const project = {
+      ...defaultProject,
+      id: 'prj_explicit',
+      name: 'explicit-project',
+      accountId: 'team_scope',
+    };
+
+    useUser();
+    useTeams('team_scope');
+    client.config.currentTeam = 'team_scope';
+    useProject(project);
+
+    const link = await getLinkedProject(client, {
+      cwd,
+      projectName: 'explicit-project',
+      projectNameIsExplicit: true,
+      scopeIsExplicit: true,
+    });
+
+    expect(link.status).toEqual('linked');
   });
 
   it('should return link with legacy `repo.json` (top-level orgId)', async () => {
@@ -481,7 +587,7 @@ describe('getLinkedProject', () => {
     expect(link.repoRoot).toEqual(cwd);
   });
 
-  it('should resolve project via API when projectName is provided, apiFallback is true, and no local link exists', async () => {
+  it('should resolve an explicit projectName via API when no local link exists', async () => {
     const cwd = setupTmpDir('no-local-link');
 
     useUser();
@@ -496,7 +602,7 @@ describe('getLinkedProject', () => {
     const link = await getLinkedProject(client, {
       cwd,
       projectName: 'api-fallback-project',
-      apiFallback: true,
+      projectNameIsExplicit: true,
     });
     if (link.status !== 'linked') {
       throw new Error('Expected to be linked');
@@ -507,19 +613,33 @@ describe('getLinkedProject', () => {
     expect(link.repoRoot).toBeUndefined();
   });
 
-  it('should return not_linked when projectName is provided, apiFallback is true, and the project does not exist anywhere', async () => {
+  it('should not fall back when an explicit projectName does not exist', async () => {
     const cwd = setupTmpDir('no-local-link-not-found');
 
     useUser();
     useTeams('team_dummy');
-    // Intentionally no useProject — every API lookup 404s.
-
-    const link = await getLinkedProject(client, {
-      cwd,
-      projectName: 'definitely-missing',
-      apiFallback: true,
+    useProject({
+      ...defaultProject,
+      id: 'env-project',
+      name: 'env-project',
+      accountId: 'team_dummy',
     });
-    expect(link.status).toEqual('not_linked');
+    useUnknownProject();
+
+    process.env.VERCEL_ORG_ID = 'team_dummy';
+    process.env.VERCEL_PROJECT_ID = 'env-project';
+    try {
+      const link = await getLinkedProject(client, {
+        cwd,
+        projectName: 'definitely-missing',
+        projectNameIsExplicit: true,
+      });
+      expect(link.status).toEqual('not_linked');
+      expect(link.orgId).toEqual('team_dummy');
+    } finally {
+      delete process.env.VERCEL_ORG_ID;
+      delete process.env.VERCEL_PROJECT_ID;
+    }
   });
 
   it('should not call API fallback when no projectName is provided', async () => {
@@ -532,7 +652,7 @@ describe('getLinkedProject', () => {
     expect(link.status).toEqual('not_linked');
   });
 
-  it('should not call API fallback when projectName is provided but apiFallback is not enabled', async () => {
+  it('should not call the API when projectName is implicit', async () => {
     const cwd = setupTmpDir('no-link-implicit-name');
 
     useUser();

--- a/packages/cli/test/unit/util/projects/project-not-found-error.test.ts
+++ b/packages/cli/test/unit/util/projects/project-not-found-error.test.ts
@@ -62,6 +62,21 @@ describe('printProjectNotFoundError', () => {
       );
       expect(exitSpy).not.toHaveBeenCalled();
     });
+
+    it('names the scope used for project lookup', async () => {
+      useUser();
+      const teams = useTeams('team_searched');
+      const searchedSlug = Array.isArray(teams)
+        ? teams[0].slug
+        : teams.teams[0].slug;
+      client.config.currentTeam = 'team_default';
+
+      await printProjectNotFoundError(client, 'foo', 'deploy', 'team_searched');
+
+      expect(client.stderr.getFullOutput()).toContain(
+        `current scope (${searchedSlug})`
+      );
+    });
   });
 
   describe('non-interactive mode', () => {


### PR DESCRIPTION
## Why

An explicit project selector should choose a project for one command. It should not be overridden by environment IDs, a local link, or the persisted default team.

## Changes

- Track whether project and scope were explicitly supplied.
- Resolve an explicit project within the effective organization.
- Prevent unknown explicit projects from falling back to another project.
- Return the organization actually searched for accurate errors.
- Avoid requiring readable local metadata when scope is explicit.

Resolution order for the organization:

1. Explicit `--scope`
2. Complete `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` pair
3. Matching local or repository link
4. Persisted/default team

## Review notes

`getLinkedProjectOrFail()` remains as a documented compatibility entry point. A later PR in this stack migrates its remaining callers and removes it.

## Validation

- Resolver precedence, not-found, malformed metadata, and repository-root unit tests
- Existing build/deploy/pull not-found tests
- See PR 5 for testing matrix for avoiding regressions


Stack: 2 of 5. Depends on #17080; next: #17082.

