### PR TITLE
[cli] Add ai-gateway api-keys list/inspect/remove + create parity flags

### DIFF
--- a/.changeset/ai-gateway-api-keys-crud.md
+++ b/.changeset/ai-gateway-api-keys-crud.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel ai-gateway api-keys` list, inspect, and remove subcommands for full CRUD parity with the API-key management endpoints, and extend `create` with `--expiration` and `--alert-thresholds`.

--- a/packages/cli/src/commands/ai-gateway/api-keys-create.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys-create.ts
@@ -16,8 +16,15 @@ import { AGENT_STATUS, AGENT_REASON } from '../../util/agent-output-constants';
 import {
   buildQuota,
   isValidRefreshPeriod,
+  parseAlertThresholds,
+  VALID_ALERT_THRESHOLDS,
   VALID_REFRESH_PERIODS,
 } from '../../util/ai-gateway/quota';
+import {
+  isValidExpiry,
+  presetToExpiresAt,
+  VALID_EXPIRY_VALUES,
+} from '../../util/ai-gateway/expiry';
 
 export default async function create(client: Client, argv: string[]) {
   const telemetry = new AiGatewayApiKeysCreateTelemetryClient({
@@ -40,12 +47,16 @@ export default async function create(client: Client, argv: string[]) {
   const budget = opts['--budget'] as number | undefined;
   const refreshPeriod = opts['--refresh-period'] as string | undefined;
   const includeByok = opts['--include-byok'] as boolean | undefined;
+  const alertThresholdsInput = opts['--alert-thresholds'] as string | undefined;
+  const expiration = opts['--expiration'] as string | undefined;
 
   // Track telemetry
   telemetry.trackCliOptionName(name);
   telemetry.trackCliOptionBudget(budget);
   telemetry.trackCliOptionRefreshPeriod(refreshPeriod);
   telemetry.trackCliFlagIncludeByok(includeByok);
+  telemetry.trackCliOptionAlertThresholds(alertThresholdsInput);
+  telemetry.trackCliOptionExpiration(expiration);
 
   // Validate --budget if provided
   if (budget !== undefined && budget < 1) {
@@ -93,8 +104,50 @@ export default async function create(client: Client, argv: string[]) {
     return 1;
   }
 
+  // Validate --alert-thresholds if provided
+  let alertThresholds: number[] | undefined;
+  if (alertThresholdsInput !== undefined) {
+    const result = parseAlertThresholds(alertThresholdsInput);
+    if (!result.valid) {
+      const message = `Invalid alert threshold "${result.invalid}". Must be a comma-separated subset of: ${VALID_ALERT_THRESHOLDS.join(', ')}.`;
+      output.error(message);
+      return 1;
+    }
+    alertThresholds = result.values;
+  }
+
+  // Validate --expiration if provided
+  if (expiration !== undefined && !isValidExpiry(expiration)) {
+    const message = `Invalid expiration "${expiration}". Must be one of: ${VALID_EXPIRY_VALUES.join(', ')}.`;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_EXPIRATION,
+        message,
+        next: [
+          {
+            command: getCommandNamePlain(
+              'ai-gateway api-keys create --expiration 90d'
+            ),
+          },
+        ],
+      },
+      1
+    );
+    output.error(message);
+    return 1;
+  }
+  const expiresAt =
+    expiration !== undefined ? presetToExpiresAt(expiration) : undefined;
+
   // Build aiGatewayQuota only when any quota flag is provided
-  const aiGatewayQuota = buildQuota({ budget, refreshPeriod, includeByok });
+  const aiGatewayQuota = buildQuota({
+    budget,
+    refreshPeriod,
+    includeByok,
+    alertThresholds,
+  });
 
   // Ensure a team is selected; fail in non-interactive/piped mode if missing
   if (!client.config.currentTeam) {
@@ -118,6 +171,7 @@ export default async function create(client: Client, argv: string[]) {
     const result = await createApiKeyRequest(client, {
       name,
       aiGatewayQuota,
+      ...(expiresAt !== undefined && { expiresAt }),
     });
 
     output.stopSpinner();

--- a/packages/cli/src/commands/ai-gateway/api-keys-inspect.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys-inspect.ts
@@ -1,0 +1,124 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import type Client from '../../util/client';
+import { getApiKey, type ApiKey } from '../../util/ai-gateway/api-keys';
+import { ensureTeam } from '../../util/ai-gateway/ensure-team';
+import output from '../../output-manager';
+import { AiGatewayApiKeysInspectTelemetryClient } from '../../util/telemetry/commands/ai-gateway/api-keys-inspect';
+import { inspectSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { renderResource } from '../../util/ai-gateway/output';
+
+export default async function inspect(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayApiKeysInspectTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(inspectSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+
+  const [id] = args;
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  if (!id) {
+    output.error(
+      `${getCommandName('ai-gateway api-keys inspect <id>')} expects an API key id.`
+    );
+    return 1;
+  }
+
+  if (!(await ensureTeam(client))) {
+    return 1;
+  }
+
+  return renderResource<ApiKey>(client, {
+    asJson: formatResult.jsonOutput,
+    spinnerText: 'Fetching API key',
+    fetch: () => getApiKey(client, id),
+    toJSON: apiKey => ({ apiKey }),
+    isEmpty: () => false,
+    emptyMessage: '',
+    header: apiKey => `API key ${chalk.bold(apiKey.name || apiKey.id)}`,
+    renderTable: printApiKeyDetails,
+  });
+}
+
+function dim(value: string) {
+  return chalk.gray(value);
+}
+
+function yesNo(value: boolean) {
+  return value ? 'yes' : 'no';
+}
+
+function printApiKeyDetails(apiKey: ApiKey) {
+  const rows: string[][] = [
+    ['id', apiKey.id],
+    ['name', apiKey.name || dim('–')],
+    ['key', apiKey.partialKey ? `…${apiKey.partialKey}` : dim('–')],
+    ['purpose', apiKey.purpose],
+    ['project', apiKey.projectId ?? dim('all projects')],
+    [
+      'created',
+      apiKey.createdAt ? new Date(apiKey.createdAt).toLocaleString() : dim('–'),
+    ],
+    [
+      'last used',
+      apiKey.activeAt
+        ? new Date(apiKey.activeAt).toLocaleString()
+        : dim('never'),
+    ],
+    [
+      'expires',
+      apiKey.expiresAt
+        ? new Date(apiKey.expiresAt).toLocaleString()
+        : dim('never'),
+    ],
+    ['created by', apiKey.createdBy || dim('–')],
+  ];
+
+  const quota = apiKey.quota;
+  if (quota) {
+    rows.push(
+      ['budget', `$${quota.limitAmount}`],
+      ['spend', `$${quota.currentSpend}`],
+      ['byok spend', `$${quota.currentByokSpend}`],
+      ['include byok', yesNo(quota.includeByokInQuota)],
+      ['refresh', quota.refreshPeriod],
+      [
+        'alerts',
+        quota.alertThresholds && quota.alertThresholds.length > 0
+          ? quota.alertThresholds.map(threshold => `${threshold}%`).join(', ')
+          : dim('none'),
+      ],
+      ['active', yesNo(quota.active)]
+    );
+  } else {
+    rows.push(['budget', dim('none')]);
+  }
+
+  return `${table(
+    rows.map(([label, value]) => [dim(label), value]),
+    { align: ['l', 'l'], hsep: 4 }
+  ).replace(/^/gm, '  ')}\n\n`;
+}

--- a/packages/cli/src/commands/ai-gateway/api-keys-list.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys-list.ts
@@ -1,0 +1,77 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import type Client from '../../util/client';
+import { listApiKeys, type ApiKey } from '../../util/ai-gateway/api-keys';
+import { ensureTeam } from '../../util/ai-gateway/ensure-team';
+import output from '../../output-manager';
+import { AiGatewayApiKeysListTelemetryClient } from '../../util/telemetry/commands/ai-gateway/api-keys-list';
+import { listSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { renderResource } from '../../util/ai-gateway/output';
+
+export default async function list(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayApiKeysListTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(listSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { flags: opts } = parsedArgs;
+
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  if (!(await ensureTeam(client))) {
+    return 1;
+  }
+
+  return renderResource<ApiKey[]>(client, {
+    asJson: formatResult.jsonOutput,
+    spinnerText: 'Fetching API keys',
+    fetch: () => listApiKeys(client),
+    toJSON: apiKeys => ({ apiKeys }),
+    isEmpty: apiKeys => apiKeys.length === 0,
+    emptyMessage: `No API keys found. Create one with ${getCommandName('ai-gateway api-keys create')}.`,
+    header: () => 'API keys',
+    renderTable: printApiKeysTable,
+  });
+}
+
+function printApiKeysTable(apiKeys: ApiKey[]) {
+  return `${table(
+    [
+      ['id', 'name', 'key', 'budget', 'spend', 'refresh', 'created'].map(
+        header => chalk.gray(header)
+      ),
+      ...apiKeys.map(apiKey => [
+        apiKey.id,
+        apiKey.name || chalk.gray('–'),
+        apiKey.partialKey ? `…${apiKey.partialKey}` : chalk.gray('–'),
+        apiKey.quota ? `$${apiKey.quota.limitAmount}` : chalk.gray('–'),
+        apiKey.quota ? `$${apiKey.quota.currentSpend}` : chalk.gray('–'),
+        apiKey.quota?.refreshPeriod ?? chalk.gray('–'),
+        apiKey.createdAt
+          ? new Date(apiKey.createdAt).toLocaleDateString()
+          : chalk.gray('–'),
+      ]),
+    ],
+    { align: ['l', 'l', 'l', 'l', 'l', 'l', 'l'], hsep: 4 }
+  ).replace(/^/gm, '  ')}\n\n`;
+}

--- a/packages/cli/src/commands/ai-gateway/api-keys-remove.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys-remove.ts
@@ -1,0 +1,99 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { deleteApiKey } from '../../util/ai-gateway/api-keys';
+import { ensureTeam } from '../../util/ai-gateway/ensure-team';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { AiGatewayApiKeysRemoveTelemetryClient } from '../../util/telemetry/commands/ai-gateway/api-keys-remove';
+import { removeSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+
+export default async function remove(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayApiKeysRemoveTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(removeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+
+  const [id] = args;
+  const yes = opts['--yes'] as boolean | undefined;
+
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliFlagYes(yes);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  if (!id) {
+    output.error(
+      `${getCommandName('ai-gateway api-keys rm <id>')} expects an API key id.`
+    );
+    return 1;
+  }
+
+  if (!(await ensureTeam(client))) {
+    return 1;
+  }
+
+  if (!yes) {
+    if (!client.stdin.isTTY) {
+      output.error('To remove in non-interactive mode, re-run with --yes.');
+      return 1;
+    }
+    const confirmed = await client.input.confirm(
+      `Remove API key ${chalk.bold(id)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  const removeStamp = stamp();
+  output.spinner('Removing API key');
+
+  try {
+    await deleteApiKey(client, id);
+    output.stopSpinner();
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify({ id, removed: true }, null, 2)}\n`
+      );
+    } else {
+      output.success(`API key ${chalk.bold(id)} removed ${removeStamp()}`);
+    }
+    return 0;
+  } catch (err: unknown) {
+    output.stopSpinner();
+    if (isAPIError(err) && err.status === 404) {
+      output.error(`API key "${id}" not found.`);
+      return 1;
+    }
+    if (isAPIError(err)) {
+      output.error(err.message);
+      return 1;
+    }
+    throw err;
+  }
+}

--- a/packages/cli/src/commands/ai-gateway/api-keys.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys.ts
@@ -4,7 +4,16 @@ import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import getSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import create from './api-keys-create';
-import { apiKeysSubcommand, createSubcommand } from './command';
+import list from './api-keys-list';
+import inspect from './api-keys-inspect';
+import remove from './api-keys-remove';
+import {
+  apiKeysSubcommand,
+  createSubcommand,
+  listSubcommand,
+  inspectSubcommand,
+  removeSubcommand,
+} from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
@@ -13,6 +22,9 @@ import { printError } from '../../util/error';
 
 const COMMAND_CONFIG = {
   create: getCommandAliases(createSubcommand),
+  list: getCommandAliases(listSubcommand),
+  inspect: getCommandAliases(inspectSubcommand),
+  remove: getCommandAliases(removeSubcommand),
 };
 
 export default async function apiKeys(client: Client) {
@@ -65,6 +77,30 @@ export default async function apiKeys(client: Client) {
       }
       telemetry.trackCliSubcommandCreate(subcommandOriginal);
       return create(client, args);
+    case 'list':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('ai-gateway api-keys', subcommandOriginal);
+        printHelp(listSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return list(client, args);
+    case 'inspect':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('ai-gateway api-keys', subcommandOriginal);
+        printHelp(inspectSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandInspect(subcommandOriginal);
+      return inspect(client, args);
+    case 'remove':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('ai-gateway api-keys', subcommandOriginal);
+        printHelp(removeSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
+      return remove(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(apiKeysSubcommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -39,6 +39,24 @@ export const createSubcommand = {
       deprecated: false,
       description: 'Include BYOK usage in quota (default: false)',
     },
+    {
+      name: 'alert-thresholds',
+      shorthand: null,
+      type: String,
+      argument: 'LIST',
+      deprecated: false,
+      description:
+        'Comma-separated spend percentages to alert at, a subset of 50,75,100 (e.g. 75,100)',
+    },
+    {
+      name: 'expiration',
+      shorthand: null,
+      type: String,
+      argument: 'PERIOD',
+      deprecated: false,
+      description:
+        'Expiry for the key: 7d, 30d, 60d, 90d, 1y, or none (default: none)',
+    },
   ],
   examples: [
     {
@@ -49,6 +67,52 @@ export const createSubcommand = {
       name: 'Create an API key with a budget',
       value: `${packageName} ai-gateway api-keys create --name my-key --budget 500 --refresh-period monthly`,
     },
+    {
+      name: 'Create a key that expires and alerts on spend',
+      value: `${packageName} ai-gateway api-keys create --budget 500 --alert-thresholds 75,100 --expiration 90d`,
+    },
+  ],
+} as const;
+
+export const listSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List AI Gateway API keys',
+  arguments: [],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'List API keys',
+      value: `${packageName} ai-gateway api-keys ls`,
+    },
+  ],
+} as const;
+
+export const inspectSubcommand = {
+  name: 'inspect',
+  aliases: [],
+  description: 'Show details about an AI Gateway API key',
+  arguments: [{ name: 'id', required: true }],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'Inspect an API key',
+      value: `${packageName} ai-gateway api-keys inspect key_123`,
+    },
+  ],
+} as const;
+
+export const removeSubcommand = {
+  name: 'remove',
+  aliases: ['rm', 'delete'],
+  description: 'Remove an AI Gateway API key',
+  arguments: [{ name: 'id', required: true }],
+  options: [yesOption, formatOption],
+  examples: [
+    {
+      name: 'Remove an API key',
+      value: `${packageName} ai-gateway api-keys rm key_123`,
+    },
   ],
 } as const;
 
@@ -57,7 +121,12 @@ export const apiKeysSubcommand = {
   aliases: [],
   description: 'Manage AI Gateway API keys',
   arguments: [],
-  subcommands: [createSubcommand],
+  subcommands: [
+    createSubcommand,
+    listSubcommand,
+    inspectSubcommand,
+    removeSubcommand,
+  ],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/util/ai-gateway/api-keys.ts
+++ b/packages/cli/src/util/ai-gateway/api-keys.ts
@@ -1,0 +1,82 @@
+import type Client from '../client';
+
+/**
+ * AI Gateway quota attached to an API key. Mirrors the backend
+ * `APIKeyQuotaSchema` (services/api-keys/src/lib/api-key-schema.ts).
+ */
+export type ApiKeyQuota = {
+  quotaEntityId: string;
+  limitAmount: number;
+  currentSpend: number;
+  currentByokSpend: number;
+  includeByokInQuota: boolean;
+  refreshPeriod: 'daily' | 'weekly' | 'monthly' | 'none';
+  active: boolean;
+  archived: boolean;
+  alertThresholds?: number[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+/**
+ * An API key as returned by the api-keys service. Mirrors the backend
+ * `APIKeySchema` (services/api-keys/src/lib/api-key-schema.ts).
+ */
+export type ApiKey = {
+  id: string;
+  name: string;
+  partialKey: string;
+  teamId: string;
+  purpose: string;
+  projectId: string | null;
+  expiresAt: number | null;
+  activeAt: number;
+  createdAt: number;
+  createdBy: string;
+  leakedAt: number | null;
+  leakedUrl: string | null;
+  createdByAppId: string | null;
+  quota?: ApiKeyQuota;
+};
+
+type ListApiKeysResponse = {
+  apiKeys: ApiKey[];
+  pagination: {
+    count: number;
+    next: string | null;
+    prev: string | null;
+  };
+};
+
+/**
+ * List the current team's AI Gateway API keys. The list endpoint accepts an
+ * optional `purpose` filter; we scope to `ai-gateway` so only Gateway keys
+ * show up in this command family.
+ */
+export async function listApiKeys(client: Client): Promise<ApiKey[]> {
+  const { apiKeys } = await client.fetch<ListApiKeysResponse>(
+    '/v1/api-keys?purpose=ai-gateway',
+    { method: 'GET' }
+  );
+  return apiKeys ?? [];
+}
+
+export async function getApiKey(
+  client: Client,
+  apiKeyId: string
+): Promise<ApiKey> {
+  const { apiKey } = await client.fetch<{ apiKey: ApiKey }>(
+    `/v1/api-keys/${encodeURIComponent(apiKeyId)}`,
+    { method: 'GET' }
+  );
+  return apiKey;
+}
+
+export async function deleteApiKey(
+  client: Client,
+  apiKeyId: string
+): Promise<void> {
+  await client.fetch(`/v1/api-keys/${encodeURIComponent(apiKeyId)}`, {
+    method: 'DELETE',
+  });
+}

--- a/packages/cli/src/util/ai-gateway/create-api-key.ts
+++ b/packages/cli/src/util/ai-gateway/create-api-key.ts
@@ -4,6 +4,7 @@ export type AiGatewayQuota = {
   limitAmount?: number;
   refreshPeriod?: string;
   includeByokInQuota?: boolean;
+  alertThresholds?: number[];
 };
 
 type CreateApiKeyRequest = {

--- a/packages/cli/src/util/ai-gateway/quota.ts
+++ b/packages/cli/src/util/ai-gateway/quota.ts
@@ -13,21 +13,60 @@ export function isValidRefreshPeriod(period: string): period is RefreshPeriod {
   return (VALID_REFRESH_PERIODS as readonly string[]).includes(period);
 }
 
+export const VALID_ALERT_THRESHOLDS = [50, 75, 100] as const;
+
+/**
+ * Parse a comma-separated list of spend-alert thresholds (e.g. "75,100") into
+ * a de-duplicated number array. Each value must be one of
+ * {@link VALID_ALERT_THRESHOLDS}. Returns the offending token when invalid.
+ */
+export function parseAlertThresholds(
+  input: string
+): { valid: true; values: number[] } | { valid: false; invalid: string } {
+  const values: number[] = [];
+  const tokens = input
+    .split(',')
+    .map(token => token.trim())
+    .filter(token => token.length > 0);
+  for (const token of tokens) {
+    const num = Number(token);
+    if (
+      !Number.isInteger(num) ||
+      !(VALID_ALERT_THRESHOLDS as readonly number[]).includes(num)
+    ) {
+      return { valid: false, invalid: token };
+    }
+    if (!values.includes(num)) {
+      values.push(num);
+    }
+  }
+  return { valid: true, values };
+}
+
 export function buildQuota(opts: {
   budget?: number;
   refreshPeriod?: string;
   includeByok?: boolean;
+  alertThresholds?: number[];
 }): AiGatewayQuota | undefined {
   const effectiveRefresh =
     opts.refreshPeriod && opts.refreshPeriod !== 'none'
       ? opts.refreshPeriod
       : undefined;
-  if (opts.budget === undefined && !effectiveRefresh && !opts.includeByok) {
+  const hasAlertThresholds =
+    opts.alertThresholds !== undefined && opts.alertThresholds.length > 0;
+  if (
+    opts.budget === undefined &&
+    !effectiveRefresh &&
+    !opts.includeByok &&
+    !hasAlertThresholds
+  ) {
     return undefined;
   }
   return {
     ...(opts.budget !== undefined && { limitAmount: opts.budget }),
     ...(effectiveRefresh && { refreshPeriod: effectiveRefresh }),
     ...(opts.includeByok && { includeByokInQuota: true }),
+    ...(hasAlertThresholds && { alertThresholds: opts.alertThresholds }),
   };
 }

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-create.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-create.ts
@@ -38,4 +38,22 @@ export class AiGatewayApiKeysCreateTelemetryClient
       this.trackCliFlag('include-byok');
     }
   }
+
+  trackCliOptionAlertThresholds(alertThresholds: string | undefined) {
+    if (alertThresholds) {
+      this.trackCliOption({
+        option: 'alert-thresholds',
+        value: alertThresholds,
+      });
+    }
+  }
+
+  trackCliOptionExpiration(expiration: string | undefined) {
+    if (expiration) {
+      this.trackCliOption({
+        option: 'expiration',
+        value: expiration,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-inspect.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-inspect.ts
@@ -1,0 +1,20 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { inspectSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayApiKeysInspectTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof inspectSubcommand>
+{
+  trackCliArgumentId(id: string | undefined) {
+    if (id) {
+      this.trackCliArgument({ arg: 'id', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({ option: 'format', value: format });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-list.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-list.ts
@@ -1,0 +1,14 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { listSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayApiKeysListTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof listSubcommand>
+{
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({ option: 'format', value: format });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-remove.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-remove.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { removeSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayApiKeysRemoveTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof removeSubcommand>
+{
+  trackCliArgumentId(id: string | undefined) {
+    if (id) {
+      this.trackCliArgument({ arg: 'id', value: this.redactedValue });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({ option: 'format', value: format });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys.ts
@@ -12,4 +12,25 @@ export class AiGatewayApiKeysTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/ai-gateway/api-keys-create.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/api-keys-create.test.ts
@@ -85,7 +85,66 @@ describe('ai-gateway api-keys create', () => {
     });
   });
 
+  describe('success with expiration and alert thresholds', () => {
+    it('creates an API key with --expiration and --alert-thresholds', async () => {
+      const team = useTeam();
+      useUser();
+      let body: unknown;
+      client.scenario.post('/v1/api-keys', (req, res) => {
+        body = req.body;
+        res.json(mockApiKeyResponse);
+      });
+      client.config.currentTeam = team.id;
+      client.setArgv(
+        'ai-gateway',
+        'api-keys',
+        'create',
+        '--budget',
+        '500',
+        '--alert-thresholds',
+        '75,100',
+        '--expiration',
+        '90d'
+      );
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stdout).toOutput(mockApiKeyResponse.apiKeyString);
+      expect(await exitCodePromise).toBe(0);
+      expect(body).toMatchObject({
+        aiGatewayQuota: { limitAmount: 500, alertThresholds: [75, 100] },
+      });
+      expect((body as { expiresAt?: number }).expiresAt).toBeTypeOf('number');
+    });
+  });
+
   describe('validation', () => {
+    it('fails with invalid --alert-thresholds', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'api-keys',
+        'create',
+        '--alert-thresholds',
+        '80'
+      );
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stderr).toOutput('Invalid alert threshold "80"');
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('fails with invalid --expiration', async () => {
+      useUser();
+      client.setArgv('ai-gateway', 'api-keys', 'create', '--expiration', '5m');
+
+      const exitCodePromise = aiGateway(client);
+
+      await expect(client.stderr).toOutput('Invalid expiration "5m"');
+      expect(await exitCodePromise).toBe(1);
+    });
+
     it('fails with invalid --refresh-period', async () => {
       useUser();
       client.setArgv(

--- a/packages/cli/test/unit/commands/ai-gateway/api-keys-inspect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/api-keys-inspect.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+const sampleApiKey = {
+  id: 'key_1',
+  name: 'production',
+  partialKey: 't7V',
+  teamId: 'team_abc',
+  purpose: 'ai-gateway',
+  projectId: null,
+  expiresAt: null,
+  activeAt: 1700000000000,
+  createdAt: 1700000000000,
+  createdBy: 'user_1',
+  leakedAt: null,
+  leakedUrl: null,
+  createdByAppId: null,
+  quota: {
+    quotaEntityId: 'quota_1',
+    limitAmount: 500,
+    currentSpend: 42,
+    currentByokSpend: 0,
+    includeByokInQuota: false,
+    refreshPeriod: 'monthly',
+    active: true,
+    archived: false,
+    alertThresholds: [75, 100],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  },
+};
+
+function useGetApiKey(apiKey: unknown = sampleApiKey, id = 'key_1') {
+  client.scenario.get(`/v1/api-keys/${id}`, (_req, res) => {
+    res.json({ apiKey });
+  });
+}
+
+function useGetNotFound(id = 'missing') {
+  client.scenario.get(`/v1/api-keys/${id}`, (_req, res) => {
+    res
+      .status(404)
+      .json({ error: { code: 'not_found', message: 'API key not found.' } });
+  });
+}
+
+describe('ai-gateway api-keys inspect', () => {
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'api-keys', 'inspect', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:api-keys', value: 'api-keys' },
+        { key: 'flag:help', value: 'ai-gateway api-keys:inspect' },
+      ]);
+    });
+  });
+
+  it('shows details including quota', async () => {
+    const team = useTeam();
+    useUser();
+    useGetApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'inspect', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    // The quota block renders a `budget` row for keys that have a quota.
+    await expect(client.stdout).toOutput('budget');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('shows details for a key without a quota', async () => {
+    const team = useTeam();
+    useUser();
+    const { quota, ...noQuota } = sampleApiKey;
+    void quota;
+    useGetApiKey(noQuota);
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'inspect', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('production');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('requires an id', async () => {
+    useUser();
+    client.setArgv('ai-gateway', 'api-keys', 'inspect');
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('expects an API key id');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('reports a 404 as not found', async () => {
+    const team = useTeam();
+    useUser();
+    useGetNotFound();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'inspect', 'missing');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('API key not found');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    const team = useTeam();
+    useUser();
+    useGetApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv(
+      'ai-gateway',
+      'api-keys',
+      'inspect',
+      'key_1',
+      '--format',
+      'json'
+    );
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('"apiKey"');
+    expect(await exitCodePromise).toBe(0);
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/api-keys-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/api-keys-list.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+const sampleApiKey = {
+  id: 'key_1',
+  name: 'production',
+  partialKey: 't7V',
+  teamId: 'team_abc',
+  purpose: 'ai-gateway',
+  projectId: null,
+  expiresAt: null,
+  activeAt: 1700000000000,
+  createdAt: 1700000000000,
+  createdBy: 'user_1',
+  leakedAt: null,
+  leakedUrl: null,
+  createdByAppId: null,
+  quota: {
+    quotaEntityId: 'quota_1',
+    limitAmount: 500,
+    currentSpend: 42,
+    currentByokSpend: 0,
+    includeByokInQuota: false,
+    refreshPeriod: 'monthly',
+    active: true,
+    archived: false,
+    alertThresholds: [75, 100],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  },
+};
+
+function useListApiKeys(apiKeys: unknown[] = [sampleApiKey]) {
+  let query: unknown;
+  client.scenario.get('/v1/api-keys', (req, res) => {
+    query = req.query;
+    res.json({
+      apiKeys,
+      pagination: { count: apiKeys.length, next: null, prev: null },
+    });
+  });
+  return () => query;
+}
+
+describe('ai-gateway api-keys list', () => {
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'api-keys', 'list', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:api-keys', value: 'api-keys' },
+        { key: 'flag:help', value: 'ai-gateway api-keys:list' },
+      ]);
+    });
+  });
+
+  it('lists API keys in a table', async () => {
+    const team = useTeam();
+    useUser();
+    const getQuery = useListApiKeys();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('production');
+    expect(await exitCodePromise).toBe(0);
+    // Scoped to ai-gateway keys only.
+    expect(getQuery()).toMatchObject({ purpose: 'ai-gateway' });
+  });
+
+  it('reports when there are no API keys', async () => {
+    const team = useTeam();
+    useUser();
+    useListApiKeys([]);
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'ls');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('No API keys found');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    const team = useTeam();
+    useUser();
+    useListApiKeys();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'list', '--format', 'json');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('"apiKeys"');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('fails without a team in non-interactive mode', async () => {
+    useUser();
+    client.config.currentTeam = undefined;
+    client.stdin.isTTY = false;
+    client.setArgv('ai-gateway', 'api-keys', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('No team selected');
+    expect(await exitCodePromise).toBe(1);
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/api-keys-remove.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/api-keys-remove.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+function useDeleteApiKey(id = 'key_1') {
+  client.scenario.delete(`/v1/api-keys/${id}`, (_req, res) => {
+    res.status(204).end();
+  });
+}
+
+function useDeleteNotFound(id = 'missing') {
+  client.scenario.delete(`/v1/api-keys/${id}`, (_req, res) => {
+    res
+      .status(404)
+      .json({ error: { code: 'not_found', message: 'API key not found.' } });
+  });
+}
+
+describe('ai-gateway api-keys remove', () => {
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'api-keys', 'remove', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:api-keys', value: 'api-keys' },
+        { key: 'flag:help', value: 'ai-gateway api-keys:remove' },
+      ]);
+    });
+  });
+
+  it('removes a key with --yes', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'key_1', '--yes');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('removed');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('removes a key via the delete alias', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'delete', 'key_1', '--yes');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('removed');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv(
+      'ai-gateway',
+      'api-keys',
+      'rm',
+      'key_1',
+      '--yes',
+      '--format',
+      'json'
+    );
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('"removed": true');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('requires an id', async () => {
+    useUser();
+    client.setArgv('ai-gateway', 'api-keys', 'rm', '--yes');
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('expects an API key id');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('fails in non-interactive mode without --yes', async () => {
+    const team = useTeam();
+    useUser();
+    client.config.currentTeam = team.id;
+    client.stdin.isTTY = false;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('re-run with --yes');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('reports a 404 as not found', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteNotFound();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'missing', '--yes');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('API key "missing" not found');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('removes after interactive confirmation', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('Remove API key');
+    client.stdin.write('y\n');
+
+    await expect(client.stderr).toOutput('removed');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('cancels when confirmation is declined', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('Remove API key');
+    client.stdin.write('n\n');
+
+    await expect(client.stderr).toOutput('Canceled');
+    expect(await exitCodePromise).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

- The `vercel ai-gateway api-keys` command only wired up `create`, so AI Gateway users could mint keys from the CLI but had to leave it to list, inspect, or delete them. This closes that gap by surfacing the exposed single-resource API-key endpoints.

## Summary

- Adds `api-keys list`/`ls`, `api-keys inspect <id>`, and `api-keys remove <id>`/`rm`/`delete`, mapping to `GET /v1/api-keys`, `GET /v1/api-keys/:id`, and `DELETE /v1/api-keys/:id`.
- Extends `api-keys create` with `--expiration` and `--alert-thresholds` for parity with the create endpoint.
- Reuses the existing ai-gateway command-family rendering (`renderResource` + `table`), team gating (`ensureTeam`), and JSON output helpers — no new UI patterns.
- Quota update and the bulk endpoints are intentionally out of scope.

## Validation

- New unit suites for list/inspect/remove and extended create coverage; full ai-gateway suite passes (175 tests).

▲ Created with [Vercel devbox](https://vercel.com/vercel/~/sandboxes/devboxes/35os7mszisbe66s2j6ak0vxmh13g)