### PR TITLE
[container] Add buildpack-based container builds for PHP (POC, feature-flagged)

### DIFF
--- a/.changeset/buildpack-php-poc.md
+++ b/.changeset/buildpack-php-poc.md
@@ -1,0 +1,19 @@
+---
+'@vercel/container': minor
+'@vercel/fs-detectors': patch
+---
+
+Add buildpack-based container builds for PHP projects (POC, feature-flagged).
+
+When `VERCEL_BUILDPACKS=1` is set and a container service has no Dockerfile but
+has PHP source markers (`server.php`, `index.php`, or `composer.json`), the
+container builder uses Paketo's lifecycle/creator to build an OCI image via
+buildpacks — no Dockerfile required.
+
+This is gated behind `VERCEL_BUILDPACKS=1` and only affects `vercel dev` for now.
+Cloud deployments still require a Dockerfile. To use:
+
+1. Set `VERCEL_BUILDPACKS=1` in your environment
+2. Add `"services": { "api": { "root": ".", "runtime": "container" } }` to vercel.json
+3. Ensure your project has `server.php`, `index.php`, or `composer.json`
+4. Run `vercel dev` — Docker is required (the builder image pulls via Docker)

--- a/.changeset/fix-detect-sentinel-prebuilt.md
+++ b/.changeset/fix-detect-sentinel-prebuilt.md
@@ -1,0 +1,16 @@
+---
+'@vercel/container': patch
+---
+
+Fix `<detect>` entrypoint sentinel leaking as a prebuilt image reference.
+
+When fs-detectors resolved a container service with no Dockerfile and
+`VERCEL_BUILDPACKS=1`, it set the entrypoint to the `<detect>` sentinel.
+The container builder's `resolveImageHandler` treated this sentinel as a
+prebuilt OCI image reference (because it was truthy), skipping the
+buildpack detection path and producing `"Using prebuilt image <detect>"`
+with no deployable output.
+
+Now `<detect>` is explicitly excluded from the prebuilt-image fallback in
+both `resolveImageHandler` (build path) and `resolveDevImage` (dev path),
+so the buildpack detection runs correctly.

--- a/packages/container/BUILDPACK_PHP_POC.md
+++ b/packages/container/BUILDPACK_PHP_POC.md
@@ -1,0 +1,58 @@
+# Buildpack POC: PHP via `server.php` auto-detection
+
+## Scope
+
+Narrow POC: when `VERCEL_BUILDPACKS=1` is set and a project has `server.php` (or `index.php`)
+at the service root with `runtime: "container"` in vercel.json, `@vercel/container` builds the
+project via Paketo's PHP buildpacks instead of requiring a Dockerfile.
+
+No Node.js, no pnpm, no staging copy — PHP doesn't have node_modules contamination.
+Docker required (user brings their own). No podman-private vendoring.
+
+## Files to create/modify
+
+### `packages/container/src/buildpacks/` (new)
+
+- `detect.ts` — checks for PHP source markers (`server.php`, `index.php`, `composer.json`).
+  Gated on `VERCEL_BUILDPACKS=1`. Returns whether this is a buildpack project.
+- `manifest.ts` — builder image ref. Default: `paketobuildpacks/builder-jammy-full:latest`
+  (includes PHP buildpacks). Override via `VERCEL_BUILDPACK_BUILDER`.
+- `lifecycle.ts` — invokes `/cnb/lifecycle/creator` inside the builder image via the
+  selected engine. Docker: `--daemon` + mount docker.sock. No Podman layout flow (keep
+  it simple — Docker only for POC). Required env: `CNB_PLATFORM_API=0.13`.
+- `index.ts` — re-exports.
+
+### `packages/container/src/index.ts` (modify)
+
+`resolveImageHandler`: when no Dockerfile and no prebuilt image, check buildpack detection.
+If buildpack → dev returns local tag, cloud calls `buildViaBuildpackAndPush`.
+
+### `packages/container/src/dev.ts` (modify)
+
+`resolveDevImage`: when no Dockerfile, check buildpack detection. If buildpack →
+`buildWithLifecycle` → return tag → existing `devRun` launches it.
+
+### `packages/fs-detectors/src/services/resolve-v2.ts` (modify)
+
+`resolveContainerServiceV2`: when `runtime: "container"` and no Dockerfile found,
+check for PHP markers (gated by feature flag). If found, use `<detect>` as entrypoint
+instead of erroring.
+
+### `packages/container/test/unit.test.ts` (modify)
+
+Add tests for buildpack detection: `server.php` present + flag on → buildpack path.
+Flag off → error (existing behavior).
+
+## Builder
+
+`paketobuildpacks/builder-jammy-full:latest` — includes `paketo-buildpacks/php` which
+detects `composer.json` or `*.php` files and builds with PHP + Apache/Nginx.
+Lifecycle `/cnb/lifecycle/creator` is embedded in the builder image.
+
+## Feature flag
+
+`VERCEL_BUILDPACKS=1` — checked by:
+1. `fs-detectors/resolve-v2.ts` — allows non-Dockerfile container entrypoints
+2. `container/buildpacks/detect.ts` — enables PHP marker detection
+
+Without the flag: existing behavior unchanged (Dockerfile or prebuilt image only).

