### PR TITLE
[cli] Document Blob auth options in blob subcommand help

### DIFF
--- a/.changeset/blob-auth-options-help.md
+++ b/.changeset/blob-auth-options-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Document Blob auth options (`--rw-token`, `--oidc-token`, `--store-id`) in the help output of every `vercel blob` subcommand that accepts them

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -28,6 +28,38 @@ const accessOption = {
   choices: ['public', 'private'],
 } as const;
 
+const rwTokenOption = {
+  name: 'rw-token',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description:
+    'Read-write token for the Blob store. Defaults to the BLOB_READ_WRITE_TOKEN environment variable. Used when OIDC credentials are not available',
+  argument: 'STRING',
+} as const;
+
+const oidcTokenOption = {
+  name: 'oidc-token',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description:
+    'OIDC token to authenticate with the Blob store (must be passed together with --store-id). Defaults to the VERCEL_OIDC_TOKEN environment variable. Takes priority over the read-write token',
+  argument: 'STRING',
+} as const;
+
+const storeIdOption = {
+  name: 'store-id',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+  description:
+    'Blob store id, with or without the "store_" prefix (must be passed together with --oidc-token). Defaults to the BLOB_STORE_ID environment variable',
+  argument: 'STRING',
+} as const;
+
+const authOptions = [rwTokenOption, oidcTokenOption, storeIdOption] as const;
+
 import { yesOption } from '../../util/arg-common';
 
 const environmentOption = {
@@ -81,6 +113,7 @@ export const listSubcommand = {
       argument: 'String',
       choices: ['folded', 'expanded'],
     },
+    ...authOptions,
   ],
   examples: [],
 } as const;
@@ -149,6 +182,7 @@ export const putSubcommand = {
       argument: 'Boolean',
     },
     ifMatchOption,
+    ...authOptions,
   ],
   examples: [],
 } as const;
@@ -163,7 +197,7 @@ export const delSubcommand = {
       required: true,
     },
   ],
-  options: [ifMatchOption],
+  options: [ifMatchOption, ...authOptions],
   examples: [],
 } as const;
 
@@ -210,6 +244,7 @@ export const copySubcommand = {
       argument: 'Number',
     },
     ifMatchOption,
+    ...authOptions,
   ],
   examples: [],
 } as const;
@@ -235,6 +270,7 @@ export const getSubcommand = {
       argument: 'PATH',
     },
     ifNoneMatchOption,
+    ...authOptions,
   ],
   examples: [],
 } as const;
@@ -304,6 +340,7 @@ export const signedTokenSubcommand = {
       deprecated: false,
       description: 'Output signed token payload as JSON',
     },
+    ...authOptions,
   ],
   examples: [
     {
@@ -430,6 +467,7 @@ export const presignSubcommand = {
       deprecated: false,
       description: 'Output presign result as JSON',
     },
+    ...authOptions,
   ],
   examples: [
     {
@@ -500,7 +538,7 @@ export const deleteStoreSubcommand = {
       required: false,
     },
   ],
-  options: [yesOption],
+  options: [yesOption, ...authOptions],
   examples: [],
 } as const;
 
@@ -509,7 +547,7 @@ export const emptyStoreSubcommand = {
   aliases: [],
   description: 'Delete all blobs in a Blob store',
   arguments: [],
-  options: [yesOption],
+  options: [yesOption, ...authOptions],
   examples: [],
 } as const;
 
@@ -523,7 +561,7 @@ export const getStoreInfoSubcommand = {
       required: false,
     },
   ],
-  options: [],
+  options: [...authOptions],
   examples: [],
 } as const;
 
@@ -587,33 +625,16 @@ export const blobCommand = {
     listStoresSubcommand,
     emptyStoreSubcommand,
   ],
