### PR TITLE
Support DS (DNSSEC) record type in vercel dns add

### DIFF
--- a/.changeset/dns-ds-record-type.md
+++ b/.changeset/dns-ds-record-type.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Support the DS (DNSSEC Delegation Signer) record type in `vercel dns add`.

--- a/packages/cli/src/commands/dns/add.ts
+++ b/packages/cli/src/commands/dns/add.ts
@@ -232,7 +232,7 @@ export default async function add(client: Client, argv: string[]) {
         {
           status: AGENT_STATUS.ERROR,
           reason: AGENT_REASON.INVALID_DNS_TYPE,
-          message: `Invalid <type> parameter "${record.meta.type}". Expected one of A, AAAA, ALIAS, CAA, CNAME, MX, SRV, TXT.`,
+          message: `Invalid <type> parameter "${record.meta.type}". Expected one of A, AAAA, ALIAS, CAA, CNAME, DS, MX, SRV, TXT.`,
         },
         1
       );
@@ -240,7 +240,7 @@ export default async function add(client: Client, argv: string[]) {
     output.error(
       `Invalid <type> parameter "${
         record.meta.type
-      }". Expected one of A, AAAA, ALIAS, CAA, CNAME, MX, SRV, TXT ${chalk.gray(
+      }". Expected one of A, AAAA, ALIAS, CAA, CNAME, DS, MX, SRV, TXT ${chalk.gray(
         addStamp()
       )}`
     );

--- a/packages/cli/src/commands/dns/command.ts
+++ b/packages/cli/src/commands/dns/command.ts
@@ -88,7 +88,7 @@ export const dnsCommand = {
     {
       name: 'Add an A record for a subdomain',
       value: [
-        `${packageName} dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | TXT>  <VALUE>`,
+        `${packageName} dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | DS | TXT>  <VALUE>`,
         `${packageName} dns add zeit.rocks api A 198.51.100.100`,
       ],
     },
@@ -111,6 +111,13 @@ export const dnsCommand = {
       value: [
         `${packageName} dns add <DOMAIN> <NAME> CAA '<FLAGS> <TAG> "<VALUE>"'`,
         `${packageName} dns add zeit.rocks '@' CAA '0 issue "example.com"'`,
+      ],
+    },
+    {
+      name: 'Add a DS record',
+      value: [
+        `${packageName} dns add <DOMAIN> <NAME> DS '<KEY TAG> <ALGORITHM> <DIGEST TYPE> <DIGEST>'`,
+        `${packageName} dns add zeit.rocks sub DS '2371 13 2 5be1a3f7'`,
       ],
     },
     {

--- a/packages/cli/src/util/dns/get-dns-data.ts
+++ b/packages/cli/src/util/dns/get-dns-data.ts
@@ -3,7 +3,17 @@ import type { DNSRecordData } from '@vercel-internals/types';
 import type Client from '../client';
 import output from '../../output-manager';
 
-const RECORD_TYPES = ['A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'SRV', 'TXT'];
+const RECORD_TYPES = [
+  'A',
+  'AAAA',
+  'ALIAS',
+  'CAA',
+  'CNAME',
+  'DS',
+  'MX',
+  'SRV',
+  'TXT',
+];
 
 export default async function getDNSData(
   client: Client,

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -854,7 +854,7 @@ export class DNSInvalidType extends NowError<
     super({
       code: 'DNS_INVALID_TYPE',
       meta: { type },
-      message: `Invalid <type> parameter "${type}". Expected one of A, AAAA, ALIAS, CAA, CNAME, MX, SRV, TXT`,
+      message: `Invalid <type> parameter "${type}". Expected one of A, AAAA, ALIAS, CAA, CNAME, DS, MX, SRV, TXT`,
     });
   }
 }

--- a/packages/cli/src/util/telemetry/commands/dns/add.ts
+++ b/packages/cli/src/util/telemetry/commands/dns/add.ts
@@ -7,6 +7,7 @@ const ALLOWED_RECORD_TYPES = [
   'AAAA',
   'ALIAS',
   'CNAME',
+  'DS',
   'TXT',
   'MX',
   'SRV',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1781,7 +1781,7 @@ exports[`help command > dns help output snapshots > dns help column width 40 1`]
 
   - Add an A record for a subdomain
 
-    $ vercel dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | TXT>  <VALUE>
+    $ vercel dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | DS | TXT>  <VALUE>
     $ vercel dns add zeit.rocks api A 198.51.100.100
 
   - Add an MX record (@ as a name refers to the domain)
@@ -1798,6 +1798,11 @@ exports[`help command > dns help output snapshots > dns help column width 40 1`]
 
     $ vercel dns add <DOMAIN> <NAME> CAA '<FLAGS> <TAG> "<VALUE>"'
     $ vercel dns add zeit.rocks '@' CAA '0 issue "example.com"'
+
+  - Add a DS record
+
+    $ vercel dns add <DOMAIN> <NAME> DS '<KEY TAG> <ALGORITHM> <DIGEST TYPE> <DIGEST>'
+    $ vercel dns add zeit.rocks sub DS '2371 13 2 5be1a3f7'
 
   - Import a Zone file
 
@@ -1849,7 +1854,7 @@ exports[`help command > dns help output snapshots > dns help column width 80 1`]
 
   - Add an A record for a subdomain
 
-    $ vercel dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | TXT>  <VALUE>
+    $ vercel dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | DS | TXT>  <VALUE>
     $ vercel dns add zeit.rocks api A 198.51.100.100
 
   - Add an MX record (@ as a name refers to the domain)
@@ -1866,6 +1871,11 @@ exports[`help command > dns help output snapshots > dns help column width 80 1`]
 
     $ vercel dns add <DOMAIN> <NAME> CAA '<FLAGS> <TAG> "<VALUE>"'
     $ vercel dns add zeit.rocks '@' CAA '0 issue "example.com"'
+
+  - Add a DS record
+
+    $ vercel dns add <DOMAIN> <NAME> DS '<KEY TAG> <ALGORITHM> <DIGEST TYPE> <DIGEST>'
+    $ vercel dns add zeit.rocks sub DS '2371 13 2 5be1a3f7'
 
   - Import a Zone file
 
@@ -1913,7 +1923,7 @@ exports[`help command > dns help output snapshots > dns help column width 120 1`
 
   - Add an A record for a subdomain
 
-    $ vercel dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | TXT>  <VALUE>
+    $ vercel dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | DS | TXT>  <VALUE>
     $ vercel dns add zeit.rocks api A 198.51.100.100
 
   - Add an MX record (@ as a name refers to the domain)
@@ -1930,6 +1940,11 @@ exports[`help command > dns help output snapshots > dns help column width 120 1`
 
     $ vercel dns add <DOMAIN> <NAME> CAA '<FLAGS> <TAG> "<VALUE>"'
     $ vercel dns add zeit.rocks '@' CAA '0 issue "example.com"'
+
+  - Add a DS record
+
+    $ vercel dns add <DOMAIN> <NAME> DS '<KEY TAG> <ALGORITHM> <DIGEST TYPE> <DIGEST>'
+    $ vercel dns add zeit.rocks sub DS '2371 13 2 5be1a3f7'
 
   - Import a Zone file
 

--- a/packages/cli/test/unit/commands/dns/add.test.ts
+++ b/packages/cli/test/unit/commands/dns/add.test.ts
@@ -65,6 +65,40 @@ describe('dns add', () => {
         'Success! DNS record for domain example.com (rec_123) created'
       );
     });
+
+    it('succeeds when adding a value-based DS record', async () => {
+      client.nonInteractive = true;
+      let posted: unknown;
+      client.scenario.post(`/v3/domains/:domain?/records`, (req, res) => {
+        posted = req.body;
+        res.json({ uid: 'rec_ds' });
+      });
+      client.setArgv(
+        'dns',
+        'add',
+        'example.com',
+        'sub',
+        'DS',
+        '2371 13 2 5be1a3f7'
+      );
+      const exitCode = await dns(client);
+      expect(exitCode).toBe(0);
+      expect(posted).toMatchObject({
+        name: 'sub',
+        type: 'DS',
+        value: '2371 13 2 5be1a3f7',
+      });
+      await expect(client.stderr).toOutput(
+        'Success! DNS record for domain example.com (rec_ds) created'
+      );
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:add', value: 'add' },
+        { key: 'argument:domain', value: '[REDACTED]' },
+        { key: 'argument:name', value: '[REDACTED]' },
+        { key: 'argument:type', value: 'DS' },
+        { key: 'argument:values', value: '[REDACTED]' },
+      ]);
+    });
   });
 
   it('tracks arguments', async () => {


### PR DESCRIPTION
## Why

Customers who manage DNSSEC for a delegated (child) zone need to publish a **DS (Delegation Signer)** record. The CLI rejected `DS` at the interactive record-type prompt, reported it as an unsupported type in the `dns add` error copy, and redacted it in telemetry.

Pairs with the API change that makes `DS` an accepted record type (vercel/api#80298).

## Summary

DS is value-based (`vercel dns add <domain> <name> DS '<keyTag> <algorithm> <digestType> <digest>'`), so the request-body build and `dns ls` display already handle it once the type is accepted. This change:

- Adds `DS` to the interactive record-type allow-list (`get-dns-data.ts`).
- Adds `DS` to the "Expected one of ..." error strings (`errors-ts.ts`, `add.ts`).
- Adds `DS` to the telemetry allow-list so DS adds are recorded instead of `[REDACTED]`.
- Adds `DS` to the `dns add` help example list plus a dedicated DS example.

## Validation

- `vitest run test/unit/commands/dns test/unit/commands/help.test.ts` — 166 passing, including a new test that a non-interactive `dns add ... DS '<value>'` posts `{ name, type: 'DS', value }` and records `argument:type: DS` in telemetry.
- Regenerated the `dns add` help snapshot (DS-only diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)