### PR TITLE
feat(ai-gateway): surface per-team model availability in `models list` (AIG-187)

### DIFF
--- a/.changeset/aig-187-models-availability.md
+++ b/.changeset/aig-187-models-availability.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Show per-team model availability in `vercel ai-gateway models list`. When the AI Gateway annotates the authenticated `/v1/models` response for a team with an active restriction (provider allowlist / ZDR), the list now includes an `available` column (and the machine-readable `unavailable_reason`), so you can see which models your team can route to without probing each one. Unauthenticated and unrestricted listings are unchanged.

--- a/.changeset/aig-187-models-availability.md
+++ b/.changeset/aig-187-models-availability.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Show per-team model availability in `vercel ai-gateway models list`. When the AI Gateway annotates the authenticated `/v1/models` response for a team with an active restriction (provider allowlist / ZDR), the list now includes an `available` column (and the machine-readable `unavailable_reason`), so you can see which models your team can route to without probing each one. Unauthenticated and unrestricted listings are unchanged.
+Show per-team model availability in `vercel ai-gateway models list`. The list includes an `available` column and machine-readable reason codes, including team-wide account blockers such as a required payment method, so you can see which models the active team can route to without probing each one.

--- a/packages/cli/src/commands/ai-gateway/models-list.ts
+++ b/packages/cli/src/commands/ai-gateway/models-list.ts
@@ -51,16 +51,39 @@ export default async function list(client: Client, argv: string[]) {
 }
 
 function printModelsTable(models: Model[]) {
+  // `available` is present only when the gateway annotated the response for a
+  // restricted team (AIG-187). Show the column only then, so output for
+  // unauthenticated / unrestricted listings is unchanged.
+  const showAvailability = models.some(m => m.available !== undefined);
+
+  const availabilityCell = (model: Model): string => {
+    if (model.available === undefined) return chalk.gray('–');
+    if (model.available) return chalk.green('yes');
+    return model.available_reason
+      ? chalk.red(`no (${model.available_reason})`)
+      : chalk.red('no');
+  };
+
+  const headers = ['id', 'name', 'owner', 'type'];
+  if (showAvailability) headers.push('available');
+  const align = showAvailability
+    ? (['l', 'l', 'l', 'l', 'l'] as const)
+    : (['l', 'l', 'l', 'l'] as const);
+
   return `${table(
     [
-      ['id', 'name', 'owner', 'type'].map(header => chalk.gray(header)),
-      ...models.map(model => [
-        model.id,
-        model.name ?? chalk.gray('–'),
-        model.owned_by ?? chalk.gray('–'),
-        model.type ?? chalk.gray('–'),
-      ]),
+      headers.map(header => chalk.gray(header)),
+      ...models.map(model => {
+        const row = [
+          model.id,
+          model.name ?? chalk.gray('–'),
+          model.owned_by ?? chalk.gray('–'),
+          model.type ?? chalk.gray('–'),
+        ];
+        if (showAvailability) row.push(availabilityCell(model));
+        return row;
+      }),
     ],
-    { align: ['l', 'l', 'l', 'l'], hsep: 4 }
+    { align: [...align], hsep: 4 }
   ).replace(/^/gm, '  ')}\n\n`;
 }

