### PR TITLE
[python] Security hardening: authenticate v2beta queue callbacks

### DIFF
--- a/.changeset/v2beta-callback-auth.md
+++ b/.changeset/v2beta-callback-auth.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-workers': patch
+---
+
+Authenticate v2beta queue callbacks before executing workers. The callback now always re-fetches the authoritative message by id from the queue service and ignores the inline request body, and routes the re-fetch and ack/visibility calls to the shard named by the `ce-vqsregion` header.

--- a/python/vercel-workers/src/vercel/workers/_queue/callback.py
+++ b/python/vercel-workers/src/vercel/workers/_queue/callback.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from vercel.workers._queue.types import (
@@ -10,6 +11,10 @@ from vercel.workers._queue.types import (
 )
 
 CLOUD_EVENT_TYPE_V2BETA = "com.vercel.queue.v2beta"
+
+# Vercel region code, e.g. "iad1"; matches the @vercel/queue SDK validation.
+# Guards against injecting an attacker-controlled header value into the VQS URL.
+_REGION_PATTERN = re.compile(r"^[a-z]{2,5}[0-9]{1,2}$")
 
 
 def _get_environ_header(environ: dict[str, Any], name: str, default: str = "") -> str:
@@ -64,7 +69,7 @@ def parse_v2beta_callback(
     else:
         payload = raw_body
 
-    return {
+    parsed: ParsedV2BetaCallback = {
         "queueName": queue_name,
         "consumerGroup": consumer_group,
         "messageId": message_id,
@@ -73,6 +78,16 @@ def parse_v2beta_callback(
         "createdAt": created_at,
         "payload": payload,
     }
+
+    # Carry the region so the re-fetch targets the shard the message lives on,
+    # not the worker's default region.
+    region = _get_environ_header(environ, "Ce-Vqsregion")
+    if region:
+        if not _REGION_PATTERN.fullmatch(region):
+            raise ValueError(f'invalid "ce-vqsregion" header: "{region}"')
+        parsed["region"] = region
+
+    return parsed
 
 
 def parse_cloudevent(body: bytes) -> tuple[str, str, str]:

--- a/python/vercel-workers/src/vercel/workers/_queue/receive.py
+++ b/python/vercel-workers/src/vercel/workers/_queue/receive.py
@@ -204,6 +204,7 @@ def receive_message_by_id(
     *,
     visibility_timeout_seconds: int | None = None,
     timeout: float | None = 10.0,
+    region: str | None = None,
 ) -> tuple[Any, int, str, str]:
     """
     Minimal receive-by-id:
@@ -211,9 +212,13 @@ def receive_message_by_id(
       POST {base_url}{base_path}/{queue_name}/consumer/{consumer_group}/id/{messageId}
       Accept: multipart/mixed
 
+    ``region`` routes the request to a specific regional VQS shard (e.g. from a
+    callback's ``ce-vqsregion`` header); when omitted the worker's default
+    region is used.
+
     Returns (payload, delivery_count, created_at, receipt_handle).
     """
-    base_url = get_queue_base_url().rstrip("/")
+    base_url = get_queue_base_url(region).rstrip("/")
     base_path = get_queue_base_path()
     auth_token = get_queue_token(None)
 
@@ -297,29 +302,24 @@ def resolve_v2beta_message(
     timeout: float | None = 10.0,
 ) -> ParsedV2BetaCallback:
     """
-    Ensure a parsed v2beta callback carries a payload and receipt handle.
+    Fetch the authoritative message for a v2beta callback from the queue service.
 
-    Vercel Queues v2beta can delivers messages in 2 modes:
+    A v2beta callback's headers and body are attacker-reachable, so the inline
+    payload/receipt handle are never trusted: the message is always re-fetched
+    by id via ``receive_message_by_id`` (authenticated with the queue token),
+    the same as the v1beta path. A request whose message id is not in the queue
+    service fails closed and never reaches a worker.
 
-    - Inline: the HTTP body carries the payload and
-      ``ce-vqsreceipthandle`` / ``ce-vqsdeliverycount`` / ``ce-vqscreatedat``
-      headers are present.
-    - Metadata-only: the HTTP body is empty and the payload-related headers
-      are absent. The SDK is expected to call ``receive_message_by_id``
-      to fetch the message body and obtain a receipt handle.
-
-    Returns the input unchanged when the inline mode delivered everything;
-    otherwise returns a new dict augmented with the fetched fields.
+    Returns a new dict with the authoritative payload, receipt handle,
+    delivery count and creation timestamp.
     """
-    if parsed["receiptHandle"]:
-        return parsed
-
     payload, delivery_count, created_at, receipt_handle = receive_message_by_id(
         parsed["queueName"],
         parsed["consumerGroup"],
         parsed["messageId"],
         visibility_timeout_seconds=visibility_timeout_seconds,
         timeout=timeout,
+        region=parsed.get("region"),
     )
     return {
         **parsed,
@@ -337,8 +337,9 @@ def delete_message(
     receipt_handle: str,
     *,
     timeout: float | None = 10.0,
+    region: str | None = None,
 ) -> None:
-    base_url = get_queue_base_url().rstrip("/")
+    base_url = get_queue_base_url(region).rstrip("/")
     base_path = get_queue_base_path()
     auth_token = get_queue_token(None)
 
@@ -383,8 +384,9 @@ def change_visibility(
     visibility_timeout_seconds: int,
     *,
     timeout: float | None = 10.0,
+    region: str | None = None,
 ) -> None:
-    base_url = get_queue_base_url().rstrip("/")
+    base_url = get_queue_base_url(region).rstrip("/")
     base_path = get_queue_base_path()
     auth_token = get_queue_token(None)
 
@@ -447,6 +449,7 @@ class VisibilityExtender:
         refresh_interval_seconds: float,
         timeout: float | None = 10.0,
         debug: bool = False,
+        region: str | None = None,
     ) -> None:
         self.queue_name = queue_name
         self.consumer_group = consumer_group
@@ -456,6 +459,7 @@ class VisibilityExtender:
         self.refresh_interval_seconds = float(refresh_interval_seconds)
         self.timeout = timeout
         self.debug = debug
+        self.region = region
 
         self._stop = threading.Event()
         self._lock = threading.Lock()
@@ -497,6 +501,7 @@ class VisibilityExtender:
                         self.receipt_handle,
                         int(self.visibility_timeout_seconds),
                         timeout=self.timeout,
+                        region=self.region,
                     )
                 except Exception as exc:  # noqa: BLE001
                     if self.debug:

--- a/python/vercel-workers/src/vercel/workers/_queue/send.py
+++ b/python/vercel-workers/src/vercel/workers/_queue/send.py
@@ -83,23 +83,25 @@ def _resolve_duration_alias(
     return _duration_to_seconds(name, duration if duration is not None else seconds)
 
 
-def get_queue_base_url() -> str:
+def get_queue_base_url(region: str | None = None) -> str:
     """
     Return the base URL for the Vercel Queue Service API.
 
     Mirrors the JS client behaviour:
-      - VERCEL_QUEUE_BASE_URL environment variable
-      - if VERCEL_REGION environment variable is set then routes to
-        region specific endpoint, e.g. "https://iad1.vercel-queue.com"
+      - VERCEL_QUEUE_BASE_URL environment variable (dev/proxy; wins outright)
+      - an explicit ``region`` (e.g. from a callback's ``ce-vqsregion`` header),
+        routing to that shard, e.g. "https://iad1.vercel-queue.com"
+      - if VERCEL_REGION environment variable is set then routes to that
+        region's endpoint
       - otherwise to "https://vercel-queue.com"
     """
     base_url = os.environ.get("VERCEL_QUEUE_BASE_URL")
     if base_url:
         return base_url.rstrip("/")
 
-    region = os.environ.get("VERCEL_REGION")
-    if region:
-        return f"https://{region}.vercel-queue.com"
+    resolved_region = region or os.environ.get("VERCEL_REGION")
+    if resolved_region:
+        return f"https://{resolved_region}.vercel-queue.com"
     else:
         return "https://vercel-queue.com"
 

--- a/python/vercel-workers/src/vercel/workers/_queue/types.py
+++ b/python/vercel-workers/src/vercel/workers/_queue/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Any, TypedDict, TypeGuard
+from typing import Any, NotRequired, TypedDict, TypeGuard
 from uuid import UUID
 
 
@@ -65,6 +65,9 @@ class ParsedV2BetaCallback(TypedDict):
     deliveryCount: int
     createdAt: str
     payload: Any
+    # Regional shard from the ``ce-vqsregion`` header, used to route the
+    # re-fetch; absent when the header is not sent.
+    region: NotRequired[str]
 
 
 class CloudEventData(TypedDict):

--- a/python/vercel-workers/src/vercel/workers/celery/app.py
+++ b/python/vercel-workers/src/vercel/workers/celery/app.py
@@ -66,6 +66,7 @@ def handle_queue_callback(
         )
 
         is_v2beta = queue_callback.is_v2beta_callback(environ or {})
+        region: str | None = None
 
         if is_v2beta:
             v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
@@ -82,6 +83,7 @@ def handle_queue_callback(
             delivery_count = v2["deliveryCount"]
             created_at = v2["createdAt"]
             payload: Any = v2["payload"]
+            region = v2.get("region")
         else:
             queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
             (
@@ -105,6 +107,7 @@ def handle_queue_callback(
             visibility_timeout_seconds=cfg.visibility_timeout_seconds,
             refresh_interval_seconds=cfg.visibility_refresh_interval_seconds,
             timeout=cfg.timeout,
+            region=region,
         )
         extender.start()
 
@@ -124,6 +127,7 @@ def handle_queue_callback(
                             receipt_handle,
                             int(timeout_seconds),
                             timeout=cfg.timeout,
+                            region=region,
                         ),
                     )
                 else:
@@ -134,6 +138,7 @@ def handle_queue_callback(
                         receipt_handle,
                         int(timeout_seconds),
                         timeout=cfg.timeout,
+                        region=region,
                     )
             else:
                 if extender is not None:
@@ -144,6 +149,7 @@ def handle_queue_callback(
                             message_id,
                             receipt_handle,
                             timeout=cfg.timeout,
+                            region=region,
                         ),
                     )
                 else:
@@ -153,6 +159,7 @@ def handle_queue_callback(
                         message_id,
                         receipt_handle,
                         timeout=cfg.timeout,
+                        region=region,
                     )
 
         body = json.dumps(

--- a/python/vercel-workers/src/vercel/workers/client.py
+++ b/python/vercel-workers/src/vercel/workers/client.py
@@ -114,6 +114,7 @@ def _delete_message_sync(
     message_id: str,
     receipt_handle: str,
     extender: callback.VisibilityExtender | None,
+    region: str | None = None,
 ) -> None:
     if extender is not None:
         extender.finalize(
@@ -122,6 +123,7 @@ def _delete_message_sync(
                 consumer_group,
                 message_id,
                 receipt_handle,
+                region=region,
             ),
         )
     else:
@@ -130,6 +132,7 @@ def _delete_message_sync(
             consumer_group,
             message_id,
             receipt_handle,
+            region=region,
         )
 
 
@@ -218,6 +221,7 @@ def _handle_queue_callback(
         receipt_handle = ""
         delivery_count = 0
         created_at = ""
+        region: str | None = None
 
         v2: callback.ParsedV2BetaCallback | None = None
         if is_v2beta:
@@ -250,6 +254,7 @@ def _handle_queue_callback(
             delivery_count = v2["deliveryCount"]
             created_at = v2["createdAt"]
             payload = v2["payload"]
+            region = v2.get("region")
         else:
             payload, delivery_count, created_at, receipt_handle = callback.receive_message_by_id(
                 queue_name,
@@ -274,6 +279,7 @@ def _handle_queue_callback(
                 receipt_handle,
                 visibility_timeout_seconds=visibility_timeout_seconds,
                 refresh_interval_seconds=refresh_interval_seconds,
+                region=region,
             )
             extender.start()
 
@@ -294,6 +300,7 @@ def _handle_queue_callback(
                             message_id,
                             receipt_handle,
                             int(timeout_seconds),
+                            region=region,
                         ),
                     )
                 else:
@@ -303,6 +310,7 @@ def _handle_queue_callback(
                         message_id,
                         receipt_handle,
                         int(timeout_seconds),
+                        region=region,
                     )
             else:
                 _delete_message_sync(
@@ -311,6 +319,7 @@ def _handle_queue_callback(
                     message_id,
                     receipt_handle,
                     extender,
+                    region,
                 )
 
         return json_response(200, {"ok": True})

--- a/python/vercel-workers/src/vercel/workers/django/app.py
+++ b/python/vercel-workers/src/vercel/workers/django/app.py
@@ -164,6 +164,7 @@ def handle_queue_callback(
 
     try:
         is_v2beta = queue_callback.is_v2beta_callback(environ or {})
+        region: str | None = None
 
         v2: queue_callback.ParsedV2BetaCallback | None = None
         if is_v2beta:
@@ -197,6 +198,7 @@ def handle_queue_callback(
             delivery_count = v2["deliveryCount"]
             created_at = v2["createdAt"]
             payload: Any = v2["payload"]
+            region = v2.get("region")
         else:
             (
                 payload,
@@ -221,6 +223,7 @@ def handle_queue_callback(
                 visibility_timeout_seconds=cfg.visibility_timeout_seconds,
                 refresh_interval_seconds=cfg.visibility_refresh_interval_seconds,
                 timeout=cfg.timeout,
+                region=region,
             )
             extender.start()
 
@@ -293,6 +296,7 @@ def handle_queue_callback(
                             receipt_handle,
                             int(delay_seconds),
                             timeout=cfg.timeout,
+                            region=region,
                         ),
                     )
                 body = json.dumps(
@@ -326,6 +330,7 @@ def handle_queue_callback(
                         message_id,
                         receipt_handle,
                         timeout=cfg.timeout,
+                        region=region,
                     ),
                 )
             body = json.dumps(
@@ -358,6 +363,7 @@ def handle_queue_callback(
                     message_id,
                     receipt_handle,
                     timeout=cfg.timeout,
+                    region=region,
                 ),
             )
 

--- a/python/vercel-workers/src/vercel/workers/dramatiq/app.py
+++ b/python/vercel-workers/src/vercel/workers/dramatiq/app.py
@@ -126,6 +126,7 @@ def handle_queue_callback(
 
     try:
         is_v2beta = queue_callback.is_v2beta_callback(environ or {})
+        region: str | None = None
 
         if is_v2beta:
             v2 = queue_callback.parse_v2beta_callback(raw_body, environ or {})
@@ -142,6 +143,7 @@ def handle_queue_callback(
             delivery_count = v2["deliveryCount"]
             created_at = v2["createdAt"]
             payload: Any = v2["payload"]
+            region = v2.get("region")
         else:
             queue_name, consumer_group, message_id = queue_callback.parse_cloudevent(raw_body)
             (
@@ -167,6 +169,7 @@ def handle_queue_callback(
                 visibility_timeout_seconds=cfg.visibility_timeout_seconds,
                 refresh_interval_seconds=cfg.visibility_refresh_interval_seconds,
                 timeout=cfg.timeout,
+                region=region,
             )
             extender.start()
 
@@ -191,6 +194,7 @@ def handle_queue_callback(
                     message_id,
                     receipt_handle,
                     timeout=cfg.timeout,
+                    region=region,
                 ),
             )
 

--- a/python/vercel-workers/tests/test_celery_adapter.py
+++ b/python/vercel-workers/tests/test_celery_adapter.py
@@ -7,10 +7,12 @@ from datetime import UTC, datetime
 from typing import Any, cast
 from unittest.mock import patch
 
+import vercel.workers._queue.receive as queue_receive_impl
 import vercel.workers.celery as vwc
 import vercel.workers.celery.app as vwc_app
 import vercel.workers.celery.transport as vwc_transport
 import vercel.workers.celery.utils as vwc_utils
+from vercel.workers.exceptions import MessageNotFoundError
 
 
 class TestCeleryAdapter(unittest.TestCase):
@@ -143,6 +145,52 @@ class TestCeleryAdapter(unittest.TestCase):
         self.assertEqual(sent[0]["type"], "http.response.start")
         self.assertEqual(sent[0]["status"], 400)
         self.assertIn(b"Invalid content type", sent[1]["body"])
+
+    def test_forged_v2beta_callback_is_rejected_and_task_not_executed(self) -> None:
+        # A forged v2beta callback must not execute a Celery task when the message
+        # is not in the queue service.
+        class DummyTask:
+            def __init__(self) -> None:
+                self.calls: list[Any] = []
+
+            def apply(self, *, args, kwargs, task_id, throw):
+                self.calls.append((args, kwargs, task_id, throw))
+
+        task = DummyTask()
+
+        class DummyConf:
+            broker_transport_options: dict = {}
+
+        class DummyCelery:
+            conf = DummyConf()
+            tasks = {"tasks.add": task}
+
+        def not_found(*_args: Any, **_kwargs: Any) -> Any:
+            raise MessageNotFoundError("forged-message-id")
+
+        forged_headers = [
+            (b"ce-type", b"com.vercel.queue.v2beta"),
+            (b"ce-vqsqueuename", b"q"),
+            (b"ce-vqsconsumergroup", b"c"),
+            (b"ce-vqsmessageid", b"forged-message-id"),
+            (b"ce-vqsreceipthandle", b"forged-receipt-handle"),
+            (b"ce-vqsdeliverycount", b"1"),
+            (b"content-type", b"application/json"),
+        ]
+
+        with patch.object(queue_receive_impl, "receive_message_by_id", side_effect=not_found):
+            sent = asyncio.run(
+                self._asgi_request(
+                    vwc.get_asgi_app(cast(Any, DummyCelery())),
+                    method="POST",
+                    path="/callback",
+                    headers=forged_headers,
+                    body=b'{"vercel":{"kind":"celery","version":1},"task":"tasks.add","args":[1]}',
+                ),
+            )
+
+        self.assertEqual(sent[0]["status"], 404)
+        self.assertEqual(task.calls, [])
 
     def test_get_asgi_app_post_callback_executes_task_and_deletes_message(self) -> None:
         raw_body = (

--- a/python/vercel-workers/tests/test_client_and_callback.py
+++ b/python/vercel-workers/tests/test_client_and_callback.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import unittest
 from dataclasses import dataclass
@@ -23,7 +24,7 @@ from vercel.workers._queue.subscribe import (
     select_subscriptions,
 )
 from vercel.workers.client import WorkerJSONEncoder
-from vercel.workers.exceptions import TokenResolutionError
+from vercel.workers.exceptions import MessageNotFoundError, TokenResolutionError
 
 
 class CreateUserPayload(BaseModel):
@@ -328,6 +329,11 @@ class TestWorkerDirectives(unittest.TestCase):
         queue_client.subscribe(topic="q")(worker)
 
         with (
+            patch.object(
+                queue_receive_impl,
+                "receive_message_by_id",
+                return_value=({"ok": True}, 1, "now", "receipt"),
+            ),
             patch.object(queue_client.callback, "change_visibility") as change_visibility,
             patch.object(queue_client.callback, "delete_message") as delete_message,
         ):
@@ -337,7 +343,7 @@ class TestWorkerDirectives(unittest.TestCase):
             )
 
         self.assertEqual(status, 200)
-        change_visibility.assert_called_once_with("q", "c", "m", "receipt", 120)
+        change_visibility.assert_called_once_with("q", "c", "m", "receipt", 120, region=None)
         delete_message.assert_not_called()
 
     def test_retry_after_raise_delays_message(self) -> None:
@@ -347,6 +353,11 @@ class TestWorkerDirectives(unittest.TestCase):
         queue_client.subscribe(topic="q")(worker)
 
         with (
+            patch.object(
+                queue_receive_impl,
+                "receive_message_by_id",
+                return_value=({"ok": True}, 1, "now", "receipt"),
+            ),
             patch.object(queue_client.callback, "change_visibility") as change_visibility,
             patch.object(queue_client.callback, "delete_message") as delete_message,
         ):
@@ -356,7 +367,7 @@ class TestWorkerDirectives(unittest.TestCase):
             )
 
         self.assertEqual(status, 200)
-        change_visibility.assert_called_once_with("q", "c", "m", "receipt", 30)
+        change_visibility.assert_called_once_with("q", "c", "m", "receipt", 30, region=None)
         delete_message.assert_not_called()
 
     def test_dict_return_is_not_a_retry_directive(self) -> None:
@@ -366,6 +377,11 @@ class TestWorkerDirectives(unittest.TestCase):
         queue_client.subscribe(topic="q")(worker)
 
         with (
+            patch.object(
+                queue_receive_impl,
+                "receive_message_by_id",
+                return_value=({"ok": True}, 1, "now", "receipt"),
+            ),
             patch.object(queue_client.callback, "change_visibility") as change_visibility,
             patch.object(queue_client.callback, "delete_message") as delete_message,
         ):
@@ -375,7 +391,7 @@ class TestWorkerDirectives(unittest.TestCase):
             )
 
         self.assertEqual(status, 200)
-        delete_message.assert_called_once_with("q", "c", "m", "receipt")
+        delete_message.assert_called_once_with("q", "c", "m", "receipt", region=None)
         change_visibility.assert_not_called()
 
     def test_ack_return_deletes_message(self) -> None:
@@ -385,6 +401,11 @@ class TestWorkerDirectives(unittest.TestCase):
         queue_client.subscribe(topic="q")(worker)
 
         with (
+            patch.object(
+                queue_receive_impl,
+                "receive_message_by_id",
+                return_value=({"ok": True}, 1, "now", "receipt"),
+            ),
             patch.object(queue_client.callback, "change_visibility") as change_visibility,
             patch.object(queue_client.callback, "delete_message") as delete_message,
         ):
@@ -394,7 +415,7 @@ class TestWorkerDirectives(unittest.TestCase):
             )
 
         self.assertEqual(status, 200)
-        delete_message.assert_called_once_with("q", "c", "m", "receipt")
+        delete_message.assert_called_once_with("q", "c", "m", "receipt", region=None)
         change_visibility.assert_not_called()
 
     def test_ack_raise_deletes_message(self) -> None:
@@ -404,6 +425,11 @@ class TestWorkerDirectives(unittest.TestCase):
         queue_client.subscribe(topic="q")(worker)
 
         with (
+            patch.object(
+                queue_receive_impl,
+                "receive_message_by_id",
+                return_value=({"ok": True}, 1, "now", "receipt"),
+            ),
             patch.object(queue_client.callback, "change_visibility") as change_visibility,
             patch.object(queue_client.callback, "delete_message") as delete_message,
         ):
@@ -413,8 +439,250 @@ class TestWorkerDirectives(unittest.TestCase):
             )
 
         self.assertEqual(status, 200)
-        delete_message.assert_called_once_with("q", "c", "m", "receipt")
+        delete_message.assert_called_once_with("q", "c", "m", "receipt", region=None)
         change_visibility.assert_not_called()
+
+
+def _wsgi_post(
+    app: Any,
+    *,
+    environ_extra: dict[str, str],
+    body: bytes,
+    path: str = "/callback",
+) -> tuple[str, bytes]:
+    """Drive a WSGI app through a POST request and return (status, body)."""
+    environ: dict[str, Any] = {
+        "REQUEST_METHOD": "POST",
+        "PATH_INFO": path,
+        "wsgi.input": io.BytesIO(body),
+        "CONTENT_LENGTH": str(len(body)),
+        **environ_extra,
+    }
+    captured: dict[str, Any] = {}
+
+    def start_response(status: str, headers: list[tuple[str, str]]) -> None:
+        captured["status"] = status
+        captured["headers"] = headers
+
+    result = app(environ, start_response)
+    return captured["status"], b"".join(result)
+
+
+# A forged v2beta callback: valid-looking Ce-Vqs* headers plus an attacker-chosen
+# inline body and receipt handle.
+_FORGED_V2BETA_ENVIRON: dict[str, str] = {
+    "CONTENT_TYPE": "application/json",
+    "HTTP_CE_TYPE": "com.vercel.queue.v2beta",
+    "HTTP_CE_VQSQUEUENAME": "q",
+    "HTTP_CE_VQSCONSUMERGROUP": "c",
+    "HTTP_CE_VQSMESSAGEID": "forged-message-id",
+    "HTTP_CE_VQSRECEIPTHANDLE": "forged-receipt-handle",
+    "HTTP_CE_VQSDELIVERYCOUNT": "1",
+    "HTTP_CE_VQSCREATEDAT": "now",
+}
+_FORGED_V2BETA_BODY = b'{"leak":"env-secrets"}'
+
+
+class TestV2BetaCallbackAuthentication(unittest.TestCase):
+    """Forged v2beta callbacks must not run workers."""
+
+    def setUp(self) -> None:
+        queue_client._subscriptions.clear()
+
+    def tearDown(self) -> None:
+        queue_client._subscriptions.clear()
+
+    def test_forged_v2beta_request_is_rejected_and_worker_not_invoked(self) -> None:
+        calls: list[Any] = []
+
+        def worker(message, metadata):  # pyright: ignore[reportMissingParameterType, reportUnknownParameterType]
+            calls.append(message)
+
+        queue_client.subscribe(topic="q")(worker)
+
+        # The queue service has no such message: a forged id 404s on re-fetch.
+        def not_found(*_args: Any, **_kwargs: Any) -> Any:
+            raise MessageNotFoundError("forged-message-id")
+
+        with (
+            patch.object(queue_receive_impl, "receive_message_by_id", side_effect=not_found),
+            patch.object(queue_client.callback, "delete_message") as delete_message,
+            patch.object(queue_client.callback, "change_visibility") as change_visibility,
+        ):
+            status, body = _wsgi_post(
+                queue_client.get_wsgi_app(),
+                environ_extra=_FORGED_V2BETA_ENVIRON,
+                body=_FORGED_V2BETA_BODY,
+            )
+
+        self.assertTrue(status.startswith("404"), status)
+        self.assertEqual(calls, [])
+        delete_message.assert_not_called()
+        change_visibility.assert_not_called()
+
+    def test_authentic_v2beta_request_executes_worker_with_authoritative_payload(self) -> None:
+        calls: list[Any] = []
+
+        def worker(message, metadata):  # pyright: ignore[reportMissingParameterType, reportUnknownParameterType]
+            calls.append(message)
+
+        queue_client.subscribe(topic="q")(worker)
+
+        # The authoritative payload comes from the queue service, NOT the request body.
+        with (
+            patch.object(
+                queue_receive_impl,
+                "receive_message_by_id",
+                return_value=({"real": "payload"}, 1, "now", "server-receipt"),
+            ),
+            patch.object(queue_client.callback, "delete_message"),
+            patch.object(queue_client.callback, "change_visibility"),
+        ):
+            status, _body = _wsgi_post(
+                queue_client.get_wsgi_app(),
+                environ_extra=_FORGED_V2BETA_ENVIRON,
+                body=_FORGED_V2BETA_BODY,
+            )
+
+        self.assertTrue(status.startswith("200"), status)
+        # Worker ran with the server payload; the attacker's inline body was ignored.
+        self.assertEqual(calls, [{"real": "payload"}])
+
+    def test_v1beta_forged_request_is_rejected_and_worker_not_invoked(self) -> None:
+        calls: list[Any] = []
+
+        def worker(message, metadata):  # pyright: ignore[reportMissingParameterType, reportUnknownParameterType]
+            calls.append(message)
+
+        queue_client.subscribe(topic="q")(worker)
+
+        raw_body = json.dumps(
+            {
+                "type": "com.vercel.queue.v1beta",
+                "data": {"queueName": "q", "consumerGroup": "c", "messageId": "forged"},
+            },
+        ).encode()
+
+        def not_found(*_args: Any, **_kwargs: Any) -> Any:
+            raise MessageNotFoundError("forged")
+
+        with (
+            patch.object(queue_client.callback, "receive_message_by_id", side_effect=not_found),
+            patch.object(queue_client.callback, "delete_message") as delete_message,
+        ):
+            status, _body = _wsgi_post(
+                queue_client.get_wsgi_app(),
+                environ_extra={"CONTENT_TYPE": "application/cloudevents+json"},
+                body=raw_body,
+            )
+
+        self.assertTrue(status.startswith("404"), status)
+        self.assertEqual(calls, [])
+        delete_message.assert_not_called()
+
+
+class _CapturingResponse:
+    # Only status_code is read: a 404 raises before any other attribute is touched.
+    status_code = 404
+
+
+class _CapturingHttpxClient:
+    """Captures the URL of the re-fetch request, then returns a 404."""
+
+    urls: list[str] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def __enter__(self) -> _CapturingHttpxClient:
+        return self
+
+    def __exit__(self, *args: Any) -> Literal[False]:
+        return False
+
+    def post(self, url: str, **kwargs: Any) -> _CapturingResponse:
+        _CapturingHttpxClient.urls.append(url)
+        return _CapturingResponse()
+
+
+class TestV2BetaRegionRouting(unittest.TestCase):
+    """The authoritative re-fetch must target the message's regional VQS shard."""
+
+    def setUp(self) -> None:
+        queue_client._subscriptions.clear()
+        _CapturingHttpxClient.urls.clear()
+
+    def tearDown(self) -> None:
+        queue_client._subscriptions.clear()
+        _CapturingHttpxClient.urls.clear()
+
+    def test_ce_vqsregion_header_routes_refetch_to_that_region(self) -> None:
+        queue_client.subscribe(topic="q")(lambda message, metadata: None)
+
+        environ = {**_FORGED_V2BETA_ENVIRON, "HTTP_CE_VQSREGION": "iad1"}
+
+        with (
+            patch.dict(queue_service.os.environ, {"VERCEL_QUEUE_TOKEN": "tok"}, clear=True),
+            patch.object(queue_receive_impl.httpx, "Client", _CapturingHttpxClient),
+        ):
+            status, _body = _wsgi_post(
+                queue_client.get_wsgi_app(),
+                environ_extra=environ,
+                body=_FORGED_V2BETA_BODY,
+            )
+
+        # 404 because the fake queue service has no such message, but the URL it
+        # was fetched from must be the iad1 shard, not the worker's default host.
+        self.assertTrue(status.startswith("404"), status)
+        self.assertEqual(len(_CapturingHttpxClient.urls), 1)
+        self.assertTrue(
+            _CapturingHttpxClient.urls[0].startswith("https://iad1.vercel-queue.com"),
+            _CapturingHttpxClient.urls[0],
+        )
+
+    def test_ce_vqsregion_routes_ack_to_that_region(self) -> None:
+        # The receipt handle is region-scoped, so the ack must target the same shard.
+        queue_client.subscribe(topic="q")(lambda message, metadata: None)
+
+        environ = {**_FORGED_V2BETA_ENVIRON, "HTTP_CE_VQSREGION": "iad1"}
+
+        with (
+            patch.object(
+                queue_receive_impl,
+                "receive_message_by_id",
+                return_value=({"real": "payload"}, 1, "now", "server-receipt"),
+            ),
+            patch.object(queue_client.callback, "delete_message") as delete_message,
+            patch.object(queue_client.callback, "change_visibility"),
+        ):
+            status, _body = _wsgi_post(
+                queue_client.get_wsgi_app(),
+                environ_extra=environ,
+                body=_FORGED_V2BETA_BODY,
+            )
+
+        self.assertTrue(status.startswith("200"), status)
+        delete_message.assert_called_once_with(
+            "q", "c", "forged-message-id", "server-receipt", region="iad1"
+        )
+
+    def test_invalid_ce_vqsregion_header_is_rejected(self) -> None:
+        calls: list[Any] = []
+        queue_client.subscribe(topic="q")(lambda message, metadata: calls.append(message))
+
+        environ = {**_FORGED_V2BETA_ENVIRON, "HTTP_CE_VQSREGION": "not-a-region"}
+
+        with patch.object(queue_receive_impl.httpx, "Client", _CapturingHttpxClient):
+            status, _body = _wsgi_post(
+                queue_client.get_wsgi_app(),
+                environ_extra=environ,
+                body=_FORGED_V2BETA_BODY,
+            )
+
+        # Malformed region → 400, no re-fetch attempted, worker never runs.
+        self.assertTrue(status.startswith("400"), status)
+        self.assertEqual(_CapturingHttpxClient.urls, [])
+        self.assertEqual(calls, [])
 
 
 class TestWorkerJSONEncoder(unittest.TestCase):

--- a/python/vercel-workers/tests/test_django_adapter.py
+++ b/python/vercel-workers/tests/test_django_adapter.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import vercel.workers._queue.receive as queue_receive_impl
 import vercel.workers._queue.send as queue_service
 from vercel.workers import _queue
 
@@ -275,6 +276,62 @@ class TestDjangoAsgiApp(unittest.TestCase):
         self.assertEqual(sent[0]["status"], 200)
         self.assertEqual(sent[1]["type"], "http.response.body")
         self.assertEqual(sent[1]["body"], b"ok")
+
+    def test_forged_v2beta_callback_is_rejected_and_task_not_executed(self) -> None:
+        # A forged v2beta callback must not execute a Django task when the message
+        # is not in the queue service.
+        task_executed: list[Any] = []
+
+        def fake_task_func(*args: Any, **kwargs: Any) -> str:
+            task_executed.append((args, kwargs))
+            return "success"
+
+        mock_task = MagicMock()
+        mock_task.module_path = "myapp.tasks.my_task"
+        mock_task.takes_context = False
+        mock_task.queue_name = "q"
+        mock_task.priority = 0
+        mock_task.call = fake_task_func
+
+        mock_backend = MagicMock()
+        mock_backend.options = {}
+        mock_backend.queues = None
+        mock_backend.alias = "default"
+
+        def not_found(*_args: Any, **_kwargs: Any) -> Any:
+            raise queue_receive_impl.MessageNotFoundError("forged-message-id")
+
+        forged_headers = [
+            (b"ce-type", b"com.vercel.queue.v2beta"),
+            (b"ce-vqsqueuename", b"q"),
+            (b"ce-vqsconsumergroup", b"c"),
+            (b"ce-vqsmessageid", b"forged-message-id"),
+            (b"ce-vqsreceipthandle", b"forged-receipt-handle"),
+            (b"ce-vqsdeliverycount", b"1"),
+            (b"content-type", b"application/json"),
+        ]
+
+        async def run() -> list[dict]:
+            with (
+                patch.object(vwd_app, "_resolve_backend", return_value=mock_backend),
+                patch.object(
+                    queue_receive_impl,
+                    "receive_message_by_id",
+                    side_effect=not_found,
+                ),
+            ):
+                app = vwd_app.get_asgi_app(backend_alias="default")
+                return await self._asgi_request(
+                    app,
+                    method="POST",
+                    path="/callback",
+                    headers=forged_headers,
+                    body=b'{"vercel":{"kind":"django-tasks","version":1}}',
+                )
+
+        sent = asyncio.run(run())
+        self.assertEqual(sent[0]["status"], 404)
+        self.assertEqual(task_executed, [])
 
     def test_rejects_non_cloudevents_json(self) -> None:
         """Test that non-CloudEvents content type is rejected."""

--- a/python/vercel-workers/tests/test_dramatiq_adapter.py
+++ b/python/vercel-workers/tests/test_dramatiq_adapter.py
@@ -18,6 +18,7 @@ pytest.importorskip("dramatiq")
 import dramatiq
 from dramatiq.message import Message
 
+import vercel.workers._queue.receive as queue_receive_impl
 from vercel.workers import _queue
 from vercel.workers.dramatiq import (
     DramatiqWorkerConfig,
@@ -32,6 +33,7 @@ from vercel.workers.dramatiq.broker import (
     _message_to_envelope,
 )
 from vercel.workers.dramatiq.worker import _execute_message
+from vercel.workers.exceptions import MessageNotFoundError
 
 
 class TestVercelQueuesBrokerOptions:
@@ -756,3 +758,39 @@ class TestRetriesCallbackBehaviour:
         mock_qc.delete_message.assert_called_once()
         # Terminal failure does not re-enqueue.
         mock_send.assert_not_called()
+
+
+class TestForgedV2BetaCallback:
+    """Forged v2beta callbacks must not run actors."""
+
+    def test_forged_v2beta_callback_is_rejected_and_actor_not_executed(self) -> None:
+        executed: list[Any] = []
+
+        broker = VercelQueuesBroker()
+
+        @dramatiq.actor(broker=broker, queue_name="q")
+        def forged_actor() -> None:
+            executed.append(True)
+
+        forged_environ = {
+            "HTTP_CE_TYPE": "com.vercel.queue.v2beta",
+            "HTTP_CE_VQSQUEUENAME": "q",
+            "HTTP_CE_VQSCONSUMERGROUP": "c",
+            "HTTP_CE_VQSMESSAGEID": "forged-message-id",
+            "HTTP_CE_VQSRECEIPTHANDLE": "forged-receipt-handle",
+            "HTTP_CE_VQSDELIVERYCOUNT": "1",
+            "CONTENT_TYPE": "application/json",
+        }
+
+        def not_found(*_args: Any, **_kwargs: Any) -> Any:
+            raise MessageNotFoundError("forged-message-id")
+
+        with patch.object(queue_receive_impl, "receive_message_by_id", side_effect=not_found):
+            status_code, _headers, _body = handle_queue_callback(
+                broker,
+                b'{"queue_name":"q","actor_name":"forged_actor","args":[],"kwargs":{}}',
+                forged_environ,
+            )
+
+        assert status_code == 404
+        assert executed == []


### PR DESCRIPTION
Harden the `vercel-workers` v2beta queue callback path so a worker only runs for a genuinely queued message.

Previously v2beta callbacks trusted attacker-reachable `Ce-Vqs*` headers and the request body as the message envelope, so any caller reaching the callback route could run a registered worker with a forged payload. The callback now always re-fetches the authoritative message by id from the queue service (as the v1beta path already does) and ignores the inline body. The re-fetch and ack/visibility calls are routed to the shard named by the validated `ce-vqsregion` header.

**Happy path**
- A genuine callback re-fetches the message by id with the queue token and runs the worker with the authoritative server payload
- The `ce-vqsregion` header routes the re-fetch and the ack/visibility calls to the correct regional shard
- The v1beta path is unchanged

**Unhappy path**
- A forged callback whose message id is not in the queue service fails closed with a 404 and never runs a worker
- The inline request body and receipt handle are never trusted, so a forged payload cannot reach a worker
- An invalid `ce-vqsregion` header is rejected with a 400 before any re-fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)