### PR TITLE
[CLI] fixing empty sensitive var

### DIFF
--- a/.changeset/tidy-planes-brush.md
+++ b/.changeset/tidy-planes-brush.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Write `[SENSITIVE]` placeholder instead of an empty string when `vercel env pull` encounters sensitive environment variables whose values cannot be read, so an unset value is distinguishable from a redacted one

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path';
 import type Client from '../../util/client';
 import param from '../../util/output/param';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
-import {
+import getEnvRecords, {
   type EnvRecordsSource,
   pullEnvRecords,
 } from '../../util/env/get-env-records';
@@ -77,6 +77,34 @@ const VARIABLES_TO_IGNORE = [
   'VERCEL_SPEED_INSIGHTS_ID',
   'VERCEL_WEB_ANALYTICS_ID',
 ];
+
+export const SENSITIVE_PLACEHOLDER = '[SENSITIVE]';
+
+async function getRedactedSensitiveKeys(
+  client: Client,
+  projectId: string | undefined,
+  source: EnvRecordsSource,
+  target: string,
+  gitBranch: string | undefined,
+  records: Record<string, string>
+): Promise<Set<string>> {
+  const emptyKeys = Object.keys(records).filter(key => !records[key]);
+  if (!projectId || emptyKeys.length === 0) {
+    return new Set();
+  }
+  try {
+    const { envs } = await getEnvRecords(client, projectId, source, {
+      target,
+      gitBranch,
+    });
+    const sensitiveKeys = new Set(
+      envs.filter(env => env.type === 'sensitive').map(env => env.key)
+    );
+    return new Set(emptyKeys.filter(key => sensitiveKeys.has(key)));
+  } catch {
+    return new Set();
+  }
+}
 
 export default async function pull(
   client: Client,
@@ -279,7 +307,19 @@ export async function envPullCommandLogic(
     );
     fileChanged = contents !== existingContents;
   } else {
+    const sensitiveKeys = await getRedactedSensitiveKeys(
+      client,
+      deploymentId ? undefined : link.project.id,
+      source,
+      environment,
+      gitBranch,
+      records
+    );
+
     const mergedRecords: Record<string, string | undefined> = { ...records };
+    for (const key of sensitiveKeys) {
+      mergedRecords[key] = SENSITIVE_PLACEHOLDER;
+    }
     if (oldEnv) {
       for (const [key, value] of Object.entries(oldEnv)) {
         if (

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -459,6 +459,8 @@ function exposeSystemEnvs(
   for (const env of projectEnvs) {
     if (env.type === 'system') {
       envs[env.key] = getSystemEnvValue(env.value, { vercelUrl });
+    } else if (env.type === 'sensitive') {
+      envs[env.key] = '';
     } else {
       envs[env.key] = env.value;
     }

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -297,6 +297,53 @@ describe('env pull', () => {
     );
   });
 
+  it('writes a placeholder for redacted sensitive env vars', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject(
+      {
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+      },
+      [
+        ...envs,
+        {
+          type: 'sensitive',
+          id: 'sens1234sens5678',
+          key: 'SENSITIVE_SECRET',
+          value: '',
+          target: ['production'],
+          gitBranch: undefined,
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+        {
+          type: 'encrypted',
+          id: 'empt1234empt5678',
+          key: 'ACTUALLY_EMPTY',
+          value: '',
+          target: ['production'],
+          gitBranch: undefined,
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    const cwd = setupUnitFixture('vercel-env-pull');
+    client.cwd = cwd;
+    client.setArgv('env', 'pull', '--yes', '--environment', 'production');
+    const exitCode = await env(client);
+    expect(exitCode, 'exit code for "env"').toEqual(0);
+
+    const rawProdEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(rawProdEnv).toContain('SENSITIVE_SECRET="[SENSITIVE]"');
+    expect(rawProdEnv).not.toContain('SENSITIVE_SECRET=""');
+    expect(rawProdEnv).toContain('ACTUALLY_EMPTY=""');
+  });
+
   it('should handle pulling from specific Git branch', async () => {
     useUser();
     useTeams('team_dummy');


### PR DESCRIPTION
This fixes the reported issue if an agent pulls a sensitive var it is completely empty, which throws off agents 