### PR TITLE
[services] Add package manifest to container builder.

### DIFF
--- a/.changeset/twelve-icons-marry.md
+++ b/.changeset/twelve-icons-marry.md
@@ -1,0 +1,5 @@
+---
+'@vercel/container': minor
+---
+
+Add package manifest to container builder.

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "type-check": "tsc --noEmit",
-    "test-unit": "vitest run --config ../../vitest.config.mts test/unit.test.ts",
-    "vitest-unit": "glob --absolute 'test/unit.test.ts'"
+    "test-unit": "vitest run --config ../../vitest.config.mts test/unit.test.ts test/diagnostics.test.ts",
+    "vitest-unit": "glob --absolute 'test/*.test.ts'"
   },
   "files": [
     "dist"

--- a/packages/container/src/diagnostics.ts
+++ b/packages/container/src/diagnostics.ts
@@ -1,0 +1,31 @@
+import {
+  writeProjectManifest,
+  createDiagnostics,
+  MANIFEST_VERSION,
+  type PackageManifest,
+} from '@vercel/build-utils';
+
+export async function generateProjectManifest({
+  workPath,
+  framework,
+  serviceType,
+}: {
+  workPath: string;
+  framework?: string | null;
+  serviceType?: string | null;
+}): Promise<void> {
+  try {
+    const manifest: PackageManifest = {
+      version: MANIFEST_VERSION,
+      runtime: 'container',
+      ...(framework ? { framework } : {}),
+      ...(serviceType ? { serviceType } : {}),
+      dependencies: [],
+    };
+    await writeProjectManifest(manifest, workPath, 'container');
+  } catch {
+    // Never throw — build must succeed
+  }
+}
+
+export const diagnostics = createDiagnostics('container');

--- a/packages/container/src/index.ts
+++ b/packages/container/src/index.ts
@@ -1,5 +1,9 @@
 import type { BuildOptions, BuildResultV2, Span } from '@vercel/build-utils';
-import { getLambdaOptionsFromFunction } from '@vercel/build-utils';
+import {
+  getLambdaOptionsFromFunction,
+  getReportedServiceType,
+} from '@vercel/build-utils';
+import { generateProjectManifest } from './diagnostics';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import {
@@ -33,6 +37,7 @@ export const version = 2;
 
 export { startDevServer } from './dev';
 export { prepareCache } from './prepare-cache';
+export { diagnostics } from './diagnostics';
 
 function resolveFunctionSourceFile(options: BuildOptions): string {
   const entrypoint = readString(options.entrypoint) ?? '';
@@ -386,6 +391,14 @@ export async function build(options: BuildOptions): Promise<BuildResultV2> {
   });
 
   const command = normalizeCommand(options.config.command);
+
+  await generateProjectManifest({
+    workPath: options.workPath,
+    framework: options.config.framework ?? undefined,
+    serviceType: options.service
+      ? getReportedServiceType(options.service)
+      : undefined,
+  });
 
   // Do a normal build: the function lands at the natural `index` path and a
   // catch-all route forwards every request to it. Without it there is no `/`

--- a/packages/container/test/diagnostics.test.ts
+++ b/packages/container/test/diagnostics.test.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  FileBlob,
+  MANIFEST_FILENAME,
+  MANIFEST_VERSION,
+  manifestPath,
+} from '@vercel/build-utils';
+import { generateProjectManifest, diagnostics } from '../src/diagnostics';
+
+const DIAGNOSTICS_PATH = manifestPath('container');
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(tmpdir(), 'vc-container-diag-test-'));
+}
+
+describe('generateProjectManifest', () => {
+  it('writes a manifest with runtime "container" and empty dependencies', async () => {
+    const workPath = makeTempDir();
+    await generateProjectManifest({ workPath });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.version).toBe(MANIFEST_VERSION);
+    expect(manifest.runtime).toBe('container');
+    expect(manifest.dependencies).toEqual([]);
+  });
+
+  it('includes framework when provided', async () => {
+    const workPath = makeTempDir();
+    await generateProjectManifest({ workPath, framework: 'container' });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.framework).toBe('container');
+  });
+
+  it('includes serviceType when provided', async () => {
+    const workPath = makeTempDir();
+    await generateProjectManifest({ workPath, serviceType: 'web' });
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(workPath, DIAGNOSTICS_PATH), 'utf-8')
+    );
+    expect(manifest.serviceType).toBe('web');
+  });
+});
+
+describe('diagnostics callback', () => {
+  it('returns empty object when manifest file does not exist', async () => {
+    const workPath = makeTempDir();
+    const result = await diagnostics({ workPath } as any);
+    expect(result).toEqual({});
+  });
+
+  it('returns a FileBlob for the manifest with correct content', async () => {
+    const workPath = makeTempDir();
+    const manifestFile = path.join(workPath, DIAGNOSTICS_PATH);
+    fs.mkdirSync(path.dirname(manifestFile), { recursive: true });
+    const content = JSON.stringify({
+      version: MANIFEST_VERSION,
+      runtime: 'container',
+      dependencies: [],
+    });
+    fs.writeFileSync(manifestFile, content);
+
+    const result = await diagnostics({ workPath } as any);
+    const blob = result[MANIFEST_FILENAME] as FileBlob;
+    expect(blob).toBeInstanceOf(FileBlob);
+    expect(JSON.parse(blob.data as string)).toEqual({
+      version: MANIFEST_VERSION,
+      runtime: 'container',
+      dependencies: [],
+    });
+  });
+});


### PR DESCRIPTION
Emit package manifest from @vercel/container. This allows the cli to then assemble it into a `project-manifest.json` and/or `deploy-manifest.json`