### PR TITLE
[static-build] point at misplaced build output in the "No Output Directory" error

### DIFF
--- a/.changeset/nervous-poets-wonder.md
+++ b/.changeset/nervous-poets-wonder.md
@@ -1,0 +1,5 @@
+---
+'@vercel/static-build': patch
+---
+
+Improve the "No Output Directory" build error: when the build produced Build Output API output (`.vercel/output`) or a directory matching the expected Output Directory name somewhere other than the validated location — for example a framework build that ran in a subdirectory — the error now reports where the output was found and suggests setting the project's Root Directory, instead of pointing at the Output Directory setting.

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -58,6 +58,10 @@ import {
   defaultCachePathGlob,
 } from '@vercel/build-utils';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
+import {
+  findMisplacedOutput,
+  formatMisplacedOutputHint,
+} from './misplaced-output';
 import * as BuildOutputV1 from './utils/build-output-v1';
 import * as BuildOutputV2 from './utils/build-output-v2';
 import * as BuildOutputV3 from './utils/build-output-v3';
@@ -113,7 +117,10 @@ function validateDistDir(distDir: string, workPath: string) {
 
     let message = `No Output Directory named "${distDirName}" found after the Build completed.`;
 
-    if (vercelJsonExists && buildCommandExists) {
+    const misplaced = findMisplacedOutput(workPath, distDirName, distDir);
+    if (misplaced) {
+      message += formatMisplacedOutputHint(misplaced);
+    } else if (vercelJsonExists && buildCommandExists) {
       message += ` Update vercel.json#outputDirectory to ensure the correct output directory is generated.`;
     } else {
       message += ` Configure the Output Directory in your Project Settings. Alternatively, configure vercel.json#outputDirectory.`;

--- a/packages/static-build/src/misplaced-output.ts
+++ b/packages/static-build/src/misplaced-output.ts
@@ -1,0 +1,126 @@
+import path from 'path';
+import { existsSync, readdirSync, statSync } from 'fs';
+
+const IGNORED_DIRECTORY_NAMES = new Set(['node_modules']);
+const MAX_DEPTH = 3;
+const MAX_VISITED_DIRECTORIES = 2000;
+
+export interface MisplacedOutput {
+  /**
+   * Path of the discovered output, relative to `workPath`
+   * (e.g. "agent/.vercel/output" or "packages/api/.output").
+   */
+  outputPath: string;
+  /**
+   * Directory that produced the output, relative to `workPath`
+   * ("" when the output was found at `workPath` itself).
+   */
+  rootDirectory: string;
+}
+
+function isDirectorySafe(dirPath: string): boolean {
+  try {
+    return statSync(dirPath).isDirectory();
+  } catch (_e) {
+    return false;
+  }
+}
+
+/**
+ * After a build completes without producing the expected Output Directory,
+ * look for build output that landed somewhere else under `workPath` — either
+ * Build Output API output (`.vercel/output/config.json`) or a directory with
+ * the expected Output Directory name. This happens when the Build Command
+ * runs the framework build in a different directory than the one Vercel
+ * scans (e.g. an agent or app living in a subdirectory of the repository
+ * without the project's Root Directory pointing at it).
+ *
+ * Returns the first match (breadth-first, so shallowest wins), or
+ * `undefined` when nothing was found.
+ */
+export function findMisplacedOutput(
+  workPath: string,
+  distDirName: string,
+  expectedDistDir: string
+): MisplacedOutput | undefined {
+  const queue: Array<{ dir: string; depth: number }> = [
+    { dir: workPath, depth: 0 },
+  ];
+  let visited = 0;
+  let distDirNameMatch: MisplacedOutput | undefined;
+
+  while (queue.length > 0) {
+    const { dir, depth } = queue.shift()!;
+    if (visited++ >= MAX_VISITED_DIRECTORIES) {
+      break;
+    }
+
+    const buildOutputConfig = path.join(
+      dir,
+      '.vercel',
+      'output',
+      'config.json'
+    );
+    if (existsSync(buildOutputConfig)) {
+      return {
+        outputPath: path.relative(
+          workPath,
+          path.join(dir, '.vercel', 'output')
+        ),
+        rootDirectory: path.relative(workPath, dir),
+      };
+    }
+
+    const distDirCandidate = path.join(dir, distDirName);
+    if (
+      !distDirNameMatch &&
+      path.resolve(distDirCandidate) !== path.resolve(expectedDistDir) &&
+      isDirectorySafe(distDirCandidate)
+    ) {
+      distDirNameMatch = {
+        outputPath: path.relative(workPath, distDirCandidate),
+        rootDirectory: path.relative(workPath, dir),
+      };
+    }
+
+    if (depth >= MAX_DEPTH) {
+      continue;
+    }
+
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch (_e) {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (
+        !entry.isDirectory() ||
+        entry.name.startsWith('.') ||
+        IGNORED_DIRECTORY_NAMES.has(entry.name)
+      ) {
+        continue;
+      }
+      queue.push({ dir: path.join(dir, entry.name), depth: depth + 1 });
+    }
+  }
+
+  return distDirNameMatch;
+}
+
+/**
+ * Builds the actionable sentence appended to the "No Output Directory"
+ * error when misplaced build output was discovered.
+ */
+export function formatMisplacedOutputHint(misplaced: MisplacedOutput): string {
+  const { outputPath, rootDirectory } = misplaced;
+  if (rootDirectory === '') {
+    return ` Build output was found at "${outputPath}" instead.`;
+  }
+  return (
+    ` Build output was found at "${outputPath}" instead.` +
+    ` If your application lives in "${rootDirectory}", set the project's Root Directory to "${rootDirectory}",` +
+    ` or update the Build Command so the build runs at the Root Directory.`
+  );
+}

--- a/packages/static-build/test/build-fixtures/misplaced-output-eve/build.mjs
+++ b/packages/static-build/test/build-fixtures/misplaced-output-eve/build.mjs
@@ -1,0 +1,8 @@
+// Mimics `cd agent-app && eve build` on Vercel: the framework emits
+// Build Output API one directory below the work path.
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outputDir = join(process.cwd(), 'agent-app', '.vercel', 'output');
+mkdirSync(outputDir, { recursive: true });
+writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ version: 3 }));

