### PR TITLE
feat(cli): add --project support for redirects

### DIFF
--- a/.changeset/quick-redirects-select.md
+++ b/.changeset/quick-redirects-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Redirects commands to select a project explicitly with `--project`.

--- a/.changeset/steady-firewalls-select.md
+++ b/.changeset/steady-firewalls-select.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Firewall commands to select a project explicitly with `--project`.

--- a/packages/cli/src/commands/firewall/attack-mode/disable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/disable.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { attackModeDisableSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -48,7 +51,7 @@ export default async function disable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/enable.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/enable.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { attackModeEnableSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import updateAttackMode from '../../../util/firewall/update-attack-mode';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -65,7 +68,7 @@ export default async function enable(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project } = link;

--- a/packages/cli/src/commands/firewall/attack-mode/index.ts
+++ b/packages/cli/src/commands/firewall/attack-mode/index.ts
@@ -15,20 +15,18 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   enable: getCommandAliases(attackModeEnableSubcommand),
   disable: getCommandAliases(attackModeDisableSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     attackModeSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/command.ts
+++ b/packages/cli/src/commands/firewall/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const overviewSubcommand = {
   name: 'overview',
@@ -8,6 +8,7 @@ export const overviewSubcommand = {
     "Show a summary of your project's firewall configuration, including active rules, IP blocks, bypasses, and any unpublished draft changes",
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -31,6 +32,7 @@ export const diffSubcommand = {
     'Show draft changes that have been made but are not yet published to production',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -53,7 +55,7 @@ export const publishSubcommand = {
   description:
     'Publish all draft firewall changes to production, making them live immediately',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Publish draft changes',
@@ -72,7 +74,7 @@ export const discardSubcommand = {
   description:
     'Permanently discard all unpublished draft changes, reverting to the current production configuration',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Discard draft changes',
@@ -93,6 +95,7 @@ export const systemBypassListSubcommand = {
     'List all system bypass rules that allow specific IPs to skip firewall checks',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -116,6 +119,7 @@ export const systemBypassAddSubcommand = {
     'Add a system bypass rule to allow a specific IP address to skip firewall checks. Takes effect immediately (no publish required)',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'domain',
       shorthand: null,
@@ -151,6 +155,7 @@ export const systemBypassRemoveSubcommand = {
     'Remove a system bypass rule so the IP is no longer exempt from firewall checks. Takes effect immediately (no publish required)',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'domain',
       shorthand: null,
@@ -204,6 +209,7 @@ export const ipBlocksListSubcommand = {
     'List all IP blocking rules, including any unpublished draft changes',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -227,6 +233,7 @@ export const ipBlocksBlockSubcommand = {
     'Block an IP address or CIDR range from accessing your project. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'hostname',
       shorthand: null,
@@ -267,6 +274,7 @@ export const ipBlocksUnblockSubcommand = {
     'Remove an IP blocking rule to allow the address to access your project again. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'id-or-ip', required: true }],
   options: [
+    projectOption,
     {
       name: 'hostname',
       shorthand: null,
@@ -331,6 +339,7 @@ export const rulesListSubcommand = {
     'List all custom firewall rules, including any unpublished draft changes',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'expand',
       shorthand: 'e',
@@ -365,6 +374,7 @@ export const rulesInspectSubcommand = {
     'Show the full configuration of a custom firewall rule, including conditions, action, and rate limit settings',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'json',
       shorthand: null,
@@ -392,6 +402,7 @@ export const rulesAddSubcommand = {
     'Create a new custom firewall rule using AI, an interactive builder, JSON, or command-line flags. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name', required: false }],
   options: [
+    projectOption,
     {
       name: 'ai',
       shorthand: null,
@@ -537,6 +548,7 @@ export const rulesEditSubcommand = {
     'Edit an existing custom firewall rule using AI, an interactive editor, JSON, or command-line flags. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'ai',
       shorthand: null,
@@ -691,7 +703,7 @@ export const rulesEnableSubcommand = {
   description:
     'Enable a disabled custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Enable a rule',
@@ -706,7 +718,7 @@ export const rulesDisableSubcommand = {
   description:
     'Disable a custom firewall rule without removing it. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Disable a rule',
@@ -721,7 +733,7 @@ export const rulesRemoveSubcommand = {
   description:
     'Remove a custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Remove a rule',
@@ -737,6 +749,7 @@ export const rulesReorderSubcommand = {
     'Change the priority order of a custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
+    projectOption,
     {
       name: 'position',
       shorthand: null,
@@ -816,6 +829,7 @@ export const attackModeEnableSubcommand = {
     'Enable attack mode — all visitors will be shown a verification challenge before accessing your site. Takes effect immediately (no publish required)',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'duration',
       shorthand: null,
@@ -843,7 +857,7 @@ export const attackModeDisableSubcommand = {
   description:
     'Disable attack mode — visitors will no longer be challenged. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Disable attack mode',
@@ -879,7 +893,7 @@ export const systemMitigationsPauseSubcommand = {
   description:
     'Pause automatic DDoS protection and system-level traffic filtering for 24 hours. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Pause system mitigations',
@@ -894,7 +908,7 @@ export const systemMitigationsResumeSubcommand = {
   description:
     'Resume automatic DDoS protection and system-level traffic filtering. Takes effect immediately (no publish required)',
   arguments: [],
-  options: [yesOption],
+  options: [projectOption, yesOption],
   examples: [
     {
       name: 'Resume system mitigations',

--- a/packages/cli/src/commands/firewall/diff.ts
+++ b/packages/cli/src/commands/firewall/diff.ts
@@ -1,20 +1,22 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { diffSubcommand } from './command';
-import { parseSubcommandArgs, outputJson } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import { formatDiffOutput } from '../../util/firewall/format';
-import { getCommandName } from '../../util/pkg-name';
 import { outputAgentError } from '../../util/agent-output';
 
 export default async function diff(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, diffSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -50,7 +52,7 @@ export default async function diff(client: Client, argv: string[]) {
     output.print(formatDiffOutput(draft.changes, activeRulesMap));
     output.print('\n\n');
     output.print(
-      `  Run ${chalk.cyan(getCommandName('firewall publish'))} to publish, or ${chalk.cyan(getCommandName('firewall discard'))} to discard.\n\n`
+      `  Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard'))} to discard.\n\n`
     );
 
     return 0;

--- a/packages/cli/src/commands/firewall/discard.ts
+++ b/packages/cli/src/commands/firewall/discard.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import deleteFirewallDraft from '../../util/firewall/delete-firewall-draft';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -15,7 +18,7 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/index.ts
+++ b/packages/cli/src/commands/firewall/index.ts
@@ -29,6 +29,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { FirewallTelemetryClient } from '../../util/telemetry/commands/firewall';
+import { getProjectOptionFromArgs } from '../../util/arg-common';
 
 const COMMAND_CONFIG = {
   overview: getCommandAliases(overviewSubcommand),
@@ -83,6 +84,10 @@ export default async function main(client: Client) {
     );
   }
 
+  if (subcommand && !needHelp) {
+    telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
+  }
+
   switch (subcommand) {
     case 'overview':
       if (needHelp) {
@@ -119,27 +124,27 @@ export default async function main(client: Client) {
     case 'rules': {
       telemetry.trackCliSubcommandRules(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return rules(client, nestedArgs);
+      return rules(client, nestedArgs, telemetry);
     }
     case 'ip-blocks': {
       telemetry.trackCliSubcommandIpBlocks(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return ipBlocks(client, nestedArgs);
+      return ipBlocks(client, nestedArgs, telemetry);
     }
     case 'system-bypass': {
       telemetry.trackCliSubcommandSystemBypass(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return systemBypass(client, nestedArgs);
+      return systemBypass(client, nestedArgs, telemetry);
     }
     case 'attack-mode': {
       telemetry.trackCliSubcommandAttackMode(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return attackMode(client, nestedArgs);
+      return attackMode(client, nestedArgs, telemetry);
     }
     case 'system-mitigations': {
       telemetry.trackCliSubcommandSystemMitigations(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;
-      return systemMitigations(client, nestedArgs);
+      return systemMitigations(client, nestedArgs, telemetry);
     }
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/firewall/ip-blocks/block.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/block.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksBlockSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -63,7 +63,7 @@ export default async function block(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/ip-blocks/index.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/index.ts
@@ -17,7 +17,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(ipBlocksListSubcommand),
@@ -25,13 +25,11 @@ const COMMAND_CONFIG = {
   unblock: getCommandAliases(ipBlocksUnblockSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(ipBlocksSubcommand.options);
   let parsedArgs;
   try {

--- a/packages/cli/src/commands/firewall/ip-blocks/list.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/list.ts
@@ -1,16 +1,18 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateIpRules,
   formatIpBlocksTable,
 } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function list(client: Client, argv: string[]) {
@@ -22,7 +24,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -64,7 +66,7 @@ export default async function list(client: Client, argv: string[]) {
     const ipChanges = changes.filter(c => c.action.startsWith('ip.')).length;
     if (ipChanges > 0) {
       output.print(
-        `\n  ${chalk.yellow(`${ipChanges} unpublished IP block change${ipChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(getCommandName('firewall publish'))} to publish.\n`
+        `\n  ${chalk.yellow(`${ipChanges} unpublished IP block change${ipChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish.\n`
       );
     } else {
       output.print(`\n  ${chalk.dim('Showing live configuration.')}\n`);

--- a/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
@@ -1,18 +1,17 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { ipBlocksUnblockSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   offerAutoPublish,
   resolveIpRule,
 } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
-import { getCommandName } from '../../../util/pkg-name';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
 
@@ -31,7 +30,7 @@ export default async function unblock(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -61,7 +60,7 @@ export default async function unblock(client: Client, argv: string[]) {
 
     if (matches.length === 0) {
       output.error(
-        `No IP block found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall ip-blocks list'))} to view all rules.`
+        `No IP block found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall ip-blocks list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { overviewSubcommand } from './command';
-import { parseSubcommandArgs, outputJson } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import getBypass from '../../util/firewall/get-bypass';
 import {
@@ -18,7 +21,7 @@ export default async function overview(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, overviewSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/publish.ts
+++ b/packages/cli/src/commands/firewall/publish.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../util/agent-output';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -15,7 +18,7 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/add-ai.ts
+++ b/packages/cli/src/commands/firewall/rules/add-ai.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
 import output from '../../../output-manager';
 import {
+  withGlobalFlags,
   detectExistingDraft,
   offerAutoPublish,
   printActionImpactWarning,

--- a/packages/cli/src/commands/firewall/rules/add.ts
+++ b/packages/cli/src/commands/firewall/rules/add.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesAddSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -25,7 +25,6 @@ import type {
 } from '../../../util/firewall/types';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
-import { getCommandName } from '../../../util/pkg-name';
 import { handleAIAdd } from './add-ai';
 import { addInteractive } from './add-interactive';
 
@@ -88,7 +87,7 @@ export default async function add(client: Client, argv: string[]) {
     }
 
     // AI mode
-    const link = await ensureProjectLink(client, 'firewall');
+    const link = await ensureProjectLink(client, parsed.flags['--project']);
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -130,7 +129,7 @@ export default async function add(client: Client, argv: string[]) {
       ],
     });
 
-    const link = await ensureProjectLink(client, 'firewall');
+    const link = await ensureProjectLink(client, parsed.flags['--project']);
     if (typeof link === 'number') return link;
     const { project, org } = link;
     const teamId = org.type === 'team' ? org.id : undefined;
@@ -291,7 +290,7 @@ async function handleFlagAdd(
   const name = parsed.args[0] as string | undefined;
   if (!name) {
     output.error(
-      `Missing rule name. Provide as the first argument: ${chalk.cyan(getCommandName('firewall rules add "Rule name" --condition ...'))}`
+      `Missing rule name. Provide as the first argument: ${chalk.cyan(withGlobalFlags(client, 'firewall rules add "Rule name" --condition ...'))}`
     );
     return 1;
   }
@@ -399,7 +398,11 @@ async function createRule(
   parsed: { args: string[]; flags: Record<string, unknown> },
   rule: Omit<FirewallRule, 'id'>
 ): Promise<number> {
-  const link = await ensureProjectLink(client, 'firewall');
+  const projectName = parsed.flags['--project'];
+  const link = await ensureProjectLink(
+    client,
+    typeof projectName === 'string' ? projectName : undefined
+  );
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/rules/disable.ts
+++ b/packages/cli/src/commands/firewall/rules/disable.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesDisableSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -15,7 +15,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function disable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -26,7 +25,7 @@ export default async function disable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -77,7 +76,7 @@ export default async function disable(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules disable <name-or-id>')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules disable <name-or-id>')}`
       );
       return 1;
     }
@@ -109,7 +108,7 @@ export default async function disable(client: Client, argv: string[]) {
   if (allMatches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/edit.ts
+++ b/packages/cli/src/commands/firewall/rules/edit.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesEditSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
@@ -30,7 +30,6 @@ import type { FirewallRule } from '../../../util/firewall/types';
 import { runInteractiveEditLoop } from './edit-interactive';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function edit(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -43,7 +42,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   let identifier = parsed.args[0] as string | undefined;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -64,7 +63,7 @@ export default async function edit(client: Client, argv: string[]) {
 
     if (client.nonInteractive || !client.stdin.isTTY) {
       output.error(
-        `Missing required argument: <name-or-id>. Run ${chalk.cyan(getCommandName('firewall rules list'))} to see all rules.`
+        `Missing required argument: <name-or-id>. Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to see all rules.`
       );
       return 1;
     }
@@ -96,7 +95,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   if (matches.length === 0) {
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/enable.ts
+++ b/packages/cli/src/commands/firewall/rules/enable.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesEnableSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function enable(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function enable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -78,7 +77,7 @@ export default async function enable(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules enable <name-or-id>')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules enable <name-or-id>')}`
       );
       return 1;
     }
@@ -110,7 +109,7 @@ export default async function enable(client: Client, argv: string[]) {
   if (allMatches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/index.ts
+++ b/packages/cli/src/commands/firewall/rules/index.ts
@@ -27,7 +27,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(rulesListSubcommand),
@@ -40,13 +40,11 @@ const COMMAND_CONFIG = {
   reorder: getCommandAliases(rulesReorderSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(rulesSubcommand.options);
   let parsedArgs;
   try {

--- a/packages/cli/src/commands/firewall/rules/inspect.ts
+++ b/packages/cli/src/commands/firewall/rules/inspect.ts
@@ -1,13 +1,16 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesInspectSubcommand } from '../command';
-import { parseSubcommandArgs, resolveRule, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  resolveRule,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import { formatRuleDetail } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function inspect(client: Client, argv: string[]) {
@@ -46,12 +49,12 @@ export default async function inspect(client: Client, argv: string[]) {
       );
     }
     output.error(
-      `Rule name or ID is required. Usage: ${getCommandName('firewall rules inspect <name-or-id>')}`
+      `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules inspect <name-or-id>')}`
     );
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -88,7 +91,7 @@ export default async function inspect(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+        `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/rules/list.ts
+++ b/packages/cli/src/commands/firewall/rules/list.ts
@@ -1,17 +1,19 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateRules,
   formatRulesTable,
   formatRuleExpanded,
 } from '../../../util/firewall/format';
-import { getCommandName } from '../../../util/pkg-name';
 import { outputAgentError } from '../../../util/agent-output';
 
 export default async function list(client: Client, argv: string[]) {
@@ -23,7 +25,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -104,7 +106,7 @@ export default async function list(client: Client, argv: string[]) {
     ).length;
     if (ruleChanges > 0) {
       output.print(
-        `\n  ${chalk.yellow(`${ruleChanges} unpublished rule change${ruleChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(getCommandName('firewall publish'))} to publish.\n`
+        `\n  ${chalk.yellow(`${ruleChanges} unpublished rule change${ruleChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish.\n`
       );
     } else {
       output.print(`\n  ${chalk.dim('Showing live configuration.')}\n`);

--- a/packages/cli/src/commands/firewall/rules/remove.ts
+++ b/packages/cli/src/commands/firewall/rules/remove.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesRemoveSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function remove(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function remove(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -78,7 +77,7 @@ export default async function remove(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules remove <name-or-id> --yes')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules remove <name-or-id> --yes')}`
       );
       return 1;
     }
@@ -104,7 +103,7 @@ export default async function remove(client: Client, argv: string[]) {
   if (matches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/rules/reorder.ts
+++ b/packages/cli/src/commands/firewall/rules/reorder.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { rulesReorderSubcommand } from '../command';
 import {
+  withGlobalFlags,
   parseSubcommandArgs,
+  ensureProjectLink,
   resolveRule,
   confirmAction,
   detectExistingDraft,
@@ -16,7 +16,6 @@ import { outputAgentError } from '../../../util/agent-output';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import stamp from '../../../util/output/stamp';
-import { getCommandName } from '../../../util/pkg-name';
 
 export default async function reorder(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(
@@ -27,7 +26,7 @@ export default async function reorder(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -76,7 +75,7 @@ export default async function reorder(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${getCommandName('firewall rules reorder <name-or-id> --position N --yes')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules reorder <name-or-id> --position N --yes')}`
       );
       return 1;
     }
@@ -102,7 +101,7 @@ export default async function reorder(client: Client, argv: string[]) {
   if (matches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(getCommandName('firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
     );
     return 1;
   }

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -1,9 +1,13 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
 import { printError } from '../../util/error';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { getCommandNamePlain } from '../../util/pkg-name';
 import output from '../../output-manager';
-import { outputAgentError, buildCommandWithYes } from '../../util/agent-output';
+import {
+  outputAgentError,
+  buildCommandWithYes,
+  withGlobalFlags as withClientGlobalFlags,
+} from '../../util/agent-output';
 import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import type { Command } from '../help';
@@ -15,6 +19,19 @@ import type { FirewallIpRule, FirewallRule } from '../../util/firewall/types';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import stamp from '../../util/output/stamp';
+import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
+
+/**
+ * Plain suggested command with global flags from argv (--cwd, --non-interactive, etc.).
+ */
+export function withGlobalFlags(
+  client: Client,
+  commandTemplate: string
+): string {
+  return withClientGlobalFlags(client, commandTemplate, {
+    preserveProject: true,
+  });
+}
 
 export async function parseSubcommandArgs(
   argv: string[],
@@ -30,7 +47,9 @@ export async function parseSubcommandArgs(
   } catch (err) {
     if (client?.nonInteractive) {
       const rawMessage = err instanceof Error ? err.message : String(err);
-      const flags = getGlobalFlagsFromArgs(client.argv.slice(2));
+      const flags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+        preserveProject: true,
+      });
       outputAgentError(
         client,
         {
@@ -55,6 +74,10 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
+}
+
+export function ensureProjectLink(client: Client, projectName?: string) {
+  return ensureProjectLinkForCommand(client, 'firewall', projectName);
 }
 
 export async function confirmAction(
@@ -117,7 +140,7 @@ export async function offerAutoPublish(
   opts: { teamId?: string; skipPrompts?: boolean }
 ): Promise<void> {
   output.print(
-    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(getCommandName('firewall publish'))} to make it live, or ${chalk.cyan(getCommandName('firewall discard'))} to undo.`)}\n`
+    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to make it live, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard'))} to undo.`)}\n`
   );
 
   if (
@@ -152,7 +175,7 @@ export async function offerAutoPublish(
     }
   } else if (hadExistingDraft) {
     output.warn(
-      `There are other draft changes. Review with ${chalk.cyan(getCommandName('firewall diff'))} before publishing.`
+      `There are other draft changes. Review with ${chalk.cyan(withGlobalFlags(client, 'firewall diff'))} before publishing.`
     );
   }
 }

--- a/packages/cli/src/commands/firewall/system-bypass/add.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/add.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassAddSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import {
   validateBypassIp,
@@ -57,7 +60,7 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/index.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/index.ts
@@ -17,7 +17,7 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(systemBypassListSubcommand),
@@ -25,13 +25,11 @@ const COMMAND_CONFIG = {
   remove: getCommandAliases(systemBypassRemoveSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     systemBypassSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/system-bypass/list.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/list.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  outputJson,
+  withGlobalFlags,
+} from '../shared';
 import getBypass from '../../../util/firewall/get-bypass';
 import {
   formatBypassTable,
@@ -21,7 +24,7 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-bypass/remove.ts
+++ b/packages/cli/src/commands/firewall/system-bypass/remove.ts
@@ -1,16 +1,18 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemBypassRemoveSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import {
   validateBypassIp,
   validateHostname,
 } from '../../../util/firewall/validate';
-import { getCommandName } from '../../../util/pkg-name';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
 
@@ -47,7 +49,7 @@ export default async function remove(client: Client, argv: string[]) {
     }
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -89,7 +91,7 @@ export default async function remove(client: Client, argv: string[]) {
     const error = e as { status?: number; message?: string };
     if (error.status === 404) {
       output.error(
-        `No bypass rule found for ${chalk.bold(ip)}. Run ${chalk.cyan(getCommandName('firewall system-bypass list'))} to view all rules.`
+        `No bypass rule found for ${chalk.bold(ip)}. Run ${chalk.cyan(withGlobalFlags(client, 'firewall system-bypass list'))} to view all rules.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/firewall/system-mitigations/index.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/index.ts
@@ -15,20 +15,18 @@ import {
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
 import output from '../../../output-manager';
 import { getCommandAliases } from '../..';
-import { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
+import type { FirewallTelemetryClient } from '../../../util/telemetry/commands/firewall';
 
 const COMMAND_CONFIG = {
   pause: getCommandAliases(systemMitigationsPauseSubcommand),
   resume: getCommandAliases(systemMitigationsResumeSubcommand),
 };
 
-export default async function main(client: Client, args: string[]) {
-  const telemetry = new FirewallTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
-
+export default async function main(
+  client: Client,
+  args: string[],
+  telemetry: FirewallTelemetryClient
+) {
   const flagsSpecification = getFlagsSpecification(
     systemMitigationsSubcommand.options
   );

--- a/packages/cli/src/commands/firewall/system-mitigations/pause.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/pause.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemMitigationsPauseSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import addBypass from '../../../util/firewall/add-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -51,7 +54,7 @@ export default async function pause(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/firewall/system-mitigations/resume.ts
+++ b/packages/cli/src/commands/firewall/system-mitigations/resume.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
-import { withGlobalFlags } from '../../../util/agent-output';
 import type Client from '../../../util/client';
-import { ensureProjectLink } from '../../../util/projects/ensure-project-link';
 import output from '../../../output-manager';
 import { systemMitigationsResumeSubcommand } from '../command';
-import { parseSubcommandArgs, confirmAction } from '../shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  withGlobalFlags,
+} from '../shared';
 import removeBypass from '../../../util/firewall/remove-bypass';
 import stamp from '../../../util/output/stamp';
 import { outputAgentError } from '../../../util/agent-output';
@@ -51,7 +54,7 @@ export default async function resume(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'firewall');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { outputActionRequired } from '../../util/agent-output';
 import {
@@ -11,6 +10,7 @@ import {
 import { addSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   isValidUrl,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
@@ -30,7 +30,7 @@ export default async function add(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, addSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/command.ts
+++ b/packages/cli/src/commands/redirects/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { yesOption } from '../../util/arg-common';
+import { projectOption, yesOption } from '../../util/arg-common';
 
 export const listSubcommand = {
   name: 'list',
@@ -8,6 +8,7 @@ export const listSubcommand = {
     'List all redirects for the current project. These redirects apply to all deployments and environments. There may also be redirects defined in a deployment that are not listed here.',
   arguments: [],
   options: [
+    projectOption,
     {
       name: 'search',
       description: 'Search for redirects by source or destination',
@@ -73,7 +74,7 @@ export const listVersionsSubcommand = {
   aliases: ['ls-versions'],
   description: 'List all versions of redirects',
   arguments: [],
-  options: [],
+  options: [projectOption],
   examples: [
     {
       name: 'List all redirect versions',
@@ -97,6 +98,7 @@ export const addSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       name: 'status',
       description: 'HTTP status code (301, 302, 307, or 308)',
@@ -163,6 +165,7 @@ export const uploadSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip confirmation prompt',
@@ -206,6 +209,7 @@ export const removeSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when removing a redirect',
@@ -230,6 +234,7 @@ export const promoteSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when promoting',
@@ -254,6 +259,7 @@ export const restoreSubcommand = {
     },
   ],
   options: [
+    projectOption,
     {
       ...yesOption,
       description: 'Skip the confirmation prompt when restoring',

--- a/packages/cli/src/commands/redirects/index.ts
+++ b/packages/cli/src/commands/redirects/index.ts
@@ -25,6 +25,7 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { RedirectsTelemetryClient } from '../../util/telemetry/commands/redirects';
+import { getProjectOptionFromArgs } from '../../util/arg-common';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
@@ -75,6 +76,10 @@ export default async function main(client: Client) {
         columns: client.stderr.columns,
       })
     );
+  }
+
+  if (subcommand && !needHelp) {
+    telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/redirects/list-versions.ts
+++ b/packages/cli/src/commands/redirects/list-versions.ts
@@ -2,10 +2,9 @@ import chalk from 'chalk';
 import ms from 'ms';
 import plural from 'pluralize';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listVersionsSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import { parseSubcommandArgs, ensureProjectLink } from './shared';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import type { RedirectVersion } from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
@@ -15,7 +14,7 @@ export default async function listVersions(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listVersionsSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/list.ts
+++ b/packages/cli/src/commands/redirects/list.ts
@@ -1,21 +1,23 @@
 import chalk from 'chalk';
 import plural from 'pluralize';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import { listSubcommand } from './command';
-import { parseSubcommandArgs } from './shared';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  withGlobalFlags,
+} from './shared';
 import getRedirects from '../../util/redirects/get-redirects';
 import getRedirectVersions from '../../util/redirects/get-redirect-versions';
 import stamp from '../../util/output/stamp';
 import formatTable from '../../util/format-table';
-import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 
 export default async function list(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, listSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -39,7 +41,7 @@ export default async function list(client: Client, argv: string[]) {
     if (!stagingVersion) {
       output.error(
         `No staging version found for ${chalk.bold(project.name)}. Run ${chalk.cyan(
-          'vercel redirects list-versions'
+          withGlobalFlags(client, 'redirects list-versions')
         )} to see available versions.`
       );
       return 1;
@@ -68,7 +70,7 @@ export default async function list(client: Client, argv: string[]) {
     if (!version) {
       output.error(
         `Version "${versionIdFlag}" not found. Run ${chalk.cyan(
-          'vercel redirects list-versions'
+          withGlobalFlags(client, 'redirects list-versions')
         )} to see available versions.`
       );
       return 1;
@@ -154,8 +156,8 @@ export default async function list(client: Client, argv: string[]) {
       !versionIdFlag
     ) {
       output.log(
-        `  ${getCommandNamePlain('redirects list')} shows production redirects only. ` +
-          `If you added redirects but do not see them here, they may still be staged only—run ${getCommandNamePlain('redirects list --staging')} to view staged changes.`
+        `  ${withGlobalFlags(client, 'redirects list')} shows production redirects only. ` +
+          `If you added redirects but do not see them here, they may still be staged only—run ${withGlobalFlags(client, 'redirects list --staging')} to view staged changes.`
       );
     }
 
@@ -174,7 +176,9 @@ export default async function list(client: Client, argv: string[]) {
     if (perPage) {
       command += ` --per-page ${perPage}`;
     }
-    output.log(`To display the next page, run ${getCommandName(command)}`);
+    output.log(
+      `To display the next page, run ${withGlobalFlags(client, command)}`
+    );
   }
 
   return 0;

--- a/packages/cli/src/commands/redirects/promote.ts
+++ b/packages/cli/src/commands/redirects/promote.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,6 +14,7 @@ import {
 import { promoteSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -68,7 +68,7 @@ export default async function promote(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/remove.ts
+++ b/packages/cli/src/commands/redirects/remove.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,11 +14,13 @@ import {
 import { removeSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   buildRedirectsSuggestionFlags,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
   getRedirectPromoteSuggestionFlags,
+  withGlobalFlags,
 } from './shared';
 import { validateRequiredArguments } from '../../util/command-arguments';
 import { getCommandNamePlain } from '../../util/pkg-name';
@@ -59,7 +60,7 @@ export default async function remove(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -178,7 +179,7 @@ export default async function remove(client: Client, argv: string[]) {
         ],
       }),
       ...(existingStagingVersion && {
-        hint: `Review staged changes with ${getCommandNamePlain('redirects list --staging')} before promoting.`,
+        hint: `Review staged changes with ${withGlobalFlags(client, 'redirects list --staging')} before promoting.`,
       }),
     };
     client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);

--- a/packages/cli/src/commands/redirects/restore.ts
+++ b/packages/cli/src/commands/redirects/restore.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -15,6 +14,7 @@ import {
 import { restoreSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   confirmAction,
   getArgsAfterRedirectsSubcommand,
   getRedirectGlobalFlagsOnly,
@@ -71,7 +71,7 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -7,14 +7,19 @@ import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
 } from '../../util/command-arguments';
-import { getGlobalFlagsFromArgs } from '../../util/arg-common';
+import {
+  getGlobalFlagsFromArgs,
+  getSameSubcommandSuggestionFlags,
+} from '../../util/arg-common';
 import { withGlobalFlags as withClientGlobalFlags } from '../../util/agent-output';
 
 export function withGlobalFlags(
   client: Client,
   commandTemplate: string
 ): string {
-  return withClientGlobalFlags(client, commandTemplate, true);
+  return withClientGlobalFlags(client, commandTemplate, {
+    preserveProject: true,
+  });
 }
 
 export async function parseSubcommandArgs(
@@ -113,18 +118,7 @@ export function buildRedirectsSuggestionFlags(
   options: { ensureYes?: boolean } = {}
 ): string[] {
   const after = getArgsAfterRedirectsSubcommand(fullArgs, subcommand);
-  const flagParts: string[] = [];
-  for (let i = 0; i < after.length; i++) {
-    if (!after[i].startsWith('-')) continue;
-    flagParts.push(after[i]);
-    if (
-      after[i] === '--project' &&
-      i + 1 < after.length &&
-      !after[i + 1].startsWith('-')
-    ) {
-      flagParts.push(after[++i]);
-    }
-  }
+  const flagParts = getSameSubcommandSuggestionFlags(after);
   if (
     options.ensureYes !== false &&
     !flagParts.some(a => a === '--yes' || a === '-y')

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -2,14 +2,20 @@ import type Client from '../../util/client';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
 import type { Command } from '../help';
+import { ensureProjectLink as ensureProjectLinkForCommand } from '../../util/projects/ensure-project-link';
 import {
   parseSubcommandArguments,
   type ParsedSubcommandArguments,
 } from '../../util/command-arguments';
-import {
-  GLOBAL_CLI_FLAG_NAMES,
-  globalCliFlagTakesValue,
-} from '../../util/arg-common';
+import { getGlobalFlagsFromArgs } from '../../util/arg-common';
+import { withGlobalFlags as withClientGlobalFlags } from '../../util/agent-output';
+
+export function withGlobalFlags(
+  client: Client,
+  commandTemplate: string
+): string {
+  return withClientGlobalFlags(client, commandTemplate, true);
+}
 
 export async function parseSubcommandArgs(
   argv: string[],
@@ -25,6 +31,10 @@ export async function parseSubcommandArgs(
   }
 
   return parsedArgs;
+}
+
+export function ensureProjectLink(client: Client, projectName?: string) {
+  return ensureProjectLinkForCommand(client, 'redirects', projectName);
 }
 
 export async function confirmAction(
@@ -56,19 +66,6 @@ export function isValidUrl(url: string): boolean {
 }
 
 /**
- * Flags that belong only to redirects add/upload/remove. Forwarding them into
- * suggested `redirects list`, `redirects promote`, or `redirects list-versions`
- * commands causes parse errors for agents.
- */
-const REDIRECTS_SUBCOMMAND_EXCLUSIVE_FLAGS = new Set([
-  '--status',
-  '--case-sensitive',
-  '--preserve-query-params',
-  '--name',
-  '--overwrite',
-]);
-
-/**
  * Slice argv after `vercel` (i.e. client.argv.slice(2)) starting after the
  * given redirects subcommand name.
  */
@@ -87,44 +84,9 @@ export function getArgsAfterRedirectsSubcommand(
 export function getRedirectGlobalFlagsOnly(
   afterSubcommandArgs: string[]
 ): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < afterSubcommandArgs.length; i++) {
-    const a = afterSubcommandArgs[i];
-    if (!a.startsWith('-')) continue;
-
-    let name = a;
-    const hasEq = a.includes('=');
-    if (hasEq) {
-      name = a.slice(0, a.indexOf('='));
-    }
-
-    if (REDIRECTS_SUBCOMMAND_EXCLUSIVE_FLAGS.has(name)) {
-      if (
-        !hasEq &&
-        (name === '--status' || name === '--name') &&
-        i + 1 < afterSubcommandArgs.length &&
-        !afterSubcommandArgs[i + 1].startsWith('-')
-      ) {
-        i++;
-      }
-      continue;
-    }
-
-    if (!GLOBAL_CLI_FLAG_NAMES.has(name)) {
-      continue;
-    }
-
-    out.push(a);
-    if (!hasEq && globalCliFlagTakesValue(name)) {
-      if (
-        i + 1 < afterSubcommandArgs.length &&
-        !afterSubcommandArgs[i + 1].startsWith('-')
-      ) {
-        out.push(afterSubcommandArgs[++i]);
-      }
-    }
-  }
-  return out;
+  return getGlobalFlagsFromArgs(afterSubcommandArgs, {
+    preserveProject: true,
+  });
 }
 
 /**
@@ -151,7 +113,18 @@ export function buildRedirectsSuggestionFlags(
   options: { ensureYes?: boolean } = {}
 ): string[] {
   const after = getArgsAfterRedirectsSubcommand(fullArgs, subcommand);
-  const flagParts = after.filter(a => a.startsWith('-'));
+  const flagParts: string[] = [];
+  for (let i = 0; i < after.length; i++) {
+    if (!after[i].startsWith('-')) continue;
+    flagParts.push(after[i]);
+    if (
+      after[i] === '--project' &&
+      i + 1 < after.length &&
+      !after[i + 1].startsWith('-')
+    ) {
+      flagParts.push(after[++i]);
+    }
+  }
   if (
     options.ensureYes !== false &&
     !flagParts.some(a => a === '--yes' || a === '-y')

--- a/packages/cli/src/commands/redirects/upload.ts
+++ b/packages/cli/src/commands/redirects/upload.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'fs';
 import { basename } from 'path';
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { ensureProjectLink } from '../../util/projects/ensure-project-link';
 import output from '../../output-manager';
 import {
   outputActionRequired,
@@ -16,9 +15,11 @@ import {
 import { uploadSubcommand } from './command';
 import {
   parseSubcommandArgs,
+  ensureProjectLink,
   getArgsAfterRedirectsSubcommand,
   getRedirectPromoteSuggestionFlags,
   buildRedirectsSuggestionFlags,
+  withGlobalFlags,
 } from './shared';
 import { getCommandNamePlain } from '../../util/pkg-name';
 import stamp from '../../util/output/stamp';
@@ -51,7 +52,7 @@ export default async function upload(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, uploadSubcommand);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await ensureProjectLink(client, 'redirects');
+  const link = await ensureProjectLink(client, parsed.flags['--project']);
   if (typeof link === 'number') return link;
 
   const { project, org } = link;
@@ -263,7 +264,7 @@ export default async function upload(client: Client, argv: string[]) {
           ],
         }),
         ...(existingStagingVersion && {
-          hint: `Review staged changes with ${getCommandNamePlain('redirects list --staging')} before promoting.`,
+          hint: `Review staged changes with ${withGlobalFlags(client, 'redirects list --staging')} before promoting.`,
         }),
       };
       client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);

--- a/packages/cli/test/unit/commands/firewall/overview.test.ts
+++ b/packages/cli/test/unit/commands/firewall/overview.test.ts
@@ -13,7 +13,10 @@ import {
 } from '../../../mocks/firewall';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('firewall overview', () => {
   beforeEach(() => {
@@ -62,6 +65,23 @@ describe('firewall overview', () => {
     expect(fullOutput).toContain('2 active, 1 inactive (3 total)');
     expect(fullOutput).toContain('IP Blocks');
     expect(fullOutput).toContain('System Bypass');
+  });
+
+  it('shows the overview for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-firewall',
+      name: 'explicit-firewall',
+      accountId: 'team_dummy',
+    });
+    useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
+    useGetBypass([]);
+    client.setArgv('firewall', 'overview', '--project', 'explicit-firewall');
+
+    await expect(firewall(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Enabled');
   });
 
   it('should show firewall overview when disabled', async () => {

--- a/packages/cli/test/unit/commands/firewall/rules-enable.test.ts
+++ b/packages/cli/test/unit/commands/firewall/rules-enable.test.ts
@@ -13,7 +13,10 @@ import {
 } from '../../../mocks/firewall';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('firewall rules enable', () => {
   beforeEach(() => {
@@ -45,6 +48,38 @@ describe('firewall rules enable', () => {
 
     expect(lastPatchBody.action).toBe('rules.update');
     expect(lastPatchBody.value.active).toBe(true);
+  });
+
+  it('enables a rule for the project selected by --project', async () => {
+    const active = createConfig({ rules: [createRule(3)] });
+    useListFirewallConfigs(active, null);
+    usePatchDraft();
+    useActivateConfig();
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-firewall',
+      name: 'explicit-firewall',
+      accountId: 'team_dummy',
+    });
+    client.setArgv(
+      'firewall',
+      'rules',
+      'enable',
+      'Test Rule 3',
+      '--project',
+      'explicit-firewall',
+      '--yes'
+    );
+
+    await expect(firewall(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Enabled');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'subcommand:rules', value: 'rules' },
+      { key: 'subcommand:rules:enable', value: 'enable' },
+    ]);
   });
 
   it('should report already enabled', async () => {

--- a/packages/cli/test/unit/commands/redirects/add.test.ts
+++ b/packages/cli/test/unit/commands/redirects/add.test.ts
@@ -493,7 +493,20 @@ describe('redirects add', () => {
         throw new Error('exit');
       }) as () => never);
 
-      client.setArgv('redirects', 'add');
+      client.setArgv(
+        'redirects',
+        'add',
+        '--status',
+        '301',
+        '--name',
+        'release-1',
+        '--project',
+        'redirects-test',
+        '--scope',
+        'team_dummy',
+        '--cwd',
+        '/tmp/project'
+      );
       await expect(redirects(client)).rejects.toThrow('exit');
 
       expect(logSpy).toHaveBeenCalled();
@@ -502,8 +515,9 @@ describe('redirects add', () => {
       expect(payload.reason).toBe('missing_arguments');
       expect(payload.message).toContain('source and destination are required');
       expect(Array.isArray(payload.next)).toBe(true);
-      expect(payload.next[0].command).toContain('redirects add');
-      expect(payload.next[0].command).toContain('--yes');
+      expect(payload.next[0].command).toBe(
+        'vercel redirects add <source> <destination> --status 301 --name release-1 --project redirects-test --scope team_dummy --cwd /tmp/project --yes'
+      );
       expect(payload.next[0].when).toBe('to add a redirect');
 
       logSpy.mockRestore();

--- a/packages/cli/test/unit/commands/redirects/add.test.ts
+++ b/packages/cli/test/unit/commands/redirects/add.test.ts
@@ -4,7 +4,10 @@ import redirects from '../../../../src/commands/redirects';
 import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('redirects add', () => {
   beforeEach(() => {
@@ -14,6 +17,7 @@ describe('redirects add', () => {
       ...defaultProject,
       id: 'redirects-test',
       name: 'redirects-test',
+      accountId: 'team_dummy',
     });
     client.scenario.get('/v9/projects/:projectNameOrId', (_req, res) => {
       res.json(project);
@@ -565,6 +569,34 @@ describe('redirects add', () => {
         true
       );
 
+      client.nonInteractive = false;
+    });
+
+    it('adds a redirect to the project selected by --project', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+      client.cwd = setupTmpDir();
+      client.config.currentTeam = 'team_dummy';
+      client.nonInteractive = true;
+      client.setArgv(
+        'redirects',
+        'add',
+        '/old-path',
+        '/new-path',
+        '--project',
+        'redirects-test',
+        '--yes'
+      );
+
+      expect(await redirects(client)).toEqual(0);
+      const output = JSON.parse(client.stdout.getFullOutput());
+      expect(output.next).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            command: expect.stringContaining('--project redirects-test'),
+          }),
+        ])
+      );
       client.nonInteractive = false;
     });
 

--- a/packages/cli/test/unit/commands/redirects/list.test.ts
+++ b/packages/cli/test/unit/commands/redirects/list.test.ts
@@ -5,7 +5,10 @@ import { useUser } from '../../../mocks/user';
 import { useRedirects } from '../../../mocks/redirects';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
-import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import {
+  setupTmpDir,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
 
 describe('redirects list', () => {
   beforeEach(() => {
@@ -44,6 +47,26 @@ describe('redirects list', () => {
     const exitCode = await redirects(client);
     expect(exitCode, 'exit code for "redirects list"').toEqual(0);
     await expect(client.stderr).toOutput('3 Redirects found');
+  });
+
+  it('lists redirects for the project selected by --project', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject({
+      ...defaultProject,
+      id: 'explicit-redirects',
+      name: 'explicit-redirects',
+      accountId: 'team_dummy',
+    });
+    useRedirects(3);
+    client.setArgv('redirects', 'list', '--project', 'explicit-redirects');
+
+    await expect(redirects(client)).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('3 Redirects found');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'subcommand:list', value: 'list' },
+    ]);
   });
 
   it('should list redirects using ls alias', async () => {


### PR DESCRIPTION
## Summary

Adds `--project <name-or-id>` to:

```text
redirects add, list, list-versions, promote, remove, restore, upload
```

Redirects can now be listed from an unlinked directory:

```bash
vercel redirects list --project payments-api --scope acme
```

The selected project is used only for this command. Existing confirmations, errors, and linked-directory behavior remain unchanged, and follow-up commands retain `--project` when needed.

## Validation

- Representative Redirects read and mutation unit tests
- Aggregate stacked CLI rollout suite
- Biome lint and `git diff --check`

**Stack:** #17114 → this PR → #17116