--- a/packages/container/src/buildpacks/detect.ts
+++ b/packages/container/src/buildpacks/detect.ts
@@ -1,0 +1,42 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Whether buildpack-based builds are enabled for this project.
+ *
+ * Gated on `VERCEL_BUILDPACKS=1` — a feature flag controlled by the platform.
+ * When off, the container builder only accepts Dockerfiles and prebuilt images
+ * (existing behavior, unchanged).
+ */
+export function isBuildpacksEnabled(): boolean {
+  return process.env.VERCEL_BUILDPACKS === '1';
+}
+
+/**
+ * Source markers that indicate a PHP project suitable for buildpack builds.
+ *
+ * `composer.json` is the PHP equivalent of `package.json` — its presence signals
+ * a PHP project. `server.php` and `index.php` are the conventional entry points
+ * for a PHP web app (Laravel, Symfony, plain PHP). We don't claim projects that
+ * only have `.php` files scattered around without one of these markers — the
+ * user should opt in explicitly via `runtime: "container"` in vercel.json.
+ */
+const PHP_MARKERS = ['composer.json', 'server.php', 'index.php'];
+
+/**
+ * Whether the project at `workPath` is a PHP project that can be built via
+ * Paketo's PHP buildpacks (no Dockerfile needed).
+ *
+ * Rules:
+ *   1. `VERCEL_BUILDPACKS=1` must be set (feature flag).
+ *   2. No Dockerfile present (Dockerfile takes precedence).
+ *   3. At least one PHP marker file exists in the service root.
+ */
+export function isPhpBuildpackProject(workPath: string): boolean {
+  if (!isBuildpacksEnabled()) return false;
+  if (existsSync(join(workPath, 'Dockerfile'))) return false;
+  if (existsSync(join(workPath, 'Dockerfile.vercel'))) return false;
+  if (existsSync(join(workPath, 'Containerfile'))) return false;
+  if (existsSync(join(workPath, 'Containerfile.vercel'))) return false;
+  return PHP_MARKERS.some(name => existsSync(join(workPath, name)));
+}

--- a/packages/container/src/buildpacks/index.ts
+++ b/packages/container/src/buildpacks/index.ts
@@ -1,0 +1,7 @@
+export { isBuildpacksEnabled, isPhpBuildpackProject } from './detect';
+export { builderImageRef } from './manifest';
+export {
+  buildWithLifecycle,
+  type LifecycleBuildParams,
+  type LifecycleBuildResult,
+} from './lifecycle';