-  options: [
+  options: [...authOptions],
+  examples: [
     {
-      name: 'rw-token',
-      shorthand: null,
-      type: String,
-      deprecated: false,
-      description: 'Read_Write_Token for the Blob store',
-      argument: 'String',
+      name: 'Authenticate with OIDC credentials. When omitted, the CLI reads VERCEL_OIDC_TOKEN and BLOB_STORE_ID from the environment or .env.local (populated automatically in linked projects)',
+      value:
+        'vercel blob list --oidc-token <VERCEL_OIDC_TOKEN> --store-id <BLOB_STORE_ID>',
     },
     {
-      name: 'oidc-token',
-      shorthand: null,
-      type: String,
-      deprecated: false,
-      description:
-        'OIDC token for the Blob store (must be passed together with --store-id)',
-      argument: 'String',
-    },
-    {
-      name: 'store-id',
-      shorthand: null,
-      type: String,
-      deprecated: false,
-      description:
-        'Blob store id, with or without the "store_" prefix (must be passed together with --oidc-token)',
-      argument: 'String',
+      name: 'Authenticate with a read-write token when OIDC credentials are not available. When omitted, the CLI reads BLOB_READ_WRITE_TOKEN from the environment or .env.local',
+      value: 'vercel blob list --rw-token <BLOB_READ_WRITE_TOKEN>',
     },
   ],
-  examples: [],
 } as const;