--- a/packages/static-build/test/build-fixtures/misplaced-output-eve/package.json
+++ b/packages/static-build/test/build-fixtures/misplaced-output-eve/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "misplaced-output-eve",
+  "private": true,
+  "dependencies": {
+    "eve": "0.0.0"
+  }
+}

--- a/packages/static-build/test/misplaced-output.test.ts
+++ b/packages/static-build/test/misplaced-output.test.ts
@@ -1,0 +1,183 @@
+import os from 'os';
+import path from 'path';
+import { mkdtemp, mkdirp, remove, writeFile } from 'fs-extra';
+import { build } from '../src';
+import {
+  findMisplacedOutput,
+  formatMisplacedOutputHint,
+} from '../src/misplaced-output';
+
+vi.setConfig({ testTimeout: 2 * 60 * 1000 });
+
+describe('build() with misplaced Build Output API output', () => {
+  it('explains where the output was found and suggests Root Directory', async () => {
+    // Reproduces the eve deployment failure: the project's framework preset
+    // ("eve") expects `.output`, but the Build Command runs the framework
+    // build in a subdirectory, so Build Output API output lands at
+    // `agent-app/.vercel/output` where neither the Build Output check nor
+    // the Output Directory validation looks.
+    const workPath = path.join(
+      __dirname,
+      'build-fixtures',
+      'misplaced-output-eve'
+    );
+
+    try {
+      await expect(
+        build({
+          files: {},
+          entrypoint: 'package.json',
+          repoRootPath: workPath,
+          workPath,
+          config: {
+            zeroConfig: true,
+            framework: 'eve',
+            buildCommand: 'node build.mjs',
+          },
+          meta: { skipDownload: true, cliVersion: '0.0.0' },
+        })
+      ).rejects.toThrow(
+        new RegExp(
+          `No Output Directory named "\\.output" found after the Build completed\\.` +
+            ` Build output was found at "agent-app[\\\\/]\\.vercel[\\\\/]output" instead\\.` +
+            ` If your application lives in "agent-app", set the project's Root Directory to "agent-app"`
+        )
+      );
+    } finally {
+      await remove(path.join(workPath, 'agent-app'));
+    }
+  });
+});
+
+describe('findMisplacedOutput()', () => {
+  let workPath: string;
+
+  beforeEach(async () => {
+    workPath = await mkdtemp(path.join(os.tmpdir(), 'misplaced-output-'));
+  });
+
+  afterEach(async () => {
+    await remove(workPath);
+  });
+
+  it('returns undefined when no output exists anywhere', async () => {
+    await mkdirp(path.join(workPath, 'src'));
+    expect(
+      findMisplacedOutput(workPath, '.output', path.join(workPath, '.output'))
+    ).toBeUndefined();
+  });
+
+  it('finds Build Output API output in a subdirectory', async () => {
+    // The reproduced eve case: a root build script runs `eve build` inside
+    // `agent-app`, so `.vercel/output` lands one level below where the
+    // platform validates the (never-created on Vercel) `.output` directory.
+    const outputDir = path.join(workPath, 'agent-app', '.vercel', 'output');
+    await mkdirp(outputDir);
+    await writeFile(path.join(outputDir, 'config.json'), '{"version":3}');
+
+    const misplaced = findMisplacedOutput(
+      workPath,
+      '.output',
+      path.join(workPath, '.output')
+    );
+    expect(misplaced).toEqual({
+      outputPath: path.join('agent-app', '.vercel', 'output'),
+      rootDirectory: 'agent-app',
+    });
+  });
+
+  it('finds Build Output API output at the work path itself', async () => {
+    const outputDir = path.join(workPath, '.vercel', 'output');
+    await mkdirp(outputDir);
+    await writeFile(path.join(outputDir, 'config.json'), '{"version":3}');
+
+    const misplaced = findMisplacedOutput(
+      workPath,
+      '.output',
+      path.join(workPath, 'sub', '.output')
+    );
+    expect(misplaced).toEqual({
+      outputPath: path.join('.vercel', 'output'),
+      rootDirectory: '',
+    });
+  });
+
+  it('ignores a .vercel directory without Build Output config.json', async () => {
+    await mkdirp(path.join(workPath, 'app', '.vercel', 'output'));
+    expect(
+      findMisplacedOutput(workPath, '.output', path.join(workPath, '.output'))
+    ).toBeUndefined();
+  });
+
+  it('finds a directory matching the expected Output Directory name', async () => {
+    await mkdirp(path.join(workPath, 'packages', 'site', 'dist'));
+
+    const misplaced = findMisplacedOutput(
+      workPath,
+      'dist',
+      path.join(workPath, 'dist')
+    );
+    expect(misplaced).toEqual({
+      outputPath: path.join('packages', 'site', 'dist'),
+      rootDirectory: path.join('packages', 'site'),
+    });
+  });
+
+  it('does not report the expected dist dir itself as misplaced', async () => {
+    // `distDir` is only validated after it was found missing, but guard
+    // against races/symlinked paths reporting the expected location.
+    expect(
+      findMisplacedOutput(workPath, '.output', path.join(workPath, '.output'))
+    ).toBeUndefined();
+  });
+
+  it('prefers Build Output API output over a dist dir name match', async () => {
+    await mkdirp(path.join(workPath, 'a', '.output'));
+    const outputDir = path.join(workPath, 'b', '.vercel', 'output');
+    await mkdirp(outputDir);
+    await writeFile(path.join(outputDir, 'config.json'), '{"version":3}');
+
+    const misplaced = findMisplacedOutput(
+      workPath,
+      '.output',
+      path.join(workPath, '.output')
+    );
+    expect(misplaced?.outputPath).toEqual(path.join('b', '.vercel', 'output'));
+  });
+
+  it('does not descend into node_modules', async () => {
+    const outputDir = path.join(
+      workPath,
+      'node_modules',
+      'some-pkg',
+      '.vercel',
+      'output'
+    );
+    await mkdirp(outputDir);
+    await writeFile(path.join(outputDir, 'config.json'), '{"version":3}');
+
+    expect(
+      findMisplacedOutput(workPath, '.output', path.join(workPath, '.output'))
+    ).toBeUndefined();
+  });
+});
+
+describe('formatMisplacedOutputHint()', () => {
+  it('suggests setting the Root Directory for subdirectory output', () => {
+    const hint = formatMisplacedOutputHint({
+      outputPath: path.join('agent-app', '.vercel', 'output'),
+      rootDirectory: 'agent-app',
+    });
+    expect(hint).toContain('agent-app');
+    expect(hint).toContain('Root Directory');
+  });
+
+  it('only reports the location when output is at the work path', () => {
+    const hint = formatMisplacedOutputHint({
+      outputPath: path.join('.vercel', 'output'),
+      rootDirectory: '',
+    });
+    expect(hint).toContain(path.join('.vercel', 'output'));
+    expect(hint).not.toContain('Root Directory');
+  });
+});