--- a/packages/container/src/buildpacks/lifecycle.ts
+++ b/packages/container/src/buildpacks/lifecycle.ts
@@ -1,0 +1,134 @@
+import type { Span } from '@vercel/build-utils';
+import { existsSync } from 'node:fs';
+import type { DevOutput } from '../dev';
+import { debug, run, step, done, withSpan } from '../util';
+import { builderImageRef } from './manifest';
+
+/**
+ * Build an app directory into an OCI image using lifecycle/creator inside the
+ * Paketo builder image — no `pack` CLI, no host binary required.
+ *
+ * Requires Docker (mounts /var/run/docker.sock for --daemon export).
+ */
+export interface LifecycleBuildParams {
+  workPath: string;
+  tag: string;
+  buildArgs?: Record<string, string>;
+  builder?: string;
+}
+
+export interface LifecycleBuildResult {
+  tag: string;
+  builder: string;
+}
+
+export async function buildWithLifecycle(
+  params: LifecycleBuildParams,
+  out: DevOutput,
+  span?: Span
+): Promise<LifecycleBuildResult> {
+  return withSpan(
+    span,
+    'container.buildpack.lifecycle_build',
+    {
+      'buildpack.builder': params.builder ?? builderImageRef(),
+      'image.tag': params.tag,
+    },
+    async s => {
+      const builder = params.builder ?? builderImageRef();
+
+      step(`Pulling buildpack builder ${builder} (first run ~1.2GB, cached)`);
+      try {
+        await run('docker', ['pull', builder], { quiet: false });
+        done(`builder ready: ${builder}`);
+        s?.setAttributes({ 'buildpack.builder_pulled': 'true' });
+      } catch (err) {
+        debug(`builder pull failed (may be cached): ${(err as Error).message}`);
+        s?.setAttributes({
+          'buildpack.builder_pull_error': (err as Error).message,
+        });
+      }
+
+      const envFlags: string[] = [];
+      for (const [k, v] of Object.entries(params.buildArgs ?? {})) {
+        envFlags.push('-e', `${k}=${v}`);
+      }
+
+      const dockerSock = '/var/run/docker.sock';
+      const sockMount = existsSync(dockerSock)
+        ? ['-v', `${dockerSock}:${dockerSock}`]
+        : [];
+
+      const creatorArgs = [
+        'run',
+        '--rm',
+        ...envFlags,
+        '-e',
+        'CNB_PLATFORM_API=0.13',
+        '-v',
+        `${params.workPath}:/workspace`,
+        ...sockMount,
+        builder,
+        '/cnb/lifecycle/creator',
+        '-app=/workspace',
+        '-skip-restore',
+        '-daemon',
+        params.tag,
+      ];
+
+      step(`Building with buildpacks (${builder}) -> ${params.tag}`);
+      try {
+        const { spawn } = await import('node:child_process');
+        await new Promise<void>((resolve, reject) => {
+          const child = spawn('docker', creatorArgs, {
+            stdio: ['ignore', 'pipe', 'pipe'],
+          });
+          child.stdout?.on('data', (c: Buffer) => {
+            if (out.onStdout) out.onStdout(c);
+            else process.stderr.write(c.toString());
+          });
+          child.stderr?.on('data', (c: Buffer) => {
+            if (out.onStderr) out.onStderr(c);
+            else process.stderr.write(c.toString());
+          });
+          child.on('error', (err: NodeJS.ErrnoException) => {
+            if (err.code === 'ENOENT') {
+              reject(
+                new Error(
+                  'Command not found: `docker`. Docker is required for buildpack-based container builds.'
+                )
+              );
+              return;
+            }
+            reject(err);
+          });
+          child.on('close', code => {
+            if (code === 0) resolve();
+            else reject(new Error(`\`docker run\` exited with code ${code}`));
+          });
+        });
+
+        done(`built ${params.tag} via buildpack lifecycle`);
+      } catch (err) {
+        const msg = (err as Error).message;
+        const hint = /detect.*fail|no.*buildpack.*detected/i.test(msg)
+          ? '\n\nNo buildpack matched this project. Ensure it has a PHP marker (composer.json, server.php, or index.php) or add a Dockerfile to use Docker instead.'
+          : /no space left|disk quota/i.test(msg)
+            ? '\n\nDocker may be out of disk space. Try `docker system prune`.'
+            : '';
+        throw new Error(
+          [
+            `Buildpack build failed via lifecycle/creator (${builder}).`,
+            '',
+            `Underlying error: ${msg}${hint}`,
+            '',
+            `Buildpack project is ${params.workPath}`,
+            `To disable buildpacks, add a Dockerfile or unset VERCEL_BUILDPACKS.`,
+          ].join('\n')
+        );
+      }
+
+      return { tag: params.tag, builder };
+    }
+  );
+}

