### PR TITLE
Fix README link for local CLI setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ cd ./packages/cli
 pnpm vercel <cli-commands...>
 ```
 
-See [CLI Local Development](../packages/cli#local-development) for more details.
+See [CLI Local Development](./packages/cli#local-development) for more details.
 
 ### Verifying your change
 


### PR DESCRIPTION
Summary:
Markdown in the link was incorrectly going up a level.

Test Plan:
Check readme.md in branch, link works now
