### PR TITLE
[python] extract workflows' namespaces from code

### DIFF
--- a/.changeset/python-workflow-namespaces.md
+++ b/.changeset/python-workflow-namespaces.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+Attach Python workflow functions to the queue topic selected by their `Workflows` namespace and allow multiple entrypoints with distinct namespaces.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -99,10 +99,12 @@ import {
   type Subscriber,
 } from './subscribers';
 import {
+  detectWorkflowNamespaces,
+  detectWorkflowNamespacesFromSource,
   getPyprojectWorkflows,
   getWorkflowConsumerName,
   getWorkflowOutputPath,
-  WORKFLOW_TOPIC_PATTERN,
+  getWorkflowTopicPattern,
   type PyprojectWorkflow,
 } from './workflows';
 
@@ -145,7 +147,17 @@ export async function getDevSidecars({
   }
 
   const subscribers = await getPyprojectSubscribers(workPath);
-  const workflows = await getPyprojectWorkflows(workPath);
+  let workflows = await getPyprojectWorkflows(workPath);
+  if (workflows.length > 0) {
+    workflows = await detectWorkflowNamespacesFromSource({
+      workflows,
+      pythonBin:
+        process.env.PYTHON_BIN ||
+        (process.platform === 'win32' ? 'python' : 'python3'),
+      env: process.env,
+      workPath,
+    });
+  }
   return [
     ...subscribers.map(
       (subscriber): DevSubscriber => ({
@@ -180,7 +192,7 @@ export async function getDevSidecars({
             handlerFunction: workflow.variableName,
           },
         },
-        topics: [{ topic: WORKFLOW_TOPIC_PATTERN }],
+        topics: [{ topic: getWorkflowTopicPattern(workflow.namespace) }],
       })
     ),
   ];
@@ -1091,6 +1103,15 @@ export const build: BuildVX = async ({
     });
   }
 
+  if (workflows.length > 0) {
+    workflows = await detectWorkflowNamespaces({
+      workflows,
+      pythonBin: getVenvPythonBin(venvPath),
+      env: pythonEnv,
+      workPath,
+    });
+  }
+
   // Run quirks: detect dependencies that need special handling (e.g. prisma)
   // and perform fix-up routines before bundling.
   const quirksResult = await runQuirks({ venvPath, pythonEnv, workPath });