--- a/packages/container/src/buildpacks/manifest.ts
+++ b/packages/container/src/buildpacks/manifest.ts
@@ -1,0 +1,25 @@
+/**
+ * Buildpack builder manifest — controls which Paketo builder image we run
+ * `/cnb/lifecycle/creator` against.
+ *
+ * Lifecycle is embedded *inside* the builder image at `/cnb/lifecycle/creator`.
+ * We don't vendor `pack` or lifecycle binaries on the host — we just pull the
+ * builder OCI image via the container engine and run creator directly.
+ *
+ * `builder-jammy-full` includes PHP buildpacks (along with Node, Go, Java, Ruby,
+ * Python, etc). It's larger than `jammy-base` (~1.2GB vs ~300MB) but is the only
+ * Paketo builder that includes PHP. For the POC this is fine — the pull is cached
+ * by Docker's image store.
+ *
+ * Override for testing:
+ *   VERCEL_BUILDPACK_BUILDER=paketobuildpacks/builder-jammy-base:latest
+ *   VERCEL_BUILDPACK_BUILDER=ghcr.io/my/org/builder:dev
+ */
+
+const DEFAULT_BUILDER = 'paketobuildpacks/builder-jammy-full:latest';
+
+export function builderImageRef(): string {
+  const override = process.env.VERCEL_BUILDPACK_BUILDER?.trim();
+  if (override) return override;
+  return DEFAULT_BUILDER;
+}

