### PR TITLE
feat(vc buy): add flat rate cdn to vc buy

### DIFF
--- a/.changeset/flat-cdns-buy.md
+++ b/.changeset/flat-cdns-buy.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow purchasing Flat Rate CDN Base, Standard, and Advanced addons with `vercel buy addon`.

--- a/packages/cli/src/commands/buy/command.ts
+++ b/packages/cli/src/commands/buy/command.ts
@@ -49,13 +49,22 @@ export const creditsSubcommand = {
 } as const;
 
 // TODO(mingchungx): Add other addons
-export const SUPPORTED_ADDON_ALIASES = ['siem', 'customEnvironment'] as const;
+export const SUPPORTED_ADDON_ALIASES = [
+  'siem',
+  'customEnvironment',
+  'flatRateCdnBase',
+  'flatRateCdnStandard',
+  'flatRateCdnAdvanced',
+] as const;
 export type AddonAlias = (typeof SUPPORTED_ADDON_ALIASES)[number];
 
 // TODO(mingchungx): Add other labels
 export const ADDON_LABELS: Record<AddonAlias, string> = {
   siem: 'SIEM',
   customEnvironment: 'Custom Environments',
+  flatRateCdnBase: 'Flat Rate CDN Base',
+  flatRateCdnStandard: 'Flat Rate CDN Standard',
+  flatRateCdnAdvanced: 'Flat Rate CDN Advanced',
 };
 
 export const addonSubcommand = {
@@ -88,6 +97,18 @@ export const addonSubcommand = {
     {
       name: 'Purchase 1 unit of the Custom Environments addon',
       value: `${packageName} buy addon customEnvironment 1`,
+    },
+    {
+      name: 'Purchase the Flat Rate CDN Base addon',
+      value: `${packageName} buy addon flatRateCdnBase 1`,
+    },
+    {
+      name: 'Purchase the Flat Rate CDN Standard addon',
+      value: `${packageName} buy addon flatRateCdnStandard 1`,
+    },
+    {
+      name: 'Purchase the Flat Rate CDN Advanced addon',
+      value: `${packageName} buy addon flatRateCdnAdvanced 1`,
     },
   ],
 } as const;
@@ -160,6 +181,10 @@ export const buyCommand = {
     {
       name: 'Purchase the Custom Environments addon',
       value: `${packageName} buy addon customEnvironment 1`,
+    },
+    {
+      name: 'Purchase the Flat Rate CDN Base addon',
+      value: `${packageName} buy addon flatRateCdnBase 1`,
     },
     {
       name: 'Upgrade to Pro',

--- a/packages/cli/test/unit/commands/buy/addon.test.ts
+++ b/packages/cli/test/unit/commands/buy/addon.test.ts
@@ -118,6 +118,32 @@ describe('buy addon', () => {
       const exitCode = await buy(client);
       expect(exitCode).toBe(0);
     });
+
+    it.each([
+      'flatRateCdnBase',
+      'flatRateCdnStandard',
+      'flatRateCdnAdvanced',
+    ])('purchases the %s addon', async productAlias => {
+      setupTeam();
+      useBuyEndpoint((req, res) => {
+        expect(req.body).toEqual({
+          item: {
+            type: 'addon',
+            productAlias,
+            quantity: 1,
+          },
+        });
+        res.json({
+          subscriptionIntent: {
+            id: 'subint_test_123',
+            status: 'succeeded',
+          },
+        });
+      });
+      client.setArgv('buy', 'addon', productAlias, '1', '--yes');
+
+      expect(await buy(client)).toBe(0);
+    });
   });
 
   describe('confirmation prompt', () => {
@@ -260,6 +286,10 @@ describe('buy addon', () => {
       client.setArgv('buy', 'addon', '--help');
       const exitCode = await buy(client);
       expect(exitCode).toBe(2);
+      const output = client.stderr.getFullOutput();
+      expect(output).toContain('flatRateCdnBase');
+      expect(output).toContain('flatRateCdnStandard');
+      expect(output).toContain('flatRateCdnAdvanced');
     });
 
     it('tracks telemetry', async () => {


### PR DESCRIPTION
allow any of the flat rate cdn tiers to be purchased via vc buy

this is gated on the server side with a flag, so it will respond a 404 if this team does not have access