@@ -1617,7 +1638,7 @@ export const build: BuildVX = async ({
     const experimentalTriggers: TriggerEvent[] = [
       {
         type: 'queue/v2beta',
-        topic: WORKFLOW_TOPIC_PATTERN,
+        topic: getWorkflowTopicPattern(workflow.namespace),
         consumer: getWorkflowConsumerName(workflow.name),
       },
     ];

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -149,11 +149,18 @@ export async function getDevSidecars({
   const subscribers = await getPyprojectSubscribers(workPath);
   let workflows = await getPyprojectWorkflows(workPath);
   if (workflows.length > 0) {
+    const uvPath = findUvInPath();
+    if (!uvPath) {
+      throw new NowBuildError({
+        code: 'PYTHON_UV_NOT_FOUND',
+        message:
+          'uv is required to inspect Python workflow namespaces during local development.',
+      });
+    }
     workflows = await detectWorkflowNamespacesFromSource({
       workflows,
-      pythonBin:
-        process.env.PYTHON_BIN ||
-        (process.platform === 'win32' ? 'python' : 'python3'),
+      uvPath,
+      uvRunArgs: ['--no-project'],
       env: process.env,
       workPath,
     });
@@ -1106,7 +1113,8 @@ export const build: BuildVX = async ({
   if (workflows.length > 0) {
     workflows = await detectWorkflowNamespaces({
       workflows,
-      pythonBin: getVenvPythonBin(venvPath),
+      uvPath: uv.getPath(),
+      uvRunArgs: ['--active', '--no-sync'],
       env: pythonEnv,
       workPath,
     });

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -58,6 +58,36 @@ export function getUvCacheDir(workPath: string): string {
   return join(workPath, ...UV_CACHE_DIR_SUBPATH);
 }
 
+export async function runUvCommand(options: {
+  uvPath: string;
+  args: string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ stdout: string; stderr: string }> {
+  const { uvPath, args, cwd, env } = options;
+  debug(`Running "uv ${args.join(' ')}" in ${cwd}...`);
+  return execa(uvPath, args, {
+    cwd,
+    env: getProtectedUvEnv(env),
+  });
+}
+
+export async function runUvPythonCommand(options: {
+  uvPath: string;
+  args: string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  uvRunArgs?: string[];
+}): Promise<{ stdout: string; stderr: string }> {
+  const { uvPath, args, cwd, env, uvRunArgs = [] } = options;
+  return runUvCommand({
+    uvPath,
+    args: ['run', ...uvRunArgs, 'python', ...args],
+    cwd,
+    env,
+  });
+}
+
 export class UvRunner {
   private uvPath: string;
   private uvCacheDir?: string;
@@ -246,10 +276,11 @@ export class UvRunner {
     venvPath: string
   ): Promise<void> {
     const pretty = `uv ${args.join(' ')}`;
-    debug(`Running "${pretty}"...`);
 
     try {
-      await execa(this.uvPath, args, {
+      await runUvCommand({
+        uvPath: this.uvPath,
+        args,
         cwd,
         env: this.getVenvEnv(venvPath),
       });

--- a/packages/python/src/workflows.ts
+++ b/packages/python/src/workflows.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import fs from 'fs';
+import execa from 'execa';
 import {
   NowBuildError,
   readConfigFile,
@@ -13,6 +14,14 @@ import {
 } from './module-entrypoint';
 
 const WORKFLOW_OUTPUT_DIR = '_py_workflows';
+const WORKFLOW_NAMESPACE_PATTERN = /^[a-z][a-z0-9]*$/;
+const namespaceScriptPath = join(
+  __dirname,
+  '..',
+  'templates',
+  'vc_workflow_detect.py'
+);
+const namespaceScript = fs.readFileSync(namespaceScriptPath, 'utf-8');
 
 /**
  * Workflow runs and steps are delivered on `__wkf_`-prefixed topics whose
@@ -27,10 +36,16 @@ export interface PyprojectWorkflow {
   entrypoint: string;
   moduleName: string;
   variableName: string;
+  namespace?: string | null;
 }
 
 interface RawWorkflow {
   entrypoint?: unknown;
+}
+
+interface WorkflowNamespaceResult {
+  namespace?: unknown;
+  error?: string;
 }
 
 const WORKFLOW_FIELD_NAMES = new Set(['entrypoint']);
@@ -51,6 +66,152 @@ export function getWorkflowConsumerName(workflowName: string): string {
   return sanitizeConsumerName(getWorkflowOutputPath(workflowName));
 }
 
+export function getWorkflowTopicPattern(namespace?: string | null): string {
+  return namespace ? `__${namespace}_wkf_*` : WORKFLOW_TOPIC_PATTERN;
+}
+
+export async function detectWorkflowNamespaces(opts: {
+  workflows: PyprojectWorkflow[];
+  pythonBin: string;
+  env: NodeJS.ProcessEnv;
+  workPath: string;
+}): Promise<PyprojectWorkflow[]> {
+  const { workflows, pythonBin, env, workPath } = opts;
+  const detected = await Promise.all(
+    workflows.map(async workflow => ({
+      ...workflow,
+      namespace: await detectWorkflowNamespace({
+        pythonBin,
+        env,
+        workPath,
+        moduleName: workflow.moduleName,
+        variableName: workflow.variableName,
+      }),
+    }))
+  );
+  assertUniqueWorkflowNamespaces(detected);
+  return detected;
+}
+
+export async function detectWorkflowNamespacesFromSource(opts: {
+  workflows: PyprojectWorkflow[];
+  pythonBin: string;
+  env: NodeJS.ProcessEnv;
+  workPath: string;
+}): Promise<PyprojectWorkflow[]> {
+  const { workflows, pythonBin, env, workPath } = opts;
+  const detected = await Promise.all(
+    workflows.map(async workflow => ({
+      ...workflow,
+      namespace: await detectWorkflowNamespaceFromSource({
+        pythonBin,
+        env,
+        workPath,
+        entrypoint: workflow.entrypoint,
+        variableName: workflow.variableName,
+      }),
+    }))
+  );
+  assertUniqueWorkflowNamespaces(detected);
+  return detected;
+}
+
+export async function detectWorkflowNamespace(opts: {
+  pythonBin: string;
+  env: NodeJS.ProcessEnv;
+  workPath: string;
+  moduleName: string;
+  variableName: string;
+}): Promise<string | null> {
+  const { pythonBin, env, workPath, moduleName, variableName } = opts;
+  return runWorkflowNamespaceDetection({
+    pythonBin,
+    env,
+    workPath,
+    args: [moduleName, variableName],
+    entrypointLabel: `${moduleName}:${variableName}`,
+  });
+}
+
+export async function detectWorkflowNamespaceFromSource(opts: {
+  pythonBin: string;
+  env: NodeJS.ProcessEnv;
+  workPath: string;
+  entrypoint: string;
+  variableName: string;
+}): Promise<string | null> {
+  const { pythonBin, env, workPath, entrypoint, variableName } = opts;
+  return runWorkflowNamespaceDetection({
+    pythonBin,
+    env,
+    workPath,
+    args: ['--source', entrypoint, variableName],
+    entrypointLabel: `${entrypoint}:${variableName}`,
+  });
+}
+
+async function runWorkflowNamespaceDetection(opts: {
+  pythonBin: string;
+  env: NodeJS.ProcessEnv;
+  workPath: string;
+  args: string[];
+  entrypointLabel: string;
+}): Promise<string | null> {
+  const { pythonBin, env, workPath, args, entrypointLabel } = opts;
+  let stdout: string;
+  try {
+    const result = await execa(pythonBin, ['-c', namespaceScript, ...args], {
+      cwd: workPath,
+      env: {
+        ...env,
+        WORKFLOW_TARGET_WORLD: 'local',
+      },
+    });
+    stdout = result.stdout;
+  } catch (err: any) {
+    let detail = err?.stderr || err?.message || String(err);
+    try {
+      const parsed = JSON.parse(err?.stdout) as WorkflowNamespaceResult;
+      if (parsed.error) detail = parsed.error;
+    } catch {}
+    throw workflowDetectionError(
+      `Failed to inspect workflow entrypoint "${entrypointLabel}": ${detail}`
+    );
+  }
+
+  let parsed: WorkflowNamespaceResult;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw workflowDetectionError(
+      `Workflow namespace detection returned invalid JSON: ${stdout}`
+    );
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(parsed, 'namespace')) {
+    throw workflowDetectionError(
+      `Workflow namespace detection returned no namespace for "${entrypointLabel}"`
+    );
+  }
+
+  const namespace = parsed.namespace;
+  if (namespace !== null && typeof namespace !== 'string') {
+    throw workflowDetectionError(
+      `Workflow entrypoint "${entrypointLabel}" returned a non-string namespace`
+    );
+  }
+  if (
+    typeof namespace === 'string' &&
+    !WORKFLOW_NAMESPACE_PATTERN.test(namespace)
+  ) {
+    throw workflowDetectionError(
+      `Workflow entrypoint "${entrypointLabel}" returned invalid namespace "${namespace}"`
+    );
+  }
+
+  return namespace;
+}
+
 export async function getPyprojectWorkflows(
   workPath: string
 ): Promise<PyprojectWorkflow[]> {
@@ -66,14 +227,6 @@ export async function getPyprojectWorkflows(
   }
   if (!Array.isArray(workflows)) {
     throw workflowError('"tool.vercel.workflows" must be an array');
-  }
-  // Every workflow consumer receives every `__wkf_*` message, so a second
-  // Lambda would fail on runs registered only in the first. All workflows
-  // must be importable from a single entrypoint module.
-  if (workflows.length > 1) {
-    throw workflowError(
-      '"tool.vercel.workflows" must declare a single entrypoint that registers every workflow'
-    );
   }
 
   return Promise.all(
@@ -130,6 +283,34 @@ async function parseWorkflow(
 function workflowError(message: string): NowBuildError {
   return new NowBuildError({
     code: 'PYTHON_INVALID_WORKFLOW_CONFIG',
+    message,
+  });
+}
+
+function assertUniqueWorkflowNamespaces(workflows: PyprojectWorkflow[]): void {
+  const entrypointByNamespace = new Map<string | null, string>();
+  for (const workflow of workflows) {
+    const namespace = workflow.namespace ?? null;
+    const existingEntrypoint = entrypointByNamespace.get(namespace);
+    if (existingEntrypoint) {
+      const label =
+        namespace === null
+          ? 'the default namespace'
+          : `namespace "${namespace}"`;
+      throw workflowError(
+        `workflow entrypoints "${existingEntrypoint}" and "${workflow.moduleName}:${workflow.variableName}" both use ${label}`
+      );
+    }
+    entrypointByNamespace.set(
+      namespace,
+      `${workflow.moduleName}:${workflow.variableName}`
+    );
+  }
+}
+
+function workflowDetectionError(message: string): NowBuildError {
+  return new NowBuildError({
+    code: 'PYTHON_WORKFLOW_DETECTION_FAILED',
     message,
   });
 }

--- a/packages/python/src/workflows.ts
+++ b/packages/python/src/workflows.ts
@@ -1,6 +1,5 @@
 import { join } from 'path';
 import fs from 'fs';
-import execa from 'execa';
 import {
   NowBuildError,
   readConfigFile,
@@ -12,6 +11,7 @@ import {
   resolveExistingEntrypoint,
   safePathSegment,
 } from './module-entrypoint';
+import { runUvPythonCommand } from './uv';
 
 const WORKFLOW_OUTPUT_DIR = '_py_workflows';
 const WORKFLOW_NAMESPACE_PATTERN = /^[a-z][a-z0-9]*$/;
@@ -72,16 +72,18 @@ export function getWorkflowTopicPattern(namespace?: string | null): string {
 
 export async function detectWorkflowNamespaces(opts: {
   workflows: PyprojectWorkflow[];
-  pythonBin: string;
+  uvPath: string;
+  uvRunArgs?: string[];
   env: NodeJS.ProcessEnv;
   workPath: string;
 }): Promise<PyprojectWorkflow[]> {
-  const { workflows, pythonBin, env, workPath } = opts;
+  const { workflows, uvPath, uvRunArgs, env, workPath } = opts;
   const detected = await Promise.all(
     workflows.map(async workflow => ({
       ...workflow,
       namespace: await detectWorkflowNamespace({
-        pythonBin,
+        uvPath,
+        uvRunArgs,
         env,
         workPath,
         moduleName: workflow.moduleName,
@@ -95,16 +97,18 @@ export async function detectWorkflowNamespaces(opts: {
 
 export async function detectWorkflowNamespacesFromSource(opts: {
   workflows: PyprojectWorkflow[];
-  pythonBin: string;
+  uvPath: string;
+  uvRunArgs?: string[];
   env: NodeJS.ProcessEnv;
   workPath: string;
 }): Promise<PyprojectWorkflow[]> {
-  const { workflows, pythonBin, env, workPath } = opts;
+  const { workflows, uvPath, uvRunArgs, env, workPath } = opts;
   const detected = await Promise.all(
     workflows.map(async workflow => ({
       ...workflow,
       namespace: await detectWorkflowNamespaceFromSource({
-        pythonBin,
+        uvPath,
+        uvRunArgs,
         env,
         workPath,
         entrypoint: workflow.entrypoint,
@@ -117,15 +121,17 @@ export async function detectWorkflowNamespacesFromSource(opts: {
 }
 
 export async function detectWorkflowNamespace(opts: {
-  pythonBin: string;
+  uvPath: string;
+  uvRunArgs?: string[];
   env: NodeJS.ProcessEnv;
   workPath: string;
   moduleName: string;
   variableName: string;
 }): Promise<string | null> {
-  const { pythonBin, env, workPath, moduleName, variableName } = opts;
+  const { uvPath, uvRunArgs, env, workPath, moduleName, variableName } = opts;
   return runWorkflowNamespaceDetection({
-    pythonBin,
+    uvPath,
+    uvRunArgs,
     env,
     workPath,
     args: [moduleName, variableName],
@@ -134,15 +140,17 @@ export async function detectWorkflowNamespace(opts: {
 }
 
 export async function detectWorkflowNamespaceFromSource(opts: {
-  pythonBin: string;
+  uvPath: string;
+  uvRunArgs?: string[];
   env: NodeJS.ProcessEnv;
   workPath: string;
   entrypoint: string;
   variableName: string;
 }): Promise<string | null> {
-  const { pythonBin, env, workPath, entrypoint, variableName } = opts;
+  const { uvPath, uvRunArgs, env, workPath, entrypoint, variableName } = opts;
   return runWorkflowNamespaceDetection({
-    pythonBin,
+    uvPath,
+    uvRunArgs,
     env,
     workPath,
     args: ['--source', entrypoint, variableName],
@@ -151,16 +159,20 @@ export async function detectWorkflowNamespaceFromSource(opts: {
 }
 
 async function runWorkflowNamespaceDetection(opts: {
-  pythonBin: string;
+  uvPath: string;
+  uvRunArgs?: string[];
   env: NodeJS.ProcessEnv;
   workPath: string;
   args: string[];
   entrypointLabel: string;
 }): Promise<string | null> {
-  const { pythonBin, env, workPath, args, entrypointLabel } = opts;
+  const { uvPath, uvRunArgs, env, workPath, args, entrypointLabel } = opts;
   let stdout: string;
   try {
-    const result = await execa(pythonBin, ['-c', namespaceScript, ...args], {
+    const result = await runUvPythonCommand({
+      uvPath,
+      uvRunArgs,
+      args: ['-c', namespaceScript, ...args],
       cwd: workPath,
       env: {
         ...env,

--- a/packages/python/templates/vc_workflow_detect.py
+++ b/packages/python/templates/vc_workflow_detect.py
@@ -1,0 +1,130 @@
+"""
+Detect the queue namespace for a configured workflow registry.
+
+Usage:
+  python -c <script> <module> <attribute>
+  python -c <script> --source <file> <attribute>
+
+Prints JSON to stdout:
+  {"namespace": "billing"}
+  {"namespace": null}
+On error:
+  {"error": "description"}
+"""
+
+import ast
+import contextlib
+import importlib
+import json
+from pathlib import Path
+import sys
+from typing import NoReturn
+
+
+def _error(msg: str) -> NoReturn:
+    print(json.dumps({"error": msg}))
+    sys.exit(1)
+
+
+def _print_namespace(namespace):
+    if namespace is not None and not isinstance(namespace, str):
+        _error("Workflow namespace must be a string or None")
+    print(json.dumps({"namespace": namespace}))
+
+
+def _detect_from_module(module_name: str, attr_name: str):
+    try:
+        from vercel.workflow import Workflows
+    except ImportError as exc:
+        _error(f"Failed to import 'vercel.workflow': {exc}")
+
+    try:
+        # Keep application logging from corrupting the structured stdout result.
+        with contextlib.redirect_stdout(sys.stderr):
+            mod = importlib.import_module(module_name)
+    except Exception as exc:
+        _error(f"Failed to import module '{module_name}': {exc}")
+
+    obj = getattr(mod, attr_name, None)
+    if obj is None:
+        _error(f"Module '{module_name}' has no attribute '{attr_name}'")
+    if not isinstance(obj, Workflows):
+        _error(
+            f"'{module_name}.{attr_name}' is not a vercel.workflow.Workflows instance"
+        )
+
+    # Older SDK releases predate queue namespaces. Treat those registries as
+    # unnamespaced so existing workflow deployments remain compatible.
+    namespace = getattr(obj, "namespace", None)
+    _print_namespace(namespace)
+
+
+def _assignment_target_name(node):
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                return target.id
+    elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    return None
+
+
+def _assignment_value(node):
+    if isinstance(node, (ast.Assign, ast.AnnAssign)):
+        return node.value
+    return None
+
+
+def _detect_from_source(file_path: str, attr_name: str):
+    try:
+        source = Path(file_path).read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=file_path)
+    except Exception as exc:
+        _error(f"Failed to parse workflow entrypoint '{file_path}': {exc}")
+
+    assignments = {
+        name: _assignment_value(node)
+        for node in tree.body
+        if (name := _assignment_target_name(node)) is not None
+    }
+    value = assignments.get(attr_name)
+    if not isinstance(value, ast.Call):
+        # Preserve existing local-dev behavior for registries imported from
+        # another module or created by a factory. Build-time import detection
+        # remains authoritative for deployed queue triggers.
+        _print_namespace(None)
+        return
+
+    namespace_node = next(
+        (keyword.value for keyword in value.keywords if keyword.arg == "namespace"),
+        None,
+    )
+    if namespace_node is None:
+        _print_namespace(None)
+        return
+
+    if isinstance(namespace_node, ast.Name):
+        namespace_node = assignments.get(namespace_node.id)
+    if not (
+        isinstance(namespace_node, ast.Constant)
+        and isinstance(namespace_node.value, str)
+    ):
+        _error(
+            f"Workflow namespace for '{attr_name}' in '{file_path}' must be a "
+            "string literal or top-level string constant for local development"
+        )
+
+    _print_namespace(namespace_node.value)
+
+
+def main():
+    if len(sys.argv) == 4 and sys.argv[1] == "--source":
+        _detect_from_source(sys.argv[2], sys.argv[3])
+        return
+    if len(sys.argv) == 3:
+        _detect_from_module(sys.argv[1], sys.argv[2])
+        return
+    _error(f"Expected 2 arguments or --source plus 2 arguments, got {len(sys.argv) - 1}")
+
+
+main()

--- a/packages/python/test/fixtures/70-workflow-pyproject/flows.py
+++ b/packages/python/test/fixtures/70-workflow-pyproject/flows.py
@@ -8,7 +8,7 @@ CACHE_NAMESPACE = "workflow-jobs"
 # Workflow entrypoint ("flows:workflows"). Constructing the registry hooks the
 # workflow and step queue handlers into the Lambda built from
 # [tool.vercel.workflows] in pyproject.toml.
-workflows = Workflows()
+workflows = Workflows(namespace="addition")
 
 
 @workflows.step

--- a/packages/python/test/fixtures/70-workflow-pyproject/main.py
+++ b/packages/python/test/fixtures/70-workflow-pyproject/main.py
@@ -5,7 +5,11 @@ from pydantic import BaseModel
 from vercel.cache import get_cache
 from vercel.workflow import start
 
-from flows import CACHE_NAMESPACE, process_job
+from flows import CACHE_NAMESPACE, process_job as process_addition
+from multiplication_flows import (
+    MULTIPLICATION_CACHE_NAMESPACE,
+    process_job as process_multiplication,
+)
 
 app = FastAPI()
 
@@ -23,11 +27,25 @@ def root():
 
 @app.post("/start")
 async def start_workflow(body: StartRequest):
-    run = await start(process_job, body.request_id, body.x, body.y)
+    run = await start(process_addition, body.request_id, body.x, body.y)
     return {"ok": True, "requestId": body.request_id, "runId": run.run_id}
 
 
 @app.get("/status/{request_id}")
 def status(request_id: str):
     result = get_cache(namespace=CACHE_NAMESPACE).get(request_id)
+    return {"processed": result is not None, "result": result}
+
+
+@app.post("/start-multiplication")
+async def start_multiplication_workflow(body: StartRequest):
+    run = await start(process_multiplication, body.request_id, body.x, body.y)
+    return {"ok": True, "requestId": body.request_id, "runId": run.run_id}
+
+
+@app.get("/status-multiplication/{request_id}")
+def multiplication_status(request_id: str):
+    result = get_cache(namespace=MULTIPLICATION_CACHE_NAMESPACE).get(
+        f"multiplication:{request_id}"
+    )
     return {"processed": result is not None, "result": result}

--- a/packages/python/test/fixtures/70-workflow-pyproject/multiplication_flows.py
+++ b/packages/python/test/fixtures/70-workflow-pyproject/multiplication_flows.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from vercel.cache import get_cache
+from vercel.workflow import Workflows
+
+MULTIPLICATION_CACHE_NAMESPACE = "workflow-jobs"
+workflows = Workflows(namespace="multiplication")
+
+
+@workflows.step
+async def multiply(x: int, y: int) -> int:
+    return x * y
+
+
+@workflows.step
+async def record(request_id: str, product: int) -> None:
+    get_cache(namespace=MULTIPLICATION_CACHE_NAMESPACE).set(
+        f"multiplication:{request_id}",
+        {"requestId": request_id, "product": product},
+        options={"ttl": 300},
+    )
+
+
+@workflows.workflow
+async def process_job(request_id: str, x: int, y: int) -> int:
+    product = await multiply(x, y)
+    await record(request_id, product)
+    return product

--- a/packages/python/test/fixtures/70-workflow-pyproject/probes.json
+++ b/packages/python/test/fixtures/70-workflow-pyproject/probes.json
@@ -18,6 +18,20 @@
       "mustContain": "\"sum\":5",
       "retries": 10,
       "retryDelay": 3000
+    },
+    {
+      "path": "/start-multiplication",
+      "method": "POST",
+      "body": { "request_id": "RANDOMNESS_PLACEHOLDER", "x": 4, "y": 5 },
+      "status": 200,
+      "mustContain": "RANDOMNESS_PLACEHOLDER"
+    },
+    {
+      "path": "/status-multiplication/RANDOMNESS_PLACEHOLDER",
+      "status": 200,
+      "mustContain": "\"product\":20",
+      "retries": 10,
+      "retryDelay": 3000
     }
   ]
 }

--- a/packages/python/test/fixtures/70-workflow-pyproject/pyproject.toml
+++ b/packages/python/test/fixtures/70-workflow-pyproject/pyproject.toml
@@ -4,10 +4,13 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi",
-    "vercel",
+    "vercel==0.7.0",
 ]
 
-# Declares the workflow entrypoint compiled into a queue-triggered Lambda
-# alongside the FastAPI app. All workflows must be registered on this module.
+# Each workflow entrypoint is compiled into a queue-triggered Lambda alongside
+# the FastAPI app. Distinct namespaces isolate their workflow and step queues.
 [[tool.vercel.workflows]]
 entrypoint = "flows:workflows"
+
+[[tool.vercel.workflows]]
+entrypoint = "multiplication_flows:workflows"

--- a/packages/python/test/fixtures/70-workflow-pyproject/uv.lock
+++ b/packages/python/test/fixtures/70-workflow-pyproject/uv.lock
@@ -6,6 +6,13 @@ requires-python = ">=3.12"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
+[options.exclude-newer-package]
+vercel-internal-telemetry = false
+vercel = false
+vercel-headers = false
+vercel-oidc = false
+vercel-cache = false
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -283,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "vercel"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -291,36 +298,65 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "vercel-cache" },
     { name = "vercel-headers" },
+    { name = "vercel-internal-telemetry" },
     { name = "vercel-oidc" },
     { name = "vercel-workers" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e8/03b28af09c4885d21449c27e721007529a842faa5b1c3228622c8761b852/vercel-0.6.0.tar.gz", hash = "sha256:c540bb463cb8c262bd352aa21ecde27811a1e33393c96c720bd112c952322e6b", size = 106602, upload-time = "2026-06-29T18:55:42.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/0e/34820af4da3e8f0bb5e0ae3b237b4bfa216f4f151cf95ea56b7d61aab304/vercel-0.7.0.tar.gz", hash = "sha256:8e29b401d717bfe0b85dbc5a3dcdd7bf125165d34adab3a937f28573a4e98418", size = 185390, upload-time = "2026-07-14T04:43:09.655Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/32/3547b12e0ebc8e2758a0893fece1c86478b61a0d96b57bf7c3b891a6f52b/vercel-0.6.0-py3-none-any.whl", hash = "sha256:fb2e3ecea1e153e3bace829ae8254760ed4916e36998e4a8ce1e1af7091861a0", size = 145183, upload-time = "2026-06-29T18:55:41.116Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/5c8e93b784f3d12a3f033d0676b2dac1b0ab33457b69af83f2eaf145eb72/vercel-0.7.0-py3-none-any.whl", hash = "sha256:197749cc3fe08545e8ca6153003cb64f3d2910416081afbc4ed87d62b3656c7a", size = 211807, upload-time = "2026-07-14T04:43:08.56Z" },
+]
+
+[[package]]
+name = "vercel-cache"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "vercel-headers" },
+    { name = "vercel-internal-telemetry" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/bd/d1555ae4dd9f8951b90173d83a54ba0e587901b7c0b56e944daab2530bcc/vercel_cache-0.7.0.tar.gz", hash = "sha256:20a8d1e3cef9956902dac7e8d9caa8cae7a807b94a148d08b175c80caa93f275", size = 8910, upload-time = "2026-07-14T04:43:06.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/31/0f3154850d98dee369b183da7ce14f2c4efdc971efc6a5aeb6e502b9f400/vercel_cache-0.7.0-py3-none-any.whl", hash = "sha256:776da280a959a1df903ecc03c764704dc5335d969a0a06785e928aadbb01d677", size = 10027, upload-time = "2026-07-14T04:43:05.599Z" },
 ]
 
 [[package]]
 name = "vercel-headers"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/2e/d18dbc7b32a309daf6494a5d51d5a1ddfce9cc702600a852eb671cc21802/vercel_headers-0.6.0.tar.gz", hash = "sha256:77794510ea746c7ee086c85490028bf084a7fc924ab46cc1d746eb89040fbba7", size = 3048, upload-time = "2026-06-29T18:09:22.43Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/f4/04c9a608c9f5b4308020ec87850916b331595678294de0e3b4bea0a83020/vercel_headers-0.7.0.tar.gz", hash = "sha256:6bf37cd3d06f00f8b8650766da016c1ba08927d09a11cf1babb34fcead3d04cb", size = 5410, upload-time = "2026-07-14T04:40:06.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/fa/7fd5641c2cdbccee9538eb64eabb587ebcad2332307542a28f506f79a2c9/vercel_headers-0.6.0-py3-none-any.whl", hash = "sha256:d16c97626ef669b8c036898b08b43efa689b63aa66f187c14f52584793f87a51", size = 3365, upload-time = "2026-06-29T18:09:21.669Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a8/db8e2272adde7655d603c20c96c313ef7409fdcf8b2d1bd30c9f3293dd14/vercel_headers-0.7.0-py3-none-any.whl", hash = "sha256:39bc00801d3618ef27ff9d5cf3ff526778d90e6ab900205aa584070fce33f7ce", size = 3907, upload-time = "2026-07-14T04:40:05.357Z" },
+]
+
+[[package]]
+name = "vercel-internal-telemetry"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "vercel-oidc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/83/1a1edb8e691f10042382a2a2b3e241194e1a61e60222f5e342df24b00183/vercel_internal_telemetry-0.7.0.tar.gz", hash = "sha256:6a12f99ffdca67712bf38dbc37dd9b2c406c21c005cdd4775a1b748c5f646f34", size = 8468, upload-time = "2026-07-14T04:40:11.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/71/3549bc06eb13f89c8e95ed6311116242b4e1fcad7777b73023292c8b29ea/vercel_internal_telemetry-0.7.0-py3-none-any.whl", hash = "sha256:5cfc0156db9c66283da95c039b668afa00973169a16f6e23920f4005000c84c7", size = 8254, upload-time = "2026-07-14T04:40:10.727Z" },
 ]
 
 [[package]]
 name = "vercel-oidc"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "vercel-headers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/6d/51d875207ebbb0709ef01a1ceff6706bd3dd966c1edff732225824ed1f45/vercel_oidc-0.6.0.tar.gz", hash = "sha256:53d3af9fcf40dee0803db213c41f374d0df10fc81f33018230ce6525ba41ab5e", size = 5978, upload-time = "2026-06-29T18:12:57.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/b7/484f099376dbef869779e5fa2b94ee62e5b770721a6014b153c7f4602eb9/vercel_oidc-0.7.0.tar.gz", hash = "sha256:a5fd3d20c3e53029cab850d0f1cf821888900520fa1237c9a4811000335f9191", size = 8062, upload-time = "2026-07-14T04:40:08.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/6c/89129d15ae215cae7938b7cc5e54d7687c3ba624771e0aa85dfbaeb7b083/vercel_oidc-0.6.0-py3-none-any.whl", hash = "sha256:7db018b5a970f2d30a5c2b7fc62a21c5c79c06921bd9295c34b0960c9550d992", size = 7662, upload-time = "2026-06-29T18:12:56.9Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/83/9e96c5e4158e0f1e8c5e84f5bf51fd167c41cb0fab3c9d9a0b9e12f5bb5a/vercel_oidc-0.7.0-py3-none-any.whl", hash = "sha256:cfdf85ffd6894bf8f0c2a78be4a9808900ad21272eafe7ce6f1f8f09e4b9887f", size = 8052, upload-time = "2026-07-14T04:40:07.866Z" },
 ]
 
 [[package]]
@@ -396,5 +432,5 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi" },
-    { name = "vercel" },
+    { name = "vercel", specifier = "==0.7.0" },
 ]

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -108,6 +108,26 @@ function getBuildOutputV3(result: Awaited<ReturnType<typeof build>>) {
   return (result as any).result.output as BuildResultV3['output'];
 }
 
+function mockWorkflowNamespace(
+  namespace: string | null | Record<string, string | null>
+) {
+  vi.mocked(execa).mockImplementation(async (_command, args) => {
+    if (
+      Array.isArray(args) &&
+      args[0] === '-c' &&
+      (args.length === 4 || args[2] === '--source')
+    ) {
+      const variableName = args[args.length - 1];
+      const detected =
+        typeof namespace === 'object' && namespace !== null
+          ? namespace[variableName]
+          : namespace;
+      return { stdout: JSON.stringify({ namespace: detected }) } as any;
+    }
+    return { stdout: '' } as any;
+  });
+}
+
 /**
  * Build a PythonConstraint from a PEP 440 version specifier string.
  * Handles exact versions ("3.9"), specifiers (">=3.10,<3.12"), and
@@ -2626,9 +2646,11 @@ describe('pyproject.toml service entrypoint', () => {
     );
     fs.mkdirSync(mockWorkPath, { recursive: true });
     makeMockPython('3.11');
+    mockWorkflowNamespace(null);
   });
 
   afterEach(() => {
+    vi.mocked(execa).mockReset();
     if (fs.existsSync(mockWorkPath)) {
       fs.removeSync(mockWorkPath);
     }
@@ -2812,9 +2834,11 @@ describe('pyproject workflows', () => {
     mockWorkPath = path.join(tmpdir(), `python-workflows-${Date.now()}`);
     fs.mkdirSync(mockWorkPath, { recursive: true });
     makeMockPython('3.11');
+    mockWorkflowNamespace(null);
   });
 
   afterEach(() => {
+    vi.mocked(execa).mockReset();
     if (fs.existsSync(mockWorkPath)) {
       fs.removeSync(mockWorkPath);
     }
@@ -2869,6 +2893,37 @@ describe('pyproject workflows', () => {
         topics: [{ topic: '__wkf_*' }],
       },
     ]);
+  });
+
+  it('returns dev sidecars subscribed to the namespaced workflow topic', async () => {
+    mockWorkflowNamespace('billing');
+    fs.writeFileSync(
+      path.join(mockWorkPath, 'flows.py'),
+      'from vercel.workflow import Workflows\nworkflows = Workflows(namespace="billing")\n'
+    );
+    fs.writeFileSync(
+      path.join(mockWorkPath, 'pyproject.toml'),
+      [
+        '[project]',
+        'name = "x"',
+        'version = "0.0.1"',
+        '',
+        '[[tool.vercel.workflows]]',
+        'entrypoint = "flows:workflows"',
+        '',
+      ].join('\n')
+    );
+
+    const sidecars = await getDevSidecars({
+      workPath: mockWorkPath,
+      build: {
+        use: '@vercel/python',
+        src: '<detect>',
+        config: { framework: 'fastapi' },
+      },
+    });
+
+    expect(sidecars[0].topics).toEqual([{ topic: '__billing_wkf_*' }]);
   });
 
   it('emits one queue/v2beta Lambda consuming the workflow topic pattern', async () => {
@@ -2928,7 +2983,103 @@ describe('pyproject workflows', () => {
     );
   });
 
-  it('rejects more than one workflow entrypoint', async () => {
+  it('uses the workflow namespace for the queue trigger', async () => {
+    mockWorkflowNamespace('billing');
+    const files = {
+      'app.py': new FileBlob({
+        data: 'def app(environ, start_response): pass\n',
+      }),
+      'flows.py': new FileBlob({
+        data: [
+          'from vercel.workflow import Workflows',
+          'workflows = Workflows(namespace="billing")',
+          '',
+        ].join('\n'),
+      }),
+      'pyproject.toml': new FileBlob({
+        data: [
+          '[project]',
+          'name = "x"',
+          'version = "0.0.1"',
+          '',
+          '[[tool.vercel.workflows]]',
+          'entrypoint = "flows:workflows"',
+          '',
+        ].join('\n'),
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath: mockWorkPath,
+      files,
+      entrypoint: 'app.py',
+      meta: { isDev: false },
+      config: { framework: 'flask' },
+      repoRootPath: mockWorkPath,
+    });
+
+    const workflowPath = getWorkflowOutputPath('flows_workflows');
+    const workflow = (getBuildOutputV2(result).output as any)[workflowPath];
+    expect(workflow.experimentalTriggers).toEqual([
+      {
+        type: 'queue/v2beta',
+        topic: '__billing_wkf_*',
+        consumer: sanitizeConsumerName(workflowPath),
+      },
+    ]);
+  });
+
+  it('builds multiple workflow entrypoints with distinct namespaces', async () => {
+    mockWorkflowNamespace({
+      workflows: 'billing',
+      more: 'fulfillment',
+    });
+    const files = {
+      'app.py': new FileBlob({
+        data: 'def app(environ, start_response): pass\n',
+      }),
+      'flows.py': new FileBlob({
+        data: 'workflows = object()\nmore = object()\n',
+      }),
+      'pyproject.toml': new FileBlob({
+        data: [
+          '[project]',
+          'name = "x"',
+          'version = "0.0.1"',
+          '',
+          '[[tool.vercel.workflows]]',
+          'entrypoint = "flows:workflows"',
+          '',
+          '[[tool.vercel.workflows]]',
+          'entrypoint = "flows:more"',
+          '',
+        ].join('\n'),
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath: mockWorkPath,
+      files,
+      entrypoint: 'app.py',
+      meta: { isDev: false },
+      config: { framework: 'flask' },
+      repoRootPath: mockWorkPath,
+    });
+
+    const output = getBuildOutputV2(result).output as any;
+    expect(
+      output[getWorkflowOutputPath('flows_workflows')].experimentalTriggers
+    ).toEqual([expect.objectContaining({ topic: '__billing_wkf_*' })]);
+    expect(
+      output[getWorkflowOutputPath('flows_more')].experimentalTriggers
+    ).toEqual([expect.objectContaining({ topic: '__fulfillment_wkf_*' })]);
+  });
+
+  it('rejects workflow entrypoints with the same namespace', async () => {
+    mockWorkflowNamespace({
+      workflows: 'billing',
+      more: 'billing',
+    });
     const files = {
       'app.py': new FileBlob({
         data: 'def app(environ, start_response): pass\n',
@@ -2961,7 +3112,7 @@ describe('pyproject workflows', () => {
         config: { framework: 'flask' },
         repoRootPath: mockWorkPath,
       })
-    ).rejects.toThrow(/must declare a single entrypoint/);
+    ).rejects.toThrow(/both use namespace "billing"/);
   });
 
   it('rejects topics because workflow topics are implicit', async () => {

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -112,10 +112,11 @@ function mockWorkflowNamespace(
   namespace: string | null | Record<string, string | null>
 ) {
   vi.mocked(execa).mockImplementation(async (_command, args) => {
+    const pythonCodeIndex = Array.isArray(args) ? args.indexOf('-c') : -1;
     if (
       Array.isArray(args) &&
-      args[0] === '-c' &&
-      (args.length === 4 || args[2] === '--source')
+      pythonCodeIndex !== -1 &&
+      args.length - pythonCodeIndex >= 4
     ) {
       const variableName = args[args.length - 1];
       const detected =

--- a/packages/python/test/workflow-detect.test.ts
+++ b/packages/python/test/workflow-detect.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import { tmpdir } from 'os';
+import {
+  detectWorkflowNamespace,
+  detectWorkflowNamespaceFromSource,
+  getWorkflowTopicPattern,
+} from '../src/workflows';
+
+const pythonBin =
+  process.env.PYTHON_BIN ||
+  (process.platform === 'win32' ? 'python' : 'python3');
+
+describe('workflow namespace detection', () => {
+  let workDir: string;
+
+  afterEach(async () => {
+    if (workDir) {
+      await fs.remove(workDir);
+    }
+  });
+
+  async function setupWorkDir(flowSource: string): Promise<string> {
+    workDir = path.join(
+      tmpdir(),
+      `workflow-detect-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await fs.mkdirp(path.join(workDir, 'vercel'));
+    await fs.writeFile(path.join(workDir, 'vercel', '__init__.py'), '');
+    await fs.writeFile(
+      path.join(workDir, 'vercel', 'workflow.py'),
+      [
+        'class Workflows:',
+        '    def __init__(self, *, namespace=None):',
+        '        self.namespace = namespace',
+        '',
+      ].join('\n')
+    );
+    await fs.writeFile(path.join(workDir, 'flows.py'), flowSource);
+    return workDir;
+  }
+
+  function detect(variableName = 'workflows') {
+    return detectWorkflowNamespace({
+      pythonBin,
+      env: process.env,
+      workPath: workDir,
+      moduleName: 'flows',
+      variableName,
+    });
+  }
+
+  function detectFromSource(variableName = 'workflows') {
+    return detectWorkflowNamespaceFromSource({
+      pythonBin,
+      env: process.env,
+      workPath: workDir,
+      entrypoint: 'flows.py',
+      variableName,
+    });
+  }
+
+  it('extracts a namespace from a Workflows entrypoint', async () => {
+    await setupWorkDir(
+      [
+        'from vercel.workflow import Workflows',
+        'workflows = Workflows(namespace="billing")',
+        '',
+      ].join('\n')
+    );
+
+    await expect(detect()).resolves.toBe('billing');
+    expect(getWorkflowTopicPattern('billing')).toBe('__billing_wkf_*');
+  });
+
+  it('extracts a literal namespace from source for local development', async () => {
+    await setupWorkDir(
+      [
+        'from vercel.workflow import Workflows',
+        'WORKFLOW_NAMESPACE = "billing"',
+        'workflows = Workflows(namespace=WORKFLOW_NAMESPACE)',
+        '',
+      ].join('\n')
+    );
+
+    await expect(detectFromSource()).resolves.toBe('billing');
+  });
+
+  it('preserves the default unnamespaced topic', async () => {
+    await setupWorkDir(
+      [
+        'from vercel.workflow import Workflows',
+        'workflows = Workflows()',
+        '',
+      ].join('\n')
+    );
+
+    await expect(detect()).resolves.toBeNull();
+    await expect(detectFromSource()).resolves.toBeNull();
+    expect(getWorkflowTopicPattern(null)).toBe('__wkf_*');
+  });
+
+  it('treats workflow registries from older SDKs as unnamespaced', async () => {
+    await setupWorkDir(
+      [
+        'from vercel.workflow import Workflows',
+        'workflows = Workflows()',
+        'del workflows.namespace',
+        '',
+      ].join('\n')
+    );
+
+    await expect(detect()).resolves.toBeNull();
+  });
+
+  it('rejects an entrypoint that is not a Workflows instance', async () => {
+    await setupWorkDir('workflows = object()\n');
+
+    await expect(detect()).rejects.toThrow(
+      /is not a vercel\.workflow\.Workflows instance/
+    );
+  });
+
+  it('reports missing entrypoint attributes', async () => {
+    await setupWorkDir('value = object()\n');
+
+    await expect(detect('missing')).rejects.toThrow(
+      /has no attribute 'missing'/
+    );
+  });
+
+  it('rejects an invalid namespace returned by the entrypoint', async () => {
+    await setupWorkDir(
+      [
+        'from vercel.workflow import Workflows',
+        'workflows = Workflows(namespace="Billing")',
+        '',
+      ].join('\n')
+    );
+
+    await expect(detect()).rejects.toThrow(
+      /returned invalid namespace "Billing"/
+    );
+  });
+
+  it('rejects dynamic namespaces during local source detection', async () => {
+    await setupWorkDir(
+      [
+        'import os',
+        'from vercel.workflow import Workflows',
+        'workflows = Workflows(namespace=os.getenv("WORKFLOW_NAMESPACE"))',
+        '',
+      ].join('\n')
+    );
+
+    await expect(detectFromSource()).rejects.toThrow(
+      /must be a string literal or top-level string constant/
+    );
+  });
+});

--- a/packages/python/test/workflow-detect.test.ts
+++ b/packages/python/test/workflow-detect.test.ts
@@ -8,9 +8,7 @@ import {
   getWorkflowTopicPattern,
 } from '../src/workflows';
 
-const pythonBin =
-  process.env.PYTHON_BIN ||
-  (process.platform === 'win32' ? 'python' : 'python3');
+const uvPath = process.env.UV_BIN || 'uv';
 
 describe('workflow namespace detection', () => {
   let workDir: string;
@@ -43,7 +41,8 @@ describe('workflow namespace detection', () => {
 
   function detect(variableName = 'workflows') {
     return detectWorkflowNamespace({
-      pythonBin,
+      uvPath,
+      uvRunArgs: ['--no-project'],
       env: process.env,
       workPath: workDir,
       moduleName: 'flows',
@@ -53,7 +52,8 @@ describe('workflow namespace detection', () => {
 
   function detectFromSource(variableName = 'workflows') {
     return detectWorkflowNamespaceFromSource({
-      pythonBin,
+      uvPath,
+      uvRunArgs: ['--no-project'],
       env: process.env,
       workPath: workDir,
       entrypoint: 'flows.py',


### PR DESCRIPTION
To support multiple workflows with `[[tool.vercel.workflows]]`, each workflow must be namespaced so that their queue topics do not collide, this can be done with:

```python
wf_a = Workflows(namespace="a")
wf_b = Workflows(namespace="b")
```

With this, now we can allow more than one entry in `[[tool.vercel.workflows]]`
```toml
[[tool.vercel.workflows]]
entrypoint = "workflows:wf_a"

[[tool.vercel.workflows]]
entrypoint = "workflows:wf_b"
```

We extract the namespace from the entrypoint dynamically at build time much like we did for Python cron jobs with the Cron sdk