### PR TITLE
feat(cli): add --project support for env, target, flags, routes, redirects, firewall, and git

### DIFF
--- a/.changeset/bright-routes-select.md
+++ b/.changeset/bright-routes-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Routes commands to select a project explicitly with `--project`.

--- a/.changeset/bright-routes-select.md
+++ b/.changeset/bright-routes-select.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Allow Routes commands to select a project explicitly with `--project`.

--- a/.changeset/brisk-git-select.md
+++ b/.changeset/brisk-git-select.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Allow Git connect and disconnect commands to select a project explicitly with `--project`.
+Allow target, Flags rules, and Git commands to select a project explicitly with `--project`.

--- a/.changeset/brisk-git-select.md
+++ b/.changeset/brisk-git-select.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Allow target, Flags rules, and Git commands to select a project explicitly with `--project`.
+Allow target, Flags rules, and Git commands to select a project explicitly with `--project`, using shared subcommand parsing and required argument validation helpers.

--- a/.changeset/brisk-git-select.md
+++ b/.changeset/brisk-git-select.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Allow target, Flags rules, and Git commands to select a project explicitly with `--project`, using shared subcommand parsing and required argument validation helpers.
+Allow Env, Target, Flags rules, Routes, Redirects, Firewall, and Git commands to select a project explicitly with `--project`, including from an unlinked directory.

--- a/.changeset/brisk-git-select.md
+++ b/.changeset/brisk-git-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Git connect and disconnect commands to select a project explicitly with `--project`.

--- a/.changeset/calm-flags-select.md
+++ b/.changeset/calm-flags-select.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Allow Flags rules commands to select a project explicitly with `--project`.

--- a/.changeset/calm-flags-select.md
+++ b/.changeset/calm-flags-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Flags rules commands to select a project explicitly with `--project`.

--- a/.changeset/neat-envs-select.md
+++ b/.changeset/neat-envs-select.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Allow environment variable list, pull, run, add, remove, and update commands to select a project explicitly with `--project`.

--- a/.changeset/neat-envs-select.md
+++ b/.changeset/neat-envs-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow environment variable list, pull, run, add, remove, and update commands to select a project explicitly with `--project`.

--- a/.changeset/quick-redirects-select.md
+++ b/.changeset/quick-redirects-select.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Allow Redirects commands to select a project explicitly with `--project`.

--- a/.changeset/quick-redirects-select.md
+++ b/.changeset/quick-redirects-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Redirects commands to select a project explicitly with `--project`.

--- a/.changeset/steady-firewalls-select.md
+++ b/.changeset/steady-firewalls-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Firewall commands to select a project explicitly with `--project`.

--- a/.changeset/steady-firewalls-select.md
+++ b/.changeset/steady-firewalls-select.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Allow Firewall commands to select a project explicitly with `--project`.

--- a/.changeset/tidy-targets-select.md
+++ b/.changeset/tidy-targets-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow `target list` to select a project explicitly with `--project`.

--- a/.changeset/tidy-targets-select.md
+++ b/.changeset/tidy-targets-select.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Allow `target list` to select a project explicitly with `--project`.

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -28,7 +28,7 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { addSubcommand } from './command';
-import { getLinkedProject } from '../../util/projects/link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 import { determineAgent } from '@vercel/detect-agent';
 import { suggestNextCommands } from '../../util/suggest-next-commands';
 import getTeamById from '../../util/teams/get-team-by-id';
@@ -275,6 +275,7 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliFlagForce(opts['--force']);
   telemetryClient.trackCliFlagGuidance(opts['--guidance']);
   telemetryClient.trackCliFlagYes(opts['--yes']);
