### PR TITLE
refactor(cli): extract project link helper

### DIFF
--- a/.changeset/calm-links-share.md
+++ b/.changeset/calm-links-share.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Extract project-link validation shared by routes, redirects, and firewall commands.

--- a/packages/cli/src/commands/firewall/attack-mode/disable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/disable.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { attackModeDisableSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -51,7 +47,7 @@ export default async function disable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/enable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/enable.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { attackModeEnableSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -68,7 +64,7 @@ export default async function enable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/diff.ts
+++ b/packages/cli/src/commands/firewall/diff.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { diffSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  outputJson,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import { formatDiffOutput } from '../../util/firewall/format';
 import { getCommandName } from '../../util/pkg-name';
@@ -17,7 +13,7 @@ export default async function diff(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, diffSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/discard.ts
+++ b/packages/cli/src/commands/firewall/discard.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  confirmAction,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import deleteFirewallDraft from '../../util/firewall/delete-firewall-draft';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -18,7 +14,7 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/block.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/block.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksBlockSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -63,7 +63,7 @@ export default async function block(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/list.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/list.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksListSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  outputJson,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateIpRules,
@@ -25,7 +21,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksUnblockSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   confirmAction,
   offerAutoPublish,
   resolveIpRule,
@@ -31,7 +31,7 @@ export default async function unblock(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { overviewSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  outputJson,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import getBypass from '../../util/firewall/get-bypass';
 import {
@@ -21,7 +17,7 @@ export default async function overview(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, overviewSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/publish.ts
+++ b/packages/cli/src/commands/firewall/publish.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  confirmAction,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -18,7 +14,7 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/add.ts
+++ b/packages/cli/src/commands/firewall/rules/add.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesAddSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -88,7 +88,7 @@ export default async function add(client: Client, argv: string[]) {
     }
 
     // AI mode
-    const link = await ensureProjectLink(client);
+    const link = await ensureProjectLink(client, 'firewall');
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -130,7 +130,7 @@ export default async function add(client: Client, argv: string[]) {
       ],
     });
 
-    const link = await ensureProjectLink(client);
+    const link = await ensureProjectLink(client, 'firewall');
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -399,7 +399,7 @@ async function createRule(
   parsed: { args: string[]; flags: Record<string, unknown> },
   rule: Omit<FirewallRule, 'id'>
 ): Promise<number> {
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/disable.ts
+++ b/packages/cli/src/commands/firewall/rules/disable.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesDisableSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -26,7 +26,7 @@ export default async function disable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/edit.ts
+++ b/packages/cli/src/commands/firewall/rules/edit.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesEditSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -43,7 +43,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   let identifier = parsed.args[0] as string | undefined;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/enable.ts
+++ b/packages/cli/src/commands/firewall/rules/enable.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesEnableSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -27,7 +27,7 @@ export default async function enable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/inspect.ts
+++ b/packages/cli/src/commands/firewall/rules/inspect.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesInspectSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRule,
   outputJson,
   withGlobalFlags,
@@ -55,7 +55,7 @@ export default async function inspect(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/list.ts
+++ b/packages/cli/src/commands/firewall/rules/list.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesListSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  outputJson,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateRules,
@@ -26,7 +22,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/remove.ts
+++ b/packages/cli/src/commands/firewall/rules/remove.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesRemoveSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -27,7 +27,7 @@ export default async function remove(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/reorder.ts
+++ b/packages/cli/src/commands/firewall/rules/reorder.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesReorderSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -27,7 +27,7 @@ export default async function reorder(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -3,7 +3,6 @@ import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { getLinkedProject } from '../../util/projects/link';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
 import { outputAgentError, buildCommandWithYes } from '../../util/agent-output';
@@ -72,46 +71,6 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
-}
-
-export async function ensureProjectLink(client: Client) {
-  const link = await getLinkedProject(client);
-
-  if (link.status === 'error') {
-    return link.exitCode;
-  } else if (link.status === 'not_linked') {
-    if (client.nonInteractive) {
-      const flags = getGlobalFlagsOnlyFromArgs(client.argv.slice(2));
-      const cmd = getCommandNamePlain(`link ${flags.join(' ')}`.trim());
-      outputAgentError(
-        client,
-        {
-          status: AGENT_STATUS.ERROR,
-          reason: AGENT_REASON.NOT_LINKED,
-          userActionRequired: true,
-          message:
-            'Your codebase is not linked to a Vercel project. Run link first, then retry firewall commands.',
-          next: [
-            {
-              command: cmd,
-              when: 'to link this directory to a project',
-            },
-          ],
-        },
-        1
-      );
-      return 1;
-    }
-    output.error(
-      `Your codebase isn't linked to a project on Vercel. Run ${getCommandName('link')} to begin.`
-    );
-    return 1;
-  }
-
-  client.config.currentTeam =
-    link.org.type === 'team' ? link.org.id : undefined;
-
-  return link;
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/firewall/system-bypass/add.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/add.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassAddSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import {
   validateBypassIp,
@@ -60,7 +56,7 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/list.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/list.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassListSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  outputJson,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from '../shared';
 import getBypass from '../../../util/firewall/get-bypass';
 import {
   formatBypassTable,
@@ -24,7 +20,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/remove.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/remove.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassRemoveSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import {
   validateBypassIp,
@@ -50,7 +46,7 @@ export default async function remove(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/pause.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/pause.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemMitigationsPauseSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -54,7 +50,7 @@ export default async function pause(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/resume.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/resume.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemMitigationsResumeSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -54,7 +50,7 @@ export default async function resume(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'firewall');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { outputActionRequired } from '../../util/agent-output';
 import {
@@ -10,7 +11,6 @@ import {
 import { addSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   isValidUrl,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
@@ -30,7 +30,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'redirects');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/list-versions.ts
+++ b/packages/cli/src/commands/redirects/list-versions.ts
@@ -2,9 +2,10 @@ import chalk from 'chalk';
 import ms from 'ms';
 import plural from 'pluralize';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import { parseSubcommandArgs, ensureProjectLink } from './shared';
+import { parseSubcommandArgs } from './shared';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import type { RedirectVersion } from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
@@ -14,7 +15,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listVersionsSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'redirects');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/list.ts
+++ b/packages/cli/src/commands/redirects/list.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk';
 import plural from 'pluralize';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
-import { parseSubcommandArgs, ensureProjectLink } from './shared';
+import { parseSubcommandArgs } from './shared';
 import getRedirects from '../../util/redirects/get-redirects';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
@@ -14,7 +15,7 @@ export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'redirects');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/promote.ts
+++ b/packages/cli/src/commands/redirects/promote.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -14,7 +15,6 @@ import {
 import { promoteSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   validateRequiredArgs,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
@@ -68,7 +68,7 @@ export default async function promote(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'redirects');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/remove.ts
+++ b/packages/cli/src/commands/redirects/remove.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -14,7 +15,6 @@ import {
 import { removeSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   validateRequiredArgs,
   confirmAction,
   buildRedirectsSuggestionFlags,
@@ -59,7 +59,7 @@ export default async function remove(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'redirects');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/restore.ts
+++ b/packages/cli/src/commands/redirects/restore.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -14,7 +15,6 @@ import {
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   validateRequiredArgs,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
@@ -71,7 +71,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'redirects');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -2,11 +2,7 @@ import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { getLinkedProject } from '../../util/projects/link';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
-import { outputAgentError } from '../../util/agent-output';
-import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import type { Command } from '../help';
 import {
   GLOBAL_CLI_FLAG_NAMES,
@@ -46,37 +42,6 @@ export function validateRequiredArgs(
     }
   }
   return null;
-}
-
-export async function ensureProjectLink(client: Client) {
-  const link = await getLinkedProject(client);
-
-  if (link.status === 'error') {
-    return link.exitCode;
-  } else if (link.status === 'not_linked') {
-    if (client.nonInteractive) {
-      const linkCmd = getCommandNamePlain('link');
-      outputAgentError(
-        client,
-        {
-          status: AGENT_STATUS.ERROR,
-          reason: AGENT_REASON.NOT_LINKED,
-          message: `Your codebase isn't linked to a project on Vercel. Run ${linkCmd} to begin.`,
-          next: [{ command: linkCmd }],
-        },
-        1
-      );
-    }
-    output.error(
-      `Your codebase isn't linked to a project on Vercel. Run ${getCommandName('link')} to begin.`
-    );
-    return 1;
-  }
-
-  client.config.currentTeam =
-    link.org.type === 'team' ? link.org.id : undefined;
-
-  return link;
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/redirects/upload.ts
+++ b/packages/cli/src/commands/redirects/upload.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import { basename } from 'path';
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,7 +16,6 @@ import {
 import { uploadSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   getArgsAfterRedirectsSubcommand,
   getRedirectPromoteSuggestionFlags,
   buildRedirectsSuggestionFlags,
@@ -51,7 +51,7 @@ export default async function upload(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, uploadSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'redirects');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/add.ts
+++ b/packages/cli/src/commands/routes/add.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { addSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  parsePosition,
-  offerAutoPromote,
-} from './shared';
+import { parseSubcommandArgs, parsePosition, offerAutoPromote } from './shared';
 import addRoute from '../../util/routes/add-route';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import { parseConditions } from '../../util/routes/parse-conditions';
@@ -127,7 +123,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/delete.ts
+++ b/packages/cli/src/commands/routes/delete.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { deleteSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRoutes,
   offerAutoPromote,
   withGlobalFlags,
@@ -22,7 +22,7 @@ export default async function deleteRoute(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, deleteSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/disable.ts
+++ b/packages/cli/src/commands/routes/disable.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { disableSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRoute,
   offerAutoPromote,
   withGlobalFlags,
@@ -20,7 +20,7 @@ export default async function disable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, disableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/discard.ts
+++ b/packages/cli/src/commands/routes/discard.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   confirmAction,
   printDiffSummary,
   withGlobalFlags,
@@ -20,7 +20,7 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { editSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRoute,
   offerAutoPromote,
   withGlobalFlags,
@@ -40,7 +40,7 @@ export default async function edit(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, editSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/enable.ts
+++ b/packages/cli/src/commands/routes/enable.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { enableSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRoute,
   offerAutoPromote,
   withGlobalFlags,
@@ -20,7 +20,7 @@ export default async function enable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, enableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/export.ts
+++ b/packages/cli/src/commands/routes/export.ts
@@ -1,11 +1,8 @@
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { exportSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, withGlobalFlags } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
 import { getCommandName } from '../../util/pkg-name';
@@ -81,7 +78,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, exportSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/inspect.ts
+++ b/packages/cli/src/commands/routes/inspect.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { inspectSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   formatCondition,
   formatTransform,
   TRANSFORM_TYPE_LABELS,
@@ -33,7 +33,7 @@ export default async function inspect(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, inspectSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/list-versions.ts
+++ b/packages/cli/src/commands/routes/list-versions.ts
@@ -1,13 +1,10 @@
 import chalk from 'chalk';
 import ms from 'ms';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  ensureProjectLink,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, withGlobalFlags } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
@@ -22,7 +19,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/list.ts
+++ b/packages/cli/src/commands/routes/list.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import plural from 'pluralize';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   findVersionById,
   formatCondition,
   formatTransform,
@@ -29,7 +29,7 @@ export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   confirmAction,
   printDiffSummary,
   withGlobalFlags,
@@ -20,7 +20,7 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/reorder.ts
+++ b/packages/cli/src/commands/routes/reorder.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { reorderSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   resolveRoute,
   parsePosition,
   offerAutoPromote,
@@ -22,7 +22,7 @@ export default async function reorder(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, reorderSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
   confirmAction,
   validateRequiredArgs,
   printDiffSummary,
@@ -46,7 +46,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client);
+  const link = await ensureProjectLink(client, 'routes');
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -3,7 +3,6 @@ import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { getLinkedProject } from '../../util/projects/link';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
 import { outputAgentError, buildCommandWithYes } from '../../util/agent-output';
@@ -135,46 +134,6 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
-}
-
-export async function ensureProjectLink(client: Client) {
-  const link = await getLinkedProject(client);
-
-  if (link.status === 'error') {
-    return link.exitCode;
-  } else if (link.status === 'not_linked') {
-    if (client.nonInteractive) {
-      const flags = getGlobalFlagsOnlyFromArgs(client.argv.slice(2));
-      const cmd = getCommandNamePlain(`link ${flags.join(' ')}`.trim());
-      outputAgentError(
-        client,
-        {
-          status: AGENT_STATUS.ERROR,
-          reason: AGENT_REASON.NOT_LINKED,
-          userActionRequired: true,
-          message:
-            'Your codebase is not linked to a Vercel project. Run link first, then retry routes commands.',
-          next: [
-            {
-              command: cmd,
-              when: 'to link this directory to a project',
-            },
-          ],
-        },
-        1
-      );
-      return 1;
-    }
-    output.error(
-      `Your codebase isn't linked to a project on Vercel. Run ${getCommandName('link')} to begin.`
-    );
-    return 1;
-  }
-
-  client.config.currentTeam =
-    link.org.type === 'team' ? link.org.id : undefined;
-
-  return link;
 }
 
 export async function confirmAction(

--- a/packages/cli/src/util/projects/ensure-project-link.ts
+++ b/packages/cli/src/util/projects/ensure-project-link.ts
@@ -4,15 +4,19 @@ import { getGlobalFlagsOnlyFromArgs } from '../arg-common';
 import { outputAgentError } from '../agent-output';
 import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
 import { getCommandName, getCommandNamePlain } from '../pkg-name';
-import { getLinkedProject } from './link';
+import { resolveProjectContext } from './resolve-project-context';
 
 export type ProjectLinkCommand = 'redirects' | 'routes' | 'firewall';
 
 export async function ensureProjectLink(
   client: Client,
-  command: ProjectLinkCommand
+  command: ProjectLinkCommand,
+  projectName?: string
 ) {
-  const link = await getLinkedProject(client);
+  const link = await resolveProjectContext({
+    client,
+    projectNameOrId: projectName,
+  });
 
   if (link.status === 'error') {
     return link.exitCode;

--- a/packages/cli/src/util/projects/ensure-project-link.ts
+++ b/packages/cli/src/util/projects/ensure-project-link.ts
@@ -1,0 +1,65 @@
+import type Client from '../client';
+import output from '../../output-manager';
+import { getGlobalFlagsOnlyFromArgs } from '../arg-common';
+import { outputAgentError } from '../agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
+import { getCommandName, getCommandNamePlain } from '../pkg-name';
+import { getLinkedProject } from './link';
+
+export type ProjectLinkCommand = 'redirects' | 'routes' | 'firewall';
+
+export async function ensureProjectLink(
+  client: Client,
+  command: ProjectLinkCommand
+) {
+  const link = await getLinkedProject(client);
+
+  if (link.status === 'error') {
+    return link.exitCode;
+  } else if (link.status === 'not_linked') {
+    if (client.nonInteractive) {
+      if (command === 'redirects') {
+        const linkCmd = getCommandNamePlain('link');
+        outputAgentError(
+          client,
+          {
+            status: AGENT_STATUS.ERROR,
+            reason: AGENT_REASON.NOT_LINKED,
+            message: `Your codebase isn't linked to a project on Vercel. Run ${linkCmd} to begin.`,
+            next: [{ command: linkCmd }],
+          },
+          1
+        );
+      } else {
+        const flags = getGlobalFlagsOnlyFromArgs(client.argv.slice(2));
+        const cmd = getCommandNamePlain(`link ${flags.join(' ')}`.trim());
+        outputAgentError(
+          client,
+          {
+            status: AGENT_STATUS.ERROR,
+            reason: AGENT_REASON.NOT_LINKED,
+            userActionRequired: true,
+            message: `Your codebase is not linked to a Vercel project. Run link first, then retry ${command} commands.`,
+            next: [
+              {
+                command: cmd,
+                when: 'to link this directory to a project',
+              },
+            ],
+          },
+          1
+        );
+        return 1;
+      }
+    }
+    output.error(
+      `Your codebase isn't linked to a project on Vercel. Run ${getCommandName('link')} to begin.`
+    );
+    return 1;
+  }
+
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  return link;
+}

--- a/packages/cli/test/unit/util/projects/ensure-project-link.test.ts
+++ b/packages/cli/test/unit/util/projects/ensure-project-link.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
+import { defaultProject } from '../../../mocks/project';
 import { ensureProjectLink } from '../../../../src/util/projects/ensure-project-link';
 import * as agentOutput from '../../../../src/util/agent-output';
 import * as linkModule from '../../../../src/util/projects/link';
@@ -38,7 +39,7 @@ describe('ensureProjectLink', () => {
     const link = {
       status: 'linked' as const,
       org: { id: 'team_123', slug: 'acme', type: 'team' as const },
-      project: { id: 'project_123', name: 'site' },
+      project: { ...defaultProject, id: 'project_123', name: 'site' },
     };
     getLinkedProject.mockResolvedValue(link);
 

--- a/packages/cli/test/unit/util/projects/ensure-project-link.test.ts
+++ b/packages/cli/test/unit/util/projects/ensure-project-link.test.ts
@@ -3,10 +3,10 @@ import { client } from '../../../mocks/client';
 import { defaultProject } from '../../../mocks/project';
 import { ensureProjectLink } from '../../../../src/util/projects/ensure-project-link';
 import * as agentOutput from '../../../../src/util/agent-output';
-import * as linkModule from '../../../../src/util/projects/link';
+import * as projectContextModule from '../../../../src/util/projects/resolve-project-context';
 
-vi.mock('../../../../src/util/projects/link', () => ({
-  getLinkedProject: vi.fn(),
+vi.mock('../../../../src/util/projects/resolve-project-context', () => ({
+  resolveProjectContext: vi.fn(),
 }));
 
 vi.mock('../../../../src/util/agent-output', async importOriginal => {
@@ -18,7 +18,9 @@ vi.mock('../../../../src/util/agent-output', async importOriginal => {
   };
 });
 
-const getLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const resolveProjectContext = vi.mocked(
+  projectContextModule.resolveProjectContext
+);
 const outputAgentError = vi.mocked(agentOutput.outputAgentError);
 
 describe('ensureProjectLink', () => {
@@ -27,7 +29,7 @@ describe('ensureProjectLink', () => {
   });
 
   it('returns link errors unchanged', async () => {
-    getLinkedProject.mockResolvedValue({
+    resolveProjectContext.mockResolvedValue({
       status: 'error',
       exitCode: 2,
     });
@@ -41,14 +43,35 @@ describe('ensureProjectLink', () => {
       org: { id: 'team_123', slug: 'acme', type: 'team' as const },
       project: { ...defaultProject, id: 'project_123', name: 'site' },
     };
-    getLinkedProject.mockResolvedValue(link);
+    resolveProjectContext.mockResolvedValue(link);
 
     await expect(ensureProjectLink(client, 'routes')).resolves.toBe(link);
+    expect(resolveProjectContext).toHaveBeenCalledWith({
+      client,
+      projectNameOrId: undefined,
+    });
     expect(client.config.currentTeam).toBe('team_123');
   });
 
+  it('passes an explicit project to the shared resolver', async () => {
+    const link = {
+      status: 'linked' as const,
+      org: { id: 'team_123', slug: 'acme', type: 'team' as const },
+      project: { ...defaultProject, id: 'project_123', name: 'site' },
+    };
+    resolveProjectContext.mockResolvedValue(link);
+
+    await expect(
+      ensureProjectLink(client, 'routes', 'payments-api')
+    ).resolves.toBe(link);
+    expect(resolveProjectContext).toHaveBeenCalledWith({
+      client,
+      projectNameOrId: 'payments-api',
+    });
+  });
+
   it('preserves the redirects non-interactive error payload', async () => {
-    getLinkedProject.mockResolvedValue({
+    resolveProjectContext.mockResolvedValue({
       status: 'not_linked',
       org: null,
       project: null,
@@ -73,7 +96,7 @@ describe('ensureProjectLink', () => {
     'routes',
     'firewall',
   ] as const)('preserves the %s non-interactive error payload and global flags', async command => {
-    getLinkedProject.mockResolvedValue({
+    resolveProjectContext.mockResolvedValue({
       status: 'not_linked',
       org: null,
       project: null,

--- a/packages/cli/test/unit/util/projects/ensure-project-link.test.ts
+++ b/packages/cli/test/unit/util/projects/ensure-project-link.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { ensureProjectLink } from '../../../../src/util/projects/ensure-project-link';
+import * as agentOutput from '../../../../src/util/agent-output';
+import * as linkModule from '../../../../src/util/projects/link';
+
+vi.mock('../../../../src/util/projects/link', () => ({
+  getLinkedProject: vi.fn(),
+}));
+
+vi.mock('../../../../src/util/agent-output', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../../src/util/agent-output')>();
+  return {
+    ...actual,
+    outputAgentError: vi.fn(),
+  };
+});
+
+const getLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const outputAgentError = vi.mocked(agentOutput.outputAgentError);
+
+describe('ensureProjectLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns link errors unchanged', async () => {
+    getLinkedProject.mockResolvedValue({
+      status: 'error',
+      exitCode: 2,
+    });
+
+    await expect(ensureProjectLink(client, 'routes')).resolves.toBe(2);
+  });
+
+  it('returns the linked project and updates the current team', async () => {
+    const link = {
+      status: 'linked' as const,
+      org: { id: 'team_123', slug: 'acme', type: 'team' as const },
+      project: { id: 'project_123', name: 'site' },
+    };
+    getLinkedProject.mockResolvedValue(link);
+
+    await expect(ensureProjectLink(client, 'routes')).resolves.toBe(link);
+    expect(client.config.currentTeam).toBe('team_123');
+  });
+
+  it('preserves the redirects non-interactive error payload', async () => {
+    getLinkedProject.mockResolvedValue({
+      status: 'not_linked',
+      org: null,
+      project: null,
+    });
+    client.nonInteractive = true;
+
+    await expect(ensureProjectLink(client, 'redirects')).resolves.toBe(1);
+    expect(outputAgentError).toHaveBeenCalledWith(
+      client,
+      {
+        status: 'error',
+        reason: 'not_linked',
+        message:
+          "Your codebase isn't linked to a project on Vercel. Run vercel link to begin.",
+        next: [{ command: 'vercel link' }],
+      },
+      1
+    );
+  });
+
+  it.each([
+    'routes',
+    'firewall',
+  ] as const)('preserves the %s non-interactive error payload and global flags', async command => {
+    getLinkedProject.mockResolvedValue({
+      status: 'not_linked',
+      org: null,
+      project: null,
+    });
+    client.nonInteractive = true;
+    client.setArgv(command, 'list', '--cwd', '/tmp/site', '--non-interactive');
+
+    await expect(ensureProjectLink(client, command)).resolves.toBe(1);
+    expect(outputAgentError).toHaveBeenCalledWith(
+      client,
+      {
+        status: 'error',
+        reason: 'not_linked',
+        userActionRequired: true,
+        message: `Your codebase is not linked to a Vercel project. Run link first, then retry ${command} commands.`,
+        next: [
+          {
+            command: 'vercel link --cwd /tmp/site --non-interactive',
+            when: 'to link this directory to a project',
+          },
+        ],
+      },
+      1
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Routes, Redirects, and Firewall each had their own copy of the same “find the current project or explain how to link one” function. This PR moves that code into one shared helper.

```ts
ensureProjectLink(client, 'routes');
ensureProjectLink(client, 'redirects');
ensureProjectLink(client, 'firewall');
```

The helper also accepts an optional project name for the `--project` command PRs later in this stack:

```ts
ensureProjectLink(client, 'routes', projectName);
```

No command passes that third argument yet, so this PR does not change CLI behavior. Routes begins using it in #17114.

## Validation

- Focused `ensure-project-link` unit tests
- Routes, Redirects, and Firewall suites in the full stack

**Stack:** this PR → #17110
