### PR TITLE
feat(connect): add claims field to ConnectTokenResponse

### DIFF
--- a/.changeset/connect-claims-field.md
+++ b/.changeset/connect-claims-field.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Add optional `claims` field to `ConnectTokenResponse` for allow-listed upstream OAuth token claims

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -71,6 +71,8 @@ export interface ConnectTokenResponse {
   externalSubject?: string;
   /** Driver-specific metadata stored during OAuth */
   metadata?: Record<string, unknown>;
+  /** Allow-listed claims propagated from the upstream OAuth token. */
+  claims?: Record<string, unknown>;
 }
 
 export type ConnectVendorErrorPayload = Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Adds an optional `claims?: Record<string, unknown>` field to `ConnectTokenResponse` for allow-listed claims propagated from the upstream OAuth token (e.g. Okta groups).
- Companion SDK change for vercel/api's allow-listed OAuth token claims feature.

## Test plan
- [ ] Verify the field is populated when the API returns allow-listed claims
- [ ] Verify backward compatibility — existing consumers are unaffected since the field is optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)