### PR TITLE
[cli] skip coding agents setup tests on macOS

### DIFF
--- a/.changeset/petite-lions-jog.md
+++ b/.changeset/petite-lions-jog.md
@@ -1,0 +1,4 @@
+---
+---
+
+[cli] skip coding agents setup tests on macOS

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -1,4 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe as vitestDescribe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+// Temporarily quarantine this suite on macOS: it is the only file in CLI shard
+// 1/7 that does not complete and times out both the Node 20 and Node 22 jobs.
+const describe = vitestDescribe.skipIf(process.platform === 'darwin');
 import {
   mkdtempSync,
   readFileSync,


### PR DESCRIPTION
## Summary

Temporarily skip `coding-agents-setup.test.ts` on macOS while retaining its coverage on Linux and Windows.

## Evidence

- [`Unit / CLI (mac/node20) [1/7]`](https://github.com/vercel/vercel/actions/runs/29303884400/job/86993248117) ran from `03:35:59Z` to `04:02:48Z` and failed after the workflow's 25-minute test-step timeout.
- The shard continued reporting completed test files, but `coding-agents-setup.test.ts` never emitted a completion result.
- The same file was introduced recently in #16859 and expanded in follow-up PRs.

## Verification

- Pre-commit hook passed `biome format --write --no-errors-on-unmatched`.
- Pre-commit hook passed `biome lint --no-errors-on-unmatched`.
- `git diff --check` passed before commit.
- Local test run intentionally not performed; CI should demonstrate that the macOS shard completes with this suite quarantined.