+  telemetryClient.trackCliOptionProject(opts['--project']);
 
   if (args.length > 3) {
     output.error(
@@ -300,7 +301,10 @@ export default async function add(client: Client, argv: string[]) {
 
   // Non-interactive: resolve link and choices once, then report all missing requirements in a single JSON (no iteration)
   if (client.nonInteractive) {
-    const link = await getLinkedProject(client);
+    const link = await resolveProjectContext({
+      client,
+      projectNameOrId: opts['--project'],
+    });
     if (link.status === 'error') {
       return link.exitCode;
     }
@@ -587,7 +591,10 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await getLinkedProject(client);
+  const link = await resolveProjectContext({
+    client,
+    projectNameOrId: opts['--project'],
+  });
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {
@@ -742,11 +749,14 @@ export default async function add(client: Client, argv: string[]) {
   ];
 
   if (!envGitBranch && choices.length === 0 && !opts['--force']) {
+    const projectFlag = opts['--project']
+      ? ` --project ${opts['--project']}`
+      : '';
     output.error(
       `The variable ${param(
         envName
       )} has already been added to all Environments. To remove, run ${getCommandName(
-        `env rm ${envName}`
+        `env rm ${envName}${projectFlag}`
       )}.`
     );
     return 1;
@@ -1149,7 +1159,13 @@ export default async function add(client: Client, argv: string[]) {
   const guidanceMode = parsedArgs.flags['--guidance'] ?? isAgent;
 
   if (guidanceMode) {
-    suggestNextCommands([getCommandName(`env ls`), getCommandName(`env pull`)]);
+    const projectFlag = opts['--project']
+      ? ` --project ${opts['--project']}`
+      : '';
+    suggestNextCommands([
+      getCommandName(`env ls${projectFlag}`),
+      getCommandName(`env pull${projectFlag}`),
+    ]);
   }
 
   return 0;

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -56,6 +56,7 @@ export const addSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'sensitive',
       description: 'Store the value as sensitive for Production or Preview',
@@ -164,6 +165,7 @@ export const removeSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description:
@@ -207,6 +209,7 @@ export const pullSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'environment',
       description: 'Set the Environment when pulling Environment Variables',
@@ -267,6 +270,7 @@ export const runSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'environment',
       description:
@@ -314,6 +318,7 @@ export const updateSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'sensitive',
       description: 'Update to a sensitive Environment Variable',

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -125,7 +125,7 @@ export default async function main(client: Client) {
         return 2;
       }
       telemetry.trackCliSubcommandRun(subcommandOriginal);
-      exitCode = await run(client);
+      exitCode = await run(client, telemetry);
       break;
     case 'update':
       if (needHelp) {

--- a/packages/cli/src/commands/env/ls.ts
+++ b/packages/cli/src/commands/env/ls.ts
@@ -132,11 +132,12 @@ export default async function ls(client: Client, argv: string[]) {
   if (!asJson) {
     const { isAgent } = await determineAgent();
     const guidanceMode = parsedArgs.flags['--guidance'] ?? isAgent;
-    if (guidanceMode && !projectName) {
+    if (guidanceMode) {
+      const projectFlag = projectName ? ` --project ${projectName}` : '';
       suggestNextCommands([
-        getCommandName('env add'),
-        getCommandName('env rm'),
-        getCommandName('env pull'),
+        getCommandName(`env add${projectFlag}`),
+        getCommandName(`env rm${projectFlag}`),
+        getCommandName(`env pull${projectFlag}`),
       ]);
     }
   }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -27,7 +27,8 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
-import { getLinkedProject } from '../../util/projects/link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
+import getDeployment from '../../util/get-deployment';
 import { isAPIError } from '../../util/errors-ts';
 import { performDeviceCodeFlow } from '../login/future';
 import {
@@ -147,8 +148,12 @@ export default async function pull(
   telemetryClient.trackCliOptionGitBranch(gitBranch);
   telemetryClient.trackCliOptionEnvironment(opts['--environment']);
   telemetryClient.trackCliOptionId(opts['--id']);
+  telemetryClient.trackCliOptionProject(opts['--project']);
 
-  const link = await getLinkedProject(client);
+  const link = await resolveProjectContext({
+    client,
+    projectNameOrId: opts['--project'],
+  });
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {
@@ -188,6 +193,16 @@ export default async function pull(
     link.org.type === 'team' ? link.org.id : undefined;
 
   const deploymentId = opts['--id'];
+
+  if (deploymentId && opts['--project']) {
+    const deployment = await getDeployment(client, link.org.slug, deploymentId);
+    if (deployment.projectId && deployment.projectId !== link.project.id) {
+      output.error(
+        `Deployment ${chalk.bold(deploymentId)} does not belong to project ${chalk.bold(link.project.name)}.`
+      );
+      return 1;
+    }
+  }
 
   const environment =
     parseTarget({
@@ -231,17 +246,21 @@ export async function envPullCommandLogic(
     output.log(`Overwriting existing ${chalk.bold(filename)} file`);
   } else if (exists && !skipConfirmation && !oidcTokenOnly) {
     if (client.nonInteractive) {
+      const preserved = getPreservedArgsForEnvPull(client.argv).filter(
+        arg => arg !== '--yes' && arg !== '-y'
+      );
+      const suffix = preserved.length > 0 ? ` ${preserved.join(' ')}` : '';
       outputActionRequired(client, {
         status: 'action_required',
         reason: 'env_file_exists',
         message: `File ${param(filename)} already exists and was not created by Vercel CLI. Use --yes to overwrite or specify a different filename.`,
         next: [
           {
-            command: getCommandNamePlain(`env pull ${filename} --yes`),
+            command: getCommandNamePlain(`env pull ${filename} --yes${suffix}`),
             when: 'Overwrite this file',
           },
           {
-            command: getCommandNamePlain('env pull <filename>'),
+            command: getCommandNamePlain(`env pull <filename>${suffix}`),
             when: 'Use a different filename',
           },
         ],

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -17,7 +17,7 @@ import { removeSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
-import { getLinkedProject } from '../../util/projects/link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 import {
   outputActionRequired,
   outputAgentError,
@@ -81,8 +81,12 @@ export default async function rm(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentEnvironment(envTarget);
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliFlagYes(opts['--yes']);
+  telemetryClient.trackCliOptionProject(opts['--project']);
 
-  const link = await getLinkedProject(client);
+  const link = await resolveProjectContext({
+    client,
+    projectNameOrId: opts['--project'],
+  });
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/run.ts
+++ b/packages/cli/src/commands/env/run.ts
@@ -6,10 +6,11 @@ import { printError } from '../../util/error';
 import { runSubcommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
-import { getLinkedProject } from '../../util/projects/link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 import { pullEnvRecords } from '../../util/env/get-env-records';
 import parseTarget from '../../util/parse-target';
 import { getCommandName } from '../../util/pkg-name';
+import type { EnvTelemetryClient } from '../../util/telemetry/commands/env';
 
 /**
  * Parses argv for the run subcommand, splitting on `--` to separate
@@ -44,7 +45,10 @@ export function needsHelpForRun(client: Client): boolean {
   }
 }
 
-export default async function run(client: Client): Promise<number> {
+export default async function run(
+  client: Client,
+  telemetry: EnvTelemetryClient
+): Promise<number> {
   const { vercelArgs, userCommand } = parseRunArgs(client.argv);
 
   let parsedArgs;
@@ -64,8 +68,14 @@ export default async function run(client: Client): Promise<number> {
     return 1;
   }
 
-  // Get the linked project
-  const link = await getLinkedProject(client);
+  // Resolve the selected project
+  const projectName = parsedArgs.flags['--project'];
+  telemetry.trackCliOptionProject(projectName);
+
+  const link = await resolveProjectContext({
+    client,
+    projectNameOrId: projectName,
+  });
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -22,9 +22,10 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { updateSubcommand } from './command';
-import { getLinkedProject } from '../../util/projects/link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 import getTeamById from '../../util/teams/get-team-by-id';
 import type { ProjectEnvVariable } from '@vercel-internals/types';
+import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 
 function selectedEnvTargetsDevelopment(env: ProjectEnvVariable): boolean {
   if (typeof env.target === 'string') return env.target === 'development';
@@ -180,7 +181,12 @@ export default async function update(client: Client, argv: string[]) {
     }
   }
 
-  const link = await getLinkedProject(client);
+  telemetryClient.trackCliOptionProject(opts['--project']);
+
+  const link = await resolveProjectContext({
+    client,
+    projectNameOrId: opts['--project'],
+  });
   if (link.status === 'error') {
     return link.exitCode;
   } else if (link.status === 'not_linked') {
@@ -233,23 +239,23 @@ export default async function update(client: Client, argv: string[]) {
   const matchingEnvs = envs.filter(r => r.key === envName);
 
   if (matchingEnvs.length === 0) {
+    const listFlags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+      preserveProject: true,
+    });
+    const listArgs = `env ls ${listFlags.join(' ')}`.trim();
     if (client.nonInteractive) {
       outputAgentError(
         client,
         {
           status: 'error',
           reason: 'env_not_found',
-          message: `The variable ${envName} was not found. Run ${getCommandNamePlain(
-            'env ls'
-          )} to see all available Environment Variables.`,
+          message: `The variable ${envName} was not found. Run ${getCommandNamePlain(listArgs)} to see all available Environment Variables.`,
         },
         1
       );
     }
     output.error(
-      `The variable ${param(envName)} was not found. Run ${getCommandName(
-        `env ls`
-      )} to see all available Environment Variables.`
+      `The variable ${param(envName)} was not found. Run ${getCommandName(listArgs)} to see all available Environment Variables.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/attack-mode/disable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/disable.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { attackModeDisableSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   withGlobalFlags,
 } from '../shared';
@@ -51,7 +51,7 @@ export default async function disable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/disable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/disable.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { attackModeDisableSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -48,7 +51,7 @@ export default async function disable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/disable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/disable.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { attackModeDisableSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -51,7 +47,11 @@ export default async function disable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/enable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/enable.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { attackModeEnableSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -65,7 +68,7 @@ export default async function enable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/enable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/enable.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { attackModeEnableSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -68,7 +64,11 @@ export default async function enable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/enable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/enable.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { attackModeEnableSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   withGlobalFlags,
 } from '../shared';
@@ -68,7 +68,7 @@ export default async function enable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/index.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/index.ts
@@ -15,20 +15,18 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   enable: getCommandAliases(attackModeEnableSubcommand),
   disable: getCommandAliases(attackModeDisableSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     attackModeSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/command.ts
+++ b/packages/cli/src/commands/firewall/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const overviewSubcommand = {
   name: 'overview',
@@ -8,6 +8,7 @@ export const overviewSubcommand = {
     "Show a summary of your project's firewall configuration, including active rules, IP blocks, bypasses, and any unpublished draft changes",
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -31,6 +32,7 @@ export const diffSubcommand = {
     'Show draft changes that have been made but are not yet published to production',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -53,7 +55,7 @@ export const publishSubcommand = {
   description:
     'Publish all draft firewall changes to production, making them live immediately',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Publish draft changes',
@@ -72,7 +74,7 @@ export const discardSubcommand = {
   description:
     'Permanently discard all unpublished draft changes, reverting to the current production configuration',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Discard draft changes',
@@ -93,6 +95,7 @@ export const systemBypassListSubcommand = {
     'List all system bypass rules that allow specific IPs to skip firewall checks',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -116,6 +119,7 @@ export const systemBypassAddSubcommand = {
     'Add a system bypass rule to allow a specific IP address to skip firewall checks. Takes effect immediately (no publish required)',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'domain',
       shorthand: null,
@@ -151,6 +155,7 @@ export const systemBypassRemoveSubcommand = {
     'Remove a system bypass rule so the IP is no longer exempt from firewall checks. Takes effect immediately (no publish required)',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'domain',
       shorthand: null,
@@ -204,6 +209,7 @@ export const ipBlocksListSubcommand = {
     'List all IP blocking rules, including any unpublished draft changes',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -227,6 +233,7 @@ export const ipBlocksBlockSubcommand = {
     'Block an IP address or CIDR range from accessing your project. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'hostname',
       shorthand: null,
@@ -267,6 +274,7 @@ export const ipBlocksUnblockSubcommand = {
     'Remove an IP blocking rule to allow the address to access your project again. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'id-or-ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'hostname',
       shorthand: null,
@@ -331,6 +339,7 @@ export const rulesListSubcommand = {
     'List all custom firewall rules, including any unpublished draft changes',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'expand',
       shorthand: 'e',
@@ -365,6 +374,7 @@ export const rulesInspectSubcommand = {
     'Show the full configuration of a custom firewall rule, including conditions, action, and rate limit settings',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -392,6 +402,7 @@ export const rulesAddSubcommand = {
     'Create a new custom firewall rule using AI, an interactive builder, JSON, or command-line flags. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name', required: false }],
   options: [
+    projectOption,
     {
       name: 'ai',
       shorthand: null,
@@ -537,6 +548,7 @@ export const rulesEditSubcommand = {
     'Edit an existing custom firewall rule using AI, an interactive editor, JSON, or command-line flags. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'ai',
       shorthand: null,
@@ -691,7 +703,7 @@ export const rulesEnableSubcommand = {
   description:
     'Enable a disabled custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Enable a rule',
@@ -706,7 +718,7 @@ export const rulesDisableSubcommand = {
   description:
     'Disable a custom firewall rule without removing it. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Disable a rule',
@@ -721,7 +733,7 @@ export const rulesRemoveSubcommand = {
   description:
     'Remove a custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Remove a rule',
@@ -737,6 +749,7 @@ export const rulesReorderSubcommand = {
     'Change the priority order of a custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'position',
       shorthand: null,
@@ -816,6 +829,7 @@ export const attackModeEnableSubcommand = {
     'Enable attack mode — all visitors will be shown a verification challenge before accessing your site. Takes effect immediately (no publish required)',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'duration',
       shorthand: null,
@@ -843,7 +857,7 @@ export const attackModeDisableSubcommand = {
   description:
     'Disable attack mode — visitors will no longer be challenged. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Disable attack mode',
@@ -879,7 +893,7 @@ export const systemMitigationsPauseSubcommand = {
   description:
     'Pause automatic DDoS protection and system-level traffic filtering for 24 hours. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Pause system mitigations',
@@ -894,7 +908,7 @@ export const systemMitigationsResumeSubcommand = {
   description:
     'Resume automatic DDoS protection and system-level traffic filtering. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Resume system mitigations',

--- a/packages/cli/src/commands/firewall/diff.ts
+++ b/packages/cli/src/commands/firewall/diff.ts
@@ -1,20 +1,22 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { diffSubcommand } from './command';
-import { parseSubcommandArgs, outputJson } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import { formatDiffOutput } from '../../util/firewall/format';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 
 export default async function diff(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, diffSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -50,7 +52,7 @@ export default async function diff(client: Client, argv: string[]) {
     output.print(formatDiffOutput(draft.changes, activeRulesMap));
     output.print('\n\n');
     output.print(
-      `  Run ${chalk.cyan(getCommandName('firewall publish'))} to publish, or ${chalk.cyan(getCommandName('firewall discard'))} to discard.\n\n`
+      `  Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard'))} to discard.\n\n`
     );
 
     return 0;

--- a/packages/cli/src/commands/firewall/diff.ts
+++ b/packages/cli/src/commands/firewall/diff.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { diffSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  outputJson,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import { formatDiffOutput } from '../../util/firewall/format';
 import { outputAgentError } from '../../util/agent-output';
@@ -16,7 +12,11 @@ export default async function diff(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, diffSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/diff.ts
+++ b/packages/cli/src/commands/firewall/diff.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { diffSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   outputJson,
   withGlobalFlags,
 } from './shared';
@@ -16,7 +16,7 @@ export default async function diff(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, diffSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/discard.ts
+++ b/packages/cli/src/commands/firewall/discard.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  confirmAction,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import deleteFirewallDraft from '../../util/firewall/delete-firewall-draft';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -18,7 +14,11 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/discard.ts
+++ b/packages/cli/src/commands/firewall/discard.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import deleteFirewallDraft from '../../util/firewall/delete-firewall-draft';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -15,7 +18,7 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/discard.ts
+++ b/packages/cli/src/commands/firewall/discard.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { discardSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   withGlobalFlags,
 } from './shared';
@@ -18,7 +18,7 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/index.ts
+++ b/packages/cli/src/commands/firewall/index.ts
@@ -29,6 +29,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { FirewallTelemetryClient } from '../../util/telemetry/commands/firewall';
+import { getProjectOptionFromArgs } from '../../util/arg-common';
 
 const COMMAND_CONFIG = {
   overview: getCommandAliases(overviewSubcommand),
@@ -83,6 +84,10 @@ export default async function main(client: Client) {
     );
   }
 
+  if (subcommand && !needHelp) {
+    telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
+  }
+
   switch (subcommand) {
     case 'overview':
       if (needHelp) {
@@ -119,27 +124,27 @@ export default async function main(client: Client) {
     case 'rules': {
       telemetry.trackCliSubcommandRules(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return rules(client, nestedArgs);
+      return rules(client, nestedArgs, telemetry);
     }
     case 'ip-blocks': {
       telemetry.trackCliSubcommandIpBlocks(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return ipBlocks(client, nestedArgs);
+      return ipBlocks(client, nestedArgs, telemetry);
     }
     case 'system-bypass': {
       telemetry.trackCliSubcommandSystemBypass(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return systemBypass(client, nestedArgs);
+      return systemBypass(client, nestedArgs, telemetry);
     }
     case 'attack-mode': {
       telemetry.trackCliSubcommandAttackMode(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return attackMode(client, nestedArgs);
+      return attackMode(client, nestedArgs, telemetry);
     }
     case 'system-mitigations': {
       telemetry.trackCliSubcommandSystemMitigations(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return systemMitigations(client, nestedArgs);
+      return systemMitigations(client, nestedArgs, telemetry);
     }
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/firewall/ip-blocks/block.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/block.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { ipBlocksBlockSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -63,7 +63,11 @@ export default async function block(client: Client, argv: string[]) {
     }
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/block.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/block.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksBlockSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -63,7 +63,7 @@ export default async function block(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/block.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/block.ts
@@ -5,7 +5,7 @@ import { ipBlocksBlockSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -63,7 +63,7 @@ export default async function block(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/index.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/index.ts
@@ -17,7 +17,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(ipBlocksListSubcommand),
@@ -25,13 +25,11 @@ const COMMAND_CONFIG = {
   unblock: getCommandAliases(ipBlocksUnblockSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(ipBlocksSubcommand.options);
   let parsedArgs;
   try {

--- a/packages/cli/src/commands/firewall/ip-blocks/list.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/list.ts
@@ -1,16 +1,18 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateIpRules,
   formatIpBlocksTable,
 } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function list(client: Client, argv: string[]) {
@@ -22,7 +24,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -64,7 +66,7 @@ export default async function list(client: Client, argv: string[]) {
     const ipChanges = changes.filter(c => c.action.startsWith('ip.')).length;
     if (ipChanges > 0) {
       output.print(
-        `\n  ${chalk.yellow(`${ipChanges} unpublished IP block change${ipChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(getCommandName('firewall publish'))} to publish.\n`
+        `\n  ${chalk.yellow(`${ipChanges} unpublished IP block change${ipChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish.\n`
       );
     } else {
       output.print(`\n  ${chalk.dim('Showing live configuration.')}\n`);

--- a/packages/cli/src/commands/firewall/ip-blocks/list.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/list.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { ipBlocksListSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  outputJson,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateIpRules,
@@ -24,7 +20,11 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/list.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/list.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { ipBlocksListSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   outputJson,
   withGlobalFlags,
 } from '../shared';
@@ -24,7 +24,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
@@ -5,7 +5,7 @@ import { ipBlocksUnblockSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   offerAutoPublish,
   resolveIpRule,
@@ -30,7 +30,7 @@ export default async function unblock(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
@@ -1,18 +1,17 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksUnblockSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   offerAutoPublish,
   resolveIpRule,
 } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
-import { getCommandName } from '../../../util/pkg-name';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
 
@@ -31,7 +30,7 @@ export default async function unblock(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -61,7 +60,7 @@ export default async function unblock(client: Client, argv: string[]) {
 
     if (matches.length === 0) {
       output.error(
-        `No IP block found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall ip-blocks list'))} to view all rules.`
+        `No IP block found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall ip-blocks list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { ipBlocksUnblockSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   offerAutoPublish,
   resolveIpRule,
@@ -30,7 +30,11 @@ export default async function unblock(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { overviewSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   outputJson,
   withGlobalFlags,
 } from './shared';
@@ -21,7 +21,7 @@ export default async function overview(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, overviewSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { overviewSubcommand } from './command';
-import { parseSubcommandArgs, outputJson } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import getBypass from '../../util/firewall/get-bypass';
 import {
@@ -18,7 +21,7 @@ export default async function overview(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, overviewSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { overviewSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  outputJson,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import getBypass from '../../util/firewall/get-bypass';
 import {
@@ -21,7 +17,11 @@ export default async function overview(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, overviewSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/publish.ts
+++ b/packages/cli/src/commands/firewall/publish.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  confirmAction,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -18,7 +14,11 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/publish.ts
+++ b/packages/cli/src/commands/firewall/publish.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -15,7 +18,7 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/publish.ts
+++ b/packages/cli/src/commands/firewall/publish.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { publishSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   withGlobalFlags,
 } from './shared';
@@ -18,7 +18,7 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/add-ai.ts
+++ b/packages/cli/src/commands/firewall/rules/add-ai.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
 import output from '../../../output-manager';
 import {
+  withGlobalFlags,
   detectExistingDraft,
   offerAutoPublish,
   printActionImpactWarning,

--- a/packages/cli/src/commands/firewall/rules/add.ts
+++ b/packages/cli/src/commands/firewall/rules/add.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesAddSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -87,7 +87,11 @@ export default async function add(client: Client, argv: string[]) {
     }
 
     // AI mode
-    const link = await requireProjectContext(client, parsed.flags['--project']);
+    const link = await requireProjectContext(
+      client,
+      'firewall',
+      parsed.flags['--project']
+    );
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -129,7 +133,11 @@ export default async function add(client: Client, argv: string[]) {
       ],
     });
 
-    const link = await requireProjectContext(client, parsed.flags['--project']);
+    const link = await requireProjectContext(
+      client,
+      'firewall',
+      parsed.flags['--project']
+    );
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;

--- a/packages/cli/src/commands/firewall/rules/add.ts
+++ b/packages/cli/src/commands/firewall/rules/add.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesAddSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -25,7 +25,6 @@ import type {
 } from '../../../util/firewall/types';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
-import { getCommandName } from '../../../util/pkg-name';
 import { handleAIAdd } from './add-ai';
 import { addInteractive } from './add-interactive';
 
@@ -88,7 +87,7 @@ export default async function add(client: Client, argv: string[]) {
     }
 
     // AI mode
-    const link = await ensureProjectLink(client, 'firewall');
+    const link = await ensureProjectLink(client, parsed.flags['--project']);
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -130,7 +129,7 @@ export default async function add(client: Client, argv: string[]) {
       ],
     });
 
-    const link = await ensureProjectLink(client, 'firewall');
+    const link = await ensureProjectLink(client, parsed.flags['--project']);
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -291,7 +290,7 @@ async function handleFlagAdd(
   const name = parsed.args[0] as string | undefined;
   if (!name) {
     output.error(
-      `Missing rule name. Provide as the first argument: ${chalk.cyan(getCommandName('firewall rules add "Rule name" --condition ...'))}`
+      `Missing rule name. Provide as the first argument: ${chalk.cyan(withGlobalFlags(client, 'firewall rules add "Rule name" --condition ...'))}`
     );
     return 1;
   }
@@ -399,7 +398,11 @@ async function createRule(
   parsed: { args: string[]; flags: Record<string, unknown> },
   rule: Omit<FirewallRule, 'id'>
 ): Promise<number> {
-  const link = await ensureProjectLink(client, 'firewall');
+  const projectName = parsed.flags['--project'];
+  const link = await ensureProjectLink(
+    client,
+    typeof projectName === 'string' ? projectName : undefined
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/add.ts
+++ b/packages/cli/src/commands/firewall/rules/add.ts
@@ -409,6 +409,7 @@ async function createRule(
   const projectName = parsed.flags['--project'];
   const link = await requireProjectContext(
     client,
+    'firewall',
     typeof projectName === 'string' ? projectName : undefined
   );
   if (typeof link === 'number') return link;

--- a/packages/cli/src/commands/firewall/rules/add.ts
+++ b/packages/cli/src/commands/firewall/rules/add.ts
@@ -5,7 +5,7 @@ import { rulesAddSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -87,7 +87,7 @@ export default async function add(client: Client, argv: string[]) {
     }
 
     // AI mode
-    const link = await ensureProjectLink(client, parsed.flags['--project']);
+    const link = await requireProjectContext(client, parsed.flags['--project']);
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -129,7 +129,7 @@ export default async function add(client: Client, argv: string[]) {
       ],
     });
 
-    const link = await ensureProjectLink(client, parsed.flags['--project']);
+    const link = await requireProjectContext(client, parsed.flags['--project']);
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -399,7 +399,7 @@ async function createRule(
   rule: Omit<FirewallRule, 'id'>
 ): Promise<number> {
   const projectName = parsed.flags['--project'];
-  const link = await ensureProjectLink(
+  const link = await requireProjectContext(
     client,
     typeof projectName === 'string' ? projectName : undefined
   );

--- a/packages/cli/src/commands/firewall/rules/disable.ts
+++ b/packages/cli/src/commands/firewall/rules/disable.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesDisableSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -25,7 +25,11 @@ export default async function disable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/disable.ts
+++ b/packages/cli/src/commands/firewall/rules/disable.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesDisableSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -15,7 +15,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function disable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -26,7 +25,7 @@ export default async function disable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -77,7 +76,7 @@ export default async function disable(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules disable <name-or-id>')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules disable <name-or-id>')}`
       );
       return 1;
     }
@@ -109,7 +108,7 @@ export default async function disable(client: Client, argv: string[]) {
   if (allMatches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/disable.ts
+++ b/packages/cli/src/commands/firewall/rules/disable.ts
@@ -5,7 +5,7 @@ import { rulesDisableSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -25,7 +25,7 @@ export default async function disable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/edit.ts
+++ b/packages/cli/src/commands/firewall/rules/edit.ts
@@ -5,7 +5,7 @@ import { rulesEditSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -42,7 +42,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   let identifier = parsed.args[0] as string | undefined;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/edit.ts
+++ b/packages/cli/src/commands/firewall/rules/edit.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesEditSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -30,7 +30,6 @@ import type { FirewallRule } from '../../../util/firewall/types';
 import { runInteractiveEditLoop } from './edit-interactive';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function edit(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -43,7 +42,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   let identifier = parsed.args[0] as string | undefined;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -64,7 +63,7 @@ export default async function edit(client: Client, argv: string[]) {
 
     if (client.nonInteractive || !client.stdin.isTTY) {
       output.error(
-        `Missing required argument: <name-or-id>. Run ${chalk.cyan(getCommandName('firewall rules list'))} to see all rules.`
+        `Missing required argument: <name-or-id>. Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to see all rules.`
       );
       return 1;
     }
@@ -96,7 +95,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   if (matches.length === 0) {
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/edit.ts
+++ b/packages/cli/src/commands/firewall/rules/edit.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesEditSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -42,7 +42,11 @@ export default async function edit(client: Client, argv: string[]) {
 
   let identifier = parsed.args[0] as string | undefined;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/enable.ts
+++ b/packages/cli/src/commands/firewall/rules/enable.ts
@@ -5,7 +5,7 @@ import { rulesEnableSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -26,7 +26,7 @@ export default async function enable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/enable.ts
+++ b/packages/cli/src/commands/firewall/rules/enable.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesEnableSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function enable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function enable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -78,7 +77,7 @@ export default async function enable(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules enable <name-or-id>')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules enable <name-or-id>')}`
       );
       return 1;
     }
@@ -110,7 +109,7 @@ export default async function enable(client: Client, argv: string[]) {
   if (allMatches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/enable.ts
+++ b/packages/cli/src/commands/firewall/rules/enable.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesEnableSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -26,7 +26,11 @@ export default async function enable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/index.ts
+++ b/packages/cli/src/commands/firewall/rules/index.ts
@@ -27,7 +27,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(rulesListSubcommand),
@@ -40,13 +40,11 @@ const COMMAND_CONFIG = {
   reorder: getCommandAliases(rulesReorderSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(rulesSubcommand.options);
   let parsedArgs;
   try {

--- a/packages/cli/src/commands/firewall/rules/inspect.ts
+++ b/packages/cli/src/commands/firewall/rules/inspect.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesInspectSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRule,
   outputJson,
   withGlobalFlags,
@@ -54,7 +54,11 @@ export default async function inspect(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/inspect.ts
+++ b/packages/cli/src/commands/firewall/rules/inspect.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { rulesInspectSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRule,
   outputJson,
   withGlobalFlags,
@@ -54,7 +54,7 @@ export default async function inspect(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/inspect.ts
+++ b/packages/cli/src/commands/firewall/rules/inspect.ts
@@ -1,13 +1,16 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesInspectSubcommand } from '../command';
-import { parseSubcommandArgs, resolveRule, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  resolveRule,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import { formatRuleDetail } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function inspect(client: Client, argv: string[]) {
@@ -46,12 +49,12 @@ export default async function inspect(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Rule name or ID is required. Usage: ${getCommandName('firewall rules inspect <name-or-id>')}`
+      `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules inspect <name-or-id>')}`
     );
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -88,7 +91,7 @@ export default async function inspect(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+        `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/rules/list.ts
+++ b/packages/cli/src/commands/firewall/rules/list.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesListSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  outputJson,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateRules,
@@ -25,7 +21,11 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/list.ts
+++ b/packages/cli/src/commands/firewall/rules/list.ts
@@ -1,17 +1,19 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateRules,
   formatRulesTable,
   formatRuleExpanded,
 } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function list(client: Client, argv: string[]) {
@@ -23,7 +25,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -104,7 +106,7 @@ export default async function list(client: Client, argv: string[]) {
     ).length;
     if (ruleChanges > 0) {
       output.print(
-        `\n  ${chalk.yellow(`${ruleChanges} unpublished rule change${ruleChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(getCommandName('firewall publish'))} to publish.\n`
+        `\n  ${chalk.yellow(`${ruleChanges} unpublished rule change${ruleChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish.\n`
       );
     } else {
       output.print(`\n  ${chalk.dim('Showing live configuration.')}\n`);

--- a/packages/cli/src/commands/firewall/rules/list.ts
+++ b/packages/cli/src/commands/firewall/rules/list.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { rulesListSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   outputJson,
   withGlobalFlags,
 } from '../shared';
@@ -25,7 +25,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/remove.ts
+++ b/packages/cli/src/commands/firewall/rules/remove.ts
@@ -5,7 +5,7 @@ import { rulesRemoveSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -26,7 +26,7 @@ export default async function remove(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/remove.ts
+++ b/packages/cli/src/commands/firewall/rules/remove.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesRemoveSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -26,7 +26,11 @@ export default async function remove(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/remove.ts
+++ b/packages/cli/src/commands/firewall/rules/remove.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesRemoveSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function remove(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function remove(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -78,7 +77,7 @@ export default async function remove(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules remove <name-or-id> --yes')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules remove <name-or-id> --yes')}`
       );
       return 1;
     }
@@ -104,7 +103,7 @@ export default async function remove(client: Client, argv: string[]) {
   if (matches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/reorder.ts
+++ b/packages/cli/src/commands/firewall/rules/reorder.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesReorderSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function reorder(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function reorder(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -76,7 +75,7 @@ export default async function reorder(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules reorder <name-or-id> --position N --yes')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules reorder <name-or-id> --position N --yes')}`
       );
       return 1;
     }
@@ -102,7 +101,7 @@ export default async function reorder(client: Client, argv: string[]) {
   if (matches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/reorder.ts
+++ b/packages/cli/src/commands/firewall/rules/reorder.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesReorderSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -26,7 +26,11 @@ export default async function reorder(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/reorder.ts
+++ b/packages/cli/src/commands/firewall/rules/reorder.ts
@@ -5,7 +5,7 @@ import { rulesReorderSubcommand } from '../command';
 import {
   withGlobalFlags,
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -26,7 +26,7 @@ export default async function reorder(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -19,7 +19,7 @@ import type { FirewallIpRule, FirewallRule } from '../../util/firewall/types';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import stamp from '../../util/output/stamp';
-import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
+import { requireProjectContext as requireProjectContextForCommand } from '../../util/projects/require-project-context';
 
 /**
  * Plain suggested command with global flags from argv (--cwd, --non-interactive, etc.).
@@ -76,8 +76,8 @@ export async function parseSubcommandArgs(
   return parsedArgs;
 }
 
-export function ensureProjectLink(client: Client, projectName?: string) {
-  return ensureProjectLinkForCommand(client, 'firewall', projectName);
+export function requireProjectContext(client: Client, projectName?: string) {
+  return requireProjectContextForCommand(client, 'firewall', projectName);
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -19,7 +19,6 @@ import type { FirewallIpRule, FirewallRule } from '../../util/firewall/types';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import stamp from '../../util/output/stamp';
-import { requireProjectContext as requireProjectContextForCommand } from '../../util/projects/require-project-context';
 
 /**
  * Plain suggested command with global flags from argv (--cwd, --non-interactive, etc.).
@@ -74,10 +73,6 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
-}
-
-export function requireProjectContext(client: Client, projectName?: string) {
-  return requireProjectContextForCommand(client, 'firewall', projectName);
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -1,9 +1,13 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
 import { printError } from '../../util/error';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
-import { outputAgentError, buildCommandWithYes } from '../../util/agent-output';
+import {
+  outputAgentError,
+  buildCommandWithYes,
+  withGlobalFlags as withClientGlobalFlags,
+} from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
@@ -15,6 +19,19 @@ import type { FirewallIpRule, FirewallRule } from '../../util/firewall/types';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import stamp from '../../util/output/stamp';
+import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
+
+/**
+ * Plain suggested command with global flags from argv (--cwd, --non-interactive, etc.).
+ */
+export function withGlobalFlags(
+  client: Client,
+  commandTemplate: string
+): string {
+  return withClientGlobalFlags(client, commandTemplate, {
+    preserveProject: true,
+  });
+}
 
 export async function parseSubcommandArgs(
   argv: string[],
@@ -30,7 +47,9 @@ export async function parseSubcommandArgs(
   } catch (err) {
     if (client?.nonInteractive) {
       const rawMessage = err instanceof Error ? err.message : String(err);
-      const flags = getGlobalFlagsFromArgs(client.argv.slice(2));
+      const flags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+        preserveProject: true,
+      });
       outputAgentError(
         client,
         {
@@ -55,6 +74,10 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
+}
+
+export function ensureProjectLink(client: Client, projectName?: string) {
+  return ensureProjectLinkForCommand(client, 'firewall', projectName);
 }
 
 export async function confirmAction(
@@ -117,7 +140,7 @@ export async function offerAutoPublish(
   opts: { teamId?: string; skipPrompts?: boolean }
 ): Promise<void> {
   output.print(
-    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(getCommandName('firewall publish'))} to make it live, or ${chalk.cyan(getCommandName('firewall discard'))} to undo.`)}\n`
+    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to make it live, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard'))} to undo.`)}\n`
   );
 
   if (
@@ -152,7 +175,7 @@ export async function offerAutoPublish(
     }
   } else if (hadExistingDraft) {
     output.warn(
-      `There are other draft changes. Review with ${chalk.cyan(getCommandName('firewall diff'))} before publishing.`
+      `There are other draft changes. Review with ${chalk.cyan(withGlobalFlags(client, 'firewall diff'))} before publishing.`
     );
   }
 }

--- a/packages/cli/src/commands/firewall/system-bypass/add.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/add.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { systemBypassAddSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   withGlobalFlags,
 } from '../shared';
@@ -60,7 +60,7 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/add.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/add.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { systemBypassAddSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import {
   validateBypassIp,
@@ -60,7 +56,11 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/add.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/add.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassAddSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import {
   validateBypassIp,
@@ -57,7 +60,7 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/index.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/index.ts
@@ -17,7 +17,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(systemBypassListSubcommand),
@@ -25,13 +25,11 @@ const COMMAND_CONFIG = {
   remove: getCommandAliases(systemBypassRemoveSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     systemBypassSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/system-bypass/list.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/list.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import getBypass from '../../../util/firewall/get-bypass';
 import {
   formatBypassTable,
@@ -21,7 +24,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/list.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/list.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { systemBypassListSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   outputJson,
   withGlobalFlags,
 } from '../shared';
@@ -24,7 +24,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/list.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/list.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { systemBypassListSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  outputJson,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, outputJson, withGlobalFlags } from '../shared';
 import getBypass from '../../../util/firewall/get-bypass';
 import {
   formatBypassTable,
@@ -24,7 +20,11 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/remove.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/remove.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { systemBypassRemoveSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import {
   validateBypassIp,
@@ -49,7 +45,11 @@ export default async function remove(client: Client, argv: string[]) {
     }
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/remove.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/remove.ts
@@ -1,16 +1,18 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassRemoveSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import {
   validateBypassIp,
   validateHostname,
 } from '../../../util/firewall/validate';
-import { getCommandName } from '../../../util/pkg-name';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
 
@@ -47,7 +49,7 @@ export default async function remove(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -89,7 +91,7 @@ export default async function remove(client: Client, argv: string[]) {
     const error = e as { status?: number; message?: string };
     if (error.status === 404) {
       output.error(
-        `No bypass rule found for ${chalk.bold(ip)}. Run ${chalk.cyan(getCommandName('firewall system-bypass list'))} to view all rules.`
+        `No bypass rule found for ${chalk.bold(ip)}. Run ${chalk.cyan(withGlobalFlags(client, 'firewall system-bypass list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/system-bypass/remove.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/remove.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { systemBypassRemoveSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   withGlobalFlags,
 } from '../shared';
@@ -49,7 +49,7 @@ export default async function remove(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/index.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/index.ts
@@ -15,20 +15,18 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   pause: getCommandAliases(systemMitigationsPauseSubcommand),
   resume: getCommandAliases(systemMitigationsResumeSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     systemMitigationsSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/system-mitigations/pause.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/pause.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { systemMitigationsPauseSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   withGlobalFlags,
 } from '../shared';
@@ -54,7 +54,7 @@ export default async function pause(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/pause.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/pause.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { systemMitigationsPauseSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -54,7 +50,11 @@ export default async function pause(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/pause.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/pause.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemMitigationsPauseSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -51,7 +54,7 @@ export default async function pause(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/resume.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/resume.ts
@@ -4,7 +4,7 @@ import output from '../../../output-manager';
 import { systemMitigationsResumeSubcommand } from '../command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   withGlobalFlags,
 } from '../shared';
@@ -54,7 +54,7 @@ export default async function resume(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/resume.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/resume.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemMitigationsResumeSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -51,7 +54,7 @@ export default async function resume(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/resume.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/resume.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
+import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { systemMitigationsResumeSubcommand } from '../command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  confirmAction,
-  withGlobalFlags,
-} from '../shared';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -54,7 +50,11 @@ export default async function resume(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -712,6 +712,7 @@ export const rulesListSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'environment',
       shorthand: 'e',
@@ -752,6 +753,7 @@ export const rulesAddSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'environment',
       shorthand: 'e',
@@ -811,6 +813,7 @@ export const rulesUpdateSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'environment',
       shorthand: 'e',
@@ -858,6 +861,7 @@ export const rulesRemoveSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'environment',
       shorthand: 'e',
@@ -892,6 +896,7 @@ export const rulesMoveSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'environment',
       shorthand: 'e',

--- a/packages/cli/src/commands/flags/rules-add.ts
+++ b/packages/cli/src/commands/flags/rules-add.ts
@@ -86,6 +86,7 @@ export default async function rulesAdd(
   telemetryClient.trackCliOptionStart(start);
   telemetryClient.trackCliOptionPosition(position);
   telemetryClient.trackCliOptionMessage(message);
+  telemetryClient.trackCliOptionProject(flags['--project']);
 
   const outcomeOptions = {
     variantSelector,
@@ -108,6 +109,7 @@ export default async function rulesAdd(
 
   try {
     const context = await resolveRulesCommandContext(client, {
+      projectName: parsedArgs.flags['--project'],
       flagArg,
       environment,
       promptMessage: 'Select an environment to add the rule to:',

--- a/packages/cli/src/commands/flags/rules-common.ts
+++ b/packages/cli/src/commands/flags/rules-common.ts
@@ -4,7 +4,7 @@ import { getCommandName } from '../../util/pkg-name';
 import { getFlag, getFlagSettings } from '../../util/flags/get-flags';
 import { resolveFlagEnvironment } from '../../util/flags/environment-variant';
 import { formatVariantForDisplay } from '../../util/flags/resolve-variant';
-import { getLinkedProject } from '../../util/projects/link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 import output from '../../output-manager';
 import type {
   Flag,
@@ -13,6 +13,7 @@ import type {
 } from '../../util/flags/types';
 
 interface ResolveRulesContextOptions {
+  projectName?: string;
   flagArg: string;
   environment?: string;
   promptMessage: string;
@@ -32,7 +33,10 @@ export async function resolveRulesCommandContext(
   client: Client,
   options: ResolveRulesContextOptions
 ): Promise<RulesCommandContext | { exitCode: number }> {
-  const link = await getLinkedProject(client);
+  const link = await resolveProjectContext({
+    client,
+    projectNameOrId: options.projectName,
+  });
   if (link.status === 'error') {
     return { exitCode: link.exitCode };
   } else if (link.status === 'not_linked') {

--- a/packages/cli/src/commands/flags/rules-ls.ts
+++ b/packages/cli/src/commands/flags/rules-ls.ts
@@ -45,6 +45,7 @@ export default async function rulesLs(
   telemetryClient.trackCliArgumentFlag(flagArg);
   telemetryClient.trackCliOptionEnvironment(environment);
   telemetryClient.trackCliFlagJson(json);
+  telemetryClient.trackCliOptionProject(flags['--project']);
 
   if (!flagArg) {
     output.error('Please provide a flag slug or ID to list rules for');
@@ -56,6 +57,7 @@ export default async function rulesLs(
 
   try {
     const context = await resolveRulesCommandContext(client, {
+      projectName: parsedArgs.flags['--project'],
       flagArg,
       environment,
       promptMessage: 'Select an environment to list rules for:',
@@ -84,11 +86,14 @@ export default async function rulesLs(
       ? `${context.environment} (reuses ${effectiveEnvironment.inheritedFrom})`
       : context.environment;
     if (rules.length === 0) {
+      const projectFlag = flags['--project']
+        ? ` --project ${flags['--project']}`
+        : '';
       output.log(
         `No conditional rules found for ${chalk.bold(context.flag.slug)} in ${environmentLabel} ${chalk.gray(lsStamp())}`
       );
       output.log(
-        `\nAdd one with: ${getCommandName('flags rules add ' + context.flag.slug + ' --environment ' + context.environment + ' --condition user.plan:eq:pro --variant on')}`
+        `\nAdd one with: ${getCommandName('flags rules add ' + context.flag.slug + ' --environment ' + context.environment + ' --condition user.plan:eq:pro --variant on' + projectFlag)}`
       );
       return 0;
     }

--- a/packages/cli/src/commands/flags/rules-move.ts
+++ b/packages/cli/src/commands/flags/rules-move.ts
@@ -53,6 +53,7 @@ export default async function rulesMove(
   telemetryClient.trackCliOptionEnvironment(environment);
   telemetryClient.trackCliOptionPosition(position);
   telemetryClient.trackCliOptionMessage(message);
+  telemetryClient.trackCliOptionProject(flags['--project']);
 
   if (!flagArg || !ruleId || position === undefined) {
     output.error(
@@ -66,6 +67,7 @@ export default async function rulesMove(
 
   try {
     const context = await resolveRulesCommandContext(client, {
+      projectName: parsedArgs.flags['--project'],
       flagArg,
       environment,
       promptMessage: 'Select an environment containing the rule:',

--- a/packages/cli/src/commands/flags/rules-remove.ts
+++ b/packages/cli/src/commands/flags/rules-remove.ts
@@ -52,6 +52,7 @@ export default async function rulesRemove(
   telemetryClient.trackCliArgumentRule(ruleId);
   telemetryClient.trackCliOptionEnvironment(environment);
   telemetryClient.trackCliOptionMessage(message);
+  telemetryClient.trackCliOptionProject(flags['--project']);
 
   if (!flagArg || !ruleId) {
     output.error('Please provide a flag slug or ID and rule ID to remove');
@@ -63,6 +64,7 @@ export default async function rulesRemove(
 
   try {
     const context = await resolveRulesCommandContext(client, {
+      projectName: parsedArgs.flags['--project'],
       flagArg,
       environment,
       promptMessage: 'Select an environment containing the rule:',

--- a/packages/cli/src/commands/flags/rules-update.ts
+++ b/packages/cli/src/commands/flags/rules-update.ts
@@ -90,6 +90,7 @@ export default async function rulesUpdate(
   telemetryClient.trackCliOptionStage(stageInputs);
   telemetryClient.trackCliOptionStart(start);
   telemetryClient.trackCliOptionMessage(message);
+  telemetryClient.trackCliOptionProject(flags['--project']);
 
   const outcomeOptions = {
     variantSelector,
@@ -112,6 +113,7 @@ export default async function rulesUpdate(
 
   try {
     const context = await resolveRulesCommandContext(client, {
+      projectName: parsedArgs.flags['--project'],
       flagArg,
       environment,
       promptMessage: 'Select an environment containing the rule:',

--- a/packages/cli/src/commands/git/command.ts
+++ b/packages/cli/src/commands/git/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { confirmOption, yesOption } from '../../util/arg-common';
+import { confirmOption, projectOption, yesOption } from '../../util/arg-common';
 
 export const connectSubcommand = {
   name: 'connect',
@@ -12,7 +12,7 @@ export const connectSubcommand = {
       required: false,
     },
   ],
-  options: [yesOption, confirmOption],
+  options: [projectOption, yesOption, confirmOption],
   examples: [
     {
       name: 'Connect your Vercel Project to your Git repository defined in your local `.git` config',
@@ -30,7 +30,7 @@ export const disconnectSubcommand = {
   aliases: [],
   description: 'Disconnect the Git repository from your Vercel Project',
   arguments: [],
-  options: [yesOption, confirmOption],
+  options: [projectOption, yesOption, confirmOption],
   examples: [
     {
       name: 'Disconnect the Git repository',

--- a/packages/cli/src/commands/git/connect.ts
+++ b/packages/cli/src/commands/git/connect.ts
@@ -20,6 +20,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { connectSubcommand } from './command';
 import { ensureLink } from '../../util/link/ensure-link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 
 interface ConnectArgParams {
   client: Client;
@@ -59,6 +60,7 @@ export default async function connect(client: Client, argv: string[]) {
   });
   telemetry.trackCliFlagConfirm(opts['--confirm']);
   telemetry.trackCliFlagYes(opts['--yes']);
+  telemetry.trackCliOptionProject(opts['--project']);
 
   if ('--confirm' in opts) {
     output.warn('`--confirm` is deprecated, please use `--yes` instead');
@@ -79,9 +81,21 @@ export default async function connect(client: Client, argv: string[]) {
   const repoArg = args[0];
   telemetry.trackCliArgumentGitUrl(repoArg);
 
-  const linkedProject = await ensureLink('git', client, client.cwd, {
-    autoConfirm: confirm,
-  });
+  let linkedProject;
+  if (opts['--project']) {
+    const resolvedProject = await resolveProjectContext({
+      client,
+      projectNameOrId: opts['--project'],
+    });
+    if (resolvedProject.status !== 'linked') {
+      return resolvedProject.status === 'error' ? resolvedProject.exitCode : 1;
+    }
+    linkedProject = resolvedProject;
+  } else {
+    linkedProject = await ensureLink('git', client, client.cwd, {
+      autoConfirm: confirm,
+    });
+  }
   if (typeof linkedProject === 'number') {
     return linkedProject;
   }

--- a/packages/cli/src/commands/git/connect.ts
+++ b/packages/cli/src/commands/git/connect.ts
@@ -20,7 +20,6 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { connectSubcommand } from './command';
 import { ensureLink } from '../../util/link/ensure-link';
-import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 
 interface ConnectArgParams {
   client: Client;
@@ -81,21 +80,12 @@ export default async function connect(client: Client, argv: string[]) {
   const repoArg = args[0];
   telemetry.trackCliArgumentGitUrl(repoArg);
 
-  let linkedProject;
-  if (opts['--project']) {
-    const resolvedProject = await resolveProjectContext({
-      client,
-      projectNameOrId: opts['--project'],
-    });
-    if (resolvedProject.status !== 'linked') {
-      return resolvedProject.status === 'error' ? resolvedProject.exitCode : 1;
-    }
-    linkedProject = resolvedProject;
-  } else {
-    linkedProject = await ensureLink('git', client, client.cwd, {
-      autoConfirm: confirm,
-    });
-  }
+  const projectName = opts['--project'];
+  const linkedProject = await ensureLink('git', client, client.cwd, {
+    autoConfirm: confirm,
+    projectName,
+    failIfNotFound: Boolean(projectName),
+  });
   if (typeof linkedProject === 'number') {
     return linkedProject;
   }

--- a/packages/cli/src/commands/git/disconnect.ts
+++ b/packages/cli/src/commands/git/disconnect.ts
@@ -10,7 +10,6 @@ import { printError } from '../../util/error';
 import { GitDisconnectTelemetryClient } from '../../util/telemetry/commands/git/disconnect';
 import type Client from '../../util/client';
 import { ensureLink } from '../../util/link/ensure-link';
-import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 
 export default async function disconnect(client: Client, argv: string[]) {
   let parsedArgs;
@@ -49,21 +48,12 @@ export default async function disconnect(client: Client, argv: string[]) {
   }
 
   const autoConfirm = Boolean(parsedArgs.flags['--yes']);
-  let linkedProject;
-  if (opts['--project']) {
-    const resolvedProject = await resolveProjectContext({
-      client,
-      projectNameOrId: opts['--project'],
-    });
-    if (resolvedProject.status !== 'linked') {
-      return resolvedProject.status === 'error' ? resolvedProject.exitCode : 1;
-    }
-    linkedProject = resolvedProject;
-  } else {
-    linkedProject = await ensureLink('git', client, client.cwd, {
-      autoConfirm,
-    });
-  }
+  const projectName = opts['--project'];
+  const linkedProject = await ensureLink('git', client, client.cwd, {
+    autoConfirm,
+    projectName,
+    failIfNotFound: Boolean(projectName),
+  });
   if (typeof linkedProject === 'number') {
     return linkedProject;
   }

--- a/packages/cli/src/commands/git/disconnect.ts
+++ b/packages/cli/src/commands/git/disconnect.ts
@@ -10,6 +10,7 @@ import { printError } from '../../util/error';
 import { GitDisconnectTelemetryClient } from '../../util/telemetry/commands/git/disconnect';
 import type Client from '../../util/client';
 import { ensureLink } from '../../util/link/ensure-link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 
 export default async function disconnect(client: Client, argv: string[]) {
   let parsedArgs;
@@ -31,6 +32,7 @@ export default async function disconnect(client: Client, argv: string[]) {
   });
   telemetry.trackCliFlagConfirm(opts['--confirm']);
   telemetry.trackCliFlagYes(opts['--yes']);
+  telemetry.trackCliOptionProject(opts['--project']);
 
   if ('--confirm' in opts) {
     output.warn('`--confirm` is deprecated, please use `--yes` instead');
@@ -47,9 +49,21 @@ export default async function disconnect(client: Client, argv: string[]) {
   }
 
   const autoConfirm = Boolean(parsedArgs.flags['--yes']);
-  const linkedProject = await ensureLink('git', client, client.cwd, {
-    autoConfirm,
-  });
+  let linkedProject;
+  if (opts['--project']) {
+    const resolvedProject = await resolveProjectContext({
+      client,
+      projectNameOrId: opts['--project'],
+    });
+    if (resolvedProject.status !== 'linked') {
+      return resolvedProject.status === 'error' ? resolvedProject.exitCode : 1;
+    }
+    linkedProject = resolvedProject;
+  } else {
+    linkedProject = await ensureLink('git', client, client.cwd, {
+      autoConfirm,
+    });
+  }
   if (typeof linkedProject === 'number') {
     return linkedProject;
   }

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { outputActionRequired } from '../../util/agent-output';
 import {
@@ -11,6 +10,7 @@ import {
 import { addSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   isValidUrl,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
@@ -30,7 +30,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { outputActionRequired } from '../../util/agent-output';
 import {
@@ -10,7 +11,6 @@ import {
 import { addSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   isValidUrl,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
@@ -30,7 +30,11 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'redirects',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -10,7 +10,7 @@ import {
 import { addSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   isValidUrl,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
@@ -30,7 +30,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/command.ts
+++ b/packages/cli/src/commands/redirects/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const listSubcommand = {
   name: 'list',
@@ -8,6 +8,7 @@ export const listSubcommand = {
     'List all redirects for the current project. These redirects apply to all deployments and environments. There may also be redirects defined in a deployment that are not listed here.',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'search',
       description: 'Search for redirects by source or destination',
@@ -73,7 +74,7 @@ export const listVersionsSubcommand = {
   aliases: ['ls-versions'],
   description: 'List all versions of redirects',
   arguments: [],
-  options: [],
+  options: [projectOption],
   examples: [
     {
       name: 'List all redirect versions',
@@ -97,6 +98,7 @@ export const addSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'status',
       description: 'HTTP status code (301, 302, 307, or 308)',
@@ -163,6 +165,7 @@ export const uploadSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip confirmation prompt',
@@ -206,6 +209,7 @@ export const removeSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when removing a redirect',
@@ -230,6 +234,7 @@ export const promoteSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when promoting',
@@ -254,6 +259,7 @@ export const restoreSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when restoring',

--- a/packages/cli/src/commands/redirects/index.ts
+++ b/packages/cli/src/commands/redirects/index.ts
@@ -25,6 +25,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { RedirectsTelemetryClient } from '../../util/telemetry/commands/redirects';
+import { getProjectOptionFromArgs } from '../../util/arg-common';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
@@ -75,6 +76,10 @@ export default async function main(client: Client) {
         columns: client.stderr.columns,
       })
     );
+  }
+
+  if (subcommand && !needHelp) {
+    telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/redirects/list-versions.ts
+++ b/packages/cli/src/commands/redirects/list-versions.ts
@@ -2,9 +2,10 @@ import chalk from 'chalk';
 import ms from 'ms';
 import plural from 'pluralize';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import { parseSubcommandArgs, requireProjectContext } from './shared';
+import { parseSubcommandArgs } from './shared';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import type { RedirectVersion } from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
@@ -14,7 +15,11 @@ export default async function listVersions(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listVersionsSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'redirects',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/list-versions.ts
+++ b/packages/cli/src/commands/redirects/list-versions.ts
@@ -2,10 +2,9 @@ import chalk from 'chalk';
 import ms from 'ms';
 import plural from 'pluralize';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import { parseSubcommandArgs, ensureProjectLink } from './shared';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import type { RedirectVersion } from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
@@ -15,7 +14,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listVersionsSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/list-versions.ts
+++ b/packages/cli/src/commands/redirects/list-versions.ts
@@ -4,7 +4,7 @@ import plural from 'pluralize';
 import type Client from '../../util/client';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import { parseSubcommandArgs, ensureProjectLink } from './shared';
+import { parseSubcommandArgs, requireProjectContext } from './shared';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import type { RedirectVersion } from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
@@ -14,7 +14,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listVersionsSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/list.ts
+++ b/packages/cli/src/commands/redirects/list.ts
@@ -1,21 +1,23 @@
 import chalk from 'chalk';
 import plural from 'pluralize';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  withGlobalFlags,
+} from './shared';
 import getRedirects from '../../util/redirects/get-redirects';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
 import formatTable from '../../util/format-table';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 
 export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -39,7 +41,7 @@ export default async function list(client: Client, argv: string[]) {
     if (!stagingVersion) {
       output.error(
         `No staging version found for ${chalk.bold(project.name)}. Run ${chalk.cyan(
-          'vercel redirects list-versions'
+          withGlobalFlags(client, 'redirects list-versions')
         )} to see available versions.`
       );
       return 1;
@@ -68,7 +70,7 @@ export default async function list(client: Client, argv: string[]) {
     if (!version) {
       output.error(
         `Version "${versionIdFlag}" not found. Run ${chalk.cyan(
-          'vercel redirects list-versions'
+          withGlobalFlags(client, 'redirects list-versions')
         )} to see available versions.`
       );
       return 1;
@@ -154,8 +156,8 @@ export default async function list(client: Client, argv: string[]) {
       !versionIdFlag
     ) {
       output.log(
-        `  ${getCommandNamePlain('redirects list')} shows production redirects only. ` +
-          `If you added redirects but do not see them here, they may still be staged only—run ${getCommandNamePlain('redirects list --staging')} to view staged changes.`
+        `  ${withGlobalFlags(client, 'redirects list')} shows production redirects only. ` +
+          `If you added redirects but do not see them here, they may still be staged only—run ${withGlobalFlags(client, 'redirects list --staging')} to view staged changes.`
       );
     }
 
@@ -174,7 +176,9 @@ export default async function list(client: Client, argv: string[]) {
     if (perPage) {
       command += ` --per-page ${perPage}`;
     }
-    output.log(`To display the next page, run ${getCommandName(command)}`);
+    output.log(
+      `To display the next page, run ${withGlobalFlags(client, command)}`
+    );
   }
 
   return 0;

--- a/packages/cli/src/commands/redirects/list.ts
+++ b/packages/cli/src/commands/redirects/list.ts
@@ -5,7 +5,7 @@ import output from '../../output-manager';
 import { listSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   withGlobalFlags,
 } from './shared';
 import getRedirects from '../../util/redirects/get-redirects';
@@ -17,7 +17,7 @@ export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/list.ts
+++ b/packages/cli/src/commands/redirects/list.ts
@@ -1,13 +1,10 @@
 import chalk from 'chalk';
 import plural from 'pluralize';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, withGlobalFlags } from './shared';
 import getRedirects from '../../util/redirects/get-redirects';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
@@ -17,7 +14,11 @@ export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'redirects',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/promote.ts
+++ b/packages/cli/src/commands/redirects/promote.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -14,7 +15,6 @@ import {
 import { promoteSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -68,7 +68,11 @@ export default async function promote(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'redirects',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/promote.ts
+++ b/packages/cli/src/commands/redirects/promote.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,6 +14,7 @@ import {
 import { promoteSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -68,7 +68,7 @@ export default async function promote(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/promote.ts
+++ b/packages/cli/src/commands/redirects/promote.ts
@@ -14,7 +14,7 @@ import {
 import { promoteSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -68,7 +68,7 @@ export default async function promote(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/remove.ts
+++ b/packages/cli/src/commands/redirects/remove.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,11 +14,13 @@ import {
 import { removeSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
   getRedirectPromoteSuggestionFlags,
+  withGlobalFlags,
 } from './shared';
 import { validateRequiredArguments } from '../../util/command-arguments';
 import { getCommandNamePlain } from '../../util/pkg-name';
@@ -59,7 +60,7 @@ export default async function remove(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -178,7 +179,7 @@ export default async function remove(client: Client, argv: string[]) {
         ],
       }),
       ...(existingStagingVersion && {
-        hint: `Review staged changes with ${getCommandNamePlain('redirects list --staging')} before promoting.`,
+        hint: `Review staged changes with ${withGlobalFlags(client, 'redirects list --staging')} before promoting.`,
       }),
     };
     client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);

--- a/packages/cli/src/commands/redirects/remove.ts
+++ b/packages/cli/src/commands/redirects/remove.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -14,7 +15,6 @@ import {
 import { removeSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
@@ -60,7 +60,11 @@ export default async function remove(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'redirects',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/remove.ts
+++ b/packages/cli/src/commands/redirects/remove.ts
@@ -14,7 +14,7 @@ import {
 import { removeSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
@@ -60,7 +60,7 @@ export default async function remove(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/restore.ts
+++ b/packages/cli/src/commands/redirects/restore.ts
@@ -14,7 +14,7 @@ import {
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -71,7 +71,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/restore.ts
+++ b/packages/cli/src/commands/redirects/restore.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,6 +14,7 @@ import {
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -71,7 +71,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/restore.ts
+++ b/packages/cli/src/commands/redirects/restore.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -14,7 +15,6 @@ import {
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -71,7 +71,11 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'redirects',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -2,14 +2,25 @@ import type Client from '../../util/client';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
 import type { Command } from '../help';
+import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
 } from '../../util/command-arguments';
 import {
-  GLOBAL_CLI_FLAG_NAMES,
-  globalCliFlagTakesValue,
+  getGlobalFlagsFromArgs,
+  getSameSubcommandSuggestionFlags,
 } from '../../util/arg-common';
+import { withGlobalFlags as withClientGlobalFlags } from '../../util/agent-output';
+
+export function withGlobalFlags(
+  client: Client,
+  commandTemplate: string
+): string {
+  return withClientGlobalFlags(client, commandTemplate, {
+    preserveProject: true,
+  });
+}
 
 export async function parseSubcommandArgs(
   argv: string[],
@@ -25,6 +36,10 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
+}
+
+export function ensureProjectLink(client: Client, projectName?: string) {
+  return ensureProjectLinkForCommand(client, 'redirects', projectName);
 }
 
 export async function confirmAction(
@@ -56,19 +71,6 @@ export function isValidUrl(url: string): boolean {
 }
 
 /**
- * Flags that belong only to redirects add/upload/remove. Forwarding them into
- * suggested `redirects list`, `redirects promote`, or `redirects list-versions`
- * commands causes parse errors for agents.
- */
-const REDIRECTS_SUBCOMMAND_EXCLUSIVE_FLAGS = new Set([
-  '--status',
-  '--case-sensitive',
-  '--preserve-query-params',
-  '--name',
-  '--overwrite',
-]);
-
-/**
  * Slice argv after `vercel` (i.e. client.argv.slice(2)) starting after the
  * given redirects subcommand name.
  */
@@ -87,44 +89,9 @@ export function getArgsAfterRedirectsSubcommand(
 export function getRedirectGlobalFlagsOnly(
   afterSubcommandArgs: string[]
 ): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < afterSubcommandArgs.length; i++) {
-    const a = afterSubcommandArgs[i];
-    if (!a.startsWith('-')) continue;
-
-    let name = a;
-    const hasEq = a.includes('=');
-    if (hasEq) {
-      name = a.slice(0, a.indexOf('='));
-    }
-
-    if (REDIRECTS_SUBCOMMAND_EXCLUSIVE_FLAGS.has(name)) {
-      if (
-        !hasEq &&
-        (name === '--status' || name === '--name') &&
-        i + 1 < afterSubcommandArgs.length &&
-        !afterSubcommandArgs[i + 1].startsWith('-')
-      ) {
-        i++;
-      }
-      continue;
-    }
-
-    if (!GLOBAL_CLI_FLAG_NAMES.has(name)) {
-      continue;
-    }
-
-    out.push(a);
-    if (!hasEq && globalCliFlagTakesValue(name)) {
-      if (
-        i + 1 < afterSubcommandArgs.length &&
-        !afterSubcommandArgs[i + 1].startsWith('-')
-      ) {
-        out.push(afterSubcommandArgs[++i]);
-      }
-    }
-  }
-  return out;
+  return getGlobalFlagsFromArgs(afterSubcommandArgs, {
+    preserveProject: true,
+  });
 }
 
 /**
@@ -151,7 +118,7 @@ export function buildRedirectsSuggestionFlags(
   options: { ensureYes?: boolean } = {}
 ): string[] {
   const after = getArgsAfterRedirectsSubcommand(fullArgs, subcommand);
-  const flagParts = after.filter(a => a.startsWith('-'));
+  const flagParts = getSameSubcommandSuggestionFlags(after);
   if (
     options.ensureYes !== false &&
     !flagParts.some(a => a === '--yes' || a === '-y')

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -2,7 +2,6 @@ import type Client from '../../util/client';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
 import type { Command } from '../help';
-import { requireProjectContext as requireProjectContextForCommand } from '../../util/projects/require-project-context';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
@@ -36,10 +35,6 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
-}
-
-export function requireProjectContext(client: Client, projectName?: string) {
-  return requireProjectContextForCommand(client, 'redirects', projectName);
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -2,7 +2,7 @@ import type Client from '../../util/client';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
 import type { Command } from '../help';
-import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
+import { requireProjectContext as requireProjectContextForCommand } from '../../util/projects/require-project-context';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
@@ -38,8 +38,8 @@ export async function parseSubcommandArgs(
   return parsedArgs;
 }
 
-export function ensureProjectLink(client: Client, projectName?: string) {
-  return ensureProjectLinkForCommand(client, 'redirects', projectName);
+export function requireProjectContext(client: Client, projectName?: string) {
+  return requireProjectContextForCommand(client, 'redirects', projectName);
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/redirects/upload.ts
+++ b/packages/cli/src/commands/redirects/upload.ts
@@ -15,7 +15,7 @@ import {
 import { uploadSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   getArgsAfterRedirectsSubcommand,
   getRedirectPromoteSuggestionFlags,
   buildRedirectsSuggestionFlags,
@@ -52,7 +52,7 @@ export default async function upload(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, uploadSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/upload.ts
+++ b/packages/cli/src/commands/redirects/upload.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'fs';
 import { basename } from 'path';
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -16,9 +15,11 @@ import {
 import { uploadSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   getArgsAfterRedirectsSubcommand,
   getRedirectPromoteSuggestionFlags,
   buildRedirectsSuggestionFlags,
+  withGlobalFlags,
 } from './shared';
 import { getCommandNamePlain } from '../../util/pkg-name';
 import stamp from '../../util/output/stamp';
@@ -51,7 +52,7 @@ export default async function upload(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, uploadSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -263,7 +264,7 @@ export default async function upload(client: Client, argv: string[]) {
           ],
         }),
         ...(existingStagingVersion && {
-          hint: `Review staged changes with ${getCommandNamePlain('redirects list --staging')} before promoting.`,
+          hint: `Review staged changes with ${withGlobalFlags(client, 'redirects list --staging')} before promoting.`,
         }),
       };
       client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);

--- a/packages/cli/src/commands/redirects/upload.ts
+++ b/packages/cli/src/commands/redirects/upload.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import { basename } from 'path';
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,7 +16,6 @@ import {
 import { uploadSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   getArgsAfterRedirectsSubcommand,
   getRedirectPromoteSuggestionFlags,
   buildRedirectsSuggestionFlags,
@@ -52,7 +52,11 @@ export default async function upload(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, uploadSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'redirects',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/add.ts
+++ b/packages/cli/src/commands/routes/add.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { addSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   parsePosition,
   offerAutoPromote,
   withGlobalFlags,
@@ -121,7 +121,11 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/add.ts
+++ b/packages/cli/src/commands/routes/add.ts
@@ -1,10 +1,14 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { addSubcommand } from './command';
-import { parseSubcommandArgs, parsePosition, offerAutoPromote } from './shared';
+import {
+  parseSubcommandArgs,
+  requireProjectContext,
+  parsePosition,
+  offerAutoPromote,
+  withGlobalFlags,
+} from './shared';
 import addRoute from '../../util/routes/add-route';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import { parseConditions } from '../../util/routes/parse-conditions';
@@ -20,7 +24,6 @@ import {
 } from '../../util/routes/ai-transform';
 import { runInteractiveEditLoop } from './edit-interactive';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { RoutesAddTelemetryClient } from '../../util/telemetry/commands/routes';
@@ -118,7 +121,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -286,7 +289,7 @@ export default async function add(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name is required when using --yes. Usage: ${getCommandName('routes add "Route Name" --src "/path" --action rewrite --dest "/destination" --yes')}`
+      `Route name is required when using --yes. Usage: ${withGlobalFlags(client, 'routes add "Route Name" --src "/path" --action rewrite --dest "/destination" --yes')}`
     );
     return 1;
   } else {
@@ -370,7 +373,7 @@ export default async function add(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Source path is required when using --yes. Usage: ${getCommandName('routes add "Name" --src "/path" --action rewrite --dest "/dest" --yes')}`
+      `Source path is required when using --yes. Usage: ${withGlobalFlags(client, 'routes add "Name" --src "/path" --action rewrite --dest "/dest" --yes')}`
     );
     return 1;
   } else {
@@ -1016,7 +1019,7 @@ async function handleAIAdd(
       );
     }
     output.error(
-      `Cannot interactively confirm route creation in a non-TTY environment. Use full route flags with ${getCommandName('routes add <name> --src ... --yes')}, or run in a TTY.`
+      `Cannot interactively confirm route creation in a non-TTY environment. Use full route flags with ${withGlobalFlags(client, 'routes add <name> --src ... --yes')}, or run in a TTY.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/routes/command.ts
+++ b/packages/cli/src/commands/routes/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const listSubcommand = {
   name: 'list',
@@ -8,6 +8,7 @@ export const listSubcommand = {
     'List all routing rules for the current project. These routes apply to all deployments and environments.',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'search',
       description: 'Search by name, description, source, or destination',
@@ -89,6 +90,7 @@ export const listVersionsSubcommand = {
   description: 'List all versions of routing rules',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'count',
       description: 'Number of versions to fetch (default: 20, max: 100)',
@@ -121,6 +123,7 @@ export const inspectSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'diff',
       description: 'Compare staged changes against production for this route',
@@ -156,6 +159,7 @@ export const addSubcommand = {
     },
   ],
   options: [
+    projectOption,
     // Path & Matching
     {
       name: 'src',
@@ -381,6 +385,7 @@ export const publishSubcommand = {
   description: 'Publish staged routing changes to production',
   arguments: [],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when publishing',
@@ -409,6 +414,7 @@ export const restoreSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when restoring',
@@ -432,6 +438,7 @@ export const discardSubcommand = {
   description: 'Discard staged routing changes',
   arguments: [],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when discarding',
@@ -461,6 +468,7 @@ export const deleteSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when deleting',
@@ -496,7 +504,7 @@ export const enableSubcommand = {
       required: true,
     },
   ],
-  options: [],
+  options: [projectOption],
   examples: [
     {
       name: 'Enable a route by name',
@@ -519,7 +527,7 @@ export const disableSubcommand = {
       required: true,
     },
   ],
-  options: [],
+  options: [projectOption],
   examples: [
     {
       name: 'Disable a route by name',
@@ -543,6 +551,7 @@ export const reorderSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'position',
       description:
@@ -606,6 +615,7 @@ export const editSubcommand = {
     },
   ],
   options: [
+    projectOption,
     // Metadata
     {
       name: 'name',
@@ -848,6 +858,7 @@ export const exportSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'output',
       description: 'Output file format: .json (default) or .ts',

--- a/packages/cli/src/commands/routes/delete.ts
+++ b/packages/cli/src/commands/routes/delete.ts
@@ -1,24 +1,27 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { deleteSubcommand } from './command';
-import { parseSubcommandArgs, resolveRoutes, offerAutoPromote } from './shared';
+import {
+  parseSubcommandArgs,
+  requireProjectContext,
+  resolveRoutes,
+  offerAutoPromote,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import deleteRoutes from '../../util/routes/delete-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { getRouteTypeLabel } from '../../util/routes/types';
 
 export default async function deleteRoute(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, deleteSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -48,7 +51,7 @@ export default async function deleteRoute(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `At least one route name or ID is required. Usage: ${getCommandName('routes delete <name-or-id> [...]')}`
+      `At least one route name or ID is required. Usage: ${withGlobalFlags(client, 'routes delete <name-or-id> [...]')}`
     );
     return 1;
   }

--- a/packages/cli/src/commands/routes/delete.ts
+++ b/packages/cli/src/commands/routes/delete.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { deleteSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRoutes,
   offerAutoPromote,
   withGlobalFlags,
@@ -21,7 +21,11 @@ export default async function deleteRoute(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, deleteSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/disable.ts
+++ b/packages/cli/src/commands/routes/disable.ts
@@ -1,22 +1,25 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { disableSubcommand } from './command';
-import { parseSubcommandArgs, resolveRoute, offerAutoPromote } from './shared';
+import {
+  parseSubcommandArgs,
+  requireProjectContext,
+  resolveRoute,
+  offerAutoPromote,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import editRoute from '../../util/routes/edit-route';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 
 export default async function disable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, disableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -47,7 +50,7 @@ export default async function disable(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name or ID is required. Usage: ${getCommandName('routes disable <name-or-id>')}`
+      `Route name or ID is required. Usage: ${withGlobalFlags(client, 'routes disable <name-or-id>')}`
     );
     return 1;
   }
@@ -99,7 +102,7 @@ export default async function disable(client: Client, argv: string[]) {
     }
     output.error(
       `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
+        withGlobalFlags(client, 'routes list')
       )} to see all routes.`
     );
     return 1;

--- a/packages/cli/src/commands/routes/disable.ts
+++ b/packages/cli/src/commands/routes/disable.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { disableSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRoute,
   offerAutoPromote,
   withGlobalFlags,
@@ -19,7 +19,11 @@ export default async function disable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, disableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/discard.ts
+++ b/packages/cli/src/commands/routes/discard.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   printDiffSummary,
   withGlobalFlags,
@@ -19,7 +19,11 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/discard.ts
+++ b/packages/cli/src/commands/routes/discard.ts
@@ -1,22 +1,25 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction, printDiffSummary } from './shared';
+import {
+  parseSubcommandArgs,
+  requireProjectContext,
+  confirmAction,
+  printDiffSummary,
+  withGlobalFlags,
+} from './shared';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
 import getRoutes from '../../util/routes/get-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 
 export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -31,7 +34,7 @@ export default async function discard(client: Client, argv: string[]) {
   if (!stagingVersion) {
     output.warn(
       `No staged changes to discard. Make changes first with ${chalk.cyan(
-        getCommandName('routes add')
+        withGlobalFlags(client, 'routes add')
       )}.`
     );
     return 0;

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -1,14 +1,14 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { editSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  requireProjectContext,
   resolveRoute,
   offerAutoPromote,
   shellQuoteRouteIdentifierForSuggestion,
+  withGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import {
@@ -32,7 +32,6 @@ import {
   printGeneratedRoutePreview,
 } from '../../util/routes/ai-transform';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { hasAnyTransformFlags } from '../../util/routes/interactive';
 import type { RoutingRule } from '../../util/routes/types';
 
@@ -40,7 +39,7 @@ export default async function edit(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, editSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -136,7 +135,7 @@ export default async function edit(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name or ID is required. Usage: ${getCommandName('routes edit <name-or-id>')}`
+      `Route name or ID is required. Usage: ${withGlobalFlags(client, 'routes edit <name-or-id>')}`
     );
     return 1;
   }
@@ -200,9 +199,7 @@ export default async function edit(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
-      )} to see all routes.`
+      `No route found matching "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'routes list'))} to see all routes.`
     );
     return 1;
   }
@@ -350,7 +347,7 @@ export default async function edit(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `No edit flags provided. When running non-interactively, use flags like --name, --dest, --src, etc. Run ${getCommandName('routes edit --help')} for all options.`
+        `No edit flags provided. When running non-interactively, use flags like --name, --dest, --src, etc. Run ${withGlobalFlags(client, 'routes edit --help')} for all options.`
       );
       return 1;
     }
@@ -534,7 +531,7 @@ async function handleAIEdit(
 
   if (!client.stdin.isTTY) {
     output.error(
-      `Cannot interactively confirm route changes in a non-TTY environment. Use ${getCommandName('routes edit <name-or-id> --ai "..." --yes')} to skip confirmation.`
+      `Cannot interactively confirm route changes in a non-TTY environment. Use ${withGlobalFlags(client, 'routes edit <name-or-id> --ai "..." --yes')} to skip confirmation.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { editSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRoute,
   offerAutoPromote,
   shellQuoteRouteIdentifierForSuggestion,
@@ -39,7 +39,11 @@ export default async function edit(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, editSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/enable.ts
+++ b/packages/cli/src/commands/routes/enable.ts
@@ -1,22 +1,25 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { enableSubcommand } from './command';
-import { parseSubcommandArgs, resolveRoute, offerAutoPromote } from './shared';
+import {
+  parseSubcommandArgs,
+  requireProjectContext,
+  resolveRoute,
+  offerAutoPromote,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import editRoute from '../../util/routes/edit-route';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 
 export default async function enable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, enableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -47,7 +50,7 @@ export default async function enable(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name or ID is required. Usage: ${getCommandName('routes enable <name-or-id>')}`
+      `Route name or ID is required. Usage: ${withGlobalFlags(client, 'routes enable <name-or-id>')}`
     );
     return 1;
   }
@@ -105,7 +108,7 @@ export default async function enable(client: Client, argv: string[]) {
     }
     output.error(
       `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
+        withGlobalFlags(client, 'routes list')
       )} to see all routes.`
     );
     return 1;

--- a/packages/cli/src/commands/routes/enable.ts
+++ b/packages/cli/src/commands/routes/enable.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { enableSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRoute,
   offerAutoPromote,
   withGlobalFlags,
@@ -19,7 +19,11 @@ export default async function enable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, enableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/export.ts
+++ b/packages/cli/src/commands/routes/export.ts
@@ -1,11 +1,8 @@
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { exportSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, withGlobalFlags } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
 import type { RoutingRule } from '../../util/routes/types';
@@ -80,7 +77,11 @@ export default async function exportRoutes(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, exportSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/export.ts
+++ b/packages/cli/src/commands/routes/export.ts
@@ -1,12 +1,13 @@
 import type Client from '../../util/client';
-import { withGlobalFlags } from '../../util/agent-output';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { exportSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import {
+  parseSubcommandArgs,
+  requireProjectContext,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
-import { getCommandName } from '../../util/pkg-name';
 import type { RoutingRule } from '../../util/routes/types';
 import type { RouteWithSrc } from '@vercel/routing-utils';
 
@@ -79,7 +80,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, exportSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -92,7 +93,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
 
   const validFormats = ['json', 'ts'];
   if (!validFormats.includes(format)) {
-    const msg = `Invalid output format: "${rawFormat}". Valid formats: ${validFormats.join(', ')}. Usage: ${getCommandName('routes export --output json')}`;
+    const msg = `Invalid output format: "${rawFormat}". Valid formats: ${validFormats.join(', ')}. Usage: ${withGlobalFlags(client, 'routes export --output json')}`;
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -118,7 +119,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
 
     if (routes.length === 0) {
       output.log(
-        `No routes found. Create one with ${getCommandName('routes add')}.`
+        `No routes found. Create one with ${withGlobalFlags(client, 'routes add')}.`
       );
       return 0;
     }
@@ -135,7 +136,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
       );
 
       if (routesToExport.length === 0) {
-        const msg = `No route found matching "${nameOrId}". Run ${getCommandName('routes list')} to see all routes.`;
+        const msg = `No route found matching "${nameOrId}". Run ${withGlobalFlags(client, 'routes list')} to see all routes.`;
         if (client.nonInteractive) {
           outputAgentError(client, {
             status: 'error',

--- a/packages/cli/src/commands/routes/index.ts
+++ b/packages/cli/src/commands/routes/index.ts
@@ -28,6 +28,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { RoutesTelemetryClient } from '../../util/telemetry/commands/routes';
+import { getProjectOptionFromArgs } from '../../util/arg-common';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
@@ -84,6 +85,10 @@ export default async function main(client: Client) {
         columns: client.stderr.columns,
       })
     );
+  }
+
+  if (subcommand && !needHelp) {
+    telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/routes/inspect.ts
+++ b/packages/cli/src/commands/routes/inspect.ts
@@ -1,19 +1,18 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { inspectSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  requireProjectContext,
   formatCondition,
   formatTransform,
   TRANSFORM_TYPE_LABELS,
+  withGlobalFlags,
 } from './shared';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import {
@@ -28,7 +27,7 @@ export default async function inspect(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, inspectSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -63,7 +62,7 @@ export default async function inspect(client: Client, argv: string[]) {
       return 1;
     }
     output.error(
-      `Missing route name or ID. Usage: ${chalk.cyan(getCommandName('routes inspect <name-or-id>'))}`
+      `Missing route name or ID. Usage: ${chalk.cyan(withGlobalFlags(client, 'routes inspect <name-or-id>'))}`
     );
     return 1;
   }
@@ -110,7 +109,7 @@ export default async function inspect(client: Client, argv: string[]) {
     }
     output.error(
       `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
+        withGlobalFlags(client, 'routes list')
       )} to see all routes.`
     );
     return 1;

--- a/packages/cli/src/commands/routes/inspect.ts
+++ b/packages/cli/src/commands/routes/inspect.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { inspectSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   formatCondition,
   formatTransform,
   TRANSFORM_TYPE_LABELS,
@@ -27,7 +27,11 @@ export default async function inspect(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, inspectSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/list-versions.ts
+++ b/packages/cli/src/commands/routes/list-versions.ts
@@ -1,13 +1,10 @@
 import chalk from 'chalk';
 import ms from 'ms';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import {
-  parseSubcommandArgs,
-  requireProjectContext,
-  withGlobalFlags,
-} from './shared';
+import { parseSubcommandArgs, withGlobalFlags } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
@@ -22,7 +19,11 @@ export default async function listVersions(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/list-versions.ts
+++ b/packages/cli/src/commands/routes/list-versions.ts
@@ -1,11 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import ms from 'ms';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import {
+  parseSubcommandArgs,
+  requireProjectContext,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
@@ -20,7 +22,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/list.ts
+++ b/packages/cli/src/commands/routes/list.ts
@@ -1,22 +1,21 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import plural from 'pluralize';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  requireProjectContext,
   findVersionById,
   formatCondition,
   formatTransform,
+  withGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
 import formatTable from '../../util/format-table';
-import { getCommandName } from '../../util/pkg-name';
 import {
   getRouteTypeLabel,
   getSrcSyntaxLabel,
@@ -29,7 +28,7 @@ export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -138,7 +137,7 @@ export default async function list(client: Client, argv: string[]) {
     const stagingVersion = versions.find(v => v.isStaging);
 
     if (!stagingVersion) {
-      const msg = `No staged changes to diff. Run ${getCommandName('routes add')} or ${getCommandName('routes edit')} to make changes.`;
+      const msg = `No staged changes to diff. Run ${withGlobalFlags(client, 'routes add')} or ${withGlobalFlags(client, 'routes edit')} to make changes.`;
       if (client.nonInteractive) {
         outputAgentError(client, {
           status: 'error',
@@ -152,9 +151,7 @@ export default async function list(client: Client, argv: string[]) {
         process.exit(1);
       }
       output.error(
-        `No staged changes to diff. Run ${chalk.cyan(
-          getCommandName('routes add')
-        )} or ${chalk.cyan(getCommandName('routes edit'))} to make changes.`
+        `No staged changes to diff. Run ${chalk.cyan(withGlobalFlags(client, 'routes add'))} or ${chalk.cyan(withGlobalFlags(client, 'routes edit'))} to make changes.`
       );
       return 1;
     }
@@ -169,7 +166,7 @@ export default async function list(client: Client, argv: string[]) {
     const { versions } = await getRouteVersions(client, project.id, {
       teamId,
     });
-    const result = findVersionById(versions, versionIdFlag);
+    const result = findVersionById(client, versions, versionIdFlag);
 
     if (result.error || !result.version) {
       const msg = result.error ?? 'Version not found';
@@ -178,7 +175,11 @@ export default async function list(client: Client, argv: string[]) {
           status: 'error',
           reason: 'not_found',
           message: msg,
-          next: [{ command: withGlobalFlags(client, 'routes list-versions') }],
+          next: [
+            {
+              command: withGlobalFlags(client, 'routes list-versions'),
+            },
+          ],
         });
         process.exit(1);
       }

--- a/packages/cli/src/commands/routes/list.ts
+++ b/packages/cli/src/commands/routes/list.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import plural from 'pluralize';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   findVersionById,
   formatCondition,
   formatTransform,
@@ -28,7 +28,11 @@ export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   printDiffSummary,
   withGlobalFlags,
@@ -19,7 +19,11 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -1,22 +1,25 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction, printDiffSummary } from './shared';
+import {
+  parseSubcommandArgs,
+  requireProjectContext,
+  confirmAction,
+  printDiffSummary,
+  withGlobalFlags,
+} from './shared';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
 import getRoutes from '../../util/routes/get-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 
 export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -30,7 +33,7 @@ export default async function publish(client: Client, argv: string[]) {
   if (!version) {
     output.warn(
       `No staged changes to publish. Make changes first with ${chalk.cyan(
-        getCommandName('routes add')
+        withGlobalFlags(client, 'routes add')
       )}.`
     );
     return 0;

--- a/packages/cli/src/commands/routes/reorder.ts
+++ b/packages/cli/src/commands/routes/reorder.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { reorderSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   resolveRoute,
   parsePosition,
   offerAutoPromote,
@@ -21,7 +21,11 @@ export default async function reorder(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, reorderSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/reorder.ts
+++ b/packages/cli/src/commands/routes/reorder.ts
@@ -1,28 +1,27 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { reorderSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  requireProjectContext,
   resolveRoute,
   parsePosition,
   offerAutoPromote,
   shellQuoteRouteIdentifierForSuggestion,
+  withGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stageRoutes from '../../util/routes/stage-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 
 export default async function reorder(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, reorderSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -53,7 +52,7 @@ export default async function reorder(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name or ID is required. Usage: ${getCommandName('routes reorder <name-or-id> --position <pos>')}`
+      `Route name or ID is required. Usage: ${withGlobalFlags(client, 'routes reorder <name-or-id> --position <pos>')}`
     );
     return 1;
   }
@@ -121,7 +120,7 @@ export default async function reorder(client: Client, argv: string[]) {
     }
     output.error(
       `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
+        withGlobalFlags(client, 'routes list')
       )} to see all routes.`
     );
     return 1;
@@ -209,7 +208,7 @@ export default async function reorder(client: Client, argv: string[]) {
             if (refIndex === -1) {
               output.error(
                 `Reference route "${pos.referenceId}" not found. Run ${chalk.cyan(
-                  getCommandName('routes list')
+                  withGlobalFlags(client, 'routes list')
                 )} to see route IDs.`
               );
               return 1;
@@ -220,7 +219,7 @@ export default async function reorder(client: Client, argv: string[]) {
             if (refIndex === -1) {
               output.error(
                 `Reference route "${pos.referenceId}" not found. Run ${chalk.cyan(
-                  getCommandName('routes list')
+                  withGlobalFlags(client, 'routes list')
                 )} to see route IDs.`
               );
               return 1;
@@ -232,7 +231,7 @@ export default async function reorder(client: Client, argv: string[]) {
           }
         } catch (e) {
           output.error(
-            `${e instanceof Error ? e.message : 'Invalid position'}. Usage: ${getCommandName('routes reorder <name-or-id> --position <pos>')}`
+            `${e instanceof Error ? e.message : 'Invalid position'}. Usage: ${withGlobalFlags(client, 'routes reorder <name-or-id> --position <pos>')}`
           );
           return 1;
         }

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -1,21 +1,21 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  requireProjectContext,
   confirmAction,
   printDiffSummary,
   findVersionById,
+  withGlobalFlags,
 } from './shared';
 import { validateRequiredArguments } from '../../util/command-arguments';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
 import getRoutes from '../../util/routes/get-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
-import { outputAgentError, withGlobalFlags } from '../../util/agent-output';
+import { outputAgentError } from '../../util/agent-output';
 
 export default async function restore(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, restoreSubcommand, client);
@@ -45,7 +45,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -57,7 +57,7 @@ export default async function restore(client: Client, argv: string[]) {
 
   const { versions } = await getRouteVersions(client, project.id, { teamId });
 
-  const result = findVersionById(versions, versionIdentifier);
+  const result = findVersionById(client, versions, versionIdentifier);
   if (result.error) {
     if (client.nonInteractive) {
       outputAgentError(client, {
@@ -89,7 +89,7 @@ export default async function restore(client: Client, argv: string[]) {
   }
 
   if (version.isLive) {
-    const liveMsg = `Version ${version.id.slice(0, 12)} is currently live. You cannot restore the live version. Run ${getCommandName('routes list-versions')} to see previous versions you can restore.`;
+    const liveMsg = `Version ${version.id.slice(0, 12)} is currently live. You cannot restore the live version. Run ${withGlobalFlags(client, 'routes list-versions')} to see previous versions you can restore.`;
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -104,14 +104,14 @@ export default async function restore(client: Client, argv: string[]) {
       `Version ${chalk.bold(
         version.id.slice(0, 12)
       )} is currently live. You cannot restore the live version.\nRun ${chalk.cyan(
-        getCommandName('routes list-versions')
+        withGlobalFlags(client, 'routes list-versions')
       )} to see previous versions you can restore.`
     );
     return 1;
   }
 
   if (version.isStaging) {
-    const stagingMsg = `Version ${version.id.slice(0, 12)} is staged. Use ${getCommandName('routes publish')} to publish it instead.`;
+    const stagingMsg = `Version ${version.id.slice(0, 12)} is staged. Use ${withGlobalFlags(client, 'routes publish')} to publish it instead.`;
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -126,7 +126,7 @@ export default async function restore(client: Client, argv: string[]) {
       `Version ${chalk.bold(
         version.id.slice(0, 12)
       )} is staged. Use ${chalk.cyan(
-        getCommandName('routes publish')
+        withGlobalFlags(client, 'routes publish')
       )} to publish it instead.`
     );
     return 1;

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  requireProjectContext,
   confirmAction,
   printDiffSummary,
   findVersionById,
@@ -45,7 +45,11 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(client, parsed.flags['--project']);
+  const link = await requireProjectContext(
+    client,
+    'routes',
+    parsed.flags['--project']
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -1,16 +1,17 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
 import { printError } from '../../util/error';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
 import {
   outputAgentError,
   buildCommandWithYes,
-  withGlobalFlags,
+  withGlobalFlags as withClientGlobalFlags,
 } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
+import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
@@ -23,6 +24,18 @@ import {
   type RouteVersion,
   type Transform,
 } from '../../util/routes/types';
+
+/**
+ * Plain suggested command with global flags from argv (--cwd, --non-interactive, etc.).
+ */
+export function withGlobalFlags(
+  client: Client,
+  commandTemplate: string
+): string {
+  return withClientGlobalFlags(client, commandTemplate, {
+    preserveProject: true,
+  });
+}
 
 /**
  * Shell-escape route identifier for suggested `next` commands. Uses single
@@ -56,7 +69,9 @@ export async function parseSubcommandArgs(
   } catch (err) {
     if (client?.nonInteractive) {
       const rawMessage = err instanceof Error ? err.message : String(err);
-      const flags = getGlobalFlagsFromArgs(client.argv.slice(2));
+      const flags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+        preserveProject: true,
+      });
       let message = rawMessage;
       let next: Array<{ command: string; when?: string }> = [
         {
@@ -122,6 +137,10 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
+}
+
+export function requireProjectContext(client: Client, projectName?: string) {
+  return ensureProjectLinkForCommand(client, 'routes', projectName);
 }
 
 export async function confirmAction(
@@ -283,7 +302,7 @@ export async function offerAutoPromote(
 
   // Always inform the user that changes are staged
   output.print(
-    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(getCommandName('routes publish'))} to make it live, or ${chalk.cyan(getCommandName('routes discard-staging'))} to undo.`)}\n`
+    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(withGlobalFlags(client, 'routes publish'))} to make it live, or ${chalk.cyan(withGlobalFlags(client, 'routes discard-staging'))} to undo.`)}\n`
   );
 
   if (!hadExistingStagingVersion && !opts.skipPrompts) {
@@ -314,7 +333,7 @@ export async function offerAutoPromote(
     }
   } else if (hadExistingStagingVersion) {
     output.warn(
-      `There are other staged changes. Review with ${chalk.cyan(getCommandName('routes list --diff'))} before promoting.`
+      `There are other staged changes. Review with ${chalk.cyan(withGlobalFlags(client, 'routes list --diff'))} before promoting.`
     );
   }
 }
@@ -464,9 +483,7 @@ export async function resolveRoutes(
         return null;
       }
       output.error(
-        `No route found matching "${identifier}". Run ${chalk.cyan(
-          getCommandName('routes list')
-        )} to see all routes.`
+        `No route found matching "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'routes list'))} to see all routes.`
       );
       return null;
     }
@@ -480,6 +497,7 @@ export async function resolveRoutes(
  * Find a version by ID, supporting partial ID matching.
  */
 export function findVersionById(
+  client: Client,
   versions: RouteVersion[],
   identifier: string
 ):
@@ -490,7 +508,7 @@ export function findVersionById(
   if (matchingVersions.length === 0) {
     return {
       error: `Version "${identifier}" not found. Run ${chalk.cyan(
-        getCommandName('routes list-versions')
+        withGlobalFlags(client, 'routes list-versions')
       )} to see available versions.`,
     };
   }

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -11,7 +11,6 @@ import {
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
-import { requireProjectContext as requireProjectContextForCommand } from '../../util/projects/require-project-context';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
@@ -137,10 +136,6 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
-}
-
-export function requireProjectContext(client: Client, projectName?: string) {
-  return requireProjectContextForCommand(client, 'routes', projectName);
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -11,7 +11,7 @@ import {
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
-import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
+import { requireProjectContext as requireProjectContextForCommand } from '../../util/projects/require-project-context';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
@@ -140,7 +140,7 @@ export async function parseSubcommandArgs(
 }
 
 export function requireProjectContext(client: Client, projectName?: string) {
-  return ensureProjectLinkForCommand(client, 'routes', projectName);
+  return requireProjectContextForCommand(client, 'routes', projectName);
 }
 
 export async function confirmAction(

--- a/packages/cli/src/commands/target/command.ts
+++ b/packages/cli/src/commands/target/command.ts
@@ -1,4 +1,4 @@
-import { formatOption, yesOption } from '../../util/arg-common';
+import { formatOption, projectOption, yesOption } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
 
 export const listSubcommand = {
@@ -8,6 +8,7 @@ export const listSubcommand = {
   arguments: [],
   options: [
     formatOption,
+    projectOption,
     {
       ...yesOption,
       description:

--- a/packages/cli/src/commands/target/list.ts
+++ b/packages/cli/src/commands/target/list.ts
@@ -5,7 +5,6 @@ import output from '../../output-manager';
 import { listSubcommand, targetCommand } from './command';
 import { validateLsArgs } from '../../util/validate-ls-args';
 import { ensureLink } from '../../util/link/ensure-link';
-import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 import { formatProject } from '../../util/projects/format-project';
 import { formatEnvironment } from '../../util/target/format-environment';
 import { validateJsonOutput } from '../../util/output-format';
@@ -91,20 +90,11 @@ export default async function list(client: Client, argv: string[]) {
   telemetry.trackCliOptionProject(projectName);
 
   const autoConfirm = !!parsedArgs.flags['--yes'];
-  let link;
-  if (projectName) {
-    const resolvedProject = await resolveProjectContext({
-      client,
-      cwd,
-      projectNameOrId: projectName,
-    });
-    if (resolvedProject.status !== 'linked') {
-      return resolvedProject.status === 'error' ? resolvedProject.exitCode : 1;
-    }
-    link = resolvedProject;
-  } else {
-    link = await ensureLink(targetCommand.name, client, cwd, { autoConfirm });
-  }
+  const link = await ensureLink(targetCommand.name, client, cwd, {
+    autoConfirm,
+    projectName,
+    failIfNotFound: Boolean(projectName),
+  });
   if (typeof link === 'number') {
     return link;
   }

--- a/packages/cli/src/commands/target/list.ts
+++ b/packages/cli/src/commands/target/list.ts
@@ -5,6 +5,7 @@ import output from '../../output-manager';
 import { listSubcommand, targetCommand } from './command';
 import { validateLsArgs } from '../../util/validate-ls-args';
 import { ensureLink } from '../../util/link/ensure-link';
+import { resolveProjectContext } from '../../util/projects/resolve-project-context';
 import { formatProject } from '../../util/projects/format-project';
 import { formatEnvironment } from '../../util/target/format-environment';
 import { validateJsonOutput } from '../../util/output-format';
@@ -86,11 +87,24 @@ export default async function list(client: Client, argv: string[]) {
   }
   const asJson = formatResult.jsonOutput;
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
+  const projectName = parsedArgs.flags['--project'];
+  telemetry.trackCliOptionProject(projectName);
 
   const autoConfirm = !!parsedArgs.flags['--yes'];
-  const link = await ensureLink(targetCommand.name, client, cwd, {
-    autoConfirm,
-  });
+  let link;
+  if (projectName) {
+    const resolvedProject = await resolveProjectContext({
+      client,
+      cwd,
+      projectNameOrId: projectName,
+    });
+    if (resolvedProject.status !== 'linked') {
+      return resolvedProject.status === 'error' ? resolvedProject.exitCode : 1;
+    }
+    link = resolvedProject;
+  } else {
+    link = await ensureLink(targetCommand.name, client, cwd, { autoConfirm });
+  }
   if (typeof link === 'number') {
     return link;
   }

--- a/packages/cli/src/util/projects/require-project-context.ts
+++ b/packages/cli/src/util/projects/require-project-context.ts
@@ -6,11 +6,15 @@ import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
 import { getCommandName, getCommandNamePlain } from '../pkg-name';
 import { resolveProjectContext } from './resolve-project-context';
 
-export type ProjectLinkCommand = 'redirects' | 'routes' | 'firewall';
+export type ProjectContextCommand = 'redirects' | 'routes' | 'firewall';
 
-export async function ensureProjectLink(
+/**
+ * Resolves an existing project context or reports that one is required.
+ * This helper never links the directory or creates a project.
+ */
+export async function requireProjectContext(
   client: Client,
-  command: ProjectLinkCommand,
+  command: ProjectContextCommand,
   projectName?: string
 ) {
   const link = await resolveProjectContext({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2655,12 +2655,13 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
   Options:
 
-       --force          Overwrite an existing variable for the same target                                                   
-       --guidance       Show command suggestions after completion                                                            
-       --no-sensitive   Store the value as non-sensitive when policy allows                                                  
-       --sensitive      Store the value as sensitive for Production or Preview                                               
-       --value <VALUE>  Set the variable value for non-interactive use; otherwise use stdin or the prompt                    
-  -y,  --yes            Skip the confirmation prompt when adding an Environment Variable                                     
+       --force                 Overwrite an existing variable for the same target                                            
+       --guidance              Show command suggestions after completion                                                     
+       --no-sensitive          Store the value as non-sensitive when policy allows                                           
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
+       --sensitive             Store the value as sensitive for Production or Preview                                        
+       --value <VALUE>         Set the variable value for non-interactive use; otherwise use stdin or the prompt             
+  -y,  --yes                   Skip the confirmation prompt when adding an Environment Variable                              
 
 
   Global Options:
@@ -2985,6 +2986,7 @@ exports[`help command > env help output snapshots > env pull help output snapsho
        --environment <TARGET>  Set the Environment when pulling Environment Variables                                        
        --git-branch <NAME>     Specify the Git branch to pull specific Environment Variables for                             
        --id <ID>               Pull environment variables for a specific deployment (e.g. dpl_xxx)                           
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
   -y,  --yes                   Skip the confirmation prompt when removing an environment variable                            
 
 
@@ -3024,7 +3026,8 @@ exports[`help command > env help output snapshots > env remove help output snaps
 
   Options:
 
-  -y,  --yes  Skip the confirmation prompt when removing an Environment Variable                                        
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
+  -y,  --yes                   Skip the confirmation prompt when removing an Environment Variable                            
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3069,7 +3069,8 @@ exports[`help command > git help output snapshots > git connect help output snap
 
   Options:
 
-  -y,  --yes  Accept default value for all prompts                                                                      
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
+  -y,  --yes                   Accept default value for all prompts                                                          
 
 
   Global Options:
@@ -3107,7 +3108,8 @@ exports[`help command > git help output snapshots > git disconnect help output s
 
   Options:
 
-  -y,  --yes  Accept default value for all prompts                                                                      
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
+  -y,  --yes                   Accept default value for all prompts                                                          
 
 
   Global Options:
@@ -7059,8 +7061,9 @@ exports[`help command > target help output snapshots > target list help output s
 
   Options:
 
-  -F,  --format <FORMAT>  Specify the output format (json)                                                              
-  -y,  --yes              Skip confirmation when linking is required (e.g. in non-interactive mode)                     
+  -F,  --format <FORMAT>       Specify the output format (json)                                                              
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
+  -y,  --yes                   Skip confirmation when linking is required (e.g. in non-interactive mode)                     
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import stripAnsi from 'strip-ansi';
 import env from '../../../../src/commands/env';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
 import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
@@ -52,6 +55,48 @@ describe('env add', () => {
         },
       ]);
     });
+  });
+
+  it('adds a variable to the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...testProject,
+      id: 'explicit-env-add',
+      name: 'explicit-env-add',
+      accountId: 'team_dummy',
+    });
+    client.setArgv(
+      'env',
+      'add',
+      'EXPLICIT_PROJECT_VAR',
+      'development',
+      '--value',
+      'value',
+      '--yes',
+      '--project',
+      'explicit-env-add'
+    );
+
+    await expect(env(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('EXPLICIT_PROJECT_VAR');
+  });
+
+  it('continues to use the linked project when --project is omitted', async () => {
+    client.setArgv(
+      'env',
+      'add',
+      'LINKED_PROJECT_VAR',
+      'development',
+      '--value',
+      'value',
+      '--yes'
+    );
+
+    await expect(env(client)).resolves.toEqual(0);
+    expect(stripAnsi(client.stderr.getFullOutput())).toMatch(
+      /Project\s+\S+\/vercel-env-pull/
+    );
   });
 
   describe('[name]', () => {

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -230,7 +230,7 @@ describe('env ls', () => {
       ]);
     });
 
-    it('suppresses unsupported guidance for an explicitly selected project', async () => {
+    it('preserves the explicitly selected project in guidance', async () => {
       const cwd = setupTmpDir('env-ls-project-guidance');
       client.cwd = cwd;
       useProject({
@@ -251,9 +251,9 @@ describe('env ls', () => {
 
       expect(exitCode).toEqual(0);
       const output = client.stderr.getFullOutput();
-      expect(output).not.toContain('vercel env add');
-      expect(output).not.toContain('vercel env rm');
-      expect(output).not.toContain('vercel env pull');
+      expect(output).toContain('vercel env add --project guidance-project');
+      expect(output).toContain('vercel env rm --project guidance-project');
+      expect(output).toContain('vercel env pull --project guidance-project');
     });
 
     it('reports an unknown explicit project instead of linking', async () => {

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -6,7 +6,10 @@ import env from '../../../../src/commands/env';
 import pull, {
   getAcrValuesFromWWWAuthenticate,
 } from '../../../../src/commands/env/pull';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
 import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
@@ -71,6 +74,121 @@ describe('env pull', () => {
         },
       ]);
     });
+  });
+
+  it('pulls variables from the project selected by --project', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+      accountId: 'team_dummy',
+    });
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    client.setArgv(
+      'env',
+      'pull',
+      '.env.test',
+      '--yes',
+      '--project',
+      'vercel-env-pull'
+    );
+
+    await expect(env(client)).resolves.toEqual(0);
+  });
+
+  it('rejects --project when --id belongs to another project', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+      accountId: 'team_dummy',
+    });
+    client.scenario.get('/v13/deployments/dpl_other', (_req, res) => {
+      res.json({ id: 'dpl_other', projectId: 'other-project' });
+    });
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    client.setArgv(
+      'env',
+      'pull',
+      '--id',
+      'dpl_other',
+      '--project',
+      'vercel-env-pull',
+      '--yes'
+    );
+
+    await expect(env(client)).resolves.toEqual(1);
+    await expect(client.stderr).toOutput(
+      'does not belong to project vercel-env-pull'
+    );
+  });
+
+  it('accepts --project when --id belongs to the selected project', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+      accountId: 'team_dummy',
+    });
+    client.scenario.get('/v13/deployments/dpl_same', (_req, res) => {
+      res.json({ id: 'dpl_same', projectId: 'vercel-env-pull' });
+    });
+    client.scenario.get('/v3/env/pull/dpl_same', (_req, res) => {
+      res.json({ env: {}, buildEnv: { DEPLOYMENT_VAR: 'value' } });
+    });
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    client.setArgv(
+      'env',
+      'pull',
+      '.env.test',
+      '--id',
+      'dpl_same',
+      '--project',
+      'vercel-env-pull',
+      '--yes'
+    );
+
+    await expect(env(client)).resolves.toEqual(0);
+  });
+
+  it('accepts --project when the deployment response omits projectId', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+      accountId: 'team_dummy',
+    });
+    client.scenario.get('/v13/deployments/dpl_legacy', (_req, res) => {
+      res.json({ id: 'dpl_legacy' });
+    });
+    client.scenario.get('/v3/env/pull/dpl_legacy', (_req, res) => {
+      res.json({ env: {}, buildEnv: { DEPLOYMENT_VAR: 'value' } });
+    });
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    client.setArgv(
+      'env',
+      'pull',
+      '.env.test',
+      '--id',
+      'dpl_legacy',
+      '--project',
+      'vercel-env-pull',
+      '--yes'
+    );
+
+    await expect(env(client)).resolves.toEqual(0);
   });
 
   it('should handle pulling', async () => {

--- a/packages/cli/test/unit/commands/env/rm.test.ts
+++ b/packages/cli/test/unit/commands/env/rm.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import env from '../../../../src/commands/env';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
@@ -50,6 +53,43 @@ describe('env rm', () => {
         },
       ]);
     });
+  });
+
+  it('removes a variable from the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject(
+      {
+        ...defaultProject,
+        id: 'explicit-env-rm',
+        name: 'explicit-env-rm',
+        accountId: 'team_dummy',
+      },
+      [
+        {
+          type: 'encrypted',
+          id: 'explicit-env',
+          key: 'ENVIRONMENT_NAME',
+          value: 'value',
+          target: ['development'],
+          gitBranch: undefined,
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    client.setArgv(
+      'env',
+      'rm',
+      'ENVIRONMENT_NAME',
+      'development',
+      '--yes',
+      '--project',
+      'explicit-env-rm'
+    );
+
+    await expect(env(client)).resolves.toEqual(0);
   });
 
   describe('non-interactive', () => {

--- a/packages/cli/test/unit/commands/env/run.test.ts
+++ b/packages/cli/test/unit/commands/env/run.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import env from '../../../../src/commands/env';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
 import { defaultProject, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
@@ -127,6 +130,78 @@ describe('env run', () => {
   });
 
   describe('running commands', () => {
+    it('runs with variables from the project selected by --project', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+        accountId: 'team_dummy',
+      });
+      client.cwd = setupTmpDir();
+      client.config.currentTeam = 'team_dummy';
+      client.setArgv(
+        'env',
+        'run',
+        '--project',
+        'vercel-env-pull',
+        '--',
+        'echo',
+        'hello'
+      );
+
+      await expect(env(client)).resolves.toEqual(0);
+      expect(execa).toHaveBeenCalledWith(
+        'echo',
+        ['hello'],
+        expect.objectContaining({ cwd: client.cwd })
+      );
+    });
+
+    it('ignores scope flags passed to the child command', async () => {
+      useUser();
+      useTeams('team_dummy');
+      const project = {
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+        accountId: 'team_dummy',
+      };
+      let requestedTeamId: unknown;
+
+      client.scenario.get('/v9/projects/vercel-env-pull', (req, res) => {
+        requestedTeamId = req.query.teamId;
+        if (requestedTeamId !== 'team_dummy') {
+          res.status(404).send();
+          return;
+        }
+        res.json(project);
+      });
+      useProject(project);
+
+      client.cwd = setupUnitFixture('vercel-env-pull');
+      client.config.currentTeam = 'team_current';
+      client.setArgv(
+        'env',
+        'run',
+        '--project',
+        'vercel-env-pull',
+        '--',
+        'child',
+        '--scope',
+        'child-scope'
+      );
+
+      await expect(env(client)).resolves.toEqual(0);
+      expect(requestedTeamId).toEqual('team_dummy');
+      expect(execa).toHaveBeenCalledWith(
+        'child',
+        ['--scope', 'child-scope'],
+        expect.objectContaining({ cwd: client.cwd })
+      );
+    });
+
     it('should run command with development env vars by default', async () => {
       useUser();
       useTeams('team_dummy');

--- a/packages/cli/test/unit/commands/env/update.test.ts
+++ b/packages/cli/test/unit/commands/env/update.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import env from '../../../../src/commands/env';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
 import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
@@ -33,6 +36,46 @@ describe('env update', () => {
         },
       ]
     );
+  });
+
+  it('updates a variable in the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject(
+      {
+        ...defaultProject,
+        id: 'explicit-env-update',
+        name: 'explicit-env-update',
+        accountId: 'team_dummy',
+      },
+      [
+        {
+          type: 'encrypted',
+          id: 'test-env-id-123',
+          key: 'TEST_VAR',
+          value: 'test-value',
+          target: ['production'],
+          gitBranch: undefined,
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+          customEnvironmentIds: [],
+        },
+      ]
+    );
+    client.setArgv(
+      'env',
+      'update',
+      'TEST_VAR',
+      'production',
+      '--value',
+      'updated',
+      '--yes',
+      '--project',
+      'explicit-env-update'
+    );
+
+    await expect(env(client)).resolves.toEqual(0);
   });
 
   it('should show error when environment variable does not exist', async () => {

--- a/packages/cli/test/unit/commands/firewall/overview.test.ts
+++ b/packages/cli/test/unit/commands/firewall/overview.test.ts
@@ -13,7 +13,10 @@ import {
 } from '../../../mocks/firewall';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('firewall overview', () => {
   beforeEach(() => {
@@ -62,6 +65,23 @@ describe('firewall overview', () => {
     expect(fullOutput).toContain('2 active, 1 inactive (3 total)');
     expect(fullOutput).toContain('IP Blocks');
     expect(fullOutput).toContain('System Bypass');
+  });
+
+  it('shows the overview for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-firewall',
+      name: 'explicit-firewall',
+      accountId: 'team_dummy',
+    });
+    useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
+    useGetBypass([]);
+    client.setArgv('firewall', 'overview', '--project', 'explicit-firewall');
+
+    await expect(firewall(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Enabled');
   });
 
   it('should show firewall overview when disabled', async () => {

--- a/packages/cli/test/unit/commands/firewall/rules-enable.test.ts
+++ b/packages/cli/test/unit/commands/firewall/rules-enable.test.ts
@@ -13,7 +13,10 @@ import {
 } from '../../../mocks/firewall';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('firewall rules enable', () => {
   beforeEach(() => {
@@ -45,6 +48,38 @@ describe('firewall rules enable', () => {
 
     expect(lastPatchBody.action).toBe('rules.update');
     expect(lastPatchBody.value.active).toBe(true);
+  });
+
+  it('enables a rule for the project selected by --project', async () => {
+    const active = createConfig({ rules: [createRule(3)] });
+    useListFirewallConfigs(active, null);
+    usePatchDraft();
+    useActivateConfig();
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-firewall',
+      name: 'explicit-firewall',
+      accountId: 'team_dummy',
+    });
+    client.setArgv(
+      'firewall',
+      'rules',
+      'enable',
+      'Test Rule 3',
+      '--project',
+      'explicit-firewall',
+      '--yes'
+    );
+
+    await expect(firewall(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Enabled');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'subcommand:rules', value: 'rules' },
+      { key: 'subcommand:rules:enable', value: 'enable' },
+    ]);
   });
 
   it('should report already enabled', async () => {

--- a/packages/cli/test/unit/commands/flags/rules.test.ts
+++ b/packages/cli/test/unit/commands/flags/rules.test.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import flags from '../../../../src/commands/flags';
 import { formatFlagConditionComparatorList } from '../../../../src/util/flags/comparators';
 import type { Flag, UpdateFlagRequest } from '../../../../src/util/flags/types';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
 import {
   defaultFlagSettings,
@@ -103,6 +106,34 @@ describe('flags rules', () => {
       'rule_1',
       'rule_2',
     ]);
+  });
+
+  it('lists rules for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-flags-rules',
+      name: 'explicit-flags-rules',
+      accountId: 'team_dummy',
+    });
+    client.setArgv(
+      'flags',
+      'rules',
+      'ls',
+      'my-feature',
+      '--environment',
+      'production',
+      '--project',
+      'explicit-flags-rules',
+      '--json'
+    );
+
+    await expect(flags(client)).resolves.toEqual(0);
+    expect(JSON.parse(client.stdout.getFullOutput())).toMatchObject({
+      flag: 'my-feature',
+      environment: 'production',
+    });
   });
 
   it('lists inherited rules for a reused environment as JSON', async () => {

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -305,6 +305,30 @@ describe('git connect', () => {
     }
   });
 
+  it('connects the project selected by --project', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'explicit-project',
+      name: 'explicit-project',
+      accountId: 'team_dummy',
+    });
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    client.setArgv(
+      'git',
+      'connect',
+      'https://github.com/user2/repo2',
+      '--project',
+      'explicit-project',
+      '--yes'
+    );
+
+    await expect(git(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Connected');
+  });
+
   it('should fail when there is no git config', async () => {
     client.cwd = fixture('no-git-config');
     useUser();

--- a/packages/cli/test/unit/commands/git/disconnect.test.ts
+++ b/packages/cli/test/unit/commands/git/disconnect.test.ts
@@ -111,6 +111,39 @@ describe('git disconnect', () => {
     }
   });
 
+  it('disconnects the project selected by --project', async () => {
+    useUser();
+    useTeams('team_dummy');
+    const project = useProject({
+      ...defaultProject,
+      id: 'explicit-project',
+      name: 'explicit-project',
+      accountId: 'team_dummy',
+    });
+    project.project.link = {
+      type: 'github',
+      repo: 'repo',
+      org: 'user',
+      repoId: 1010,
+      gitCredentialId: '',
+      sourceless: true,
+      createdAt: 1656109539791,
+      updatedAt: 1656109539791,
+    };
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    client.setArgv(
+      'git',
+      'disconnect',
+      '--project',
+      'explicit-project',
+      '--yes'
+    );
+
+    await expect(git(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Disconnected user/repo.');
+  });
+
   describe('--yes', () => {
     it('tracks telemetry', async () => {
       const cwd = fixture('new-connection');

--- a/packages/cli/test/unit/commands/redirects/add.test.ts
+++ b/packages/cli/test/unit/commands/redirects/add.test.ts
@@ -4,7 +4,10 @@ import redirects from '../../../../src/commands/redirects';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('redirects add', () => {
   beforeEach(() => {
@@ -14,6 +17,7 @@ describe('redirects add', () => {
       ...defaultProject,
       id: 'redirects-test',
       name: 'redirects-test',
+      accountId: 'team_dummy',
     });
     client.scenario.get('/v9/projects/:projectNameOrId', (_req, res) => {
       res.json(project);
@@ -489,7 +493,20 @@ describe('redirects add', () => {
         throw new Error('exit');
       }) as () => never);
 
-      client.setArgv('redirects', 'add');
+      client.setArgv(
+        'redirects',
+        'add',
+        '--status',
+        '301',
+        '--name',
+        'release-1',
+        '--project',
+        'redirects-test',
+        '--scope',
+        'team_dummy',
+        '--cwd',
+        '/tmp/project'
+      );
       await expect(redirects(client)).rejects.toThrow('exit');
 
       expect(logSpy).toHaveBeenCalled();
@@ -498,8 +515,9 @@ describe('redirects add', () => {
       expect(payload.reason).toBe('missing_arguments');
       expect(payload.message).toContain('source and destination are required');
       expect(Array.isArray(payload.next)).toBe(true);
-      expect(payload.next[0].command).toContain('redirects add');
-      expect(payload.next[0].command).toContain('--yes');
+      expect(payload.next[0].command).toBe(
+        'vercel redirects add <source> <destination> --status 301 --name release-1 --project redirects-test --scope team_dummy --cwd /tmp/project --yes'
+      );
       expect(payload.next[0].when).toBe('to add a redirect');
 
       logSpy.mockRestore();
@@ -565,6 +583,34 @@ describe('redirects add', () => {
         true
       );
 
+      client.nonInteractive = false;
+    });
+
+    it('adds a redirect to the project selected by --project', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+      client.cwd = setupTmpDir();
+      client.config.currentTeam = 'team_dummy';
+      client.nonInteractive = true;
+      client.setArgv(
+        'redirects',
+        'add',
+        '/old-path',
+        '/new-path',
+        '--project',
+        'redirects-test',
+        '--yes'
+      );
+
+      expect(await redirects(client)).toEqual(0);
+      const output = JSON.parse(client.stdout.getFullOutput());
+      expect(output.next).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            command: expect.stringContaining('--project redirects-test'),
+          }),
+        ])
+      );
       client.nonInteractive = false;
     });
 

--- a/packages/cli/test/unit/commands/redirects/list.test.ts
+++ b/packages/cli/test/unit/commands/redirects/list.test.ts
@@ -5,7 +5,10 @@ import { useUser } from '../../../mocks/user';
 import { useRedirects } from '../../../mocks/redirects';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('redirects list', () => {
   beforeEach(() => {
@@ -44,6 +47,26 @@ describe('redirects list', () => {
     const exitCode = await redirects(client);
     expect(exitCode, 'exit code for "redirects list"').toEqual(0);
     await expect(client.stderr).toOutput('3 Redirects found');
+  });
+
+  it('lists redirects for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-redirects',
+      name: 'explicit-redirects',
+      accountId: 'team_dummy',
+    });
+    useRedirects(3);
+    client.setArgv('redirects', 'list', '--project', 'explicit-redirects');
+
+    await expect(redirects(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('3 Redirects found');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'subcommand:list', value: 'list' },
+    ]);
   });
 
   it('should list redirects using ls alias', async () => {

--- a/packages/cli/test/unit/commands/routes/edit.test.ts
+++ b/packages/cli/test/unit/commands/routes/edit.test.ts
@@ -3,7 +3,10 @@ import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import {
   useEditRoute,
   useEditRouteComprehensive,
@@ -43,6 +46,14 @@ describe('routes edit', () => {
 
   it('non-interactive missing flags: suggested command uses single quotes for spaced name (no backslash)', async () => {
     useEditRouteComprehensive();
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const exitSpy = vi
       .spyOn(process, 'exit')
@@ -53,13 +64,16 @@ describe('routes edit', () => {
       'edit',
       'API Rewrite',
       '--yes',
-      '--non-interactive'
+      '--non-interactive',
+      '--project',
+      'explicit-routes'
     );
     await routes(client);
     const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(payload.reason).toBe('missing_arguments');
     const nextCmd = payload.next?.[0]?.command ?? '';
     expect(nextCmd).toContain("'API Rewrite'");
+    expect(nextCmd).toContain('--project explicit-routes');
     expect(nextCmd).not.toContain('\\"');
     logSpy.mockRestore();
     exitSpy.mockRestore();

--- a/packages/cli/test/unit/commands/routes/enable.test.ts
+++ b/packages/cli/test/unit/commands/routes/enable.test.ts
@@ -3,7 +3,10 @@ import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { useEditRoute } from '../../../mocks/routes';
 import routes from '../../../../src/commands/routes';
 
@@ -31,6 +34,28 @@ describe('routes enable', () => {
     client.setArgv('routes', 'enable', 'Disabled Route');
     const exitCode = await routes(client);
     expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Enabled');
+  });
+
+  it('enables a route for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
+    useEditRoute();
+    client.setArgv(
+      'routes',
+      'enable',
+      'Disabled Route',
+      '--project',
+      'explicit-routes'
+    );
+
+    await expect(routes(client)).resolves.toEqual(0);
     await expect(client.stderr).toOutput('Enabled');
   });
 

--- a/packages/cli/test/unit/commands/routes/list.test.ts
+++ b/packages/cli/test/unit/commands/routes/list.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import routes from '../../../../src/commands/routes';
 import { useUser } from '../../../mocks/user';
@@ -9,7 +9,10 @@ import {
 } from '../../../mocks/routes';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('routes list', () => {
   beforeEach(() => {
@@ -48,6 +51,26 @@ describe('routes list', () => {
     const exitCode = await routes(client);
     expect(exitCode, 'exit code for "routes list"').toEqual(0);
     await expect(client.stderr).toOutput('3 Routes found');
+  });
+
+  it('lists routes for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
+    useRoutes(3);
+    client.setArgv('routes', 'list', '--project', 'explicit-routes');
+
+    await expect(routes(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('3 Routes found');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'subcommand:list', value: 'list' },
+    ]);
   });
 
   it('should list routes using ls alias', async () => {
@@ -151,6 +174,44 @@ describe('routes list', () => {
     const exitCode = await routes(client);
     expect(exitCode, 'exit code for --diff without staging').toEqual(1);
     await expect(client.stderr).toOutput('No staged changes to diff');
+  });
+
+  it('preserves --project in suggestions when no staging version exists', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as () => never);
+    client.nonInteractive = true;
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
+    useRouteVersions(0);
+    useRoutes(3);
+    client.setArgv('routes', 'list', '--diff', '--project', 'explicit-routes');
+
+    await expect(routes(client)).rejects.toThrow('exit');
+    const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+    expect(payload.message).toContain(
+      'vercel routes add --project explicit-routes'
+    );
+    expect(payload.message).toContain(
+      'vercel routes edit --project explicit-routes'
+    );
+    expect(
+      payload.next.map(({ command }: { command: string }) => command)
+    ).toEqual([
+      'vercel routes list --project explicit-routes',
+      'vercel routes add --project explicit-routes',
+    ]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+    client.nonInteractive = false;
   });
 
   describe('--expand', () => {

--- a/packages/cli/test/unit/commands/routes/reorder.test.ts
+++ b/packages/cli/test/unit/commands/routes/reorder.test.ts
@@ -3,7 +3,10 @@ import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { useStageRoutes } from '../../../mocks/routes';
 import { shellQuoteRouteIdentifierForSuggestion } from '../../../../src/commands/routes/shared';
 import routes from '../../../../src/commands/routes';
@@ -262,6 +265,14 @@ describe('routes reorder', () => {
 
   it('non-interactive: position 0 outputs JSON invalid_arguments with next commands', async () => {
     useStageRoutes();
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const exitSpy = vi
       .spyOn(process, 'exit')
@@ -274,7 +285,9 @@ describe('routes reorder', () => {
       '--position',
       '0',
       '--yes',
-      '--non-interactive'
+      '--non-interactive',
+      '--project',
+      'explicit-routes'
     );
     await routes(client);
     const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
@@ -287,6 +300,11 @@ describe('routes reorder', () => {
       payload.next.some(
         (n: { command: string }) =>
           n.command.includes('--first') || n.command.includes('--position 1')
+      )
+    ).toBe(true);
+    expect(
+      payload.next.every((n: { command: string }) =>
+        n.command.includes('--project explicit-routes')
       )
     ).toBe(true);
     expect(exitSpy).toHaveBeenCalledWith(1);

--- a/packages/cli/test/unit/commands/target/list.test.ts
+++ b/packages/cli/test/unit/commands/target/list.test.ts
@@ -116,6 +116,23 @@ describe('target ls', () => {
     });
   });
 
+  it('lists targets for the project selected by --project', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+      accountId: 'team_dummy',
+    });
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    client.setArgv('target', 'list', '--project', 'static');
+
+    await expect(target(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Environment');
+  });
+
   it('should show custom environments with `vc target ls`', async () => {
     useUser();
     const teams = useTeams('team_dummy');

--- a/packages/cli/test/unit/util/projects/require-project-context.test.ts
+++ b/packages/cli/test/unit/util/projects/require-project-context.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import { defaultProject } from '../../../mocks/project';
-import { ensureProjectLink } from '../../../../src/util/projects/ensure-project-link';
+import { requireProjectContext } from '../../../../src/util/projects/require-project-context';
 import * as agentOutput from '../../../../src/util/agent-output';
 import * as projectContextModule from '../../../../src/util/projects/resolve-project-context';
 
@@ -23,7 +23,7 @@ const resolveProjectContext = vi.mocked(
 );
 const outputAgentError = vi.mocked(agentOutput.outputAgentError);
 
-describe('ensureProjectLink', () => {
+describe('requireProjectContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -34,7 +34,7 @@ describe('ensureProjectLink', () => {
       exitCode: 2,
     });
 
-    await expect(ensureProjectLink(client, 'routes')).resolves.toBe(2);
+    await expect(requireProjectContext(client, 'routes')).resolves.toBe(2);
   });
 
   it('returns the linked project and updates the current team', async () => {
@@ -45,7 +45,7 @@ describe('ensureProjectLink', () => {
     };
     resolveProjectContext.mockResolvedValue(link);
 
-    await expect(ensureProjectLink(client, 'routes')).resolves.toBe(link);
+    await expect(requireProjectContext(client, 'routes')).resolves.toBe(link);
     expect(resolveProjectContext).toHaveBeenCalledWith({
       client,
       projectNameOrId: undefined,
@@ -62,7 +62,7 @@ describe('ensureProjectLink', () => {
     resolveProjectContext.mockResolvedValue(link);
 
     await expect(
-      ensureProjectLink(client, 'routes', 'payments-api')
+      requireProjectContext(client, 'routes', 'payments-api')
     ).resolves.toBe(link);
     expect(resolveProjectContext).toHaveBeenCalledWith({
       client,
@@ -78,7 +78,7 @@ describe('ensureProjectLink', () => {
     });
     client.nonInteractive = true;
 
-    await expect(ensureProjectLink(client, 'redirects')).resolves.toBe(1);
+    await expect(requireProjectContext(client, 'redirects')).resolves.toBe(1);
     expect(outputAgentError).toHaveBeenCalledWith(
       client,
       {
@@ -104,7 +104,7 @@ describe('ensureProjectLink', () => {
     client.nonInteractive = true;
     client.setArgv(command, 'list', '--cwd', '/tmp/site', '--non-interactive');
 
-    await expect(ensureProjectLink(client, command)).resolves.toBe(1);
+    await expect(requireProjectContext(client, command)).resolves.toBe(1);
     expect(outputAgentError).toHaveBeenCalledWith(
       client,
       {


### PR DESCRIPTION
## Summary

Adds `--project <name-or-id>` support to:

- `env add|ls|pull|rm|run|update`
- `target ls`
- `flags rules add|ls|move|remove|update`
- `routes` commands
- `redirects` commands
- `firewall` commands
- `git connect|disconnect`

These commands can target a project explicitly without first linking the working directory:

```bash
vercel env ls --project payments-api --scope acme
vercel routes list --project payments-api --scope acme
vercel firewall overview --project payments-api --scope acme
vercel git disconnect --project payments-api --scope acme
```

An explicit `--project` overrides the project linked to the current directory. When it is omitted, existing linked-directory behavior remains unchanged, including the existing linking workflow for Target and Git commands.

### Project-context helpers

| Helper | Responsibility | Built on |
|---|---|---|
| `getLinkedProject` | Lowest-level lookup. Resolves project context from `--project`, local metadata, environment variables, or repository metadata. Returns `not_linked` when unresolved and never starts linking. | — |
| `resolveProjectContext` | Read-only command lookup. Adds explicit `--project` semantics: if the requested project cannot be found, it prints the project-not-found error instead of returning `not_linked`. | `getLinkedProject` |
| `requireProjectContext` | Read-only lookup for commands that cannot operate without a project. Converts `not_linked` into the appropriate human or agent-facing “run link” error. | `resolveProjectContext` |
| `ensureLink` | Lookup plus the existing linking workflow. Commands that historically linked an unlinked directory retain that behavior. When passed `projectName` with `failIfNotFound`, an invalid explicit `--project` errors without prompting or creating a project. | `getLinkedProject`, then `setupAndLink` when needed |

### Which commands use them

| Helper | Commands | Why |
|---|---|---|
| `getLinkedProject` | Existing specialized flows including `build`, `dev`, `list`, `logs`, `mcp`, integrations, activity, metrics, traces, blob, alerts, connex, and selected microfrontends commands | These callers need the raw result because project context is optional or they have their own handling for `not_linked` and errors. |
| `resolveProjectContext` | `env` commands, `flags rules`, `cache`, `crons`, and `rolling-release` | These commands need read-only project selection and support an explicit `--project`, but retain their own handling when no project was supplied. |
| `requireProjectContext` | All `routes`, `redirects`, and `firewall` operations | These command families always require a project, must never initiate linking, and share consistent human and non-interactive errors when no context exists. |
| `ensureLink` | `git connect`, `git disconnect`, `target ls`, and existing linking flows such as `deploy`, `build`, `link`, `pull`, `open`, `curl`, and microfrontends | These commands already supported linking an unlinked directory, so they preserve that behavior while making explicit `--project` selection non-interactive and typo-safe. |

## Consolidated PRs

This PR includes the work originally reviewed in:

- #17113 — Env commands
- #17114 — Routes commands
- #17115 — Redirects commands
- #17116 — Firewall commands

## Validation

- 21 focused CLI test files
- 566 unit tests covering Env, Target, Flags, Routes, Redirects, Firewall, Git, project resolution, and help output
