### PR TITLE
[cli] Surface specific error when buying v0 credits without a paid v0 plan

### DIFF
--- a/.changeset/buy-credits-v0-plan-error.md
+++ b/.changeset/buy-credits-v0-plan-error.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Show a specific error message when purchasing v0 credits without a paid v0 plan, instead of the generic unexpected-error fallback.

--- a/packages/cli/src/util/buy/handle-purchase-error.ts
+++ b/packages/cli/src/util/buy/handle-purchase-error.ts
@@ -60,6 +60,13 @@ export function handlePurchaseError(
       tryOpenBillingPage(teamSlug, openBrowser);
       return 1;
     }
+    if (err.code === 'invalid_v0_subscription') {
+      const pricingUrl = 'https://v0.app/pricing';
+      output.error(
+        `Your team must have a paid v0 plan to purchase v0 credits. Upgrade at ${output.link(pricingUrl, pricingUrl)}`
+      );
+      return 1;
+    }
     if (err.code === 'invalid_plan') {
       output.error("Your team's current plan does not support this purchase.");
       return 1;

--- a/packages/cli/test/unit/commands/buy/credits.test.ts
+++ b/packages/cli/test/unit/commands/buy/credits.test.ts
@@ -175,6 +175,26 @@ describe('buy credits', () => {
       );
     });
 
+    it('handles invalid_v0_subscription error', async () => {
+      setupTeam();
+      client.scenario.post('/v1/billing/buy', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'invalid_v0_subscription',
+            message: 'Team must have a paid v0 plan to purchase v0 credits',
+          },
+        });
+      });
+      client.setArgv('buy', 'credits', 'v0', '100', '--yes');
+      const exitCode = await buy(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput(
+        'Your team must have a paid v0 plan to purchase v0 credits. Upgrade at https://v0.app/pricing'
+      );
+      const stderrOutput = client.stderr.getFullOutput();
+      expect(stderrOutput).not.toContain('An unexpected error occurred');
+    });
+
     it('handles payment_failed error', async () => {
       const team = setupTeam();
       client.scenario.post('/v1/billing/buy', (_req, res) => {

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -1374,8 +1374,12 @@ describe('logs', () => {
   });
 
   describe('--follow option', () => {
+    // The scenario router serves the first-registered `/v2/user` handler, so
+    // tests that assert on the current user's id must reuse this user instead
+    // of calling useUser() again.
+    let user: ReturnType<typeof useUser>;
     beforeEach(() => {
-      useUser();
+      user = useUser();
       useTeams('team_dummy');
       useProject({
         ...defaultProject,
@@ -1430,8 +1434,6 @@ describe('logs', () => {
     });
 
     it('should stream your latest deployment with --no-branch', async () => {
-      const user = useUser();
-
       // Register before useLogsDeployment(), whose catch-all
       // `/:version/deployments` route would otherwise handle this path
       let latestDeployment: ReturnType<typeof useLogsDeployment>;


### PR DESCRIPTION
### Problem

Running `vercel buy credits v0 <amount>` on a team without a paid v0 subscription (e.g. a personal Hobby team) fails with the generic fallback:

> Error: An unexpected error occurred while completing your purchase. Please try again later.

The billing buy API actually returns a 400 with code `invalid_v0_subscription` ("Team must have a paid v0 plan to purchase v0 credits"), but `handlePurchaseError` didn't recognize the code.

### Fix

Add a dedicated branch for `invalid_v0_subscription` in `handlePurchaseError`, shared by all buy flows:

> Error: Your team must have a paid v0 plan to purchase v0 credits. Upgrade at https://v0.app/pricing

### Testing

- New unit test mocks the API's exact 400 response and asserts the new message appears and the generic fallback does not.
- `pnpm test test/unit/commands/buy/` — 61/61 pass.
- `pnpm type-check` passes.
<img width="573" height="144" alt="Screenshot 2026-07-15 at 2 47 22 PM" src="https://github.com/user-attachments/assets/e843be67-5f79-4af1-8016-222b917ad334" />
