### PR TITLE
[@vercel/frameworks] Graduate Services from experimental

### DIFF
--- a/.changeset/stable-services-framework.md
+++ b/.changeset/stable-services-framework.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Mark the Services framework preset as stable.

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4783,7 +4783,6 @@ export const frameworks = [
   {
     name: 'Services',
     slug: 'services',
-    experimental: true,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/services.svg',
     tagline:
       'Multiple services deployed as serverless functions within your project.',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -244,7 +244,15 @@ describe('frameworks', () => {
     'storybook',
     'eve', // examples/fixtures live in github.com/vercel/ash
     'tanstack-start-lovable', // platform variant, no dedicated example
+    'services', // project-level preset, no dedicated framework example
   ];
+
+  it('marks Services as stable', () => {
+    const services = frameworkList.find(f => f.slug === 'services');
+
+    expect(services).toBeDefined();
+    expect(services?.experimental).toBeUndefined();
+  });
 
   it('ensure there is an example for every framework', async () => {
     const root = join(__dirname, '..', '..', '..');


### PR DESCRIPTION
## Why

- Services is now ready to be exposed as a stable project framework preset.
- Keeping it experimental removes it from the default `api-frameworks` response, causing downstream framework validation to reject otherwise valid Services projects.

## Summary

- Remove the experimental marker from the Services preset.
- Keep Services out of the single-framework example requirement and add direct regression coverage.
- Publish the change as a patch to `@vercel/frameworks`.

## Validation

- Verified the default framework filtering now retains Services and its registry entry has no experimental marker.