### PR TITLE
fix(ci): stabilize rust-toolchain action pin

### DIFF
--- a/.changeset/tidy-rust-toolchain-pin.md
+++ b/.changeset/tidy-rust-toolchain-pin.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pinned the Rust toolchain action to a commit retained in upstream history.

--- a/.changeset/tidy-rust-toolchain-pin.md
+++ b/.changeset/tidy-rust-toolchain-pin.md
@@ -1,4 +1,0 @@
----
----
-
-Pinned the Rust toolchain action to a commit retained in upstream history.

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -33,8 +33,9 @@ jobs:
           node-version: 24
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: '1.96.1'
           targets: wasm32-wasip2
 
       - name: Setup Python

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -96,7 +96,7 @@ jobs:
           package-manager-cache: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           targets: wasm32-wasip2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,9 @@ jobs:
           node-version: 24
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: '1.96.1'
           targets: wasm32-wasip2
 
       - name: Setup Python

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -51,8 +51,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: '1.96.1'
           targets: wasm32-wasip2
       - name: install pnpm@10.29.3
         run: npm i -g pnpm@10.29.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -291,8 +291,9 @@ jobs:
 
       - name: Setup Rust toolchain
         if: ${{ matrix.needsRust == true }}
-        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: '1.96.1'
           targets: wasm32-wasip2
 
       # yarn 1.22.21 introduced a Corepack bug when running tests.
@@ -432,8 +433,9 @@ jobs:
 
       - name: Setup Rust toolchain
         if: ${{ matrix.needsRust == true }}
-        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: '1.96.1'
           targets: wasm32-wasip2
 
       # yarn 1.22.21 introduced a Corepack bug when running tests.

--- a/.github/workflows/validate-binary.yml
+++ b/.github/workflows/validate-binary.yml
@@ -45,7 +45,7 @@ jobs:
           package-manager-cache: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@a75363d06101555fc97c6c7e1e65670b99104d98 # 1.96.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           targets: wasm32-wasip2


### PR DESCRIPTION
## Summary

- pin `dtolnay/rust-toolchain` action code to the full SHA for its `v1` tag, which is retained in upstream `master` history
- select Rust `1.96.1` explicitly in workflows that previously selected it through the action ref
- preserve the existing `stable` selection in release-binary and binary-validation workflows

## Why

#16876 fixed the same `zizmor` `impostor-commit` failure after an upstream version branch was force-updated, but repinned the action to another commit from the mutable `1.96.1` branch. That branch moved again, orphaning the replacement SHA.

The action's documentation warns that full-SHA pins must come from `master` history. Using the master-retained `v1` action commit and passing the toolchain as an input separates stable action provenance from Rust version selection.

## Validation

- `zizmor 1.24.1 --collect=workflows --color=never .github/workflows/` — no findings
- Prettier passed for the changed workflows and changeset
- repository pre-commit hooks passed
