### PR TITLE
feat(cli): add --project support for routes

### DIFF
--- a/.changeset/bright-routes-select.md
+++ b/.changeset/bright-routes-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Routes commands to select a project explicitly with `--project`.

--- a/.changeset/quick-redirects-select.md
+++ b/.changeset/quick-redirects-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Redirects commands to select a project explicitly with `--project`.

--- a/.changeset/steady-firewalls-select.md
+++ b/.changeset/steady-firewalls-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Firewall commands to select a project explicitly with `--project`.

--- a/packages/cli/src/commands/firewall/attack-mode/disable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/disable.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { attackModeDisableSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -48,7 +51,7 @@ export default async function disable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/enable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/enable.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { attackModeEnableSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -65,7 +68,7 @@ export default async function enable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/index.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/index.ts
@@ -15,20 +15,18 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   enable: getCommandAliases(attackModeEnableSubcommand),
   disable: getCommandAliases(attackModeDisableSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     attackModeSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/command.ts
+++ b/packages/cli/src/commands/firewall/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const overviewSubcommand = {
   name: 'overview',
@@ -8,6 +8,7 @@ export const overviewSubcommand = {
     "Show a summary of your project's firewall configuration, including active rules, IP blocks, bypasses, and any unpublished draft changes",
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -31,6 +32,7 @@ export const diffSubcommand = {
     'Show draft changes that have been made but are not yet published to production',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -53,7 +55,7 @@ export const publishSubcommand = {
   description:
     'Publish all draft firewall changes to production, making them live immediately',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Publish draft changes',
@@ -72,7 +74,7 @@ export const discardSubcommand = {
   description:
     'Permanently discard all unpublished draft changes, reverting to the current production configuration',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Discard draft changes',
@@ -93,6 +95,7 @@ export const systemBypassListSubcommand = {
     'List all system bypass rules that allow specific IPs to skip firewall checks',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -116,6 +119,7 @@ export const systemBypassAddSubcommand = {
     'Add a system bypass rule to allow a specific IP address to skip firewall checks. Takes effect immediately (no publish required)',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'domain',
       shorthand: null,
@@ -151,6 +155,7 @@ export const systemBypassRemoveSubcommand = {
     'Remove a system bypass rule so the IP is no longer exempt from firewall checks. Takes effect immediately (no publish required)',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'domain',
       shorthand: null,
@@ -204,6 +209,7 @@ export const ipBlocksListSubcommand = {
     'List all IP blocking rules, including any unpublished draft changes',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -227,6 +233,7 @@ export const ipBlocksBlockSubcommand = {
     'Block an IP address or CIDR range from accessing your project. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'hostname',
       shorthand: null,
@@ -267,6 +274,7 @@ export const ipBlocksUnblockSubcommand = {
     'Remove an IP blocking rule to allow the address to access your project again. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'id-or-ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'hostname',
       shorthand: null,
@@ -331,6 +339,7 @@ export const rulesListSubcommand = {
     'List all custom firewall rules, including any unpublished draft changes',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'expand',
       shorthand: 'e',
@@ -365,6 +374,7 @@ export const rulesInspectSubcommand = {
     'Show the full configuration of a custom firewall rule, including conditions, action, and rate limit settings',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -392,6 +402,7 @@ export const rulesAddSubcommand = {
     'Create a new custom firewall rule using AI, an interactive builder, JSON, or command-line flags. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name', required: false }],
   options: [
+    projectOption,
     {
       name: 'ai',
       shorthand: null,
@@ -537,6 +548,7 @@ export const rulesEditSubcommand = {
     'Edit an existing custom firewall rule using AI, an interactive editor, JSON, or command-line flags. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'ai',
       shorthand: null,
@@ -691,7 +703,7 @@ export const rulesEnableSubcommand = {
   description:
     'Enable a disabled custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Enable a rule',
@@ -706,7 +718,7 @@ export const rulesDisableSubcommand = {
   description:
     'Disable a custom firewall rule without removing it. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Disable a rule',
@@ -721,7 +733,7 @@ export const rulesRemoveSubcommand = {
   description:
     'Remove a custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Remove a rule',
@@ -737,6 +749,7 @@ export const rulesReorderSubcommand = {
     'Change the priority order of a custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'position',
       shorthand: null,
@@ -816,6 +829,7 @@ export const attackModeEnableSubcommand = {
     'Enable attack mode — all visitors will be shown a verification challenge before accessing your site. Takes effect immediately (no publish required)',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'duration',
       shorthand: null,
@@ -843,7 +857,7 @@ export const attackModeDisableSubcommand = {
   description:
     'Disable attack mode — visitors will no longer be challenged. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Disable attack mode',
@@ -879,7 +893,7 @@ export const systemMitigationsPauseSubcommand = {
   description:
     'Pause automatic DDoS protection and system-level traffic filtering for 24 hours. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Pause system mitigations',
@@ -894,7 +908,7 @@ export const systemMitigationsResumeSubcommand = {
   description:
     'Resume automatic DDoS protection and system-level traffic filtering. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Resume system mitigations',

--- a/packages/cli/src/commands/firewall/diff.ts
+++ b/packages/cli/src/commands/firewall/diff.ts
@@ -1,20 +1,22 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { diffSubcommand } from './command';
-import { parseSubcommandArgs, outputJson } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import { formatDiffOutput } from '../../util/firewall/format';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 
 export default async function diff(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, diffSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -50,7 +52,7 @@ export default async function diff(client: Client, argv: string[]) {
     output.print(formatDiffOutput(draft.changes, activeRulesMap));
     output.print('\n\n');
     output.print(
-      `  Run ${chalk.cyan(getCommandName('firewall publish'))} to publish, or ${chalk.cyan(getCommandName('firewall discard'))} to discard.\n\n`
+      `  Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard'))} to discard.\n\n`
     );
 
     return 0;

--- a/packages/cli/src/commands/firewall/discard.ts
+++ b/packages/cli/src/commands/firewall/discard.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import deleteFirewallDraft from '../../util/firewall/delete-firewall-draft';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -15,7 +18,7 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/index.ts
+++ b/packages/cli/src/commands/firewall/index.ts
@@ -29,6 +29,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { FirewallTelemetryClient } from '../../util/telemetry/commands/firewall';
+import { getProjectOptionFromArgs } from '../../util/arg-common';
 
 const COMMAND_CONFIG = {
   overview: getCommandAliases(overviewSubcommand),
@@ -83,6 +84,10 @@ export default async function main(client: Client) {
     );
   }
 
+  if (subcommand && !needHelp) {
+    telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
+  }
+
   switch (subcommand) {
     case 'overview':
       if (needHelp) {
@@ -119,27 +124,27 @@ export default async function main(client: Client) {
     case 'rules': {
       telemetry.trackCliSubcommandRules(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return rules(client, nestedArgs);
+      return rules(client, nestedArgs, telemetry);
     }
     case 'ip-blocks': {
       telemetry.trackCliSubcommandIpBlocks(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return ipBlocks(client, nestedArgs);
+      return ipBlocks(client, nestedArgs, telemetry);
     }
     case 'system-bypass': {
       telemetry.trackCliSubcommandSystemBypass(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return systemBypass(client, nestedArgs);
+      return systemBypass(client, nestedArgs, telemetry);
     }
     case 'attack-mode': {
       telemetry.trackCliSubcommandAttackMode(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return attackMode(client, nestedArgs);
+      return attackMode(client, nestedArgs, telemetry);
     }
     case 'system-mitigations': {
       telemetry.trackCliSubcommandSystemMitigations(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return systemMitigations(client, nestedArgs);
+      return systemMitigations(client, nestedArgs, telemetry);
     }
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/firewall/ip-blocks/block.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/block.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksBlockSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -63,7 +63,7 @@ export default async function block(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/index.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/index.ts
@@ -17,7 +17,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(ipBlocksListSubcommand),
@@ -25,13 +25,11 @@ const COMMAND_CONFIG = {
   unblock: getCommandAliases(ipBlocksUnblockSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(ipBlocksSubcommand.options);
   let parsedArgs;
   try {

--- a/packages/cli/src/commands/firewall/ip-blocks/list.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/list.ts
@@ -1,16 +1,18 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateIpRules,
   formatIpBlocksTable,
 } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function list(client: Client, argv: string[]) {
@@ -22,7 +24,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -64,7 +66,7 @@ export default async function list(client: Client, argv: string[]) {
     const ipChanges = changes.filter(c => c.action.startsWith('ip.')).length;
     if (ipChanges > 0) {
       output.print(
-        `\n  ${chalk.yellow(`${ipChanges} unpublished IP block change${ipChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(getCommandName('firewall publish'))} to publish.\n`
+        `\n  ${chalk.yellow(`${ipChanges} unpublished IP block change${ipChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish.\n`
       );
     } else {
       output.print(`\n  ${chalk.dim('Showing live configuration.')}\n`);

--- a/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
@@ -1,18 +1,17 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksUnblockSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   offerAutoPublish,
   resolveIpRule,
 } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
-import { getCommandName } from '../../../util/pkg-name';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
 
@@ -31,7 +30,7 @@ export default async function unblock(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -61,7 +60,7 @@ export default async function unblock(client: Client, argv: string[]) {
 
     if (matches.length === 0) {
       output.error(
-        `No IP block found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall ip-blocks list'))} to view all rules.`
+        `No IP block found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall ip-blocks list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { overviewSubcommand } from './command';
-import { parseSubcommandArgs, outputJson } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import getBypass from '../../util/firewall/get-bypass';
 import {
@@ -18,7 +21,7 @@ export default async function overview(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, overviewSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/publish.ts
+++ b/packages/cli/src/commands/firewall/publish.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -15,7 +18,7 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/add-ai.ts
+++ b/packages/cli/src/commands/firewall/rules/add-ai.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
 import output from '../../../output-manager';
 import {
+  withGlobalFlags,
   detectExistingDraft,
   offerAutoPublish,
   printActionImpactWarning,

--- a/packages/cli/src/commands/firewall/rules/add.ts
+++ b/packages/cli/src/commands/firewall/rules/add.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesAddSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -25,7 +25,6 @@ import type {
 } from '../../../util/firewall/types';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
-import { getCommandName } from '../../../util/pkg-name';
 import { handleAIAdd } from './add-ai';
 import { addInteractive } from './add-interactive';
 
@@ -88,7 +87,7 @@ export default async function add(client: Client, argv: string[]) {
     }
 
     // AI mode
-    const link = await ensureProjectLink(client, 'firewall');
+    const link = await ensureProjectLink(client, parsed.flags['--project']);
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -130,7 +129,7 @@ export default async function add(client: Client, argv: string[]) {
       ],
     });
 
-    const link = await ensureProjectLink(client, 'firewall');
+    const link = await ensureProjectLink(client, parsed.flags['--project']);
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -291,7 +290,7 @@ async function handleFlagAdd(
   const name = parsed.args[0] as string | undefined;
   if (!name) {
     output.error(
-      `Missing rule name. Provide as the first argument: ${chalk.cyan(getCommandName('firewall rules add "Rule name" --condition ...'))}`
+      `Missing rule name. Provide as the first argument: ${chalk.cyan(withGlobalFlags(client, 'firewall rules add "Rule name" --condition ...'))}`
     );
     return 1;
   }
@@ -399,7 +398,11 @@ async function createRule(
   parsed: { args: string[]; flags: Record<string, unknown> },
   rule: Omit<FirewallRule, 'id'>
 ): Promise<number> {
-  const link = await ensureProjectLink(client, 'firewall');
+  const projectName = parsed.flags['--project'];
+  const link = await ensureProjectLink(
+    client,
+    typeof projectName === 'string' ? projectName : undefined
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/disable.ts
+++ b/packages/cli/src/commands/firewall/rules/disable.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesDisableSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -15,7 +15,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function disable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -26,7 +25,7 @@ export default async function disable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -77,7 +76,7 @@ export default async function disable(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules disable <name-or-id>')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules disable <name-or-id>')}`
       );
       return 1;
     }
@@ -109,7 +108,7 @@ export default async function disable(client: Client, argv: string[]) {
   if (allMatches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/edit.ts
+++ b/packages/cli/src/commands/firewall/rules/edit.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesEditSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -30,7 +30,6 @@ import type { FirewallRule } from '../../../util/firewall/types';
 import { runInteractiveEditLoop } from './edit-interactive';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function edit(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -43,7 +42,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   let identifier = parsed.args[0] as string | undefined;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -64,7 +63,7 @@ export default async function edit(client: Client, argv: string[]) {
 
     if (client.nonInteractive || !client.stdin.isTTY) {
       output.error(
-        `Missing required argument: <name-or-id>. Run ${chalk.cyan(getCommandName('firewall rules list'))} to see all rules.`
+        `Missing required argument: <name-or-id>. Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to see all rules.`
       );
       return 1;
     }
@@ -96,7 +95,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   if (matches.length === 0) {
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/enable.ts
+++ b/packages/cli/src/commands/firewall/rules/enable.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesEnableSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function enable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function enable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -78,7 +77,7 @@ export default async function enable(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules enable <name-or-id>')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules enable <name-or-id>')}`
       );
       return 1;
     }
@@ -110,7 +109,7 @@ export default async function enable(client: Client, argv: string[]) {
   if (allMatches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/index.ts
+++ b/packages/cli/src/commands/firewall/rules/index.ts
@@ -27,7 +27,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(rulesListSubcommand),
@@ -40,13 +40,11 @@ const COMMAND_CONFIG = {
   reorder: getCommandAliases(rulesReorderSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(rulesSubcommand.options);
   let parsedArgs;
   try {

--- a/packages/cli/src/commands/firewall/rules/inspect.ts
+++ b/packages/cli/src/commands/firewall/rules/inspect.ts
@@ -1,13 +1,16 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesInspectSubcommand } from '../command';
-import { parseSubcommandArgs, resolveRule, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  resolveRule,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import { formatRuleDetail } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function inspect(client: Client, argv: string[]) {
@@ -46,12 +49,12 @@ export default async function inspect(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Rule name or ID is required. Usage: ${getCommandName('firewall rules inspect <name-or-id>')}`
+      `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules inspect <name-or-id>')}`
     );
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -88,7 +91,7 @@ export default async function inspect(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+        `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/rules/list.ts
+++ b/packages/cli/src/commands/firewall/rules/list.ts
@@ -1,17 +1,19 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateRules,
   formatRulesTable,
   formatRuleExpanded,
 } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function list(client: Client, argv: string[]) {
@@ -23,7 +25,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -104,7 +106,7 @@ export default async function list(client: Client, argv: string[]) {
     ).length;
     if (ruleChanges > 0) {
       output.print(
-        `\n  ${chalk.yellow(`${ruleChanges} unpublished rule change${ruleChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(getCommandName('firewall publish'))} to publish.\n`
+        `\n  ${chalk.yellow(`${ruleChanges} unpublished rule change${ruleChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish.\n`
       );
     } else {
       output.print(`\n  ${chalk.dim('Showing live configuration.')}\n`);

--- a/packages/cli/src/commands/firewall/rules/remove.ts
+++ b/packages/cli/src/commands/firewall/rules/remove.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesRemoveSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function remove(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function remove(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -78,7 +77,7 @@ export default async function remove(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules remove <name-or-id> --yes')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules remove <name-or-id> --yes')}`
       );
       return 1;
     }
@@ -104,7 +103,7 @@ export default async function remove(client: Client, argv: string[]) {
   if (matches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/reorder.ts
+++ b/packages/cli/src/commands/firewall/rules/reorder.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesReorderSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function reorder(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function reorder(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -76,7 +75,7 @@ export default async function reorder(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules reorder <name-or-id> --position N --yes')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules reorder <name-or-id> --position N --yes')}`
       );
       return 1;
     }
@@ -102,7 +101,7 @@ export default async function reorder(client: Client, argv: string[]) {
   if (matches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -1,9 +1,13 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
 import { printError } from '../../util/error';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
-import { outputAgentError, buildCommandWithYes } from '../../util/agent-output';
+import {
+  outputAgentError,
+  buildCommandWithYes,
+  withGlobalFlags as withClientGlobalFlags,
+} from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
@@ -15,6 +19,19 @@ import type { FirewallIpRule, FirewallRule } from '../../util/firewall/types';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import stamp from '../../util/output/stamp';
+import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
+
+/**
+ * Plain suggested command with global flags from argv (--cwd, --non-interactive, etc.).
+ */
+export function withGlobalFlags(
+  client: Client,
+  commandTemplate: string
+): string {
+  return withClientGlobalFlags(client, commandTemplate, {
+    preserveProject: true,
+  });
+}
 
 export async function parseSubcommandArgs(
   argv: string[],
@@ -30,7 +47,9 @@ export async function parseSubcommandArgs(
   } catch (err) {
     if (client?.nonInteractive) {
       const rawMessage = err instanceof Error ? err.message : String(err);
-      const flags = getGlobalFlagsFromArgs(client.argv.slice(2));
+      const flags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+        preserveProject: true,
+      });
       outputAgentError(
         client,
         {
@@ -55,6 +74,10 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
+}
+
+export function ensureProjectLink(client: Client, projectName?: string) {
+  return ensureProjectLinkForCommand(client, 'firewall', projectName);
 }
 
 export async function confirmAction(
@@ -117,7 +140,7 @@ export async function offerAutoPublish(
   opts: { teamId?: string; skipPrompts?: boolean }
 ): Promise<void> {
   output.print(
-    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(getCommandName('firewall publish'))} to make it live, or ${chalk.cyan(getCommandName('firewall discard'))} to undo.`)}\n`
+    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to make it live, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard'))} to undo.`)}\n`
   );
 
   if (
@@ -152,7 +175,7 @@ export async function offerAutoPublish(
     }
   } else if (hadExistingDraft) {
     output.warn(
-      `There are other draft changes. Review with ${chalk.cyan(getCommandName('firewall diff'))} before publishing.`
+      `There are other draft changes. Review with ${chalk.cyan(withGlobalFlags(client, 'firewall diff'))} before publishing.`
     );
   }
 }

--- a/packages/cli/src/commands/firewall/system-bypass/add.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/add.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassAddSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import {
   validateBypassIp,
@@ -57,7 +60,7 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/index.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/index.ts
@@ -17,7 +17,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(systemBypassListSubcommand),
@@ -25,13 +25,11 @@ const COMMAND_CONFIG = {
   remove: getCommandAliases(systemBypassRemoveSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     systemBypassSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/system-bypass/list.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/list.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import getBypass from '../../../util/firewall/get-bypass';
 import {
   formatBypassTable,
@@ -21,7 +24,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/remove.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/remove.ts
@@ -1,16 +1,18 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassRemoveSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import {
   validateBypassIp,
   validateHostname,
 } from '../../../util/firewall/validate';
-import { getCommandName } from '../../../util/pkg-name';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
 
@@ -47,7 +49,7 @@ export default async function remove(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -89,7 +91,7 @@ export default async function remove(client: Client, argv: string[]) {
     const error = e as { status?: number; message?: string };
     if (error.status === 404) {
       output.error(
-        `No bypass rule found for ${chalk.bold(ip)}. Run ${chalk.cyan(getCommandName('firewall system-bypass list'))} to view all rules.`
+        `No bypass rule found for ${chalk.bold(ip)}. Run ${chalk.cyan(withGlobalFlags(client, 'firewall system-bypass list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/system-mitigations/index.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/index.ts
@@ -15,20 +15,18 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   pause: getCommandAliases(systemMitigationsPauseSubcommand),
   resume: getCommandAliases(systemMitigationsResumeSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     systemMitigationsSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/system-mitigations/pause.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/pause.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemMitigationsPauseSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -51,7 +54,7 @@ export default async function pause(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/resume.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/resume.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemMitigationsResumeSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -51,7 +54,7 @@ export default async function resume(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { outputActionRequired } from '../../util/agent-output';
 import {
@@ -11,6 +10,7 @@ import {
 import { addSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   isValidUrl,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
@@ -30,7 +30,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/command.ts
+++ b/packages/cli/src/commands/redirects/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const listSubcommand = {
   name: 'list',
@@ -8,6 +8,7 @@ export const listSubcommand = {
     'List all redirects for the current project. These redirects apply to all deployments and environments. There may also be redirects defined in a deployment that are not listed here.',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'search',
       description: 'Search for redirects by source or destination',
@@ -73,7 +74,7 @@ export const listVersionsSubcommand = {
   aliases: ['ls-versions'],
   description: 'List all versions of redirects',
   arguments: [],
-  options: [],
+  options: [projectOption],
   examples: [
     {
       name: 'List all redirect versions',
@@ -97,6 +98,7 @@ export const addSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'status',
       description: 'HTTP status code (301, 302, 307, or 308)',
@@ -163,6 +165,7 @@ export const uploadSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip confirmation prompt',
@@ -206,6 +209,7 @@ export const removeSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when removing a redirect',
@@ -230,6 +234,7 @@ export const promoteSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when promoting',
@@ -254,6 +259,7 @@ export const restoreSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when restoring',

--- a/packages/cli/src/commands/redirects/index.ts
+++ b/packages/cli/src/commands/redirects/index.ts
@@ -25,6 +25,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { RedirectsTelemetryClient } from '../../util/telemetry/commands/redirects';
+import { getProjectOptionFromArgs } from '../../util/arg-common';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
@@ -75,6 +76,10 @@ export default async function main(client: Client) {
         columns: client.stderr.columns,
       })
     );
+  }
+
+  if (subcommand && !needHelp) {
+    telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/redirects/list-versions.ts
+++ b/packages/cli/src/commands/redirects/list-versions.ts
@@ -2,10 +2,9 @@ import chalk from 'chalk';
 import ms from 'ms';
 import plural from 'pluralize';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import { parseSubcommandArgs, ensureProjectLink } from './shared';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import type { RedirectVersion } from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
@@ -15,7 +14,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listVersionsSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/list.ts
+++ b/packages/cli/src/commands/redirects/list.ts
@@ -1,21 +1,23 @@
 import chalk from 'chalk';
 import plural from 'pluralize';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  withGlobalFlags,
+} from './shared';
 import getRedirects from '../../util/redirects/get-redirects';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
 import formatTable from '../../util/format-table';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 
 export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -39,7 +41,7 @@ export default async function list(client: Client, argv: string[]) {
     if (!stagingVersion) {
       output.error(
         `No staging version found for ${chalk.bold(project.name)}. Run ${chalk.cyan(
-          'vercel redirects list-versions'
+          withGlobalFlags(client, 'redirects list-versions')
         )} to see available versions.`
       );
       return 1;
@@ -68,7 +70,7 @@ export default async function list(client: Client, argv: string[]) {
     if (!version) {
       output.error(
         `Version "${versionIdFlag}" not found. Run ${chalk.cyan(
-          'vercel redirects list-versions'
+          withGlobalFlags(client, 'redirects list-versions')
         )} to see available versions.`
       );
       return 1;
@@ -154,8 +156,8 @@ export default async function list(client: Client, argv: string[]) {
       !versionIdFlag
     ) {
       output.log(
-        `  ${getCommandNamePlain('redirects list')} shows production redirects only. ` +
-          `If you added redirects but do not see them here, they may still be staged only—run ${getCommandNamePlain('redirects list --staging')} to view staged changes.`
+        `  ${withGlobalFlags(client, 'redirects list')} shows production redirects only. ` +
+          `If you added redirects but do not see them here, they may still be staged only—run ${withGlobalFlags(client, 'redirects list --staging')} to view staged changes.`
       );
     }
 
@@ -174,7 +176,9 @@ export default async function list(client: Client, argv: string[]) {
     if (perPage) {
       command += ` --per-page ${perPage}`;
     }
-    output.log(`To display the next page, run ${getCommandName(command)}`);
+    output.log(
+      `To display the next page, run ${withGlobalFlags(client, command)}`
+    );
   }
 
   return 0;

--- a/packages/cli/src/commands/redirects/promote.ts
+++ b/packages/cli/src/commands/redirects/promote.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,6 +14,7 @@ import {
 import { promoteSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -68,7 +68,7 @@ export default async function promote(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/remove.ts
+++ b/packages/cli/src/commands/redirects/remove.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,11 +14,13 @@ import {
 import { removeSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
   getRedirectPromoteSuggestionFlags,
+  withGlobalFlags,
 } from './shared';
 import { validateRequiredArguments } from '../../util/command-arguments';
 import { getCommandNamePlain } from '../../util/pkg-name';
@@ -59,7 +60,7 @@ export default async function remove(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -178,7 +179,7 @@ export default async function remove(client: Client, argv: string[]) {
         ],
       }),
       ...(existingStagingVersion && {
-        hint: `Review staged changes with ${getCommandNamePlain('redirects list --staging')} before promoting.`,
+        hint: `Review staged changes with ${withGlobalFlags(client, 'redirects list --staging')} before promoting.`,
       }),
     };
     client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);

--- a/packages/cli/src/commands/redirects/restore.ts
+++ b/packages/cli/src/commands/redirects/restore.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,6 +14,7 @@ import {
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -71,7 +71,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -2,14 +2,25 @@ import type Client from '../../util/client';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
 import type { Command } from '../help';
+import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
 } from '../../util/command-arguments';
 import {
-  GLOBAL_CLI_FLAG_NAMES,
-  globalCliFlagTakesValue,
+  getGlobalFlagsFromArgs,
+  getSameSubcommandSuggestionFlags,
 } from '../../util/arg-common';
+import { withGlobalFlags as withClientGlobalFlags } from '../../util/agent-output';
+
+export function withGlobalFlags(
+  client: Client,
+  commandTemplate: string
+): string {
+  return withClientGlobalFlags(client, commandTemplate, {
+    preserveProject: true,
+  });
+}
 
 export async function parseSubcommandArgs(
   argv: string[],
@@ -25,6 +36,10 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
+}
+
+export function ensureProjectLink(client: Client, projectName?: string) {
+  return ensureProjectLinkForCommand(client, 'redirects', projectName);
 }
 
 export async function confirmAction(
@@ -56,19 +71,6 @@ export function isValidUrl(url: string): boolean {
 }
 
 /**
- * Flags that belong only to redirects add/upload/remove. Forwarding them into
- * suggested `redirects list`, `redirects promote`, or `redirects list-versions`
- * commands causes parse errors for agents.
- */
-const REDIRECTS_SUBCOMMAND_EXCLUSIVE_FLAGS = new Set([
-  '--status',
-  '--case-sensitive',
-  '--preserve-query-params',
-  '--name',
-  '--overwrite',
-]);
-
-/**
  * Slice argv after `vercel` (i.e. client.argv.slice(2)) starting after the
  * given redirects subcommand name.
  */
@@ -87,44 +89,9 @@ export function getArgsAfterRedirectsSubcommand(
 export function getRedirectGlobalFlagsOnly(
   afterSubcommandArgs: string[]
 ): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < afterSubcommandArgs.length; i++) {
-    const a = afterSubcommandArgs[i];
-    if (!a.startsWith('-')) continue;
-
-    let name = a;
-    const hasEq = a.includes('=');
-    if (hasEq) {
-      name = a.slice(0, a.indexOf('='));
-    }
-
-    if (REDIRECTS_SUBCOMMAND_EXCLUSIVE_FLAGS.has(name)) {
-      if (
-        !hasEq &&
-        (name === '--status' || name === '--name') &&
-        i + 1 < afterSubcommandArgs.length &&
-        !afterSubcommandArgs[i + 1].startsWith('-')
-      ) {
-        i++;
-      }
-      continue;
-    }
-
-    if (!GLOBAL_CLI_FLAG_NAMES.has(name)) {
-      continue;
-    }
-
-    out.push(a);
-    if (!hasEq && globalCliFlagTakesValue(name)) {
-      if (
-        i + 1 < afterSubcommandArgs.length &&
-        !afterSubcommandArgs[i + 1].startsWith('-')
-      ) {
-        out.push(afterSubcommandArgs[++i]);
-      }
-    }
-  }
-  return out;
+  return getGlobalFlagsFromArgs(afterSubcommandArgs, {
+    preserveProject: true,
+  });
 }
 
 /**
@@ -151,7 +118,7 @@ export function buildRedirectsSuggestionFlags(
   options: { ensureYes?: boolean } = {}
 ): string[] {
   const after = getArgsAfterRedirectsSubcommand(fullArgs, subcommand);
-  const flagParts = after.filter(a => a.startsWith('-'));
+  const flagParts = getSameSubcommandSuggestionFlags(after);
   if (
     options.ensureYes !== false &&
     !flagParts.some(a => a === '--yes' || a === '-y')

--- a/packages/cli/src/commands/redirects/upload.ts
+++ b/packages/cli/src/commands/redirects/upload.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'fs';
 import { basename } from 'path';
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -16,9 +15,11 @@ import {
 import { uploadSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   getArgsAfterRedirectsSubcommand,
   getRedirectPromoteSuggestionFlags,
   buildRedirectsSuggestionFlags,
+  withGlobalFlags,
 } from './shared';
 import { getCommandNamePlain } from '../../util/pkg-name';
 import stamp from '../../util/output/stamp';
@@ -51,7 +52,7 @@ export default async function upload(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, uploadSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -263,7 +264,7 @@ export default async function upload(client: Client, argv: string[]) {
           ],
         }),
         ...(existingStagingVersion && {
-          hint: `Review staged changes with ${getCommandNamePlain('redirects list --staging')} before promoting.`,
+          hint: `Review staged changes with ${withGlobalFlags(client, 'redirects list --staging')} before promoting.`,
         }),
       };
       client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);

--- a/packages/cli/src/commands/routes/add.ts
+++ b/packages/cli/src/commands/routes/add.ts
@@ -1,10 +1,14 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { addSubcommand } from './command';
-import { parseSubcommandArgs, parsePosition, offerAutoPromote } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  parsePosition,
+  offerAutoPromote,
+  withGlobalFlags,
+} from './shared';
 import addRoute from '../../util/routes/add-route';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import { parseConditions } from '../../util/routes/parse-conditions';
@@ -20,7 +24,6 @@ import {
 } from '../../util/routes/ai-transform';
 import { runInteractiveEditLoop } from './edit-interactive';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { RoutesAddTelemetryClient } from '../../util/telemetry/commands/routes';
@@ -118,7 +121,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -286,7 +289,7 @@ export default async function add(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name is required when using --yes. Usage: ${getCommandName('routes add "Route Name" --src "/path" --action rewrite --dest "/destination" --yes')}`
+      `Route name is required when using --yes. Usage: ${withGlobalFlags(client, 'routes add "Route Name" --src "/path" --action rewrite --dest "/destination" --yes')}`
     );
     return 1;
   } else {
@@ -370,7 +373,7 @@ export default async function add(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Source path is required when using --yes. Usage: ${getCommandName('routes add "Name" --src "/path" --action rewrite --dest "/dest" --yes')}`
+      `Source path is required when using --yes. Usage: ${withGlobalFlags(client, 'routes add "Name" --src "/path" --action rewrite --dest "/dest" --yes')}`
     );
     return 1;
   } else {
@@ -1016,7 +1019,7 @@ async function handleAIAdd(
       );
     }
     output.error(
-      `Cannot interactively confirm route creation in a non-TTY environment. Use full route flags with ${getCommandName('routes add <name> --src ... --yes')}, or run in a TTY.`
+      `Cannot interactively confirm route creation in a non-TTY environment. Use full route flags with ${withGlobalFlags(client, 'routes add <name> --src ... --yes')}, or run in a TTY.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/routes/add.ts
+++ b/packages/cli/src/commands/routes/add.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { addSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   parsePosition,
   offerAutoPromote,
   withGlobalFlags,
@@ -121,7 +121,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/command.ts
+++ b/packages/cli/src/commands/routes/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const listSubcommand = {
   name: 'list',
@@ -8,6 +8,7 @@ export const listSubcommand = {
     'List all routing rules for the current project. These routes apply to all deployments and environments.',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'search',
       description: 'Search by name, description, source, or destination',
@@ -89,6 +90,7 @@ export const listVersionsSubcommand = {
   description: 'List all versions of routing rules',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'count',
       description: 'Number of versions to fetch (default: 20, max: 100)',
@@ -121,6 +123,7 @@ export const inspectSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'diff',
       description: 'Compare staged changes against production for this route',
@@ -156,6 +159,7 @@ export const addSubcommand = {
     },
   ],
   options: [
+    projectOption,
     // Path & Matching
     {
       name: 'src',
@@ -381,6 +385,7 @@ export const publishSubcommand = {
   description: 'Publish staged routing changes to production',
   arguments: [],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when publishing',
@@ -409,6 +414,7 @@ export const restoreSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when restoring',
@@ -432,6 +438,7 @@ export const discardSubcommand = {
   description: 'Discard staged routing changes',
   arguments: [],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when discarding',
@@ -461,6 +468,7 @@ export const deleteSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when deleting',
@@ -496,7 +504,7 @@ export const enableSubcommand = {
       required: true,
     },
   ],
-  options: [],
+  options: [projectOption],
   examples: [
     {
       name: 'Enable a route by name',
@@ -519,7 +527,7 @@ export const disableSubcommand = {
       required: true,
     },
   ],
-  options: [],
+  options: [projectOption],
   examples: [
     {
       name: 'Disable a route by name',
@@ -543,6 +551,7 @@ export const reorderSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'position',
       description:
@@ -606,6 +615,7 @@ export const editSubcommand = {
     },
   ],
   options: [
+    projectOption,
     // Metadata
     {
       name: 'name',
@@ -848,6 +858,7 @@ export const exportSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'output',
       description: 'Output file format: .json (default) or .ts',

--- a/packages/cli/src/commands/routes/delete.ts
+++ b/packages/cli/src/commands/routes/delete.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { deleteSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRoutes,
   offerAutoPromote,
   withGlobalFlags,
@@ -21,7 +21,7 @@ export default async function deleteRoute(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, deleteSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/delete.ts
+++ b/packages/cli/src/commands/routes/delete.ts
@@ -1,24 +1,27 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { deleteSubcommand } from './command';
-import { parseSubcommandArgs, resolveRoutes, offerAutoPromote } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  resolveRoutes,
+  offerAutoPromote,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import deleteRoutes from '../../util/routes/delete-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { getRouteTypeLabel } from '../../util/routes/types';
 
 export default async function deleteRoute(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, deleteSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -48,7 +51,7 @@ export default async function deleteRoute(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `At least one route name or ID is required. Usage: ${getCommandName('routes delete <name-or-id> [...]')}`
+      `At least one route name or ID is required. Usage: ${withGlobalFlags(client, 'routes delete <name-or-id> [...]')}`
     );
     return 1;
   }

--- a/packages/cli/src/commands/routes/disable.ts
+++ b/packages/cli/src/commands/routes/disable.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { disableSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRoute,
   offerAutoPromote,
   withGlobalFlags,
@@ -19,7 +19,7 @@ export default async function disable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, disableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/disable.ts
+++ b/packages/cli/src/commands/routes/disable.ts
@@ -1,22 +1,25 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { disableSubcommand } from './command';
-import { parseSubcommandArgs, resolveRoute, offerAutoPromote } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  resolveRoute,
+  offerAutoPromote,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import editRoute from '../../util/routes/edit-route';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 
 export default async function disable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, disableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -47,7 +50,7 @@ export default async function disable(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name or ID is required. Usage: ${getCommandName('routes disable <name-or-id>')}`
+      `Route name or ID is required. Usage: ${withGlobalFlags(client, 'routes disable <name-or-id>')}`
     );
     return 1;
   }
@@ -99,7 +102,7 @@ export default async function disable(client: Client, argv: string[]) {
     }
     output.error(
       `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
+        withGlobalFlags(client, 'routes list')
       )} to see all routes.`
     );
     return 1;

--- a/packages/cli/src/commands/routes/discard.ts
+++ b/packages/cli/src/commands/routes/discard.ts
@@ -1,22 +1,25 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction, printDiffSummary } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  printDiffSummary,
+  withGlobalFlags,
+} from './shared';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
 import getRoutes from '../../util/routes/get-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 
 export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -31,7 +34,7 @@ export default async function discard(client: Client, argv: string[]) {
   if (!stagingVersion) {
     output.warn(
       `No staged changes to discard. Make changes first with ${chalk.cyan(
-        getCommandName('routes add')
+        withGlobalFlags(client, 'routes add')
       )}.`
     );
     return 0;

--- a/packages/cli/src/commands/routes/discard.ts
+++ b/packages/cli/src/commands/routes/discard.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { discardSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   printDiffSummary,
   withGlobalFlags,
@@ -19,7 +19,7 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { editSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRoute,
   offerAutoPromote,
   shellQuoteRouteIdentifierForSuggestion,
@@ -32,7 +32,6 @@ import {
   printGeneratedRoutePreview,
 } from '../../util/routes/ai-transform';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { hasAnyTransformFlags } from '../../util/routes/interactive';
 import type { RoutingRule } from '../../util/routes/types';
 
@@ -40,7 +39,7 @@ export default async function edit(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, editSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -136,7 +135,7 @@ export default async function edit(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name or ID is required. Usage: ${getCommandName('routes edit <name-or-id>')}`
+      `Route name or ID is required. Usage: ${withGlobalFlags(client, 'routes edit <name-or-id>')}`
     );
     return 1;
   }
@@ -200,9 +199,7 @@ export default async function edit(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
-      )} to see all routes.`
+      `No route found matching "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'routes list'))} to see all routes.`
     );
     return 1;
   }
@@ -350,7 +347,7 @@ export default async function edit(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `No edit flags provided. When running non-interactively, use flags like --name, --dest, --src, etc. Run ${getCommandName('routes edit --help')} for all options.`
+        `No edit flags provided. When running non-interactively, use flags like --name, --dest, --src, etc. Run ${withGlobalFlags(client, 'routes edit --help')} for all options.`
       );
       return 1;
     }
@@ -534,7 +531,7 @@ async function handleAIEdit(
 
   if (!client.stdin.isTTY) {
     output.error(
-      `Cannot interactively confirm route changes in a non-TTY environment. Use ${getCommandName('routes edit <name-or-id> --ai "..." --yes')} to skip confirmation.`
+      `Cannot interactively confirm route changes in a non-TTY environment. Use ${withGlobalFlags(client, 'routes edit <name-or-id> --ai "..." --yes')} to skip confirmation.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
 import output from '../../output-manager';
 import { editSubcommand } from './command';
@@ -9,6 +8,7 @@ import {
   resolveRoute,
   offerAutoPromote,
   shellQuoteRouteIdentifierForSuggestion,
+  withGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import {

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { editSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRoute,
   offerAutoPromote,
   shellQuoteRouteIdentifierForSuggestion,
@@ -39,7 +39,7 @@ export default async function edit(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, editSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/enable.ts
+++ b/packages/cli/src/commands/routes/enable.ts
@@ -1,22 +1,25 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { enableSubcommand } from './command';
-import { parseSubcommandArgs, resolveRoute, offerAutoPromote } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  resolveRoute,
+  offerAutoPromote,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import editRoute from '../../util/routes/edit-route';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 
 export default async function enable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, enableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -47,7 +50,7 @@ export default async function enable(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name or ID is required. Usage: ${getCommandName('routes enable <name-or-id>')}`
+      `Route name or ID is required. Usage: ${withGlobalFlags(client, 'routes enable <name-or-id>')}`
     );
     return 1;
   }
@@ -105,7 +108,7 @@ export default async function enable(client: Client, argv: string[]) {
     }
     output.error(
       `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
+        withGlobalFlags(client, 'routes list')
       )} to see all routes.`
     );
     return 1;

--- a/packages/cli/src/commands/routes/enable.ts
+++ b/packages/cli/src/commands/routes/enable.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { enableSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRoute,
   offerAutoPromote,
   withGlobalFlags,
@@ -19,7 +19,7 @@ export default async function enable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, enableSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/export.ts
+++ b/packages/cli/src/commands/routes/export.ts
@@ -1,12 +1,13 @@
 import type Client from '../../util/client';
-import { withGlobalFlags } from '../../util/agent-output';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { exportSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
-import { getCommandName } from '../../util/pkg-name';
 import type { RoutingRule } from '../../util/routes/types';
 import type { RouteWithSrc } from '@vercel/routing-utils';
 
@@ -79,7 +80,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, exportSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -92,7 +93,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
 
   const validFormats = ['json', 'ts'];
   if (!validFormats.includes(format)) {
-    const msg = `Invalid output format: "${rawFormat}". Valid formats: ${validFormats.join(', ')}. Usage: ${getCommandName('routes export --output json')}`;
+    const msg = `Invalid output format: "${rawFormat}". Valid formats: ${validFormats.join(', ')}. Usage: ${withGlobalFlags(client, 'routes export --output json')}`;
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -118,7 +119,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
 
     if (routes.length === 0) {
       output.log(
-        `No routes found. Create one with ${getCommandName('routes add')}.`
+        `No routes found. Create one with ${withGlobalFlags(client, 'routes add')}.`
       );
       return 0;
     }
@@ -135,7 +136,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
       );
 
       if (routesToExport.length === 0) {
-        const msg = `No route found matching "${nameOrId}". Run ${getCommandName('routes list')} to see all routes.`;
+        const msg = `No route found matching "${nameOrId}". Run ${withGlobalFlags(client, 'routes list')} to see all routes.`;
         if (client.nonInteractive) {
           outputAgentError(client, {
             status: 'error',

--- a/packages/cli/src/commands/routes/export.ts
+++ b/packages/cli/src/commands/routes/export.ts
@@ -3,7 +3,7 @@ import output from '../../output-manager';
 import { exportSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   withGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
@@ -80,7 +80,7 @@ export default async function exportRoutes(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, exportSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/index.ts
+++ b/packages/cli/src/commands/routes/index.ts
@@ -28,6 +28,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { RoutesTelemetryClient } from '../../util/telemetry/commands/routes';
+import { getProjectOptionFromArgs } from '../../util/arg-common';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
@@ -84,6 +85,10 @@ export default async function main(client: Client) {
         columns: client.stderr.columns,
       })
     );
+  }
+
+  if (subcommand && !needHelp) {
+    telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/routes/inspect.ts
+++ b/packages/cli/src/commands/routes/inspect.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { inspectSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   formatCondition,
   formatTransform,
   TRANSFORM_TYPE_LABELS,
@@ -27,7 +27,7 @@ export default async function inspect(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, inspectSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/inspect.ts
+++ b/packages/cli/src/commands/routes/inspect.ts
@@ -1,19 +1,18 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { inspectSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   formatCondition,
   formatTransform,
   TRANSFORM_TYPE_LABELS,
+  withGlobalFlags,
 } from './shared';
 import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import {
@@ -28,7 +27,7 @@ export default async function inspect(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, inspectSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -63,7 +62,7 @@ export default async function inspect(client: Client, argv: string[]) {
       return 1;
     }
     output.error(
-      `Missing route name or ID. Usage: ${chalk.cyan(getCommandName('routes inspect <name-or-id>'))}`
+      `Missing route name or ID. Usage: ${chalk.cyan(withGlobalFlags(client, 'routes inspect <name-or-id>'))}`
     );
     return 1;
   }
@@ -110,7 +109,7 @@ export default async function inspect(client: Client, argv: string[]) {
     }
     output.error(
       `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
+        withGlobalFlags(client, 'routes list')
       )} to see all routes.`
     );
     return 1;

--- a/packages/cli/src/commands/routes/list-versions.ts
+++ b/packages/cli/src/commands/routes/list-versions.ts
@@ -1,11 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import ms from 'ms';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  withGlobalFlags,
+} from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
@@ -20,7 +22,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/list-versions.ts
+++ b/packages/cli/src/commands/routes/list-versions.ts
@@ -5,7 +5,7 @@ import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   withGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
@@ -22,7 +22,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/list.ts
+++ b/packages/cli/src/commands/routes/list.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import plural from 'pluralize';
 import type Client from '../../util/client';
 import output from '../../output-manager';
@@ -10,7 +9,7 @@ import {
   findVersionById,
   formatCondition,
   formatTransform,
-  withGlobalFlags as withProjectGlobalFlags,
+  withGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
@@ -57,7 +56,7 @@ export default async function list(client: Client, argv: string[]) {
           status: 'error',
           reason: 'invalid_arguments',
           message: msg,
-          next: [{ command: withProjectGlobalFlags(client, 'routes list') }],
+          next: [{ command: withGlobalFlags(client, 'routes list') }],
         });
         process.exit(1);
       }
@@ -73,7 +72,7 @@ export default async function list(client: Client, argv: string[]) {
         status: 'error',
         reason: 'invalid_arguments',
         message: msg,
-        next: [{ command: withProjectGlobalFlags(client, 'routes list') }],
+        next: [{ command: withGlobalFlags(client, 'routes list') }],
       });
       process.exit(1);
     }
@@ -89,9 +88,7 @@ export default async function list(client: Client, argv: string[]) {
         status: 'error',
         reason: 'invalid_arguments',
         message: msg,
-        next: [
-          { command: withProjectGlobalFlags(client, 'routes list --diff') },
-        ],
+        next: [{ command: withGlobalFlags(client, 'routes list --diff') }],
       });
       process.exit(1);
     }
@@ -117,7 +114,7 @@ export default async function list(client: Client, argv: string[]) {
           status: 'error',
           reason: 'not_found',
           message: msg,
-          next: [{ command: withProjectGlobalFlags(client, 'routes list') }],
+          next: [{ command: withGlobalFlags(client, 'routes list') }],
         });
         process.exit(1);
       }
@@ -147,8 +144,8 @@ export default async function list(client: Client, argv: string[]) {
           reason: 'not_found',
           message: msg,
           next: [
-            { command: withProjectGlobalFlags(client, 'routes list') },
-            { command: withProjectGlobalFlags(client, 'routes add') },
+            { command: withGlobalFlags(client, 'routes list') },
+            { command: withGlobalFlags(client, 'routes add') },
           ],
         });
         process.exit(1);
@@ -180,7 +177,7 @@ export default async function list(client: Client, argv: string[]) {
           message: msg,
           next: [
             {
-              command: withProjectGlobalFlags(client, 'routes list-versions'),
+              command: withGlobalFlags(client, 'routes list-versions'),
             },
           ],
         });

--- a/packages/cli/src/commands/routes/list.ts
+++ b/packages/cli/src/commands/routes/list.ts
@@ -2,11 +2,11 @@ import chalk from 'chalk';
 import { withGlobalFlags } from '../../util/agent-output';
 import plural from 'pluralize';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   findVersionById,
   formatCondition,
   formatTransform,
@@ -16,7 +16,6 @@ import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
 import formatTable from '../../util/format-table';
-import { getCommandName } from '../../util/pkg-name';
 import {
   getRouteTypeLabel,
   getSrcSyntaxLabel,
@@ -29,7 +28,7 @@ export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -138,7 +137,7 @@ export default async function list(client: Client, argv: string[]) {
     const stagingVersion = versions.find(v => v.isStaging);
 
     if (!stagingVersion) {
-      const msg = `No staged changes to diff. Run ${getCommandName('routes add')} or ${getCommandName('routes edit')} to make changes.`;
+      const msg = `No staged changes to diff. Run ${withGlobalFlags(client, 'routes add')} or ${withGlobalFlags(client, 'routes edit')} to make changes.`;
       if (client.nonInteractive) {
         outputAgentError(client, {
           status: 'error',
@@ -152,9 +151,7 @@ export default async function list(client: Client, argv: string[]) {
         process.exit(1);
       }
       output.error(
-        `No staged changes to diff. Run ${chalk.cyan(
-          getCommandName('routes add')
-        )} or ${chalk.cyan(getCommandName('routes edit'))} to make changes.`
+        `No staged changes to diff. Run ${chalk.cyan(withGlobalFlags(client, 'routes add'))} or ${chalk.cyan(withGlobalFlags(client, 'routes edit'))} to make changes.`
       );
       return 1;
     }
@@ -169,7 +166,7 @@ export default async function list(client: Client, argv: string[]) {
     const { versions } = await getRouteVersions(client, project.id, {
       teamId,
     });
-    const result = findVersionById(versions, versionIdFlag);
+    const result = findVersionById(client, versions, versionIdFlag);
 
     if (result.error || !result.version) {
       const msg = result.error ?? 'Version not found';

--- a/packages/cli/src/commands/routes/list.ts
+++ b/packages/cli/src/commands/routes/list.ts
@@ -10,6 +10,7 @@ import {
   findVersionById,
   formatCondition,
   formatTransform,
+  withGlobalFlags as withProjectGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';
@@ -56,7 +57,7 @@ export default async function list(client: Client, argv: string[]) {
           status: 'error',
           reason: 'invalid_arguments',
           message: msg,
-          next: [{ command: withGlobalFlags(client, 'routes list') }],
+          next: [{ command: withProjectGlobalFlags(client, 'routes list') }],
         });
         process.exit(1);
       }
@@ -72,7 +73,7 @@ export default async function list(client: Client, argv: string[]) {
         status: 'error',
         reason: 'invalid_arguments',
         message: msg,
-        next: [{ command: withGlobalFlags(client, 'routes list') }],
+        next: [{ command: withProjectGlobalFlags(client, 'routes list') }],
       });
       process.exit(1);
     }
@@ -88,7 +89,9 @@ export default async function list(client: Client, argv: string[]) {
         status: 'error',
         reason: 'invalid_arguments',
         message: msg,
-        next: [{ command: withGlobalFlags(client, 'routes list --diff') }],
+        next: [
+          { command: withProjectGlobalFlags(client, 'routes list --diff') },
+        ],
       });
       process.exit(1);
     }
@@ -114,7 +117,7 @@ export default async function list(client: Client, argv: string[]) {
           status: 'error',
           reason: 'not_found',
           message: msg,
-          next: [{ command: withGlobalFlags(client, 'routes list') }],
+          next: [{ command: withProjectGlobalFlags(client, 'routes list') }],
         });
         process.exit(1);
       }
@@ -144,8 +147,8 @@ export default async function list(client: Client, argv: string[]) {
           reason: 'not_found',
           message: msg,
           next: [
-            { command: withGlobalFlags(client, 'routes list') },
-            { command: withGlobalFlags(client, 'routes add') },
+            { command: withProjectGlobalFlags(client, 'routes list') },
+            { command: withProjectGlobalFlags(client, 'routes add') },
           ],
         });
         process.exit(1);
@@ -175,7 +178,11 @@ export default async function list(client: Client, argv: string[]) {
           status: 'error',
           reason: 'not_found',
           message: msg,
-          next: [{ command: withGlobalFlags(client, 'routes list-versions') }],
+          next: [
+            {
+              command: withProjectGlobalFlags(client, 'routes list-versions'),
+            },
+          ],
         });
         process.exit(1);
       }

--- a/packages/cli/src/commands/routes/list.ts
+++ b/packages/cli/src/commands/routes/list.ts
@@ -5,7 +5,7 @@ import output from '../../output-manager';
 import { listSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   findVersionById,
   formatCondition,
   formatTransform,
@@ -28,7 +28,7 @@ export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { publishSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   printDiffSummary,
   withGlobalFlags,
@@ -19,7 +19,7 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -1,22 +1,25 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction, printDiffSummary } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  printDiffSummary,
+  withGlobalFlags,
+} from './shared';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
 import getRoutes from '../../util/routes/get-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 
 export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -30,7 +33,7 @@ export default async function publish(client: Client, argv: string[]) {
   if (!version) {
     output.warn(
       `No staged changes to publish. Make changes first with ${chalk.cyan(
-        getCommandName('routes add')
+        withGlobalFlags(client, 'routes add')
       )}.`
     );
     return 0;

--- a/packages/cli/src/commands/routes/reorder.ts
+++ b/packages/cli/src/commands/routes/reorder.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { reorderSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   resolveRoute,
   parsePosition,
   offerAutoPromote,
@@ -21,7 +21,7 @@ export default async function reorder(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, reorderSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/reorder.ts
+++ b/packages/cli/src/commands/routes/reorder.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { reorderSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRoute,
   parsePosition,
   offerAutoPromote,
@@ -16,13 +16,12 @@ import getRoutes from '../../util/routes/get-routes';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import stageRoutes from '../../util/routes/stage-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
 
 export default async function reorder(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, reorderSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -53,7 +52,7 @@ export default async function reorder(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Route name or ID is required. Usage: ${getCommandName('routes reorder <name-or-id> --position <pos>')}`
+      `Route name or ID is required. Usage: ${withGlobalFlags(client, 'routes reorder <name-or-id> --position <pos>')}`
     );
     return 1;
   }
@@ -121,7 +120,7 @@ export default async function reorder(client: Client, argv: string[]) {
     }
     output.error(
       `No route found matching "${identifier}". Run ${chalk.cyan(
-        getCommandName('routes list')
+        withGlobalFlags(client, 'routes list')
       )} to see all routes.`
     );
     return 1;
@@ -209,7 +208,7 @@ export default async function reorder(client: Client, argv: string[]) {
             if (refIndex === -1) {
               output.error(
                 `Reference route "${pos.referenceId}" not found. Run ${chalk.cyan(
-                  getCommandName('routes list')
+                  withGlobalFlags(client, 'routes list')
                 )} to see route IDs.`
               );
               return 1;
@@ -220,7 +219,7 @@ export default async function reorder(client: Client, argv: string[]) {
             if (refIndex === -1) {
               output.error(
                 `Reference route "${pos.referenceId}" not found. Run ${chalk.cyan(
-                  getCommandName('routes list')
+                  withGlobalFlags(client, 'routes list')
                 )} to see route IDs.`
               );
               return 1;
@@ -232,7 +231,7 @@ export default async function reorder(client: Client, argv: string[]) {
           }
         } catch (e) {
           output.error(
-            `${e instanceof Error ? e.message : 'Invalid position'}. Usage: ${getCommandName('routes reorder <name-or-id> --position <pos>')}`
+            `${e instanceof Error ? e.message : 'Invalid position'}. Usage: ${withGlobalFlags(client, 'routes reorder <name-or-id> --position <pos>')}`
           );
           return 1;
         }

--- a/packages/cli/src/commands/routes/reorder.ts
+++ b/packages/cli/src/commands/routes/reorder.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
 import output from '../../output-manager';
 import { reorderSubcommand } from './command';
@@ -10,6 +9,7 @@ import {
   parsePosition,
   offerAutoPromote,
   shellQuoteRouteIdentifierForSuggestion,
+  withGlobalFlags,
 } from './shared';
 import { outputAgentError } from '../../util/agent-output';
 import getRoutes from '../../util/routes/get-routes';

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -1,21 +1,21 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   printDiffSummary,
   findVersionById,
+  withGlobalFlags,
 } from './shared';
 import { validateRequiredArguments } from '../../util/command-arguments';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
 import getRoutes from '../../util/routes/get-routes';
 import stamp from '../../util/output/stamp';
-import { getCommandName } from '../../util/pkg-name';
-import { outputAgentError, withGlobalFlags } from '../../util/agent-output';
+import { outputAgentError } from '../../util/agent-output';
 
 export default async function restore(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, restoreSubcommand, client);
@@ -45,7 +45,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'routes');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -57,7 +57,7 @@ export default async function restore(client: Client, argv: string[]) {
 
   const { versions } = await getRouteVersions(client, project.id, { teamId });
 
-  const result = findVersionById(versions, versionIdentifier);
+  const result = findVersionById(client, versions, versionIdentifier);
   if (result.error) {
     if (client.nonInteractive) {
       outputAgentError(client, {
@@ -89,7 +89,7 @@ export default async function restore(client: Client, argv: string[]) {
   }
 
   if (version.isLive) {
-    const liveMsg = `Version ${version.id.slice(0, 12)} is currently live. You cannot restore the live version. Run ${getCommandName('routes list-versions')} to see previous versions you can restore.`;
+    const liveMsg = `Version ${version.id.slice(0, 12)} is currently live. You cannot restore the live version. Run ${withGlobalFlags(client, 'routes list-versions')} to see previous versions you can restore.`;
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -104,14 +104,14 @@ export default async function restore(client: Client, argv: string[]) {
       `Version ${chalk.bold(
         version.id.slice(0, 12)
       )} is currently live. You cannot restore the live version.\nRun ${chalk.cyan(
-        getCommandName('routes list-versions')
+        withGlobalFlags(client, 'routes list-versions')
       )} to see previous versions you can restore.`
     );
     return 1;
   }
 
   if (version.isStaging) {
-    const stagingMsg = `Version ${version.id.slice(0, 12)} is staged. Use ${getCommandName('routes publish')} to publish it instead.`;
+    const stagingMsg = `Version ${version.id.slice(0, 12)} is staged. Use ${withGlobalFlags(client, 'routes publish')} to publish it instead.`;
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -126,7 +126,7 @@ export default async function restore(client: Client, argv: string[]) {
       `Version ${chalk.bold(
         version.id.slice(0, 12)
       )} is staged. Use ${chalk.cyan(
-        getCommandName('routes publish')
+        withGlobalFlags(client, 'routes publish')
       )} to publish it instead.`
     );
     return 1;

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -4,7 +4,7 @@ import output from '../../output-manager';
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
-  ensureProjectLink,
+  requireProjectContext,
   confirmAction,
   printDiffSummary,
   findVersionById,
@@ -45,7 +45,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, parsed.flags['--project']);
+  const link = await requireProjectContext(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -32,7 +32,9 @@ export function withGlobalFlags(
   client: Client,
   commandTemplate: string
 ): string {
-  return withClientGlobalFlags(client, commandTemplate, true);
+  return withClientGlobalFlags(client, commandTemplate, {
+    preserveProject: true,
+  });
 }
 
 /**

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -1,16 +1,17 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
 import { printError } from '../../util/error';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
 import {
   outputAgentError,
   buildCommandWithYes,
-  withGlobalFlags,
+  withGlobalFlags as withClientGlobalFlags,
 } from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
+import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
@@ -23,6 +24,16 @@ import {
   type RouteVersion,
   type Transform,
 } from '../../util/routes/types';
+
+/**
+ * Plain suggested command with global flags from argv (--cwd, --non-interactive, etc.).
+ */
+export function withGlobalFlags(
+  client: Client,
+  commandTemplate: string
+): string {
+  return withClientGlobalFlags(client, commandTemplate, true);
+}
 
 /**
  * Shell-escape route identifier for suggested `next` commands. Uses single
@@ -56,7 +67,9 @@ export async function parseSubcommandArgs(
   } catch (err) {
     if (client?.nonInteractive) {
       const rawMessage = err instanceof Error ? err.message : String(err);
-      const flags = getGlobalFlagsFromArgs(client.argv.slice(2));
+      const flags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+        preserveProject: true,
+      });
       let message = rawMessage;
       let next: Array<{ command: string; when?: string }> = [
         {
@@ -122,6 +135,10 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
+}
+
+export function ensureProjectLink(client: Client, projectName?: string) {
+  return ensureProjectLinkForCommand(client, 'routes', projectName);
 }
 
 export async function confirmAction(
@@ -283,7 +300,7 @@ export async function offerAutoPromote(
 
   // Always inform the user that changes are staged
   output.print(
-    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(getCommandName('routes publish'))} to make it live, or ${chalk.cyan(getCommandName('routes discard-staging'))} to undo.`)}\n`
+    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(withGlobalFlags(client, 'routes publish'))} to make it live, or ${chalk.cyan(withGlobalFlags(client, 'routes discard-staging'))} to undo.`)}\n`
   );
 
   if (!hadExistingStagingVersion && !opts.skipPrompts) {
@@ -314,7 +331,7 @@ export async function offerAutoPromote(
     }
   } else if (hadExistingStagingVersion) {
     output.warn(
-      `There are other staged changes. Review with ${chalk.cyan(getCommandName('routes list --diff'))} before promoting.`
+      `There are other staged changes. Review with ${chalk.cyan(withGlobalFlags(client, 'routes list --diff'))} before promoting.`
     );
   }
 }
@@ -464,9 +481,7 @@ export async function resolveRoutes(
         return null;
       }
       output.error(
-        `No route found matching "${identifier}". Run ${chalk.cyan(
-          getCommandName('routes list')
-        )} to see all routes.`
+        `No route found matching "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'routes list'))} to see all routes.`
       );
       return null;
     }
@@ -480,6 +495,7 @@ export async function resolveRoutes(
  * Find a version by ID, supporting partial ID matching.
  */
 export function findVersionById(
+  client: Client,
   versions: RouteVersion[],
   identifier: string
 ):
@@ -490,7 +506,7 @@ export function findVersionById(
   if (matchingVersions.length === 0) {
     return {
       error: `Version "${identifier}" not found. Run ${chalk.cyan(
-        getCommandName('routes list-versions')
+        withGlobalFlags(client, 'routes list-versions')
       )} to see available versions.`,
     };
   }

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -139,7 +139,7 @@ export async function parseSubcommandArgs(
   return parsedArgs;
 }
 
-export function ensureProjectLink(client: Client, projectName?: string) {
+export function requireProjectContext(client: Client, projectName?: string) {
   return ensureProjectLinkForCommand(client, 'routes', projectName);
 }
 

--- a/packages/cli/test/unit/commands/firewall/overview.test.ts
+++ b/packages/cli/test/unit/commands/firewall/overview.test.ts
@@ -13,7 +13,10 @@ import {
 } from '../../../mocks/firewall';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('firewall overview', () => {
   beforeEach(() => {
@@ -62,6 +65,23 @@ describe('firewall overview', () => {
     expect(fullOutput).toContain('2 active, 1 inactive (3 total)');
     expect(fullOutput).toContain('IP Blocks');
     expect(fullOutput).toContain('System Bypass');
+  });
+
+  it('shows the overview for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-firewall',
+      name: 'explicit-firewall',
+      accountId: 'team_dummy',
+    });
+    useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
+    useGetBypass([]);
+    client.setArgv('firewall', 'overview', '--project', 'explicit-firewall');
+
+    await expect(firewall(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Enabled');
   });
 
   it('should show firewall overview when disabled', async () => {

--- a/packages/cli/test/unit/commands/firewall/rules-enable.test.ts
+++ b/packages/cli/test/unit/commands/firewall/rules-enable.test.ts
@@ -13,7 +13,10 @@ import {
 } from '../../../mocks/firewall';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('firewall rules enable', () => {
   beforeEach(() => {
@@ -45,6 +48,38 @@ describe('firewall rules enable', () => {
 
     expect(lastPatchBody.action).toBe('rules.update');
     expect(lastPatchBody.value.active).toBe(true);
+  });
+
+  it('enables a rule for the project selected by --project', async () => {
+    const active = createConfig({ rules: [createRule(3)] });
+    useListFirewallConfigs(active, null);
+    usePatchDraft();
+    useActivateConfig();
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-firewall',
+      name: 'explicit-firewall',
+      accountId: 'team_dummy',
+    });
+    client.setArgv(
+      'firewall',
+      'rules',
+      'enable',
+      'Test Rule 3',
+      '--project',
+      'explicit-firewall',
+      '--yes'
+    );
+
+    await expect(firewall(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Enabled');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'subcommand:rules', value: 'rules' },
+      { key: 'subcommand:rules:enable', value: 'enable' },
+    ]);
   });
 
   it('should report already enabled', async () => {

--- a/packages/cli/test/unit/commands/redirects/add.test.ts
+++ b/packages/cli/test/unit/commands/redirects/add.test.ts
@@ -4,7 +4,10 @@ import redirects from '../../../../src/commands/redirects';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('redirects add', () => {
   beforeEach(() => {
@@ -14,6 +17,7 @@ describe('redirects add', () => {
       ...defaultProject,
       id: 'redirects-test',
       name: 'redirects-test',
+      accountId: 'team_dummy',
     });
     client.scenario.get('/v9/projects/:projectNameOrId', (_req, res) => {
       res.json(project);
@@ -489,7 +493,20 @@ describe('redirects add', () => {
         throw new Error('exit');
       }) as () => never);
 
-      client.setArgv('redirects', 'add');
+      client.setArgv(
+        'redirects',
+        'add',
+        '--status',
+        '301',
+        '--name',
+        'release-1',
+        '--project',
+        'redirects-test',
+        '--scope',
+        'team_dummy',
+        '--cwd',
+        '/tmp/project'
+      );
       await expect(redirects(client)).rejects.toThrow('exit');
 
       expect(logSpy).toHaveBeenCalled();
@@ -498,8 +515,9 @@ describe('redirects add', () => {
       expect(payload.reason).toBe('missing_arguments');
       expect(payload.message).toContain('source and destination are required');
       expect(Array.isArray(payload.next)).toBe(true);
-      expect(payload.next[0].command).toContain('redirects add');
-      expect(payload.next[0].command).toContain('--yes');
+      expect(payload.next[0].command).toBe(
+        'vercel redirects add <source> <destination> --status 301 --name release-1 --project redirects-test --scope team_dummy --cwd /tmp/project --yes'
+      );
       expect(payload.next[0].when).toBe('to add a redirect');
 
       logSpy.mockRestore();
@@ -565,6 +583,34 @@ describe('redirects add', () => {
         true
       );
 
+      client.nonInteractive = false;
+    });
+
+    it('adds a redirect to the project selected by --project', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+      client.cwd = setupTmpDir();
+      client.config.currentTeam = 'team_dummy';
+      client.nonInteractive = true;
+      client.setArgv(
+        'redirects',
+        'add',
+        '/old-path',
+        '/new-path',
+        '--project',
+        'redirects-test',
+        '--yes'
+      );
+
+      expect(await redirects(client)).toEqual(0);
+      const output = JSON.parse(client.stdout.getFullOutput());
+      expect(output.next).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            command: expect.stringContaining('--project redirects-test'),
+          }),
+        ])
+      );
       client.nonInteractive = false;
     });
 

--- a/packages/cli/test/unit/commands/redirects/list.test.ts
+++ b/packages/cli/test/unit/commands/redirects/list.test.ts
@@ -5,7 +5,10 @@ import { useUser } from '../../../mocks/user';
 import { useRedirects } from '../../../mocks/redirects';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('redirects list', () => {
   beforeEach(() => {
@@ -44,6 +47,26 @@ describe('redirects list', () => {
     const exitCode = await redirects(client);
     expect(exitCode, 'exit code for "redirects list"').toEqual(0);
     await expect(client.stderr).toOutput('3 Redirects found');
+  });
+
+  it('lists redirects for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-redirects',
+      name: 'explicit-redirects',
+      accountId: 'team_dummy',
+    });
+    useRedirects(3);
+    client.setArgv('redirects', 'list', '--project', 'explicit-redirects');
+
+    await expect(redirects(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('3 Redirects found');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'subcommand:list', value: 'list' },
+    ]);
   });
 
   it('should list redirects using ls alias', async () => {

--- a/packages/cli/test/unit/commands/routes/edit.test.ts
+++ b/packages/cli/test/unit/commands/routes/edit.test.ts
@@ -3,7 +3,10 @@ import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import {
   useEditRoute,
   useEditRouteComprehensive,
@@ -43,6 +46,14 @@ describe('routes edit', () => {
 
   it('non-interactive missing flags: suggested command uses single quotes for spaced name (no backslash)', async () => {
     useEditRouteComprehensive();
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const exitSpy = vi
       .spyOn(process, 'exit')
@@ -53,13 +64,16 @@ describe('routes edit', () => {
       'edit',
       'API Rewrite',
       '--yes',
-      '--non-interactive'
+      '--non-interactive',
+      '--project',
+      'explicit-routes'
     );
     await routes(client);
     const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(payload.reason).toBe('missing_arguments');
     const nextCmd = payload.next?.[0]?.command ?? '';
     expect(nextCmd).toContain("'API Rewrite'");
+    expect(nextCmd).toContain('--project explicit-routes');
     expect(nextCmd).not.toContain('\\"');
     logSpy.mockRestore();
     exitSpy.mockRestore();

--- a/packages/cli/test/unit/commands/routes/enable.test.ts
+++ b/packages/cli/test/unit/commands/routes/enable.test.ts
@@ -3,7 +3,10 @@ import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { useEditRoute } from '../../../mocks/routes';
 import routes from '../../../../src/commands/routes';
 
@@ -31,6 +34,28 @@ describe('routes enable', () => {
     client.setArgv('routes', 'enable', 'Disabled Route');
     const exitCode = await routes(client);
     expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Enabled');
+  });
+
+  it('enables a route for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
+    useEditRoute();
+    client.setArgv(
+      'routes',
+      'enable',
+      'Disabled Route',
+      '--project',
+      'explicit-routes'
+    );
+
+    await expect(routes(client)).resolves.toEqual(0);
     await expect(client.stderr).toOutput('Enabled');
   });
 

--- a/packages/cli/test/unit/commands/routes/list.test.ts
+++ b/packages/cli/test/unit/commands/routes/list.test.ts
@@ -9,7 +9,10 @@ import {
 } from '../../../mocks/routes';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('routes list', () => {
   beforeEach(() => {
@@ -48,6 +51,26 @@ describe('routes list', () => {
     const exitCode = await routes(client);
     expect(exitCode, 'exit code for "routes list"').toEqual(0);
     await expect(client.stderr).toOutput('3 Routes found');
+  });
+
+  it('lists routes for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
+    useRoutes(3);
+    client.setArgv('routes', 'list', '--project', 'explicit-routes');
+
+    await expect(routes(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('3 Routes found');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'subcommand:list', value: 'list' },
+    ]);
   });
 
   it('should list routes using ls alias', async () => {

--- a/packages/cli/test/unit/commands/routes/list.test.ts
+++ b/packages/cli/test/unit/commands/routes/list.test.ts
@@ -196,6 +196,12 @@ describe('routes list', () => {
 
     await expect(routes(client)).rejects.toThrow('exit');
     const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+    expect(payload.message).toContain(
+      'vercel routes add --project explicit-routes'
+    );
+    expect(payload.message).toContain(
+      'vercel routes edit --project explicit-routes'
+    );
     expect(
       payload.next.map(({ command }: { command: string }) => command)
     ).toEqual([

--- a/packages/cli/test/unit/commands/routes/list.test.ts
+++ b/packages/cli/test/unit/commands/routes/list.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import routes from '../../../../src/commands/routes';
 import { useUser } from '../../../mocks/user';
@@ -174,6 +174,38 @@ describe('routes list', () => {
     const exitCode = await routes(client);
     expect(exitCode, 'exit code for --diff without staging').toEqual(1);
     await expect(client.stderr).toOutput('No staged changes to diff');
+  });
+
+  it('preserves --project in suggestions when no staging version exists', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as () => never);
+    client.nonInteractive = true;
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
+    useRouteVersions(0);
+    useRoutes(3);
+    client.setArgv('routes', 'list', '--diff', '--project', 'explicit-routes');
+
+    await expect(routes(client)).rejects.toThrow('exit');
+    const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+    expect(
+      payload.next.map(({ command }: { command: string }) => command)
+    ).toEqual([
+      'vercel routes list --project explicit-routes',
+      'vercel routes add --project explicit-routes',
+    ]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+    client.nonInteractive = false;
   });
 
   describe('--expand', () => {

--- a/packages/cli/test/unit/commands/routes/reorder.test.ts
+++ b/packages/cli/test/unit/commands/routes/reorder.test.ts
@@ -3,7 +3,10 @@ import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 import { useStageRoutes } from '../../../mocks/routes';
 import { shellQuoteRouteIdentifierForSuggestion } from '../../../../src/commands/routes/shared';
 import routes from '../../../../src/commands/routes';
@@ -262,6 +265,14 @@ describe('routes reorder', () => {
 
   it('non-interactive: position 0 outputs JSON invalid_arguments with next commands', async () => {
     useStageRoutes();
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-routes',
+      name: 'explicit-routes',
+      accountId: 'team_dummy',
+    });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const exitSpy = vi
       .spyOn(process, 'exit')
@@ -274,7 +285,9 @@ describe('routes reorder', () => {
       '--position',
       '0',
       '--yes',
-      '--non-interactive'
+      '--non-interactive',
+      '--project',
+      'explicit-routes'
     );
     await routes(client);
     const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
@@ -287,6 +300,11 @@ describe('routes reorder', () => {
       payload.next.some(
         (n: { command: string }) =>
           n.command.includes('--first') || n.command.includes('--position 1')
+      )
+    ).toBe(true);
+    expect(
+      payload.next.every((n: { command: string }) =>
+        n.command.includes('--project explicit-routes')
       )
     ).toBe(true);
     expect(exitSpy).toHaveBeenCalledWith(1);


### PR DESCRIPTION
## Summary

Adds `--project <name-or-id>` to these Routes commands:

```text
add, delete, disable, discard, edit, enable, export, inspect,
list, list-versions, publish, reorder, restore
```

Routes can now be read or changed without linking the working directory first:

```bash
vercel routes list --project payments-api --scope acme
```

The selected project is passed to the shared helper added in #17109. The command does not write `.vercel/project.json`, and existing confirmations and linked-directory behavior remain unchanged.

## Validation

- Representative Routes read and mutation unit tests
- Aggregate stacked CLI rollout suite
- Biome lint and `git diff --check`

**Stack:** #17113 → this PR → #17115
