### PR TITLE
[python] Remove the ratio heuristic and always run compileall.

### DIFF
--- a/.changeset/lazy-pandas-refuse.md
+++ b/.changeset/lazy-pandas-refuse.md
@@ -2,4 +2,4 @@
 '@vercel/python': patch
 ---
 
-Always run bytecode precompilation when `VERCEL_PYTHON_COMPILEALL` is enabled, removing the coverage-ratio heuristic that skipped compiles when the estimated bytecode would not sufficiently fit the remaining zip capacity. Bytecode still only fills remaining capacity under the fill ceiling and never affects size-path selection; the compile is skipped only when the bundle already exceeds the ceiling and nothing could ship.
+Always run bytecode precompilation when `VERCEL_PYTHON_COMPILEALL` is enabled, removing the coverage-ratio heuristic that skipped compiles when the estimated bytecode would not sufficiently fit the remaining zip capacity.

--- a/.changeset/lazy-pandas-refuse.md
+++ b/.changeset/lazy-pandas-refuse.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Always run bytecode precompilation when `VERCEL_PYTHON_COMPILEALL` is enabled, removing the coverage-ratio heuristic that skipped compiles when the estimated bytecode would not sufficiently fit the remaining zip capacity. Bytecode still only fills remaining capacity under the fill ceiling and never affects size-path selection; the compile is skipped only when the bundle already exceeds the ceiling and nothing could ship.

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -1360,30 +1360,6 @@ export async function calculateBundleSize(
 }
 
 /**
- * Expected .pyc-to-.py size ratio. Measured empirically on real venvs
- * (1.06 and 1.14 across different dependency mixes); slightly high so the
- * gate errs toward skipping marginal compiles.
- */
-export const PYC_TO_PY_RATIO = 1.2;
-
-/**
- * Minimum fraction of the estimated bytecode that must fit the remaining
- * capacity to justify running compileall. Cold-start benefit is roughly
- * proportional to coverage, so partial fills above this floor are worth it.
- */
-export const BYTECODE_COVERAGE_FLOOR = 0.5;
-
-/**
- * Estimate the total bytecode size compileall would produce for the .py
- * files in the bundle. Used only to gate whether compiling is worthwhile;
- * the fill itself measures real .pyc sizes.
- */
-export async function estimateBytecodeSize(files: Files): Promise<number> {
-  const pyBytes = await calculateBundleSize(files, p => p.endsWith('.py'));
-  return PYC_TO_PY_RATIO * pyBytes;
-}
-
-/**
  * Largest-first knapsack packing algorithm.
  *
  * Given a map of package names to sizes (in bytes) and a capacity,

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -98,6 +98,12 @@ export const RUNTIME_DEPS_DIR = '/tmp/_vc_deps';
 // install), served on Hive.
 export const MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE = 5 * 1024 * 1024 * 1024;
 
+// Bytecode fill target for large functions, with the same margin as the
+// standard ceiling so the fill can never push a function over the
+// platform's uncompressed-size check (enforced at >= the 5 GiB limit).
+export const LARGE_FUNCTION_FILL_CEILING_BYTES =
+  MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE - BYTECODE_FILL_MARGIN_BYTES;
+
 const BUNDLING_DOCS_LINK =
   'https://vercel.com/docs/functions/runtimes/python#controlling-what-gets-bundled';
 

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -47,7 +47,7 @@ import {
 import {
   PythonDependencyExternalizer,
   BYTECODE_FILL_CEILING_BYTES,
-  MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE,
+  LARGE_FUNCTION_FILL_CEILING_BYTES,
   LAMBDA_SIZE_THRESHOLD_BYTES,
   lambdaKnapsack,
   calculateBundleSize,
@@ -1499,7 +1499,7 @@ export const build: BuildVX = async ({
           announceLargeFunction();
           if (compileAllEnabled) {
             await runCompileAllAndFillBytecode(
-              MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
+              LARGE_FUNCTION_FILL_CEILING_BYTES
             );
           }
         } else if (bundleResult.packingMode === 'bytecode-first') {
@@ -1534,7 +1534,7 @@ export const build: BuildVX = async ({
           }
           if (compileAllEnabled) {
             await runCompileAllAndFillBytecode(
-              MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
+              LARGE_FUNCTION_FILL_CEILING_BYTES
             );
           }
         } else if (compileAllEnabled) {

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -46,13 +46,11 @@ import {
 } from './install';
 import {
   PythonDependencyExternalizer,
-  BYTECODE_COVERAGE_FLOOR,
   BYTECODE_FILL_CEILING_BYTES,
   MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE,
   LAMBDA_SIZE_THRESHOLD_BYTES,
   lambdaKnapsack,
   calculateBundleSize,
-  estimateBytecodeSize,
   RUNTIME_DEPS_DIR,
   type GenerateBundleResult,
 } from './dependency-externalizer';
@@ -1508,17 +1506,22 @@ export const build: BuildVX = async ({
           await runPrefixCompileAndFill(bundleResult);
         } else if (compileAllEnabled) {
           // Knapsack packing (bytecode-first skipped or fell back): fill
-          // only the slack under the ceiling with bytecode for in-zip
-          // packages, and only when enough of it ships to justify the
-          // compile time. Always-bundled packages get capacity first.
+          // the slack under the ceiling with bytecode for in-zip packages.
+          // Always-bundled packages get capacity first. Skip only when the
+          // bundle already exceeds the fill ceiling, since nothing could
+          // ship.
           const currentSize = await calculateBundleSize(files);
           const capacity = BYTECODE_FILL_CEILING_BYTES - currentSize;
-          const estimate = await estimateBytecodeSize(files);
-          if (capacity >= BYTECODE_COVERAGE_FLOOR * estimate) {
+          if (capacity > 0) {
             await runCompileAllAndFillBytecode(BYTECODE_FILL_CEILING_BYTES, [
               bundleResult.alwaysBundledPackages ?? [],
               bundleResult.bundledPublicPackages ?? [],
             ]);
+          } else {
+            debug(
+              `skipping bytecode precompilation: no zip capacity remaining ` +
+                `(bundle is ${(currentSize / (1024 * 1024)).toFixed(2)} MB)`
+            );
           }
         }
       } else {
@@ -1535,13 +1538,18 @@ export const build: BuildVX = async ({
             );
           }
         } else if (compileAllEnabled) {
-          // Compile only when enough of the expected bytecode ships to
-          // justify the compile time.
+          // Fill any remaining zip capacity with bytecode. Skip only when
+          // the bundle already exceeds the fill ceiling, since nothing
+          // could ship.
           const capacity =
             BYTECODE_FILL_CEILING_BYTES - depAnalysis.totalBundleSize;
-          const estimate = await estimateBytecodeSize(files);
-          if (capacity >= BYTECODE_COVERAGE_FLOOR * estimate) {
+          if (capacity > 0) {
             await runCompileAllAndFillBytecode(BYTECODE_FILL_CEILING_BYTES);
+          } else {
+            debug(
+              `skipping bytecode precompilation: no zip capacity remaining ` +
+                `(bundle is ${(depAnalysis.totalBundleSize / (1024 * 1024)).toFixed(2)} MB)`
+            );
           }
         }
       }

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -12,6 +12,7 @@ import {
   EPHEMERAL_INSTALL_BUDGET_BYTES,
   LAMBDA_SIZE_THRESHOLD_BYTES,
   LAMBDA_EPHEMERAL_STORAGE_BYTES,
+  LARGE_FUNCTION_FILL_CEILING_BYTES,
   MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE,
 } from '../src/dependency-externalizer';
 import { classifyPackages, parseUvLock } from '@vercel/python-analysis';
@@ -311,6 +312,27 @@ describe('dependency externalizer support', () => {
 
     it('large function limit is greater than the ephemeral storage limit', () => {
       expect(MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE).toBeGreaterThan(
+        LAMBDA_EPHEMERAL_STORAGE_BYTES
+      );
+    });
+
+    it('large function fill ceiling is 5 MiB under the 5 GiB limit', () => {
+      expect(LARGE_FUNCTION_FILL_CEILING_BYTES).toBe(
+        MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE - 5 * 1024 * 1024
+      );
+    });
+
+    it('large function fill ceiling leaves margin under the size limit', () => {
+      // The margin absorbs files added after the fill (e.g. the handler
+      // trampoline) and byte-sum vs. platform measurement drift, so
+      // bytecode can never push a near-limit function over the check.
+      expect(LARGE_FUNCTION_FILL_CEILING_BYTES).toBeLessThan(
+        MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
+      );
+    });
+
+    it('large function fill ceiling is greater than the ephemeral storage limit', () => {
+      expect(LARGE_FUNCTION_FILL_CEILING_BYTES).toBeGreaterThan(
         LAMBDA_EPHEMERAL_STORAGE_BYTES
       );
     });

--- a/packages/python/test/dependency-externalizer.test.ts
+++ b/packages/python/test/dependency-externalizer.test.ts
@@ -4,11 +4,8 @@ import path from 'path';
 import { tmpdir } from 'os';
 import {
   PythonDependencyExternalizer,
-  BYTECODE_COVERAGE_FLOOR,
   BYTECODE_FILL_CEILING_BYTES,
-  PYC_TO_PY_RATIO,
   calculateBundleSize,
-  estimateBytecodeSize,
   getPackagesReachableOnPlatform,
   lambdaKnapsack,
   planPublicPackagePacking,
@@ -274,61 +271,22 @@ describe('dependency externalizer support', () => {
     });
   });
 
-  describe('estimateBytecodeSize', () => {
-    it('estimates bytecode as PYC_TO_PY_RATIO times the .py bytes', async () => {
-      const files = {
-        'app.py': new FileFsRef({ fsPath: '/nonexistent/app.py', size: 100 }),
-        '_vendor/pkg/mod.py': new FileFsRef({
-          fsPath: '/nonexistent/mod.py',
-          size: 900,
-        }),
-        'lib.so': new FileFsRef({
-          fsPath: '/nonexistent/lib.so',
-          size: 5000,
-        }),
-      };
-
-      expect(await estimateBytecodeSize(files)).toBe(PYC_TO_PY_RATIO * 1000);
-    });
-
-    it('returns 0 when the bundle has no .py files', async () => {
-      const files = {
-        'lib.so': new FileFsRef({ fsPath: '/nonexistent/lib.so', size: 5000 }),
-      };
-
-      expect(await estimateBytecodeSize(files)).toBe(0);
-    });
-  });
-
-  describe('bytecode gate math (coverage floor)', () => {
+  describe('bytecode fill capacity guard', () => {
     const MB = 1024 * 1024;
-    const gatePasses = (bundleSize: number, pyBytes: number) => {
-      const capacity = BYTECODE_FILL_CEILING_BYTES - bundleSize;
-      const estimate = PYC_TO_PY_RATIO * pyBytes;
-      return capacity >= BYTECODE_COVERAGE_FLOOR * estimate;
-    };
+    // Mirrors the gate in the builder: compile whenever any capacity
+    // remains under the fill ceiling; skip only when nothing could ship.
+    const gatePasses = (bundleSize: number) =>
+      BYTECODE_FILL_CEILING_BYTES - bundleSize > 0;
 
-    it('compiles a 101MB all-Python app despite a partial fill', () => {
-      expect(gatePasses(101 * MB, 101 * MB)).toBe(true);
+    it('compiles near-limit apps regardless of expected coverage', () => {
+      // Previously skipped by the coverage-ratio heuristic.
+      expect(gatePasses(219 * MB)).toBe(true);
+      expect(gatePasses(200 * MB)).toBe(true);
     });
 
-    it('compiles all-Python apps up to the guaranteed zone boundary', () => {
-      // 220 - S >= 0.5 * 1.2 * S  =>  S <= 220 / 1.6 = 137.5MB
-      expect(gatePasses(137 * MB, 137 * MB)).toBe(true);
-      expect(gatePasses(138 * MB, 138 * MB)).toBe(false);
-    });
-
-    it('skips near-limit apps with low expected coverage', () => {
-      expect(gatePasses(219 * MB, 40 * MB)).toBe(false);
-      expect(gatePasses(200 * MB, 80 * MB)).toBe(false);
-    });
-
-    it('compiles binary-heavy near-limit apps with little .py', () => {
-      expect(gatePasses(200 * MB, 10 * MB)).toBe(true);
-    });
-
-    it('skips when the bundle exceeds the fill ceiling', () => {
-      expect(gatePasses(221 * MB, 0)).toBe(false);
+    it('skips when the bundle meets or exceeds the fill ceiling', () => {
+      expect(gatePasses(BYTECODE_FILL_CEILING_BYTES)).toBe(false);
+      expect(gatePasses(221 * MB)).toBe(false);
     });
   });
 


### PR DESCRIPTION
Simplify the logic and just run `compileall` and pack each function with `pyc` as size allows. Also have a small buffer so bytecode doesn't accidentally cause functions to exceed the large functions size limit.