### PR TITLE
[connect] Document per-issuance tokenId on ConnectTokenResponse

### DIFF
--- a/.changeset/connect-token-id.md
+++ b/.changeset/connect-token-id.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Expose and document the per-issuance `tokenId` on `ConnectTokenResponse` (returned by `getToken`/`getTokenResponse`). It's a stable identifier for the issued token — new on each issuance/refresh — for correlating a token with its usage in Vercel observability/billing data.

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -51,12 +51,8 @@ export interface ConnectTokenParams {
 export interface ConnectTokenResponse {
   token: string;
   /**
-   * Per-issuance identifier for this token (`stk_…`). A new id is assigned each
-   * time a token is issued — including on refresh — and stays stable for that
-   * issued token's lifetime. Use it to correlate a token with its usage in
-   * Vercel observability/billing data (e.g. usage facts and drains). It is not
-   * the token itself and is safe to log. Optional: absent from responses served
-   * by Vercel API versions that predate this field.
+   * Per-issuance identifier for the token (`stk_…`), stable for its lifetime;
+   * use it to correlate the token with its usage in Vercel observability data.
    */
   tokenId?: string;
   /** Token expiration timestamp in milliseconds since epoch. */

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -50,6 +50,15 @@ export interface ConnectTokenParams {
 
 export interface ConnectTokenResponse {
   token: string;
+  /**
+   * Per-issuance identifier for this token (`stk_…`). A new id is assigned each
+   * time a token is issued — including on refresh — and stays stable for that
+   * issued token's lifetime. Use it to correlate a token with its usage in
+   * Vercel observability/billing data (e.g. usage facts and drains). It is not
+   * the token itself and is safe to log. Optional: absent from responses served
+   * by Vercel API versions that predate this field.
+   */
+  tokenId?: string;
   /** Token expiration timestamp in milliseconds since epoch. */
   expiresAt: number;
   connector: {


### PR DESCRIPTION
## Why

The Vercel Connect token API now returns a per-issuance `tokenId` (`stk_…`) on the token response — a stable identifier for the issued token (new on each issuance/refresh) used to correlate a token with its usage in Vercel observability/billing data (usage facts, drains). `getTokenResponse` already passes the API JSON straight through, so the value is present at runtime but wasn't surfaced or documented in the SDK's types.

## What

- Add `tokenId` to `ConnectTokenResponse` (`packages/connect/src/token.ts`) with a JSDoc explaining what it is and how to use it.
- Typed **optional** so responses from Vercel API versions that predate the field don't violate the type during rollout.
- Changeset (patch).

No runtime change — the field already flows through `getTokenResponse`; this only exposes and documents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)