--- a/packages/cli/src/util/telemetry/commands/blob/auth.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/auth.ts
@@ -1,0 +1,37 @@
+import { TelemetryClient } from '../..';
+
+/**
+ * The auth options (--rw-token, --oidc-token, --store-id) are shared by all
+ * `blob` subcommands that talk to a Blob store and are parsed and tracked
+ * once at the `blob` command level. Each subcommand still declares them in
+ * its options for help output, so the telemetry interfaces derived from
+ * those options require these methods on every subcommand client.
+ */
+export class BlobAuthTelemetryClient extends TelemetryClient {
+  trackCliOptionRwToken(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: '--rw-token',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionOidcToken(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: '--oidc-token',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionStoreId(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: '--store-id',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/blob/copy.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/copy.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { copySubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobCopyTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof copySubcommand>
 {
   trackCliOptionAccess(value: string | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/del.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/del.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { delSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobDelTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof delSubcommand>
 {
   trackCliArgumentUrlsOrPathnames(urlsOrPathnames: string | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/get.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/get.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { getSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobGetTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof getSubcommand>
 {
   trackCliArgumentUrlOrPathname(value: string | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -1,11 +1,11 @@
-import { TelemetryClient } from '../..';
 import type { blobCommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
+import { BlobAuthTelemetryClient } from './auth';
 export { BlobPresignTelemetryClient } from './presign';
 export { BlobSignedTokenTelemetryClient } from './signed-token';
 
 export class BlobTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof blobCommand>
 {
   trackCliSubcommandList(actual: string) {
@@ -90,32 +90,5 @@ export class BlobTelemetryClient
       subcommand: 'empty-store',
       value: actual,
     });
-  }
-
-  trackCliOptionRwToken(value: string | undefined) {
-    if (value) {
-      this.trackCliOption({
-        option: '--rw-token',
-        value: this.redactedValue,
-      });
-    }
-  }
-
-  trackCliOptionOidcToken(value: string | undefined) {
-    if (value) {
-      this.trackCliOption({
-        option: '--oidc-token',
-        value: this.redactedValue,
-      });
-    }
-  }
-
-  trackCliOptionStoreId(value: string | undefined) {
-    if (value) {
-      this.trackCliOption({
-        option: '--store-id',
-        value: this.redactedValue,
-      });
-    }
   }
 }

--- a/packages/cli/src/util/telemetry/commands/blob/list.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/list.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { listSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobListTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof listSubcommand>
 {
   trackCliOptionLimit(limit: number | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/presign.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/presign.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { presignSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobPresignTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof presignSubcommand>
 {
   trackCliArgumentPathname(value: string | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/put.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/put.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { putSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobPutTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof putSubcommand>
 {
   trackCliOptionAccess(value: string | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/signed-token.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/signed-token.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { signedTokenSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobSignedTokenTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof signedTokenSubcommand>
 {
   trackCliOptionPathname(value: string | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/store-empty.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-empty.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { emptyStoreSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobEmptyStoreTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof emptyStoreSubcommand>
 {
   trackCliFlagYes(value: boolean | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/store-get.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-get.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { getStoreInfoSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobGetStoreTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof getStoreInfoSubcommand>
 {
   trackCliArgumentStoreId(value: string | undefined) {

--- a/packages/cli/src/util/telemetry/commands/blob/store-remove.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/store-remove.ts
@@ -1,9 +1,9 @@
-import { TelemetryClient } from '../..';
+import { BlobAuthTelemetryClient } from './auth';
 import type { deleteStoreSubcommand } from '../../../../commands/blob/command';
 import type { TelemetryMethods } from '../../types';
 
 export class BlobRemoveStoreTelemetryClient
-  extends TelemetryClient
+  extends BlobAuthTelemetryClient
   implements TelemetryMethods<typeof deleteStoreSubcommand>
 {
   trackCliArgumentStoreId(value: string | undefined) {

--- a/packages/cli/test/unit/commands/blob/command.test.ts
+++ b/packages/cli/test/unit/commands/blob/command.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blobCommand,
+  copySubcommand,
+  delSubcommand,
+  deleteStoreSubcommand,
+  emptyStoreSubcommand,
+  getStoreInfoSubcommand,
+  getSubcommand,
+  listSubcommand,
+  presignSubcommand,
+  putSubcommand,
+  signedTokenSubcommand,
+} from '../../../../src/commands/blob/command';
+
+const AUTH_OPTION_NAMES = ['rw-token', 'oidc-token', 'store-id'] as const;
+
+// Every subcommand that authenticates against a Blob store must document
+// the shared auth options in its own help output, since subcommand help
+// does not render parent command options.
+const authConsumingSubcommands = [
+  listSubcommand,
+  putSubcommand,
+  getSubcommand,
+  delSubcommand,
+  copySubcommand,
+  signedTokenSubcommand,
+  presignSubcommand,
+  deleteStoreSubcommand,
+  getStoreInfoSubcommand,
+  emptyStoreSubcommand,
+];
+
+describe('blob command definitions', () => {
+  it.each(authConsumingSubcommands.map(sub => [sub.name, sub] as const))(
+    '%s subcommand documents the Blob auth options',
+    (_name, subcommand) => {
+      const optionNames = subcommand.options.map(option => option.name);
+      for (const authOption of AUTH_OPTION_NAMES) {
+        expect(optionNames).toContain(authOption);
+      }
+    }
+  );
+
+  it('blob command documents the Blob auth options', () => {
+    const optionNames = blobCommand.options.map(option => option.name);
+    for (const authOption of AUTH_OPTION_NAMES) {
+      expect(optionNames).toContain(authOption);
+    }
+  });
+});


### PR DESCRIPTION
# Problem

The `vercel blob` auth options (`--rw-token`, `--oidc-token`, `--store-id`) are only defined on the top-level `blob` command, and subcommand help does not render parent command options. As a result, `vercel blob put --help` (and every other subcommand's help) never mentions how to authenticate — even though all store-facing subcommands accept these flags. The existing descriptions also didn't explain the env var defaults (`VERCEL_OIDC_TOKEN`, `BLOB_STORE_ID`, `BLOB_READ_WRITE_TOKEN`) or that OIDC credentials take priority over the read-write token.

# Solution

Declare the shared auth options on every subcommand that authenticates against a Blob store (`list`, `put`, `get`, `del`, `copy`, `signed-token`, `presign`, `delete-store`, `get-store`, `empty-store`) so each subcommand's `--help` documents them. Clarify the option descriptions with env var defaults and resolution priority, and add top-level `vercel blob` examples for both auth methods.

The auth flags are still parsed and tracked once at the `blob` command level (behavior unchanged); a shared `BlobAuthTelemetryClient` base class satisfies the telemetry interfaces that are derived from each subcommand's option list. A unit test asserts every auth-consuming subcommand documents the three options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)