### PR DESCRIPTION
### Problem

When a framework build runs in a different directory than the one Vercel scans, the build completes successfully but its output lands where neither the Build Output API check nor the Output Directory validation looks. The resulting `No Output Directory named "..." found after the Build completed` error then gives advice that cannot fix the problem — and for Build Output API frameworks (eve, Nuxt, Nitro), it names a directory that *never* exists in Vercel builds, since those frameworks emit `.vercel/output` under `VERCEL=1` and only produce their preset's declared directory (e.g. `.output`) locally.

Reproduced end-to-end with an eve project whose Build Command runs the framework build in a subdirectory (`cd agent-app && eve build` — the shape reported by a user). The failed deployment's build log shows the collision directly:

```
[BUILD] built output at /vercel/path0/agent-app/.vercel/output
Error: No Output Directory named ".output" found after the Build completed. Configure the Output Directory in your Project Settings. Alternatively, configure vercel.json#outputDirectory.
```

A valid deployment artifact exists one directory below where the platform looked, and the error steers the user toward the Output Directory setting, which cannot help. In practice users then switch the Framework Preset to "Other", which converts the loud failure into a 3-second static junk deploy (output dir falls back to `.`) — strictly worse.

### Fix

On the already-failing path of `validateDistDir`, scan for build output that landed somewhere else under the work path — Build Output API output (`.vercel/output/config.json`, checked first) or a directory matching the expected Output Directory name. Bounded BFS: depth ≤ 3, ≤ 2000 directories, skips `node_modules` and dot-directories, shallowest match wins. When found, replace the generic advice with the actual answer:

> No Output Directory named ".output" found after the Build completed. **Build output was found at "agent-app/.vercel/output" instead. If your application lives in "agent-app", set the project's Root Directory to "agent-app", or update the Build Command so the build runs at the Root Directory.**

Notes:

- Zero cost to successful builds — the scan only runs after validation has already failed.
- Helps every framework with this shape, not just eve.
- The error code (`STATIC_BUILD_NO_OUT_DIR`) is unchanged, so downstream error classification and telemetry are unaffected.
- When no misplaced output is found, the existing messages are unchanged.

### Testing

- 10 unit tests for the scanner and hint formatting.
- An end-to-end `build()` test with a fixture reproducing the reported failure (framework `eve`, Build Command emitting `.vercel/output` in a subdirectory) asserting the new message.
- Manually verified the patched builder against the real reproduced project: both the `VERCEL=1` flavor (`agent-app/.vercel/output`, caught by the Build Output API probe) and the local flavor (`agent-app/.output`, caught by the name probe) produce the actionable message.
