### PR TITLE
refactor(cli): share subcommand argument helpers

### DIFF
--- a/.changeset/clean-command-arguments.md
+++ b/.changeset/clean-command-arguments.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Share subcommand parsing and required argument validation across CLI command families.

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -1,7 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { parseArguments } from '../../util/get-args';
-import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
@@ -9,29 +7,26 @@ import { outputAgentError, buildCommandWithYes } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
+import {
+  parseSubcommandArguments,
+  type ParsedSubcommandArguments,
+} from '../../util/command-arguments';
 import type { FirewallIpRule, FirewallRule } from '../../util/firewall/types';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import stamp from '../../util/output/stamp';
-
-export interface ParsedSubcommand {
-  args: string[];
-  flags: { [key: string]: any };
-}
 
 export async function parseSubcommandArgs(
   argv: string[],
   command: Command,
   client?: Client,
   commandPath?: string
-): Promise<ParsedSubcommand | number> {
+): Promise<ParsedSubcommandArguments | number> {
   let parsedArgs;
-  const flagsSpecification = getFlagsSpecification(command.options);
   const fullPath = commandPath || command.name;
 
   try {
-    // @ts-expect-error - TypeScript complains about the flags specification type
-    parsedArgs = parseArguments(argv, flagsSpecification);
+    parsedArgs = parseSubcommandArguments(argv, command);
   } catch (err) {
     if (client?.nonInteractive) {
       const rawMessage = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/redirects/promote.ts
+++ b/packages/cli/src/commands/redirects/promote.ts
@@ -15,12 +15,12 @@ import {
 import { promoteSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  validateRequiredArgs,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
   getRedirectPromoteSuggestionFlags,
 } from './shared';
+import { validateRequiredArguments } from '../../util/command-arguments';
 import { getCommandNamePlain } from '../../util/pkg-name';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import updateRedirectVersion from '../../util/redirects/update-redirect-version';
@@ -31,7 +31,7 @@ export default async function promote(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, promoteSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const error = validateRequiredArgs(parsed.args, ['version-id']);
+  const error = validateRequiredArguments(parsed.args, ['version-id']);
   if (error) {
     if (client.nonInteractive) {
       const afterPromote = getArgsAfterRedirectsSubcommand(

--- a/packages/cli/src/commands/redirects/remove.ts
+++ b/packages/cli/src/commands/redirects/remove.ts
@@ -15,13 +15,13 @@ import {
 import { removeSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  validateRequiredArgs,
   confirmAction,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
   getRedirectPromoteSuggestionFlags,
 } from './shared';
+import { validateRequiredArguments } from '../../util/command-arguments';
 import { getCommandNamePlain } from '../../util/pkg-name';
 import deleteRedirects from '../../util/redirects/delete-redirects';
 import getRedirects from '../../util/redirects/get-redirects';
@@ -33,7 +33,7 @@ export default async function remove(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, removeSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const error = validateRequiredArgs(parsed.args, ['source']);
+  const error = validateRequiredArguments(parsed.args, ['source']);
   if (error) {
     if (client.nonInteractive) {
       const flagParts = buildRedirectsSuggestionFlags(

--- a/packages/cli/src/commands/redirects/restore.ts
+++ b/packages/cli/src/commands/redirects/restore.ts
@@ -15,12 +15,12 @@ import {
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  validateRequiredArgs,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
   getRedirectPromoteSuggestionFlags,
 } from './shared';
+import { validateRequiredArguments } from '../../util/command-arguments';
 import { getCommandNamePlain } from '../../util/pkg-name';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import updateRedirectVersion from '../../util/redirects/update-redirect-version';
@@ -31,7 +31,7 @@ export default async function restore(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, restoreSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const error = validateRequiredArgs(parsed.args, ['version-id']);
+  const error = validateRequiredArguments(parsed.args, ['version-id']);
   if (error) {
     if (client.nonInteractive) {
       const afterRestore = getArgsAfterRedirectsSubcommand(

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -1,47 +1,30 @@
 import type Client from '../../util/client';
-import { parseArguments } from '../../util/get-args';
-import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
 import type { Command } from '../help';
+import {
+  parseSubcommandArguments,
+  type ParsedSubcommandArguments,
+} from '../../util/command-arguments';
 import {
   GLOBAL_CLI_FLAG_NAMES,
   globalCliFlagTakesValue,
 } from '../../util/arg-common';
 
-export interface ParsedSubcommand {
-  args: string[];
-  flags: { [key: string]: any };
-}
-
 export async function parseSubcommandArgs(
   argv: string[],
   command: Command
-): Promise<ParsedSubcommand | number> {
+): Promise<ParsedSubcommandArguments | number> {
   let parsedArgs;
-  const flagsSpecification = getFlagsSpecification(command.options);
 
   try {
-    // @ts-expect-error - TypeScript complains about the flags specification type
-    parsedArgs = parseArguments(argv, flagsSpecification);
+    parsedArgs = parseSubcommandArguments(argv, command);
   } catch (err) {
     printError(err);
     return 1;
   }
 
   return parsedArgs;
-}
-
-export function validateRequiredArgs(
-  args: string[],
-  required: string[]
-): string | null {
-  for (let i = 0; i < required.length; i++) {
-    if (!args[i]) {
-      return `Missing required argument: ${required[i]}`;
-    }
-  }
-  return null;
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -6,10 +6,10 @@ import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
   confirmAction,
-  validateRequiredArgs,
   printDiffSummary,
   findVersionById,
 } from './shared';
+import { validateRequiredArguments } from '../../util/command-arguments';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
 import getRoutes from '../../util/routes/get-routes';
@@ -21,7 +21,7 @@ export default async function restore(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, restoreSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const error = validateRequiredArgs(parsed.args, ['version-id']);
+  const error = validateRequiredArguments(parsed.args, ['version-id']);
   if (error) {
     if (client.nonInteractive) {
       outputAgentError(client, {

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -1,7 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { parseArguments } from '../../util/get-args';
-import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
@@ -14,6 +12,10 @@ import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
 import {
+  parseSubcommandArguments,
+  type ParsedSubcommandArguments,
+} from '../../util/command-arguments';
+import {
   getRouteTypeLabel,
   isTargetTransform,
   type RoutingRule,
@@ -21,11 +23,6 @@ import {
   type RouteVersion,
   type Transform,
 } from '../../util/routes/types';
-
-export interface ParsedSubcommand {
-  args: string[];
-  flags: { [key: string]: any };
-}
 
 /**
  * Shell-escape route identifier for suggested `next` commands. Uses single
@@ -51,13 +48,11 @@ export async function parseSubcommandArgs(
   argv: string[],
   command: Command,
   client?: Client
-): Promise<ParsedSubcommand | number> {
+): Promise<ParsedSubcommandArguments | number> {
   let parsedArgs;
-  const flagsSpecification = getFlagsSpecification(command.options);
 
   try {
-    // @ts-expect-error - TypeScript complains about the flags specification type
-    parsedArgs = parseArguments(argv, flagsSpecification);
+    parsedArgs = parseSubcommandArguments(argv, command);
   } catch (err) {
     if (client?.nonInteractive) {
       const rawMessage = err instanceof Error ? err.message : String(err);
@@ -159,18 +154,6 @@ export async function confirmAction(
   }
 
   return await client.input.confirm(message, false);
-}
-
-export function validateRequiredArgs(
-  args: string[],
-  required: string[]
-): string | null {
-  for (let i = 0; i < required.length; i++) {
-    if (!args[i]) {
-      return `Missing required argument: ${required[i]}`;
-    }
-  }
-  return null;
 }
 
 /**

--- a/packages/cli/src/util/command-arguments.ts
+++ b/packages/cli/src/util/command-arguments.ts
@@ -1,0 +1,32 @@
+import type { Command } from '../commands/help';
+import { parseArguments } from './get-args';
+import { getFlagsSpecification } from './get-flags-specification';
+
+export interface ParsedSubcommandArguments {
+  args: string[];
+  flags: { [key: string]: any };
+}
+
+/** Parse argv using a subcommand's declared options. */
+export function parseSubcommandArguments(
+  argv: string[],
+  command: Command
+): ParsedSubcommandArguments {
+  const flagsSpecification = getFlagsSpecification(command.options);
+
+  // @ts-expect-error - TypeScript complains about the flags specification type
+  return parseArguments(argv, flagsSpecification);
+}
+
+/** Return the first missing positional argument, if any. */
+export function validateRequiredArguments(
+  args: string[],
+  required: string[]
+): string | null {
+  for (let i = 0; i < required.length; i++) {
+    if (!args[i]) {
+      return `Missing required argument: ${required[i]}`;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Routes, Redirects, and Firewall repeated the same setup around `parseArguments()`. Routes and Redirects also repeated the same required-argument checks.

This PR shares those mechanics:

```ts
parseSubcommandArguments(argv, command);
validateRequiredArguments(parsed, command);
```

Each command family still controls its own error output:

- Routes and Firewall keep structured non-interactive errors.
- Redirects keeps normal `printError()` output.
- Routes keeps its special missing-`--ai` guidance.

## Validation

- Routes, Redirects, and Firewall suites: 679 tests
- Aggregate stacked rollout suite: 946 tests
- Biome lint and `git diff --check`

**Stack:** #17110 → this PR → #17112
