### PR TITLE
fix(cli): allow env ls --project outside linked directories

### DIFF
--- a/.changeset/clean-project-selection.md
+++ b/.changeset/clean-project-selection.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow `vercel env ls` to target a project explicitly without linking the current directory.

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -1,6 +1,11 @@
 import { packageName } from '../../util/pkg-name';
 import { getEnvTargetPlaceholder } from '../../util/env/env-target';
-import { forceOption, formatOption, yesOption } from '../../util/arg-common';
+import {
+  forceOption,
+  formatOption,
+  projectOption,
+  yesOption,
+} from '../../util/arg-common';
 
 const targetPlaceholder = getEnvTargetPlaceholder();
 
@@ -20,6 +25,7 @@ export const listSubcommand = {
   ],
   options: [
     formatOption,
+    projectOption,
     {
       name: 'guidance',
       description: 'Receive command suggestions once command is complete',

--- a/packages/cli/src/commands/env/ls.ts
+++ b/packages/cli/src/commands/env/ls.ts
@@ -22,7 +22,7 @@ import { listSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { getLinkedProject } from '../../util/projects/link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 import { determineAgent } from '@vercel/detect-agent';
 import { suggestNextCommands } from '../../util/suggest-next-commands';
 import { validateLsArgs } from '../../util/validate-ls-args';
@@ -69,13 +69,19 @@ export default async function ls(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliFlagGuidance(flags['--guidance']);
   telemetryClient.trackCliOptionFormat(flags['--format']);
+  const projectName = flags['--project'];
+  telemetryClient.trackCliOptionProject(projectName);
 
-  const link = await getLinkedProject(client);
+  const link = await resolveProjectContext({
+    client,
+    projectNameOrId: projectName,
+    commandName: 'env ls',
+  });
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {
     output.error(
-      `Your codebase isn’t linked to a project on Vercel. ${client.nonInteractive ? `Run ${getCommandName('link --yes --team <team-id> --project <project-id>')} to link non-interactively.` : `Run ${getCommandName('link')} to begin.`}`
+      `Your codebase isn’t linked to a project on Vercel. Pass --project <name>, or ${client.nonInteractive ? `run ${getCommandName('link --yes --team <team-id> --project <project-id>')} to link non-interactively.` : `run ${getCommandName('link')} to begin.`}`
     );
     return 1;
   }
@@ -126,11 +132,11 @@ export default async function ls(client: Client, argv: string[]) {
   if (!asJson) {
     const { isAgent } = await determineAgent();
     const guidanceMode = parsedArgs.flags['--guidance'] ?? isAgent;
-    if (guidanceMode) {
+    if (guidanceMode && !projectName) {
       suggestNextCommands([
-        getCommandName(`env add`),
+        getCommandName('env add'),
         getCommandName('env rm'),
-        getCommandName(`env pull`),
+        getCommandName('env pull'),
       ]);
     }
   }

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -1,11 +1,19 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { describe, it, expect, beforeEach } from 'vitest';
 import env from '../../../../src/commands/env';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
-import { defaultProject } from '../../../mocks/project';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
-import { useProject } from '../../../mocks/project';
 
 describe('env ls', () => {
   beforeEach(() => {
@@ -63,7 +71,7 @@ describe('env ls', () => {
   });
 
   describe('--guidance', () => {
-    it('tracks telemetry', async () => {
+    it('retains linked-project guidance and tracks telemetry', async () => {
       const command = 'env';
       const subcommand = 'ls';
 
@@ -78,6 +86,10 @@ describe('env ls', () => {
         },
         { key: 'flag:guidance', value: 'TRUE' },
       ]);
+      const output = client.stderr.getFullOutput();
+      expect(output).toContain('vercel env add');
+      expect(output).toContain('vercel env rm');
+      expect(output).toContain('vercel env pull');
     });
   });
 
@@ -181,6 +193,82 @@ describe('env ls', () => {
       // Should not contain table formatting
       expect(stderrOutput).not.toContain('environments');
       expect(stderrOutput).not.toContain('created');
+    });
+  });
+
+  describe('--project', () => {
+    it('lists variables from an unlinked directory without writing link metadata', async () => {
+      const cwd = setupTmpDir('env-ls-explicit-project');
+      client.cwd = cwd;
+      useProject(
+        {
+          ...defaultProject,
+          id: 'prj_explicit',
+          name: 'explicit-project',
+          accountId: 'team_dummy',
+        },
+        []
+      );
+
+      client.setArgv(
+        'env',
+        'ls',
+        '--project',
+        'explicit-project',
+        '--format',
+        'json'
+      );
+      const exitCode = await env(client);
+
+      expect(exitCode).toEqual(0);
+      expect(JSON.parse(client.stdout.getFullOutput())).toEqual({ envs: [] });
+      expect(existsSync(join(cwd, '.vercel'))).toBe(false);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:ls', value: 'ls' },
+        { key: 'option:format', value: 'json' },
+        { key: 'option:project', value: '[REDACTED]' },
+      ]);
+    });
+
+    it('suppresses unsupported guidance for an explicitly selected project', async () => {
+      const cwd = setupTmpDir('env-ls-project-guidance');
+      client.cwd = cwd;
+      useProject({
+        ...defaultProject,
+        id: 'prj_guidance',
+        name: 'guidance-project',
+        accountId: 'team_dummy',
+      });
+
+      client.setArgv(
+        'env',
+        'ls',
+        '--project',
+        'guidance-project',
+        '--guidance'
+      );
+      const exitCode = await env(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.stderr.getFullOutput();
+      expect(output).not.toContain('vercel env add');
+      expect(output).not.toContain('vercel env rm');
+      expect(output).not.toContain('vercel env pull');
+    });
+
+    it('reports an unknown explicit project instead of linking', async () => {
+      const cwd = setupTmpDir('env-ls-unknown-project');
+      client.cwd = cwd;
+      useUnknownProject();
+
+      client.setArgv('env', 'ls', '--project', 'does-not-exist');
+      const exitCode = await env(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Project "does-not-exist" was not found'
+      );
+      expect(existsSync(join(cwd, '.vercel'))).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Problem

`env ls` is a remote, read-only operation, but selecting a project currently requires linking the working directory. Linking may write `.vercel/project.json` and update other workspace state, which is undesirable in CI, agents, and scratch directories.

Before:

```bash
mkdir /tmp/vercel-task
cd /tmp/vercel-task
vercel env ls --format json
# Fails because the directory is not linked
```

## Changes

Add explicit project selection:

```bash
vercel env ls \
  --project payments-api \
  --scope acme \
  --format json
```

- Works outside a linked directory.
- Does not create `.vercel` metadata or start linking.
- Explicit selection overrides environment and local-link project IDs.
- Unknown projects fail with `project_not_found` instead of falling back.
- Existing linked-directory behavior remains unchanged when omitted.
- Guidance for unsupported `env add`, `rm`, and `pull --project` combinations is suppressed.

## Non-goals

- No changes to `vercel link`.
- No `--project` support for other environment subcommands yet.
- No broad migration of unrelated commands.

## Validation

- Unlinked JSON listing and no-link-write coverage
- Unknown-project and guidance coverage
- Existing linked-project guidance coverage
- See PR 5 for testing matrix for avoiding regressions

Stack: 3 of 5. Depends on #17081; next: #17083.