--- a/packages/cli/src/commands/ai-gateway/models-list.ts
+++ b/packages/cli/src/commands/ai-gateway/models-list.ts
@@ -49,7 +49,11 @@ export default async function list(client: Client, argv: string[]) {
     fetch: async () => {
       const result = await listModels(client);
       const { accountAvailability, availabilityStatus } = result;
-      if (availabilityStatus === 'degraded') {
+      const availabilityComplete =
+        availabilityStatus === 'complete' &&
+        accountAvailability !== undefined &&
+        result.models.every(model => typeof model.available === 'boolean');
+      if (!availabilityComplete) {
         output.warn(
           'Model availability could not be determined. Retry before treating unannotated models as available.'
         );
@@ -71,7 +75,8 @@ export default async function list(client: Client, argv: string[]) {
     isEmpty: result => result.models.length === 0,
     emptyMessage: 'No models found.',
     header: () => 'Models',
-    renderTable: result => printModelsTable(result.models),
+    renderTable: result =>
+      printModelsTable(result.models, result.accountAvailability),
   });
 }
 
@@ -92,7 +97,10 @@ function accountAvailabilityMessage(account: AccountAvailability): string {
   }
 }
 
-function printModelsTable(models: Model[]) {
+function printModelsTable(
+  models: Model[],
+  accountAvailability?: AccountAvailability
+) {
   // The CLI explicitly requests availability. Keep this defensive check for a
   // degraded Gateway response, where annotations are intentionally omitted
   // rather than presented as optimistic `available: true` verdicts.
@@ -101,6 +109,13 @@ function printModelsTable(models: Model[]) {
   const availabilityCell = (model: Model): string => {
     if (model.available === undefined) return chalk.gray('–');
     if (model.available) return chalk.green('yes');
+    if (
+      model.unavailable_reason === 'account_unavailable' &&
+      accountAvailability &&
+      !accountAvailability.available
+    ) {
+      return chalk.red('no');
+    }
     return model.unavailable_reason
       ? chalk.red(`no (${model.unavailable_reason})`)
       : chalk.red('no');

--- a/packages/cli/src/commands/ai-gateway/models-list.ts
+++ b/packages/cli/src/commands/ai-gateway/models-list.ts
@@ -48,17 +48,26 @@ export default async function list(client: Client, argv: string[]) {
     spinnerText: 'Fetching models',
     fetch: async () => {
       const result = await listModels(client);
-      const { accountAvailability, availabilityStatus } = result;
+      const { accountAvailability, availabilityStatus, catalogStatus } = result;
       const availabilityComplete =
         availabilityStatus === 'complete' &&
         accountAvailability !== undefined &&
         result.models.every(model => typeof model.available === 'boolean');
       if (!availabilityComplete) {
         output.warn(
-          'Model availability could not be determined. Retry before treating unannotated models as available.'
+          'Model availability is partial. Unknown models must not be treated as available.'
         );
       }
-      if (accountAvailability && !accountAvailability.available) {
+      if (catalogStatus === 'partial') {
+        output.warn(
+          'The model catalog is partial because some team-visible models could not be loaded.'
+        );
+      }
+      if (
+        accountAvailability &&
+        'available' in accountAvailability &&
+        !accountAvailability.available
+      ) {
         output.warn(accountAvailabilityMessage(accountAvailability));
       }
       return result;
@@ -71,6 +80,9 @@ export default async function list(client: Client, argv: string[]) {
       ...(result.accountAvailability && {
         account_availability: result.accountAvailability,
       }),
+      ...(result.catalogStatus && {
+        catalog_status: result.catalogStatus,
+      }),
     }),
     isEmpty: result => result.models.length === 0,
     emptyMessage: 'No models found.',
@@ -81,6 +93,9 @@ export default async function list(client: Client, argv: string[]) {
 }
 
 function accountAvailabilityMessage(account: AccountAvailability): string {
+  if (!('available' in account)) {
+    return 'Account availability could not be determined.';
+  }
   switch (account.unavailable_reason) {
     case 'payment_method_required':
       return 'Add a payment method before running models for this team.';
@@ -102,16 +117,24 @@ function printModelsTable(
   accountAvailability?: AccountAvailability
 ) {
   // The CLI explicitly requests availability. Keep this defensive check for a
-  // degraded Gateway response, where annotations are intentionally omitted
-  // rather than presented as optimistic `available: true` verdicts.
-  const showAvailability = models.some(m => m.available !== undefined);
+  // partial Gateway response, where unknown verdicts remain explicit rather
+  // than being presented as optimistic `available: true` verdicts.
+  const showAvailability = models.some(
+    model =>
+      model.available !== undefined ||
+      model.availability_unknown_reason !== undefined
+  );
 
   const availabilityCell = (model: Model): string => {
-    if (model.available === undefined) return chalk.gray('–');
+    if (model.availability_unknown_reason) {
+      return chalk.gray(`unknown (${model.availability_unknown_reason})`);
+    }
+    if (model.available === undefined) return chalk.gray('unknown');
     if (model.available) return chalk.green('yes');
     if (
       model.unavailable_reason === 'account_unavailable' &&
       accountAvailability &&
+      'available' in accountAvailability &&
       !accountAvailability.available
     ) {
       return chalk.red('no');

--- a/packages/cli/src/commands/ai-gateway/models-list.ts
+++ b/packages/cli/src/commands/ai-gateway/models-list.ts
@@ -1,7 +1,12 @@
 import chalk from 'chalk';
 import table from '../../util/output/table';
 import type Client from '../../util/client';
-import { listModels, type Model } from '../../util/ai-gateway/models';
+import {
+  listModels,
+  type AccountAvailability,
+  type Model,
+  type ModelsListResult,
+} from '../../util/ai-gateway/models';
 import output from '../../output-manager';
 import { AiGatewayModelsListTelemetryClient } from '../../util/telemetry/commands/ai-gateway/models-list';
 import { modelsListSubcommand } from './command';
@@ -38,24 +43,53 @@ export default async function list(client: Client, argv: string[]) {
     return 1;
   }
 
-  return renderResource<Model[]>(client, {
+  return renderResource<ModelsListResult>(client, {
     asJson: formatResult.jsonOutput,
     spinnerText: 'Fetching models',
     fetch: async () => {
-      const { models, availabilityStatus } = await listModels(client);
+      const result = await listModels(client);
+      const { accountAvailability, availabilityStatus } = result;
       if (availabilityStatus === 'degraded') {
         output.warn(
           'Model availability could not be determined. Retry before treating unannotated models as available.'
         );
       }
-      return models;
+      if (accountAvailability && !accountAvailability.available) {
+        output.warn(accountAvailabilityMessage(accountAvailability));
+      }
+      return result;
     },
-    toJSON: models => ({ models }),
-    isEmpty: models => models.length === 0,
+    toJSON: result => ({
+      models: result.models,
+      ...(result.availabilityStatus && {
+        availability_status: result.availabilityStatus,
+      }),
+      ...(result.accountAvailability && {
+        account_availability: result.accountAvailability,
+      }),
+    }),
+    isEmpty: result => result.models.length === 0,
     emptyMessage: 'No models found.',
     header: () => 'Models',
-    renderTable: printModelsTable,
+    renderTable: result => printModelsTable(result.models),
   });
+}
+
+function accountAvailabilityMessage(account: AccountAvailability): string {
+  switch (account.unavailable_reason) {
+    case 'payment_method_required':
+      return 'Add a payment method before running models for this team.';
+    case 'insufficient_funds':
+      return 'Add AI Gateway credits before running models for this team.';
+    case 'quota_exceeded':
+      return 'The active API key or team budget has been reached.';
+    case 'quota_invalid':
+      return "The active API key's quota settings are invalid.";
+    case 'team_blocked':
+      return "This team can't run AI Gateway models.";
+    default:
+      return "This account can't run AI Gateway models.";
+  }
 }
 
 function printModelsTable(models: Model[]) {

--- a/packages/cli/src/commands/ai-gateway/models-list.ts
+++ b/packages/cli/src/commands/ai-gateway/models-list.ts
@@ -59,8 +59,8 @@ function printModelsTable(models: Model[]) {
   const availabilityCell = (model: Model): string => {
     if (model.available === undefined) return chalk.gray('–');
     if (model.available) return chalk.green('yes');
-    return model.available_reason
-      ? chalk.red(`no (${model.available_reason})`)
+    return model.unavailable_reason
+      ? chalk.red(`no (${model.unavailable_reason})`)
       : chalk.red('no');
   };
 

--- a/packages/cli/src/commands/ai-gateway/models-list.ts
+++ b/packages/cli/src/commands/ai-gateway/models-list.ts
@@ -41,7 +41,15 @@ export default async function list(client: Client, argv: string[]) {
   return renderResource<Model[]>(client, {
     asJson: formatResult.jsonOutput,
     spinnerText: 'Fetching models',
-    fetch: () => listModels(client),
+    fetch: async () => {
+      const { models, availabilityStatus } = await listModels(client);
+      if (availabilityStatus === 'degraded') {
+        output.warn(
+          'Model availability could not be determined. Retry before treating unannotated models as available.'
+        );
+      }
+      return models;
+    },
     toJSON: models => ({ models }),
     isEmpty: models => models.length === 0,
     emptyMessage: 'No models found.',
@@ -51,9 +59,9 @@ export default async function list(client: Client, argv: string[]) {
 }
 
 function printModelsTable(models: Model[]) {
-  // `available` is present only when the gateway annotated the response for a
-  // restricted team. Show the column only then, so output for unauthenticated /
-  // unrestricted listings is unchanged.
+  // The CLI explicitly requests availability. Keep this defensive check for a
+  // degraded Gateway response, where annotations are intentionally omitted
+  // rather than presented as optimistic `available: true` verdicts.
   const showAvailability = models.some(m => m.available !== undefined);
 
   const availabilityCell = (model: Model): string => {

--- a/packages/cli/src/commands/ai-gateway/models-list.ts
+++ b/packages/cli/src/commands/ai-gateway/models-list.ts
@@ -52,8 +52,8 @@ export default async function list(client: Client, argv: string[]) {
 
 function printModelsTable(models: Model[]) {
   // `available` is present only when the gateway annotated the response for a
-  // restricted team (AIG-187). Show the column only then, so output for
-  // unauthenticated / unrestricted listings is unchanged.
+  // restricted team. Show the column only then, so output for unauthenticated /
+  // unrestricted listings is unchanged.
   const showAvailability = models.some(m => m.available !== undefined);
 
   const availabilityCell = (model: Model): string => {

--- a/packages/cli/src/util/ai-gateway/models.ts
+++ b/packages/cli/src/util/ai-gateway/models.ts
@@ -7,6 +7,15 @@ export type ModelPricing = {
   output?: string;
 };
 
+export type AvailabilityUnknownReason =
+  | 'billing_state_unresolved'
+  | 'plan_policy_unresolved'
+  | 'quota_binding_unresolved'
+  | 'rate_limit_policy_unresolved'
+  | 'realtime_policy_unresolved'
+  | 'request_context_unresolved'
+  | 'scope_budget_policy_unresolved';
+
 export type Model = {
   id: string;
   object: 'model';
@@ -25,27 +34,35 @@ export type Model = {
   // (card, credits, quota) composed with the team's routing policy for this
   // model. The `account_unavailable` reason marks exactly the policy-admitted
   // models an account blocker is holding back — they become runnable once it
-  // clears. An absent value means the verdict degraded; it must not be
-  // interpreted as routable.
+  // clears. An unknown reason is neutral and must not be interpreted as
+  // routable.
   available?: boolean;
+  availability_unknown_reason?: AvailabilityUnknownReason;
   unavailable_reason?: string;
 };
 
 export type ModelsListResult = {
   models: Model[];
-  availabilityStatus?: 'complete' | 'degraded';
+  availabilityStatus?: 'complete' | 'partial';
   accountAvailability?: AccountAvailability;
+  catalogStatus?: 'complete' | 'partial';
 };
 
-export type AccountAvailability = {
-  available: boolean;
-  unavailable_reason?:
-    | 'insufficient_funds'
-    | 'payment_method_required'
-    | 'quota_exceeded'
-    | 'quota_invalid'
-    | 'team_blocked';
-};
+export type AccountAvailability =
+  | {
+      available: boolean;
+      applies_to?: 'http';
+      unavailable_reason?:
+        | 'insufficient_funds'
+        | 'payment_method_required'
+        | 'quota_exceeded'
+        | 'quota_invalid'
+        | 'team_blocked';
+    }
+  | {
+      applies_to?: 'http';
+      availability_unknown_reason: AvailabilityUnknownReason;
+    };
 
 export type ModelEndpointPricing = {
   prompt?: string;
@@ -84,23 +101,60 @@ function gatewayBase(): string {
   return process.env.VERCEL_AI_GATEWAY_URL ?? DEFAULT_AI_GATEWAY_URL;
 }
 
+type ModelsListResponse = {
+  account_availability?: AccountAvailability;
+  availability_status?: 'complete' | 'partial';
+  catalog_status?: 'complete' | 'partial';
+  data: Model[];
+  object: 'list';
+};
+
+function isModel(value: unknown): value is Model {
+  if (typeof value !== 'object' || value === null) return false;
+  const model = value as Partial<Model>;
+  return (
+    typeof model.id === 'string' &&
+    typeof model.name === 'string' &&
+    model.object === 'model' &&
+    typeof model.owned_by === 'string'
+  );
+}
+
+function isModelsListResponse(value: unknown): value is ModelsListResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const response = value as Partial<ModelsListResponse>;
+  return (
+    response.object === 'list' &&
+    Array.isArray(response.data) &&
+    response.data.every(isModel)
+  );
+}
+
 export async function listModels(client: Client): Promise<ModelsListResult> {
   // OpenAI-style model catalog. The absolute URL bypasses the default api host,
   // but client.fetch still attaches the auth token and `?teamId=<currentTeam>`,
   // while `include_availability` explicitly opts this CLI into the Gateway's
   // team-specific availability extension without changing the default response
   // consumed by OpenAI-compatible harnesses.
+  const response = await client.fetch<unknown>(
+    `${gatewayBase()}/v1/models?include_availability`,
+    { method: 'GET' }
+  );
+  if (!isModelsListResponse(response)) {
+    throw new Error('AI Gateway returned an invalid model catalog response.');
+  }
   const {
     account_availability: accountAvailability,
-    data,
     availability_status: availabilityStatus,
-  } = await client.fetch<{
-    object: 'list';
-    data: Model[];
-    account_availability?: AccountAvailability;
-    availability_status?: 'complete' | 'degraded';
-  }>(`${gatewayBase()}/v1/models?include_availability`, { method: 'GET' });
-  return { models: data ?? [], availabilityStatus, accountAvailability };
+    catalog_status: catalogStatus,
+    data: models,
+  } = response;
+  return {
+    accountAvailability,
+    availabilityStatus,
+    catalogStatus,
+    models,
+  };
 }
 
 export async function listModelEndpoints(

--- a/packages/cli/src/util/ai-gateway/models.ts
+++ b/packages/cli/src/util/ai-gateway/models.ts
@@ -75,12 +75,11 @@ export async function listModels(client: Client): Promise<ModelsListResult> {
   // while `include_availability` explicitly opts this CLI into the Gateway's
   // team-specific availability extension without changing the default response
   // consumed by OpenAI-compatible harnesses.
-  const { data, availability_status: availabilityStatus } =
-    await client.fetch<{
-      object: 'list';
-      data: Model[];
-      availability_status?: 'complete' | 'degraded';
-    }>(`${gatewayBase()}/v1/models?include_availability`, { method: 'GET' });
+  const { data, availability_status: availabilityStatus } = await client.fetch<{
+    object: 'list';
+    data: Model[];
+    availability_status?: 'complete' | 'degraded';
+  }>(`${gatewayBase()}/v1/models?include_availability`, { method: 'GET' });
   return { models: data ?? [], availabilityStatus };
 }
 

--- a/packages/cli/src/util/ai-gateway/models.ts
+++ b/packages/cli/src/util/ai-gateway/models.ts
@@ -30,6 +30,17 @@ export type Model = {
 export type ModelsListResult = {
   models: Model[];
   availabilityStatus?: 'complete' | 'degraded';
+  accountAvailability?: AccountAvailability;
+};
+
+export type AccountAvailability = {
+  available: boolean;
+  unavailable_reason?:
+    | 'insufficient_funds'
+    | 'payment_method_required'
+    | 'quota_exceeded'
+    | 'quota_invalid'
+    | 'team_blocked';
 };
 
 export type ModelEndpointPricing = {
@@ -75,12 +86,17 @@ export async function listModels(client: Client): Promise<ModelsListResult> {
   // while `include_availability` explicitly opts this CLI into the Gateway's
   // team-specific availability extension without changing the default response
   // consumed by OpenAI-compatible harnesses.
-  const { data, availability_status: availabilityStatus } = await client.fetch<{
+  const {
+    account_availability: accountAvailability,
+    data,
+    availability_status: availabilityStatus,
+  } = await client.fetch<{
     object: 'list';
     data: Model[];
+    account_availability?: AccountAvailability;
     availability_status?: 'complete' | 'degraded';
   }>(`${gatewayBase()}/v1/models?include_availability`, { method: 'GET' });
-  return { models: data ?? [], availabilityStatus };
+  return { models: data ?? [], availabilityStatus, accountAvailability };
 }
 
 export async function listModelEndpoints(

--- a/packages/cli/src/util/ai-gateway/models.ts
+++ b/packages/cli/src/util/ai-gateway/models.ts
@@ -20,10 +20,16 @@ export type Model = {
   type?: string;
   tags?: string[];
   pricing?: ModelPricing;
-  // Per-team routing availability, present only on an authenticated request to a
-  // team with an active restriction; an absent `available` means it is routable.
+  // Per-team routing availability, returned when this client explicitly opts in
+  // via `include_availability`. An absent value means the verdict degraded; it
+  // must not be interpreted as routable.
   available?: boolean;
   unavailable_reason?: string;
+};
+
+export type ModelsListResult = {
+  models: Model[];
+  availabilityStatus?: 'complete' | 'degraded';
 };
 
 export type ModelEndpointPricing = {
@@ -63,17 +69,19 @@ function gatewayBase(): string {
   return process.env.VERCEL_AI_GATEWAY_URL ?? DEFAULT_AI_GATEWAY_URL;
 }
 
-export async function listModels(client: Client): Promise<Model[]> {
+export async function listModels(client: Client): Promise<ModelsListResult> {
   // OpenAI-style model catalog. The absolute URL bypasses the default api host,
   // but client.fetch still attaches the auth token and `?teamId=<currentTeam>`,
-  // so an authenticated caller gets their team's private models plus, for a
-  // restricted team, per-model `available` flags. Unauthenticated callers get the
-  // public catalog only.
-  const { data } = await client.fetch<{ object: 'list'; data: Model[] }>(
-    `${gatewayBase()}/v1/models`,
-    { method: 'GET' }
-  );
-  return data ?? [];
+  // while `include_availability` explicitly opts this CLI into the Gateway's
+  // team-specific availability extension without changing the default response
+  // consumed by OpenAI-compatible harnesses.
+  const { data, availability_status: availabilityStatus } =
+    await client.fetch<{
+      object: 'list';
+      data: Model[];
+      availability_status?: 'complete' | 'degraded';
+    }>(`${gatewayBase()}/v1/models?include_availability`, { method: 'GET' });
+  return { models: data ?? [], availabilityStatus };
 }
 
 export async function listModelEndpoints(

--- a/packages/cli/src/util/ai-gateway/models.ts
+++ b/packages/cli/src/util/ai-gateway/models.ts
@@ -26,7 +26,7 @@ export type Model = {
   // already sends the token + `?teamId=<currentTeam>`, so no request change is
   // needed to receive these — `--scope <team>` selects the team as usual.
   available?: boolean;
-  available_reason?: string;
+  unavailable_reason?: string;
 };
 
 export type ModelEndpointPricing = {

--- a/packages/cli/src/util/ai-gateway/models.ts
+++ b/packages/cli/src/util/ai-gateway/models.ts
@@ -20,11 +20,8 @@ export type Model = {
   type?: string;
   tags?: string[];
   pricing?: ModelPricing;
-  // Per-team routing availability (AIG-187). Only present on an authenticated
-  // request to a team that has an active restriction (provider allowlist / ZDR);
-  // an absent `available` means the team can route to the model. `client.fetch`
-  // already sends the token + `?teamId=<currentTeam>`, so no request change is
-  // needed to receive these — `--scope <team>` selects the team as usual.
+  // Per-team routing availability, present only on an authenticated request to a
+  // team with an active restriction; an absent `available` means it is routable.
   available?: boolean;
   unavailable_reason?: string;
 };
@@ -67,11 +64,11 @@ function gatewayBase(): string {
 }
 
 export async function listModels(client: Client): Promise<Model[]> {
-  // OpenAI-style model catalog. The absolute URL bypasses the default api host
-  // (new URL(url, apiUrl)), but client.fetch still attaches the auth token and
-  // `?teamId=<currentTeam>` — so an authenticated caller gets their team's
-  // private models plus, for a restricted team, per-model `available` flags
-  // (AIG-187). Unauthenticated callers get the public catalog only.
+  // OpenAI-style model catalog. The absolute URL bypasses the default api host,
+  // but client.fetch still attaches the auth token and `?teamId=<currentTeam>`,
+  // so an authenticated caller gets their team's private models plus, for a
+  // restricted team, per-model `available` flags. Unauthenticated callers get the
+  // public catalog only.
   const { data } = await client.fetch<{ object: 'list'; data: Model[] }>(
     `${gatewayBase()}/v1/models`,
     { method: 'GET' }

--- a/packages/cli/src/util/ai-gateway/models.ts
+++ b/packages/cli/src/util/ai-gateway/models.ts
@@ -20,9 +20,13 @@ export type Model = {
   type?: string;
   tags?: string[];
   pricing?: ModelPricing;
-  // Per-team routing availability, returned when this client explicitly opts in
-  // via `include_availability`. An absent value means the verdict degraded; it
-  // must not be interpreted as routable.
+  // Per-team availability, returned when this client explicitly opts in via
+  // `include_availability`. `available` is effective: the account-wide gate
+  // (card, credits, quota) composed with the team's routing policy for this
+  // model. The `account_unavailable` reason marks exactly the policy-admitted
+  // models an account blocker is holding back — they become runnable once it
+  // clears. An absent value means the verdict degraded; it must not be
+  // interpreted as routable.
   available?: boolean;
   unavailable_reason?: string;
 };

--- a/packages/cli/src/util/ai-gateway/models.ts
+++ b/packages/cli/src/util/ai-gateway/models.ts
@@ -20,6 +20,13 @@ export type Model = {
   type?: string;
   tags?: string[];
   pricing?: ModelPricing;
+  // Per-team routing availability (AIG-187). Only present on an authenticated
+  // request to a team that has an active restriction (provider allowlist / ZDR);
+  // an absent `available` means the team can route to the model. `client.fetch`
+  // already sends the token + `?teamId=<currentTeam>`, so no request change is
+  // needed to receive these — `--scope <team>` selects the team as usual.
+  available?: boolean;
+  available_reason?: string;
 };
 
 export type ModelEndpointPricing = {
@@ -60,8 +67,11 @@ function gatewayBase(): string {
 }
 
 export async function listModels(client: Client): Promise<Model[]> {
-  // Public, unauthenticated, OpenAI-style endpoint. Passing an absolute URL to
-  // client.fetch bypasses the default api host (new URL(url, apiUrl)).
+  // OpenAI-style model catalog. The absolute URL bypasses the default api host
+  // (new URL(url, apiUrl)), but client.fetch still attaches the auth token and
+  // `?teamId=<currentTeam>` — so an authenticated caller gets their team's
+  // private models plus, for a restricted team, per-model `available` flags
+  // (AIG-187). Unauthenticated callers get the public catalog only.
   const { data } = await client.fetch<{ object: 'list'; data: Model[] }>(
     `${gatewayBase()}/v1/models`,
     { method: 'GET' }

--- a/packages/cli/src/util/ai-gateway/output.ts
+++ b/packages/cli/src/util/ai-gateway/output.ts
@@ -53,7 +53,10 @@ export async function renderResource<T>(
       output.error(err.message);
       return 1;
     }
-    throw err;
+    output.error(
+      err instanceof Error ? err.message : 'An unexpected error occurred.'
+    );
+    return 1;
   }
 
   output.stopSpinner();

--- a/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
@@ -11,9 +11,17 @@ const sampleModel = {
   type: 'language',
 };
 
-function useListModels(models: unknown[] = [sampleModel]) {
-  client.scenario.get('/v1/models', (_req, res) => {
-    res.json({ object: 'list', data: models });
+function useListModels(
+  models: unknown[] = [sampleModel],
+  availabilityStatus: 'complete' | 'degraded' = 'complete'
+) {
+  client.scenario.get('/v1/models', (req, res) => {
+    expect(req.query.include_availability).toBe('');
+    res.json({
+      object: 'list',
+      data: models,
+      availability_status: availabilityStatus,
+    });
   });
 }
 
@@ -94,6 +102,19 @@ describe('ai-gateway models list', () => {
     // The rendered reason cell implies the column is present; a model without
     // the field keeps the column hidden (see 'lists models in a table').
     await expect(client.stdout).toOutput('no (no_allowlisted_provider)');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('warns when availability could not be determined', async () => {
+    useUser();
+    useListModels([sampleModel], 'degraded');
+    client.setArgv('ai-gateway', 'models', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput(
+      'Model availability could not be determined'
+    );
     expect(await exitCodePromise).toBe(0);
   });
 });

--- a/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { client } from '../../../mocks/client';
 import aiGateway from '../../../../src/commands/ai-gateway';
 import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
 
 const sampleModel = {
   id: 'anthropic/claude-opus-4.8',
@@ -12,15 +13,19 @@ const sampleModel = {
 };
 
 function useListModels(
-  models: unknown[] = [sampleModel],
+  models: unknown[] = [{ ...sampleModel, available: true }],
   availabilityStatus: 'complete' | 'degraded' = 'complete',
-  accountAvailability?: {
+  accountAvailability: {
     available: boolean;
     unavailable_reason?: string;
-  }
+  } = { available: true },
+  expectedTeamId?: string
 ) {
   client.scenario.get('/v1/models', (req, res) => {
     expect(req.query.include_availability).toBe('');
+    if (expectedTeamId) {
+      expect(req.query.teamId).toBe(expectedTeamId);
+    }
     res.json({
       object: 'list',
       data: models,
@@ -66,6 +71,21 @@ describe('ai-gateway models list', () => {
     expect(await exitCodePromise).toBe(0);
   });
 
+  it('forwards the selected team to the Gateway catalog', async () => {
+    const team = useTeam();
+    useUser();
+    client.config.currentTeam = team.id;
+    useListModels(
+      [{ ...sampleModel, available: true }],
+      'complete',
+      { available: true },
+      team.id
+    );
+    client.setArgv('ai-gateway', 'models', 'list');
+
+    expect(await aiGateway(client)).toBe(0);
+  });
+
   it('reports when there are no models', async () => {
     useUser();
     useListModels([]);
@@ -79,7 +99,12 @@ describe('ai-gateway models list', () => {
 
   it('outputs JSON with --format json', async () => {
     useUser();
-    useListModels([sampleModel], 'complete', {
+    const blockedModel = {
+      ...sampleModel,
+      available: false,
+      unavailable_reason: 'account_unavailable',
+    };
+    useListModels([blockedModel], 'complete', {
       available: false,
       unavailable_reason: 'payment_method_required',
     });
@@ -89,7 +114,7 @@ describe('ai-gateway models list', () => {
 
     await expect(client.stdout).toOutput('"models"');
     expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
-      models: [sampleModel],
+      models: [blockedModel],
       availability_status: 'complete',
       account_availability: {
         available: false,
@@ -122,6 +147,7 @@ describe('ai-gateway models list', () => {
     await expect(client.stderr).toOutput(
       'Add a payment method before running models for this team.'
     );
+    expect(client.stdout.getFullOutput()).not.toContain('account_unavailable');
     expect(await exitCodePromise).toBe(0);
   });
 
@@ -152,6 +178,41 @@ describe('ai-gateway models list', () => {
   it('warns when availability could not be determined', async () => {
     useUser();
     useListModels([sampleModel], 'degraded');
+    client.setArgv('ai-gateway', 'models', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput(
+      'Model availability could not be determined'
+    );
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('warns when an older Gateway omits availability status', async () => {
+    useUser();
+    client.scenario.get('/v1/models', (_req, res) => {
+      res.json({ object: 'list', data: [sampleModel] });
+    });
+    client.setArgv('ai-gateway', 'models', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput(
+      'Model availability could not be determined'
+    );
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('warns when a complete response contains partial annotations', async () => {
+    useUser();
+    useListModels(
+      [
+        { ...sampleModel, available: true },
+        { ...sampleModel, id: 'partial' },
+      ],
+      'complete',
+      { available: true }
+    );
     client.setArgv('ai-gateway', 'models', 'list');
 
     const exitCodePromise = aiGateway(client);

--- a/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
@@ -73,7 +73,7 @@ describe('ai-gateway models list', () => {
     expect(await exitCodePromise).toBe(0);
   });
 
-  it('shows an availability column when the gateway annotates it (AIG-187)', async () => {
+  it('shows an availability column when the gateway annotates it', async () => {
     useUser();
     useListModels([
       { ...sampleModel, available: true },

--- a/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
@@ -91,11 +91,9 @@ describe('ai-gateway models list', () => {
 
     const exitCodePromise = aiGateway(client);
 
-    // The column header and the machine-readable reason both render. Models
-    // without the field (the default, unrestricted listing) keep the column
-    // hidden — covered by 'lists models in a table' above.
-    await expect(client.stdout).toOutput('available');
-    await expect(client.stdout).toOutput('no_allowlisted_provider');
+    // The rendered reason cell implies the column is present; a model without
+    // the field keeps the column hidden (see 'lists models in a table').
+    await expect(client.stdout).toOutput('no (no_allowlisted_provider)');
     expect(await exitCodePromise).toBe(0);
   });
 });

--- a/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
@@ -14,12 +14,14 @@ const sampleModel = {
 
 function useListModels(
   models: unknown[] = [{ ...sampleModel, available: true }],
-  availabilityStatus: 'complete' | 'degraded' = 'complete',
+  availabilityStatus: 'complete' | 'partial' = 'complete',
   accountAvailability: {
-    available: boolean;
+    available?: boolean;
+    availability_unknown_reason?: string;
     unavailable_reason?: string;
   } = { available: true },
-  expectedTeamId?: string
+  expectedTeamId?: string,
+  catalogStatus: 'complete' | 'partial' = 'complete'
 ) {
   client.scenario.get('/v1/models', (req, res) => {
     expect(req.query.include_availability).toBe('');
@@ -30,6 +32,7 @@ function useListModels(
       object: 'list',
       data: models,
       availability_status: availabilityStatus,
+      catalog_status: catalogStatus,
       ...(accountAvailability && {
         account_availability: accountAvailability,
       }),
@@ -116,6 +119,7 @@ describe('ai-gateway models list', () => {
     expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
       models: [blockedModel],
       availability_status: 'complete',
+      catalog_status: 'complete',
       account_availability: {
         available: false,
         unavailable_reason: 'payment_method_required',
@@ -177,13 +181,24 @@ describe('ai-gateway models list', () => {
 
   it('warns when availability could not be determined', async () => {
     useUser();
-    useListModels([sampleModel], 'degraded');
+    useListModels(
+      [
+        {
+          ...sampleModel,
+          availability_unknown_reason: 'billing_state_unresolved',
+        },
+      ],
+      'partial',
+      { availability_unknown_reason: 'billing_state_unresolved' }
+    );
     client.setArgv('ai-gateway', 'models', 'list');
 
     const exitCodePromise = aiGateway(client);
 
-    await expect(client.stderr).toOutput(
-      'Model availability could not be determined'
+    await expect(client.stderr).toOutput('Model availability is partial');
+    await expect(client.stdout).toOutput('unknown (billing_state_unresolved)');
+    expect(client.stderr.getFullOutput()).not.toContain(
+      "This account can't run AI Gateway models."
     );
     expect(await exitCodePromise).toBe(0);
   });
@@ -197,9 +212,7 @@ describe('ai-gateway models list', () => {
 
     const exitCodePromise = aiGateway(client);
 
-    await expect(client.stderr).toOutput(
-      'Model availability could not be determined'
-    );
+    await expect(client.stderr).toOutput('Model availability is partial');
     expect(await exitCodePromise).toBe(0);
   });
 
@@ -217,9 +230,39 @@ describe('ai-gateway models list', () => {
 
     const exitCodePromise = aiGateway(client);
 
-    await expect(client.stderr).toOutput(
-      'Model availability could not be determined'
-    );
+    await expect(client.stderr).toOutput('Model availability is partial');
     expect(await exitCodePromise).toBe(0);
+  });
+
+  it('warns when the team-visible catalog is partial', async () => {
+    useUser();
+    useListModels(
+      [{ ...sampleModel, available: true }],
+      'complete',
+      { available: true },
+      undefined,
+      'partial'
+    );
+    client.setArgv('ai-gateway', 'models', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('The model catalog is partial');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('rejects a successful response that is not a Gateway model catalog', async () => {
+    useUser();
+    client.scenario.get('/v1/models', (_req, res) => {
+      res.json({ models: [] });
+    });
+    client.setArgv('ai-gateway', 'models', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput(
+      'AI Gateway returned an invalid model catalog response.'
+    );
+    expect(await exitCodePromise).toBe(1);
   });
 });

--- a/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
@@ -84,7 +84,7 @@ describe('ai-gateway models list', () => {
         name: 'GPT-5',
         type: 'language',
         available: false,
-        available_reason: 'no_allowlisted_provider',
+        unavailable_reason: 'no_allowlisted_provider',
       },
     ]);
     client.setArgv('ai-gateway', 'models', 'list');

--- a/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
@@ -13,7 +13,11 @@ const sampleModel = {
 
 function useListModels(
   models: unknown[] = [sampleModel],
-  availabilityStatus: 'complete' | 'degraded' = 'complete'
+  availabilityStatus: 'complete' | 'degraded' = 'complete',
+  accountAvailability?: {
+    available: boolean;
+    unavailable_reason?: string;
+  }
 ) {
   client.scenario.get('/v1/models', (req, res) => {
     expect(req.query.include_availability).toBe('');
@@ -21,6 +25,9 @@ function useListModels(
       object: 'list',
       data: models,
       availability_status: availabilityStatus,
+      ...(accountAvailability && {
+        account_availability: accountAvailability,
+      }),
     });
   });
 }
@@ -72,12 +79,49 @@ describe('ai-gateway models list', () => {
 
   it('outputs JSON with --format json', async () => {
     useUser();
-    useListModels();
+    useListModels([sampleModel], 'complete', {
+      available: false,
+      unavailable_reason: 'payment_method_required',
+    });
     client.setArgv('ai-gateway', 'models', 'list', '--format', 'json');
 
     const exitCodePromise = aiGateway(client);
 
     await expect(client.stdout).toOutput('"models"');
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      models: [sampleModel],
+      availability_status: 'complete',
+      account_availability: {
+        available: false,
+        unavailable_reason: 'payment_method_required',
+      },
+    });
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('explains a team-wide account blocker on stderr', async () => {
+    useUser();
+    useListModels(
+      [
+        {
+          ...sampleModel,
+          available: false,
+          unavailable_reason: 'account_unavailable',
+        },
+      ],
+      'complete',
+      {
+        available: false,
+        unavailable_reason: 'payment_method_required',
+      }
+    );
+    client.setArgv('ai-gateway', 'models', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput(
+      'Add a payment method before running models for this team.'
+    );
     expect(await exitCodePromise).toBe(0);
   });
 

--- a/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/models-list.test.ts
@@ -72,4 +72,30 @@ describe('ai-gateway models list', () => {
     await expect(client.stdout).toOutput('"models"');
     expect(await exitCodePromise).toBe(0);
   });
+
+  it('shows an availability column when the gateway annotates it (AIG-187)', async () => {
+    useUser();
+    useListModels([
+      { ...sampleModel, available: true },
+      {
+        id: 'openai/gpt-5',
+        object: 'model',
+        owned_by: 'openai',
+        name: 'GPT-5',
+        type: 'language',
+        available: false,
+        available_reason: 'no_allowlisted_provider',
+      },
+    ]);
+    client.setArgv('ai-gateway', 'models', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    // The column header and the machine-readable reason both render. Models
+    // without the field (the default, unrestricted listing) keep the column
+    // hidden — covered by 'lists models in a table' above.
+    await expect(client.stdout).toOutput('available');
+    await expect(client.stdout).toOutput('no_allowlisted_provider');
+    expect(await exitCodePromise).toBe(0);
+  });
 });


### PR DESCRIPTION
> [!WARNING]
> **Do not merge before vercel/ai-gateway#2676.** This consumer depends on that endpoint contract.

## Summary

`vercel ai-gateway models list` opts into the Gateway's authenticated per-team availability response and shows which models the selected team can route to without probing every model.

## Behavior

- Requests `/v1/models?include_availability` while preserving the default Gateway response for other consumers.
- Uses the active CLI scope through the existing `teamId` forwarding.
- Shows `yes`, `no (<reason>)`, or `unknown (<reason>)` per model.
- Explains resolved account-wide payment, credit, quota, or team blockers once instead of repeating the `account_unavailable` sentinel.
- Treats unknown account state as unknown, not as an unavailable account.
- Warns when `availability_status` or `catalog_status` is partial.
- Preserves `availability_status`, `catalog_status`, `account_availability`, row verdicts, and reason codes in JSON output.
- Rejects malformed successful responses instead of reporting a false empty catalog.
- Supports the documented `--json` flag and the existing `--format json` compatibility path.

## Validation

Latest head: `edbb52330`

- focused `models list` unit suite: **12/12 passing**
- CLI package TypeScript: passing after rebuilding current workspace dependencies
- focused Biome format and lint: passing
- pre-commit checks: passing
- `git diff --check`: passing
- rebased onto current `main`
- exact CI tarball launches successfully as `Vercel CLI 58.4.4`
- GitHub matrix checks are running on the latest head with no failures observed

An earlier CI tarball was exercised against the protected Gateway preview for multiple teams and confirmed that both `teamId` and `include_availability` were sent. The latest artifact launch is verified; repeating the protected-preview request requires a local bypass-header proxy and is intentionally not claimed here.
