### PR TITLE
fix(cli): scope `domains add` mutation to the linked team

### DIFF
--- a/.changeset/domains-add-linked-scope.md
+++ b/.changeset/domains-add-linked-scope.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vercel domains add` sending the alias mutation under a stale ambient team scope. When run inside a directory linked to a project in another team, the command now resolves the local project link (like `vercel domains ls`) and scopes the domain/alias request to the linked team, so a same-name project in the ambient team can no longer be targeted by mistake.

--- a/packages/cli/src/commands/domains/add.ts
+++ b/packages/cli/src/commands/domains/add.ts
@@ -200,7 +200,9 @@ export default async function add(client: Client, argv: string[]) {
 
   const force = opts['--force'];
   telemetry.trackCliFlagForce(force);
-  const { contextName } = await getScope(client);
+  // Scope the mutation to the linked project's team (like `domains ls`) so a
+  // stale ambient team can't be targeted.
+  const { contextName } = await getScope(client, { resolveLocalScope: true });
 
   if (args.length < 1 || args.length > 2) {
     if (client.nonInteractive) {

--- a/packages/cli/test/unit/commands/domains/add.test.ts
+++ b/packages/cli/test/unit/commands/domains/add.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
+import { join } from 'path';
+import { outputFile } from 'fs-extra';
 import domains from '../../../../src/commands/domains';
 import { client } from '../../../mocks/client';
 import { useDomain } from '../../../mocks/domains';
-import { useProject } from '../../../mocks/project';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeam } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 
 describe('domains add', () => {
   describe('--help', () => {
@@ -165,6 +169,53 @@ describe('domains add', () => {
         await expect(client.stderr).toOutput(
           `Domain ${domain.name} is already assigned to project ${project.name}`
         );
+      });
+
+      it('scopes the alias mutation to the linked team, not the ambient team', async () => {
+        // Directory linked to a project owned by team_linked, but the ambient
+        // scope is a stale team. The alias mutation must be scoped to the
+        // linked team so a same-name project in the stale team is not hit.
+        useUser();
+        useTeam('team_stale');
+        useTeam('team_linked');
+        const domain = useDomain();
+
+        const cwd = setupTmpDir();
+        client.cwd = cwd;
+        await outputFile(
+          join(cwd, '.vercel', 'project.json'),
+          JSON.stringify({ projectId: 'prj_linked', orgId: 'team_linked' })
+        );
+
+        useProject({
+          ...defaultProject,
+          id: 'prj_linked',
+          name: 'my-app',
+          accountId: 'team_linked',
+        });
+
+        client.config.currentTeam = 'team_stale';
+        client.setArgv('domains', 'add', domain.name, 'my-app');
+
+        let aliasTeamId: string | undefined;
+        client.scenario.post('/projects/:idOrName/alias', (req, res) => {
+          aliasTeamId =
+            typeof req.query.teamId === 'string' ? req.query.teamId : undefined;
+          res.json([{ domain: domain.name }]);
+        });
+        client.scenario.get(
+          `/:version/domains/${domain.name}/config`,
+          (_req, res) => {
+            res.json({});
+          }
+        );
+
+        const exitCode = await domains(client);
+        expect(exitCode, 'exit code for "domains"').toEqual(0);
+
+        // Fixed behavior: the alias mutation is sent under the linked team, so
+        // it can never resolve `my-app` in the stale ambient team.
+        expect(aliasTeamId).toEqual('team_linked');
       });
 
       describe('--force', () => {


### PR DESCRIPTION
## Summary

Security hardening for `vercel domains add`. The command resolved scope with `getScope(client)` (without `resolveLocalScope`), so it ignored the local project link. When run inside a directory linked to a project in another team than the ambient scope (`client.config.currentTeam`, e.g. left over from `vc switch`), the state-changing `POST /projects/<project>/alias` mutation went out under the ambient team, targeting the project by name.

If a same-name project existed in the ambient team, the domain could be attached to the wrong project/team. `domains ls` already resolves local scope; `domains add` was the outlier. The fix uses `getScope(client, { resolveLocalScope: true })`.

## Request scope

Directory linked to `team_linked` / `prj_linked`, ambient `currentTeam = team_stale`, running `vercel domains add example.com my-app`:

* Happy path (fixed): `POST /projects/my-app/alias?teamId=team_linked`, resolving `my-app` in the linked team.
* Unhappy path (before): `POST /projects/my-app/alias?teamId=team_stale`, resolving `my-app` in the stale team.

## Notes

* Explicit `--scope` / `--team` still wins, and unlinked directories keep their existing ambient behavior.
* Once the team scope is correct, the project name is unambiguous within that team.
* Added a unit test that links a temp dir to one team, sets a different ambient team, and asserts the alias mutation is scoped to the linked team. Full `domains add` suite passes; type-check, lint, and format are clean.