### PR TITLE
[skills] Update vercel-cli skill for recently released command behavior

### DIFF
--- a/.changeset/update-cli-skill-release-guidance.md
+++ b/.changeset/update-cli-skill-release-guidance.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update the Vercel CLI skill for recently released command behavior.

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -13,16 +13,16 @@ Parse only stdout for URLs and JSON. Warnings, progress, and `--help` print to s
 
 In agent/non-interactive mode, many commands report errors and required confirmations as a single JSON object on stdout with `status`, `reason`, `hint`, and `next` (runnable follow-up commands). Prefer running a suggested `next` command over composing a retry. Read commands such as `list`, `logs`, `inspect`, and `api` keep their normal output shape.
 
-## Critical: Project Linking
+## Project Context
 
-Commands must be run from the directory containing the `.vercel` folder (or a subdirectory of it). How `.vercel` gets set up depends on your project structure:
+Commands use the project linked in local `.vercel` metadata by default. Many project-aware commands also accept `--project <name-or-id>` with `--scope <team>` for explicit targeting without changing the link.
 
 - **`.vercel/project.json`**: Created by `vercel link`. Links a single project. Fine for single-project repos, and can work in monorepos if there's only one project.
 - **`.vercel/repo.json`**: Created by `vercel link --repo`. Links a repo that may contain multiple projects. Always a good idea when any project has a non-root directory (e.g., `apps/web`).
 
 Running from a project subdirectory (e.g., `apps/web/`) skips the "which project?" prompt since it's unambiguous.
 
-**When something goes wrong, check how things are linked first** — look at what's in `.vercel/` and whether it's `project.json` or `repo.json`. Also verify you're on the right team with `vercel whoami` — linking while on the wrong team is a common mistake.
+For linking or scope errors, inspect `.vercel/` and verify the current team with `vercel whoami`.
 
 ## Quick Start
 

--- a/skills/vercel-cli/references/environment-variables.md
+++ b/skills/vercel-cli/references/environment-variables.md
@@ -17,8 +17,6 @@ vercel env ls --format json
 vercel env ls production --format json
 ```
 
-Use `--project <name-or-id>` with `--scope <team>` when needed to override the linked project.
-
 If CLI output does not include required metadata, use `vercel api` after checking available endpoints with `vercel api list`.
 
 ## Managing Env Vars

--- a/skills/vercel-cli/references/environment-variables.md
+++ b/skills/vercel-cli/references/environment-variables.md
@@ -13,12 +13,13 @@ Variables can be plain text or sensitive (encrypted, not readable after creation
 For metadata-oriented investigations, start with:
 
 ```bash
-# Run from a linked project directory
 vercel env ls --format json
 vercel env ls production --format json
 ```
 
-If CLI output does not include required metadata, use `vercel api` after checking available endpoints with `vercel api list`. Do not invent unsupported `env ls` scope/project flags; link or switch scope first when the command requires project context.
+Use `--project <name-or-id>` with `--scope <team>` when needed to override the linked project.
+
+If CLI output does not include required metadata, use `vercel api` after checking available endpoints with `vercel api list`.
 
 ## Managing Env Vars
 

--- a/skills/vercel-cli/references/flags.md
+++ b/skills/vercel-cli/references/flags.md
@@ -42,6 +42,14 @@ vercel flags list --limit 25                               # first page of 25
 vercel flags list --limit 25 --next <cursor>              # next page
 ```
 
+## Version History
+
+```bash
+vercel flags versions my-feature                         # list version history
+vercel flags versions my-feature --environment production --json
+vercel flags versions diff my-feature --revision 4       # compare with the previous revision
+```
+
 ## Opening in Dashboard
 
 ```bash

--- a/skills/vercel-cli/references/getting-started.md
+++ b/skills/vercel-cli/references/getting-started.md
@@ -16,8 +16,6 @@ npm i -g vercel
 
 ## Project Linking
 
-Commands must be run from the directory containing `.vercel/` or a subdirectory of it.
-
 - **`.vercel/project.json`**: Created by `vercel link`. Links a single project. Fine for single-project repos, and can work in monorepos if there's only one project.
 - **`.vercel/repo.json`**: Created by `vercel link --repo`. Links a repo that may contain multiple projects. Always a good idea when any project has a non-root directory (e.g., `apps/web`).
 

--- a/skills/vercel-cli/references/monitoring-and-debugging.md
+++ b/skills/vercel-cli/references/monitoring-and-debugging.md
@@ -66,6 +66,10 @@ vercel logs --since 2024-01-01                 # filter by time
 vercel logs --query "timeout"                  # search
 ```
 
+With `--follow` and no deployment, the CLI tries the latest deployment on the current Git branch, your latest deployment, then the latest production deployment. Use `--environment production` or `--environment preview` to constrain automatic resolution.
+
+In agents, pipes, and CI, log messages expand automatically; do not add `--expand` solely for non-TTY output.
+
 Use `--follow` only for live debugging. Historical log queries should be bounded with `--since`, `--until`, and `--limit`.
 
 ## Metrics

--- a/skills/vercel-cli/references/project-infra.md
+++ b/skills/vercel-cli/references/project-infra.md
@@ -40,8 +40,6 @@ vercel git connect https://github.com/user/repo.git
 vercel git disconnect --yes
 ```
 
-Verify the linked project and scope before changing Git connections.
-
 ## Edge Config
 
 ```bash


### PR DESCRIPTION
Hand-sync of the `vercel-cli` skill with recently released CLI behavior:

- Document the new `vercel flags versions` subcommands
- Update project-context guidance for the broader explicit `--project` support from #17112
- Remove redundant linked-project caveats from Env, Git, and getting-started references
- Document `vercel logs --follow` deployment resolution and automatic non-TTY expansion

Landing this separately so a follow-up restructure of the skill starts from a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
