### PR TITLE
fix(cli): make native-trampoline test version-agnostic, fix VERCEL_VC_NATIVE leak

### DIFF
--- a/.changeset/fix-native-trampoline-version.md
+++ b/.changeset/fix-native-trampoline-version.md
@@ -1,0 +1,11 @@
+---
+'vercel': patch
+---
+
+Fix native-trampoline test hardcoding 55.0.0 that broke after version bump to 56.1.0.
+
+The test now reads the version from packages/cli/package.json and strips
+NODE_PATH/VITEST env vars so require.resolve inside the temp install does
+not leak the repo's pnpm store. Also fixes VERCEL_VC_NATIVE leak on
+ENOENT/EACCES fallback (JS fallback was mislabeled as "(native)") and
+updates the stale Part-1 comment in src/vc.js.

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -12,9 +12,8 @@ try {
 
 // Native-first: spawn a @vercel/vc-native-{platform}-{arch} binary when
 // present and exit with its result, otherwise fall through to the JS CLI.
-// Part 1 of 2: no optionalDependencies are wired yet, so resolveNative()
-// always returns null here and the CLI runs as JS. Part 2 will wire the
-// release flow to publish natives before vercel, activating this path.
+// The native package is declared as an os/cpu-filtered optionalDependency
+// so at most one platform binary downloads per install.
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
@@ -46,6 +45,7 @@ if (bin) {
     windowsHide: true,
   });
   if (r.error && (r.error.code === 'ENOENT' || r.error.code === 'EACCES')) {
+    delete process.env.VERCEL_VC_NATIVE;
     // fall through to JS
   } else {
     if (r.error) {

--- a/packages/cli/test/unit/esm/native-trampoline.test.ts
+++ b/packages/cli/test/unit/esm/native-trampoline.test.ts
@@ -6,6 +6,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   writeFileSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -25,15 +26,20 @@ import { tmpdir } from 'node:os';
  * package by walking up to `node_modules/@vercel/vc-native-*`. The test
  * mirrors that topology so resolution behaves identically.
  *
- * Part 1 of 2: no optionalDependencies are wired, so with no native package
- * present the CLI must no-op into JS. When a fake native is installed as a
- * sibling, the CLI spawns it and exits with its exit code.
+ * When no native package is present the trampoline no-ops into JS. When a
+ * fake native is installed as a sibling, the CLI spawns it and exits with
+ * its exit code. Falling through to JS on EACCES must not leave
+ * VERCEL_VC_NATIVE=1 set (otherwise the version banner would claim
+ * "(native)" while JS is running).
  */
 
 const here = dirname(fileURLToPath(import.meta.url));
 const cliRoot = join(here, '..', '..', '..');
 const distDir = join(cliRoot, 'dist');
 const binName = process.platform === 'win32' ? 'vercel.exe' : 'vercel';
+const cliVersion = JSON.parse(
+  readFileSync(join(cliRoot, 'package.json'), 'utf8')
+).version as string;
 
 // Build a production-like install layout in a temp dir:
 //   tmp/node_modules/vercel/dist/vc.js (+ version.mjs)
@@ -61,7 +67,7 @@ function buildInstall(opts: {
     mkdirSync(join(pkgDir, 'bin'), { recursive: true });
     writeFileSync(
       join(pkgDir, 'package.json'),
-      JSON.stringify({ name: pkgName, version: '55.0.0' })
+      JSON.stringify({ name: pkgName, version: cliVersion })
     );
     const binPath = join(pkgDir, 'bin', binName);
     writeFileSync(binPath, opts.body);
@@ -70,7 +76,23 @@ function buildInstall(opts: {
   return { root, vcJs: join(vercelDist, 'vc.js') };
 }
 
-describe('dist/vc.js native resolution (part 1 no-op)', () => {
+// Strip VITEST/NODE_PATH vars so require.resolve inside the temp vc.js
+// doesn't leak the repo's pnpm store (which on main currently has no
+// optionalDep but will once part 2 lands).
+function cleanEnv() {
+  const {
+    NODE_PATH: _np,
+    NODE_OPTIONS: _no,
+    VITEST: _v,
+    VITEST_POOL_ID: _vp,
+    ...rest
+  } = process.env as Record<string, string | undefined>;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(rest)) if (v != null) out[k] = v;
+  return out;
+}
+
+describe('dist/vc.js native resolution', () => {
   it('no-ops to JS when no native package is installed', () => {
     const { vcJs } = buildInstall({
       platform: process.platform,
@@ -78,9 +100,11 @@ describe('dist/vc.js native resolution (part 1 no-op)', () => {
     });
     const r = spawnSync(process.execPath, [vcJs, '--version'], {
       encoding: 'utf8',
+      env: cleanEnv(),
     });
     expect(r.status).toBe(0);
-    expect(r.stdout.trim()).toBe('55.0.0');
+    expect(r.stdout.trim()).toBe(cliVersion);
+    expect(r.stderr).not.toContain('(native)');
   });
 
   it.runIf(process.platform !== 'win32')(
@@ -93,6 +117,7 @@ describe('dist/vc.js native resolution (part 1 no-op)', () => {
       });
       const r = spawnSync(process.execPath, [vcJs, '--version'], {
         encoding: 'utf8',
+        env: cleanEnv(),
       });
       expect(r.status).toBe(7);
       expect(r.stdout.trim()).toBe('NATIVE_RAN');
@@ -110,10 +135,13 @@ describe('dist/vc.js native resolution (part 1 no-op)', () => {
       });
       const r = spawnSync(process.execPath, [vcJs, '--version'], {
         encoding: 'utf8',
+        env: cleanEnv(),
       });
-      // EACCES fall-through hits the JS --version fast path.
+      // EACCES fall-through hits the JS --version fast path. Must not be
+      // mislabeled as native — VERCEL_VC_NATIVE must be cleared on fallback.
       expect(r.status).toBe(0);
-      expect(r.stdout.trim()).toBe('55.0.0');
+      expect(r.stdout.trim()).toBe(cliVersion);
+      expect(r.stderr).not.toContain('(native)');
     }
   );
 });

--- a/packages/cli/test/unit/esm/version-banner.test.ts
+++ b/packages/cli/test/unit/esm/version-banner.test.ts
@@ -16,12 +16,24 @@ describe('vc.js version banner', () => {
       'export const version = "1.2.3";\n'
     );
 
+    // Strip NODE_PATH / VITEST vars so require.resolve inside the temp
+    // vc.js does not leak the repo's pnpm store native binary.
+    const {
+      NODE_PATH: _np,
+      NODE_OPTIONS: _no,
+      VITEST: _v,
+      VITEST_POOL_ID: _vp,
+      ...rest
+    } = process.env as Record<string, string | undefined>;
+    const cleanEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(rest)) if (v != null) cleanEnv[k] = v;
+
     const { stdout, stderr } = await execFileAsync(
       process.execPath,
       [join(dir, 'vc.js'), '--version'],
       {
         env: {
-          ...process.env,
+          ...cleanEnv,
           VERCEL_VC_NATIVE: '1',
         },
       }


### PR DESCRIPTION
Hotfix for main – unblocks other PRs.

**Failing test on main**
```
FAIL  test/unit/esm/native-trampoline.test.ts > dist/vc.js native resolution (part 1 no-op) > no-ops to JS when no native package is installed
AssertionError: expected '56.1.0' to be '55.0.0'
```

**Root cause**
#17011 merged with hardcoded `55.0.0` in the test; Version Packages bumped cli to `56.1.0` (f3efd0e).

**Fix**
- `test/unit/esm/native-trampoline.test.ts`: read `cliVersion` from `packages/cli/package.json` instead of hardcoding; add `cleanEnv()` stripping `NODE_PATH`/`NODE_OPTIONS`/`VITEST*` so `require.resolve` in temp install does not leak repo's pnpm store native (would hang 300s + EAGAIN once part 2 lands); assert `stderr` not contain `(native)` on no-op and EACCES fallback.
- `src/vc.js`: `delete process.env.VERCEL_VC_NATIVE` on ENOENT/EACCES fallback so --version banner is not mislabeled as native when JS is running (review comment from #17087, also present on main); update stale Part-1 comment.
- `version-banner.test.ts`: same env isolation fix.

Verified locally on part-2 branch: `pnpm -C packages/cli exec vitest run test/unit/esm/ → 7 files, 62 tests, 669ms` (was 260s).

Huge diff on this branch vs main previously was because squash-merge of part 1 made three-dot diff reuse ancient merge-base – reset to main fixes it. Part 2 PR #17087 now rebased on top of this fix.