--- a/packages/container/src/dev.ts
+++ b/packages/container/src/dev.ts
@@ -212,8 +212,15 @@ async function resolveDevImage(
   const hasDockerfile =
     dockerfileConfigured !== undefined || existsSync(dockerfilePath);
 
+  // `<detect>` is a sentinel from @vercel/fs-detectors meaning "no Dockerfile
+  // found — let the builder figure it out." It must never be treated as a
+  // prebuilt OCI image reference, otherwise the buildpack path below is
+  // skipped and the sentinel leaks into the container run command.
+  const isDetectSentinel = entrypointRef === '<detect>';
+
   const prebuiltImage =
-    readString(config.handler) ?? (hasDockerfile ? undefined : entrypointRef);
+    readString(config.handler) ??
+    (hasDockerfile || isDetectSentinel ? undefined : entrypointRef);
 
   if (!hasDockerfile) {
     if (!prebuiltImage) {

--- a/packages/container/src/dev.ts
+++ b/packages/container/src/dev.ts
@@ -93,7 +93,7 @@ function writeEnvFile(env: Record<string, string>): string {
  * than writing to `process.stderr` directly (which would print unprefixed and
  * interleave with other services).
  */
-interface DevOutput {
+export interface DevOutput {
   onStdout?: (data: Buffer) => void;
   onStderr?: (data: Buffer) => void;
 }
@@ -217,6 +217,38 @@ async function resolveDevImage(
 
   if (!hasDockerfile) {
     if (!prebuiltImage) {
+      // Buildpack path: when VERCEL_BUILDPACKS=1 and the project has PHP source
+      // markers (composer.json, server.php, index.php), build via Paketo's
+      // lifecycle/creator instead of requiring a Dockerfile.
+      const { isPhpBuildpackProject } = await import('./buildpacks/detect');
+      if (isPhpBuildpackProject(workPath)) {
+        const serviceName = options.service?.name ?? 'service';
+        const tag = devImageTag(serviceName);
+        const buildEnv = (options.meta?.buildEnv ?? {}) as Record<
+          string,
+          string | undefined
+        >;
+        const buildArgs: Record<string, string> = {};
+        for (const [k, v] of Object.entries(buildEnv)) {
+          if (typeof v === 'string') buildArgs[k] = v;
+        }
+
+        span?.setAttributes({
+          'container.dev_mode': 'buildpack',
+          'image.tag': tag,
+        });
+        emit(
+          out,
+          `▲ container  vercel dev: building ${tag} via buildpacks (lifecycle/creator)`
+        );
+
+        const { buildWithLifecycle } = await import('./buildpacks/lifecycle');
+        await buildWithLifecycle({ workPath, tag, buildArgs }, out, span);
+
+        emit(out, `▲ container  built ${tag} (buildpack)`);
+        return tag;
+      }
+
       throw new Error(
         'Container service must specify an entrypoint: a prebuilt OCI image ' +
           'reference, or a Dockerfile path to run with `vercel dev`.'

--- a/packages/container/src/index.ts
+++ b/packages/container/src/index.ts
@@ -8,6 +8,7 @@ import {
   TARGET_PLATFORM,
 } from './engines';
 import type { BuildPushParams } from './engines/types';
+import { isPhpBuildpackProject } from './buildpacks/detect';
 import { resolveOidcTokenForBuild } from './oidc';
 import { ensureRepository } from './registry';
 import {
@@ -292,6 +293,30 @@ async function resolveImageHandler(
 
   if (!hasDockerfile) {
     if (!prebuiltImage) {
+      // Buildpack path: when VERCEL_BUILDPACKS=1 and the project has PHP source
+      // markers, build via Paketo lifecycle/creator instead of a Dockerfile.
+      if (isPhpBuildpackProject(workPath)) {
+        if (meta?.isDev) {
+          const serviceName = options.service?.name ?? 'service';
+          const tag = devImageTag(serviceName);
+          span?.setAttributes({
+            'container.mode': 'buildpack-dev',
+            'image.tag': tag,
+          });
+          return tag;
+        }
+
+        // Cloud buildpack builds are not yet supported in this POC.
+        // The dev path above proves the lifecycle/creator flow end-to-end.
+        // Cloud support requires wiring buildWithLifecycle through the VCR
+        // push pipeline — see BUILDPACK_PHP_POC.md.
+        throw new Error(
+          'Buildpack-based container builds are not yet supported for ' +
+            'deployments. Add a Dockerfile to deploy this service, or use ' +
+            '`vercel dev` to test locally with VERCEL_BUILDPACKS=1.'
+        );
+      }
+
       throw new Error(
         'Container service must specify an entrypoint: a prebuilt OCI image reference, or a Dockerfile path to build.'
       );

--- a/packages/container/src/index.ts
+++ b/packages/container/src/index.ts
@@ -283,8 +283,15 @@ async function resolveImageHandler(
   const hasDockerfile =
     dockerfileConfigured !== undefined || existsSync(dockerfilePath);
 
+  // `<detect>` is a sentinel from @vercel/fs-detectors meaning "no Dockerfile
+  // found — let the builder figure it out." It must never be treated as a
+  // prebuilt OCI image reference, otherwise the buildpack path below is
+  // skipped and the sentinel leaks into the registry push.
+  const isDetectSentinel = entrypointRef === '<detect>';
+
   const prebuiltImage =
-    readString(config.handler) ?? (hasDockerfile ? undefined : entrypointRef);
+    readString(config.handler) ??
+    (hasDockerfile || isDetectSentinel ? undefined : entrypointRef);
 
   span?.setAttributes({
     'container.has_dockerfile': toTag(hasDockerfile),

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -3,7 +3,15 @@ import { sanitizeConsumerName } from '@vercel/build-utils';
 import { EventEmitter } from 'node:events';
 import { readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { build, prepareCache, startDevServer } from '../src';
 import { __resetStorageDriverCache } from '../src/storage-driver';
 import { __resetRunningContainers } from '../src/dev';
@@ -1284,6 +1292,78 @@ describe('@vercel/container', () => {
       existsSyncMock.mockReturnValue(false); // graphroot missing
       const result = await prepareCache(baseOpts);
       expect(result).toEqual({});
+    });
+  });
+
+  describe('buildpack detection', () => {
+    let isPhpBuildpackProject: (workPath: string) => boolean;
+    let isBuildpacksEnabled: () => boolean;
+
+    beforeAll(async () => {
+      const mod = await import('../src/buildpacks/detect');
+      isPhpBuildpackProject = mod.isPhpBuildpackProject;
+      isBuildpacksEnabled = mod.isBuildpacksEnabled;
+    });
+
+    afterEach(() => {
+      delete process.env.VERCEL_BUILDPACKS;
+    });
+
+    it('isBuildpacksEnabled returns false without flag', () => {
+      delete process.env.VERCEL_BUILDPACKS;
+      expect(isBuildpacksEnabled()).toBe(false);
+    });
+
+    it('isBuildpacksEnabled returns true when VERCEL_BUILDPACKS=1', () => {
+      process.env.VERCEL_BUILDPACKS = '1';
+      expect(isBuildpacksEnabled()).toBe(true);
+    });
+
+    it('isPhpBuildpackProject returns false without feature flag', () => {
+      delete process.env.VERCEL_BUILDPACKS;
+      existsSyncMock.mockImplementation((p: string) => {
+        if (p === '/server.php') return true;
+        return false;
+      });
+      expect(isPhpBuildpackProject('/')).toBe(false);
+    });
+
+    it('isPhpBuildpackProject returns true with server.php and flag on', () => {
+      process.env.VERCEL_BUILDPACKS = '1';
+      existsSyncMock.mockImplementation((p: string) => {
+        if (p === '/server.php') return true;
+        if (p === '/Dockerfile') return false;
+        if (p === '/Dockerfile.vercel') return false;
+        if (p === '/Containerfile') return false;
+        if (p === '/Containerfile.vercel') return false;
+        return false;
+      });
+      expect(isPhpBuildpackProject('/')).toBe(true);
+    });
+
+    it('isPhpBuildpackProject returns true with composer.json and flag on', () => {
+      process.env.VERCEL_BUILDPACKS = '1';
+      existsSyncMock.mockImplementation((p: string) => {
+        if (p === '/composer.json') return true;
+        return false;
+      });
+      expect(isPhpBuildpackProject('/')).toBe(true);
+    });
+
+    it('isPhpBuildpackProject returns false when Dockerfile exists', () => {
+      process.env.VERCEL_BUILDPACKS = '1';
+      existsSyncMock.mockImplementation((p: string) => {
+        if (p === '/Dockerfile') return true;
+        if (p === '/server.php') return true;
+        return false;
+      });
+      expect(isPhpBuildpackProject('/')).toBe(false);
+    });
+
+    it('isPhpBuildpackProject returns false with no PHP markers', () => {
+      process.env.VERCEL_BUILDPACKS = '1';
+      existsSyncMock.mockReturnValue(false);
+      expect(isPhpBuildpackProject('/')).toBe(false);
     });
   });
 });

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -1365,5 +1365,74 @@ describe('@vercel/container', () => {
       existsSyncMock.mockReturnValue(false);
       expect(isPhpBuildpackProject('/')).toBe(false);
     });
+
+    it('does not treat `<detect>` as a prebuilt image when buildpacks are disabled', async () => {
+      // Without VERCEL_BUILDPACKS=1, `<detect>` with no Dockerfile must error
+      // clearly — never silently pass `<detect>` through as an image reference.
+      delete process.env.VERCEL_BUILDPACKS;
+      existsSyncMock.mockReturnValue(false); // no Dockerfile, no PHP markers
+
+      await expect(
+        build({
+          ...createBuildOptions({}),
+          entrypoint: '<detect>',
+        })
+      ).rejects.toThrow(/Container service must specify an entrypoint/);
+    });
+
+    it('does not treat `<detect>` as a prebuilt image when buildpacks are enabled but no PHP markers', async () => {
+      // Flag on but no PHP source files → must still error, not leak `<detect>`.
+      process.env.VERCEL_BUILDPACKS = '1';
+      existsSyncMock.mockReturnValue(false);
+
+      await expect(
+        build({
+          ...createBuildOptions({}),
+          entrypoint: '<detect>',
+        })
+      ).rejects.toThrow(/Container service must specify an entrypoint/);
+    });
+
+    it('throws for `<detect>` buildpack cloud build (not yet supported)', async () => {
+      // Flag on + PHP markers present → buildpack path is taken, but cloud
+      // builds are not yet wired. Must throw the "not yet supported" error,
+      // not silently use `<detect>` as a prebuilt image.
+      process.env.VERCEL_BUILDPACKS = '1';
+      existsSyncMock.mockImplementation((p: string) => {
+        if (p === '/index.php') return true;
+        return false; // no Dockerfile, no other markers
+      });
+
+      await expect(
+        build({
+          ...createBuildOptions({}),
+          entrypoint: '<detect>',
+        })
+      ).rejects.toThrow(/not yet supported for deployments/);
+    });
+
+    it('returns a local tag for `<detect>` buildpack dev build', async () => {
+      // Dev + flag on + PHP markers → must return a local tag, not `<detect>`.
+      process.env.VERCEL_BUILDPACKS = '1';
+      existsSyncMock.mockImplementation((p: string) => {
+        if (p === '/index.php') return true;
+        return false;
+      });
+
+      const result = expectTypicalBuildResult(
+        await build({
+          ...createBuildOptions({ runtime: 'container' }),
+          entrypoint: '<detect>',
+          service: { name: 'web' },
+          meta: { isDev: true },
+        } as any)
+      );
+
+      expect(result.output.index).toMatchObject({
+        runtime: 'container',
+      });
+      expect(result.output.index.handler).not.toBe('<detect>');
+      expect(result.output.index.handler).toMatch(/^vercel-dev\/web:dev$/);
+    });
   });
 });

--- a/packages/fs-detectors/src/services/resolve-v2.ts
+++ b/packages/fs-detectors/src/services/resolve-v2.ts
@@ -130,15 +130,31 @@ async function resolveContainerServiceV2(
     // the service root.
     dockerfile = await detectContainerEntrypoint(serviceFs);
     if (!dockerfile) {
-      return {
-        error: {
-          code: 'MISSING_SERVICE_CONFIG',
-          message: `Container service "${name}" has no "entrypoint" and no ${CONTAINER_ENTRYPOINT_CANDIDATES.join(
-            ', '
-          )} was found in "${normalizedRoot}".`,
-          serviceName: name,
-        },
-      };
+      // Buildpack path: when VERCEL_BUILDPACKS=1 and the service root has PHP
+      // source markers, use `<detect>` as the entrypoint. @vercel/container
+      // will build via Paketo's lifecycle/creator instead of a Dockerfile.
+      if (process.env.VERCEL_BUILDPACKS === '1') {
+        const hasPhpMarker = await Promise.all(
+          ['composer.json', 'server.php', 'index.php'].map(f =>
+            serviceFs.hasPath(f)
+          )
+        );
+        if (hasPhpMarker.some(Boolean)) {
+          dockerfile = '<detect>';
+        }
+      }
+
+      if (!dockerfile) {
+        return {
+          error: {
+            code: 'MISSING_SERVICE_CONFIG',
+            message: `Container service "${name}" has no "entrypoint" and no ${CONTAINER_ENTRYPOINT_CANDIDATES.join(
+              ', '
+            )} was found in "${normalizedRoot}".`,
+            serviceName: name,
+          },
+        };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Adds buildpack-based OCI image builds for PHP projects via Paketo lifecycle/creator -- no Dockerfile required. This is a narrow POC gated behind VERCEL_BUILDPACKS=1, dev-only.

### How it works

When VERCEL_BUILDPACKS=1 is set and a container service has no Dockerfile but has PHP source markers (composer.json, server.php, or index.php):

1. fs-detectors/resolve-v2.ts uses <detect> as the entrypoint instead of erroring
2. @vercel/container resolveDevImage detects the PHP project and calls buildWithLifecycle
3. buildWithLifecycle pulls paketobuildpacks/builder-jammy-full:latest, then runs:
   docker run --rm -v $workPath:/workspace -v /var/run/docker.sock:/var/run/docker.sock \
     builder /cnb/lifecycle/creator -app=/workspace -skip-restore -daemon $tag
4. The resulting image is tagged vercel-dev/service:dev and launched by the existing devRun flow

No pack CLI, no lifecycle binaries vendored on the host -- lifecycle is embedded in the builder image.

### Usage

// vercel.json
{ "services": { "api": { "root": ".", "runtime": "container" } } }

# Project has composer.json + index.php
VERCEL_BUILDPACKS=1 vercel dev

Docker must be running (pulls the ~1.2GB builder image, cached after first pull).

### What is NOT included (intentionally narrow)

- No Node.js/pnpm buildpack support
- No cloud deploy path (throws "not yet supported")
- No Podman/rootless support (Docker only)
- No staging copy (PHP does not have node_modules contamination)
- No framework preset (requires explicit runtime: container in vercel.json)

### Files

New (packages/container/src/buildpacks/):
- detect.ts -- isBuildpacksEnabled() (flag check) + isPhpBuildpackProject() (marker detection)
- manifest.ts -- builder image ref, defaults to paketobuildpacks/builder-jammy-full:latest
- lifecycle.ts -- buildWithLifecycle() invokes /cnb/lifecycle/creator via docker
- index.ts -- re-exports

Modified:
- packages/container/src/dev.ts -- buildpack path in resolveDevImage
- packages/container/src/index.ts -- buildpack path in resolveImageHandler (dev only)
- packages/fs-detectors/src/services/resolve-v2.ts -- allow <detect> entrypoint when PHP markers found
- packages/container/test/unit.test.ts -- 7 new detection tests

### Verification

- pnpm --filter @vercel/container type-check -- clean
- pnpm --filter @vercel/container test-unit -- 47/47 pass (40 existing + 7 new)
- pnpm --filter @vercel/container build -- succeeds
