### PR TITLE
fix(cli): validate logs deployment selection

### DIFF
--- a/.changeset/tidy-logs-deployment.md
+++ b/.changeset/tidy-logs-deployment.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Reject conflicting Logs deployment selectors instead of silently preferring the positional argument.

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -565,14 +565,29 @@ export default async function logs(client: Client) {
   const deploymentFlag = parsedArguments.flags['--deployment'];
   const environmentOption = parsedArguments.flags['--environment'];
 
-  let deploymentOption: string | undefined = deploymentFlag;
-  if (deploymentArgument) {
-    let deploymentIdOrHost = deploymentArgument;
+  const normalizeDeploymentSelector = (selector: string | undefined) => {
+    if (!selector) return undefined;
     try {
-      deploymentIdOrHost = new URL(deploymentArgument).hostname;
+      return new URL(selector).hostname;
     } catch {}
-    deploymentOption = deploymentIdOrHost;
+    return selector;
+  };
+  const normalizedDeploymentFlag = normalizeDeploymentSelector(deploymentFlag);
+  const normalizedDeploymentArgument =
+    normalizeDeploymentSelector(deploymentArgument);
+
+  if (
+    normalizedDeploymentFlag &&
+    normalizedDeploymentArgument &&
+    normalizedDeploymentFlag !== normalizedDeploymentArgument
+  ) {
+    output.error(
+      `The deployment positional argument and ${chalk.bold('--deployment')} option must select the same deployment.`
+    );
+    return 2;
   }
+  const deploymentOption =
+    normalizedDeploymentFlag ?? normalizedDeploymentArgument;
   const levelOption = parsedArguments.flags['--level'];
   const statusCodeOption = parsedArguments.flags['--status-code'];
   const sourceOption = parsedArguments.flags['--source'];

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -1278,7 +1278,31 @@ describe('logs', () => {
       );
     });
 
-    it('should prioritize positional argument over --deployment flag', async () => {
+    it('should reject conflicting positional and --deployment selectors', async () => {
+      const user = useUser();
+      const deployment = useLogsDeployment(user);
+
+      let requestedLogs = false;
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        requestedLogs = true;
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', deployment.id, '--deployment', 'other_dpl_id');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(2);
+      expect(requestedLogs).toBe(false);
+      await expect(client.stderr).toOutput(
+        'positional argument and --deployment option must select the same deployment'
+      );
+    });
+
+    it('should accept matching positional and --deployment selectors', async () => {
       const user = useUser();
       const deployment = useLogsDeployment(user);
 
@@ -1292,7 +1316,12 @@ describe('logs', () => {
       });
 
       client.cwd = fixture('linked-project');
-      client.setArgv('logs', deployment.id, '--deployment', 'other_dpl_id');
+      client.setArgv(
+        'logs',
+        `https://${deployment.url}`,
+        '--deployment',
+        deployment.url
+      );
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);


### PR DESCRIPTION
## Summary

Normalize the positional deployment selector and `--deployment` option before choosing the deployment for `vercel logs`. Matching selectors are accepted; conflicting selectors fail before any logs API request is made.

## Examples

Previously, the positional argument silently won when both selectors disagreed:

```sh
vercel logs dpl_123 --deployment dpl_456
```

This now exits with code `2` and reports that both selectors must refer to the same deployment. No logs request is sent.

Equivalent selectors remain valid, including URL forms with or without a scheme:

```sh
vercel logs my-app-abc.vercel.app \
  --deployment https://my-app-abc.vercel.app
```

After normalization, both values select `my-app-abc.vercel.app`, so logs are fetched normally. Supplying only the positional argument or only `--deployment` is unchanged.

## Why

Silently prioritizing the positional argument made a typo or stale `--deployment` value easy to miss and could fetch logs from an unintended deployment.

## Validation

- full Logs suite: 66 passed
- one unrelated baseline failure in `should stream your latest deployment with --no-branch`; the same failure reproduces on unmodified `origin/main`
- verified the branch diff against `main`
