### PR TITLE
fix(cli): suggest closest integration on `integration add` typo

### DIFF
--- a/.changeset/integration-add-did-you-mean.md
+++ b/.changeset/integration-add-did-you-mean.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vercel integration add` (and `vercel install`) now suggests the closest matching integration when the given slug isn't found. If a substring search returns no results, it runs a fuzzy match and proposes "Did you mean …?" — prompting to install it in interactive mode, or surfacing the suggestion in the error in non-interactive mode — while still pointing at `vercel integration discover` to browse all integrations.

--- a/packages/cli/src/util/integration/fetch-integration.ts
+++ b/packages/cli/src/util/integration/fetch-integration.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import output from '../../output-manager';
+import didYouMean from '../did-you-mean';
 import type { IntegrationAddTelemetryClient } from '../telemetry/commands/integration/add';
 import type Client from '../client';
 import type { Integration } from './types';
@@ -113,15 +114,46 @@ export async function resolveAndFetchIntegration(
 
   const matches = entries.filter(entry => matchesSearchTerm(entry, slug));
 
-  if (!matches.length) {
-    output.error(
-      `No integration found matching "${slug}". Run ${chalk.cyan('vercel integration discover')} to browse available integrations.`
-    );
-    telemetry.trackCliArgumentIntegration(slug, false);
-    return null;
-  }
+  const discoverHint = `Run ${chalk.cyan('vercel integration discover')} to browse available integrations.`;
 
-  if (matches.length === 1) {
+  if (!matches.length) {
+    // No substring match — fall back to a fuzzy "did you mean" search against
+    // known slugs to catch typos (e.g. "noen" -> "neon").
+    const slugCandidates = [...new Set(entries.map(entry => entry.slug))];
+    const suggestion = didYouMean(slug.toLowerCase(), slugCandidates, 0.7);
+
+    if (!suggestion) {
+      output.error(`No integration found matching "${slug}". ${discoverHint}`);
+      telemetry.trackCliArgumentIntegration(slug, false);
+      return null;
+    }
+
+    const suggested = entries.find(entry => entry.slug === suggestion);
+    const suggestionLabel = suggested
+      ? `${chalk.bold(suggested.name)} (${suggestion})`
+      : chalk.bold(suggestion);
+
+    // Non-interactive (agent/CI): surface the suggestion plus discover hint and stop.
+    if (client.stdin.isTTY !== true) {
+      output.error(
+        `No integration found matching "${slug}". Did you mean "${suggestion}"? ${discoverHint}`
+      );
+      telemetry.trackCliArgumentIntegration(slug, false);
+      return null;
+    }
+
+    // Interactive: offer to install the closest match, but still point at discover.
+    output.log(`No integration found matching "${slug}". ${discoverHint}`);
+    const confirmed = await client.input.confirm(
+      `Did you mean ${suggestionLabel}? Install it?`,
+      true
+    );
+    if (!confirmed) {
+      telemetry.trackCliArgumentIntegration(slug, false);
+      return null;
+    }
+    slug = suggestion;
+  } else if (matches.length === 1) {
     const match = matches[0];
     if (client.stdin.isTTY === true) {
       const confirmed = await client.input.confirm(

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -2855,6 +2855,42 @@ describe('integration add (auto-provision)', () => {
       expect(exitCode).toEqual(1);
     });
 
+    it('should suggest the closest match on a typo and install on confirm', async () => {
+      client.setArgv('integration', 'add', 'noen');
+      const exitCodePromise = integrationCommand(client);
+
+      // Still points the user at the full list of integrations...
+      await expect(client.stderr).toOutput(
+        'No integration found matching "noen". Run vercel integration discover to browse available integrations.'
+      );
+      // ...and proposes the closest slug.
+      await expect(client.stderr).toOutput(
+        'Did you mean Neon Postgres (neon)?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Neon Postgres successfully provisioned'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should suggest the closest match in non-TTY mode without prompting', async () => {
+      (client.stdin as any).isTTY = false;
+      client.setArgv('integration', 'add', 'noen');
+      const exitCodePromise = integrationCommand(client);
+
+      // A single error carries both the suggestion and the discover instructions.
+      await expect(client.stderr).toOutput(
+        'No integration found matching "noen". Did you mean "neon"? Run vercel integration discover to browse available integrations.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+    });
+
     it('should list matches in non-TTY mode', async () => {
       (client.stdin as any).isTTY = false;
       client.setArgv('integration', 'add', 'postgres');


### PR DESCRIPTION
## What

When `vercel integration add <slug>` (a.k.a. `vc i <slug>`, and the `vercel install` alias) is run with a slug that matches no integration, the CLI now runs a fuzzy **"did you mean …?"** search against known marketplace slugs instead of just erroring out — while still pointing the user at `vercel integration discover` to browse the full list.

Reuses the existing `didYouMean` (jaro-winkler) util already used by `vercel init` and command-typo handling.

## Behavior

The change lives in `resolveAndFetchIntegration` (`packages/cli/src/util/integration/fetch-integration.ts`), in the branch that previously just printed `No integration found matching "<x>"`:

- **No close match** → unchanged: `No integration found matching "<x>". Run vercel integration discover …`
- **Interactive (TTY)** → prints the "no match / run discover" line, then prompts `Did you mean Neon Postgres (neon)? Install it?`; confirming installs the suggested slug.
- **Non-interactive (agent/CI)** → single error carrying both the suggestion and the discover hint: `No integration found matching "noen". Did you mean "neon"? Run vercel integration discover …` (no prompt).

The `vercel integration discover` instruction is shown on every path.

## Tests

Added two tests to `add-auto-provision.test.ts` (TTY confirm-and-install, non-TTY suggestion). Full file passes locally (122 tests). Threshold-checked so real typos resolve (`noen`→`neon`) while genuinely-unknown slugs (`nonexistent-xyz`) still produce no suggestion — preserving the existing "no match" test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)