### PR TITLE
[flags] Add evaluations command

### DIFF
--- a/.changeset/flags-evaluation-metrics.md
+++ b/.changeset/flags-evaluation-metrics.md
@@ -1,0 +1,13 @@
+---
+'vercel': minor
+---
+
+Add `vercel flags evaluations` for viewing compact, per-variant evaluation charts and bucket-level JSON data with truncation metadata.
+
+Examples:
+
+```bash
+vercel flags evaluations my-feature
+vercel flags evaluations my-feature --since 24h --granularity 1h
+vercel flags evaluations my-feature --since 24h --json
+```

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -1,6 +1,7 @@
 import { projectOption, yesOption } from '../../util/arg-common';
 import { formatFlagConditionComparatorList } from '../../util/flags/comparators';
 import { packageName } from '../../util/pkg-name';
+import { FLAG_EVALUATIONS_GRANULARITIES } from './evaluations-config';
 
 const segmentRuleOperatorDescription = `Valid operators: ${formatFlagConditionComparatorList()}`;
 
@@ -242,6 +243,63 @@ export const versionsSubcommand = {
     {
       name: 'Show what changed in a revision',
       value: `${packageName} flags versions diff my-feature-flag --revision 4`,
+    },
+  ],
+} as const;
+
+export const evaluationsSubcommand = {
+  name: 'evaluations',
+  aliases: ['evals'],
+  description: 'Display evaluation metrics for a feature flag',
+  arguments: [
+    {
+      name: 'flag',
+      required: true,
+    },
+  ],
+  options: [
+    projectOption,
+    {
+      name: 'since',
+      shorthand: 's',
+      type: String,
+      deprecated: false,
+      description:
+        'Start time: relative (1h, 30m, 2d) or ISO date (default: 1h)',
+      argument: 'TIME',
+    },
+    {
+      name: 'until',
+      shorthand: 'u',
+      type: String,
+      deprecated: false,
+      description: 'End time (default: now)',
+      argument: 'TIME',
+    },
+    {
+      name: 'granularity',
+      shorthand: 'g',
+      type: String,
+      deprecated: false,
+      description: `Time bucket size: ${FLAG_EVALUATIONS_GRANULARITIES.join(', ')} (default: auto)`,
+      argument: 'SIZE',
+    },
+    {
+      name: 'json',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output in JSON format',
+    },
+  ],
+  examples: [
+    {
+      name: 'Show evaluations by variant for the last hour',
+      value: `${packageName} flags evaluations my-feature`,
+    },
+    {
+      name: 'Show evaluation metrics as JSON',
+      value: `${packageName} flags evaluations my-feature --since 24h --json`,
     },
   ],
 } as const;
@@ -1542,6 +1600,7 @@ export const flagsCommand = {
     listSubcommand,
     inspectSubcommand,
     versionsSubcommand,
+    evaluationsSubcommand,
     createSubcommand,
     openSubcommand,
     updateSubcommand,

--- a/packages/cli/src/commands/flags/evaluations-config.ts
+++ b/packages/cli/src/commands/flags/evaluations-config.ts
@@ -1,0 +1,19 @@
+export const FLAG_EVALUATIONS_GRANULARITIES = [
+  '1m',
+  '5m',
+  '15m',
+  '1h',
+  '4h',
+  '1d',
+] as const;
+
+export type FlagEvaluationsGranularity =
+  (typeof FLAG_EVALUATIONS_GRANULARITIES)[number];
+
+export function isFlagEvaluationsGranularity(
+  value: string
+): value is FlagEvaluationsGranularity {
+  return FLAG_EVALUATIONS_GRANULARITIES.some(
+    granularity => granularity === value
+  );
+}

--- a/packages/cli/src/commands/flags/evaluations.ts
+++ b/packages/cli/src/commands/flags/evaluations.ts
@@ -1,0 +1,386 @@
+import type Client from '../../util/client';
+import { outputError } from '../../util/command-validation';
+import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
+import { getFlag } from '../../util/flags/get-flags';
+import { formatVariantListSummary } from '../../util/flags/resolve-variant';
+import type { Flag } from '../../util/flags/types';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { getCommandName } from '../../util/pkg-name';
+import { FlagsEvaluationsTelemetryClient } from '../../util/telemetry/commands/flags/evaluations';
+import { resolveTimeRange } from '../../util/time-utils';
+import output from '../../output-manager';
+import { getRollupColumnName, handleApiError } from '../metrics/output';
+import { formatText } from '../metrics/text-output';
+import {
+  computeGranularity,
+  toGranularityMsFromDuration,
+} from '../metrics/time-utils';
+import type {
+  Granularity,
+  MetricsQueryResponse,
+  ProjectScope,
+} from '../metrics/types';
+import { evaluationsSubcommand } from './command';
+import {
+  FLAG_EVALUATIONS_GRANULARITIES,
+  isFlagEvaluationsGranularity,
+} from './evaluations-config';
+import { getLinkedFlagsProject, getProjectNameFromFlags } from './project';
+
+const FLAG_EVALUATIONS_API_URL = 'https://vercel.com/api/observability/metrics';
+const FLAG_EVALUATIONS_METRIC = 'vercel.flag_evaluation.flag_evaluations';
+const FLAG_EVALUATIONS_AGGREGATION = 'sum';
+const FLAG_EVALUATIONS_ROLLUP = getRollupColumnName(
+  FLAG_EVALUATIONS_METRIC,
+  FLAG_EVALUATIONS_AGGREGATION
+);
+const DISPLAY_GROUP_BY = 'Variants';
+const QUERY_ENGINE_GROUP_BY = 'flagVariant';
+const MAX_VARIANTS = 100;
+
+function getFlagEvaluationsApiUrl(ownerId: string): string {
+  const url = new URL(
+    process.env.VERCEL_FLAG_EVALUATIONS_API_URL || FLAG_EVALUATIONS_API_URL
+  );
+  url.searchParams.set('ownerId', ownerId);
+  return url.href;
+}
+
+function escapeODataString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+function alignTimeRange(
+  startTime: Date,
+  endTime: Date,
+  granularity: Granularity
+): { startTime: Date; endTime: Date } {
+  const granularityMs = toGranularityMsFromDuration(granularity);
+  return {
+    startTime: new Date(
+      Math.floor(startTime.getTime() / granularityMs) * granularityMs
+    ),
+    endTime: new Date(
+      Math.ceil(endTime.getTime() / granularityMs) * granularityMs
+    ),
+  };
+}
+
+function getVariantDisplayName(flag: Flag, variantId: string): string {
+  if (!variantId || variantId === '(not set)') {
+    return 'Default in Code';
+  }
+
+  const variant = flag.variants.find(item => item.id === variantId);
+  return variant ? formatVariantListSummary(variant) : variantId;
+}
+
+function handleCommandError(
+  client: Client,
+  error: unknown,
+  jsonOutput: boolean
+): number {
+  if (!jsonOutput) {
+    printError(error);
+    return 1;
+  }
+
+  if (isAPIError(error)) {
+    return outputError(
+      client,
+      true,
+      error.code || 'API_ERROR',
+      error.serverMessage || `API error (${error.status}).`
+    );
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return outputError(client, true, 'UNEXPECTED_ERROR', message);
+}
+
+function handleMetricsQueryError(
+  client: Client,
+  error: unknown,
+  jsonOutput: boolean
+): number {
+  return isAPIError(error)
+    ? handleApiError(error, jsonOutput, client)
+    : handleCommandError(client, error, jsonOutput);
+}
+
+function limitEvaluationVariants(response: MetricsQueryResponse): {
+  response: MetricsQueryResponse;
+  truncated: boolean;
+} {
+  if (response.summary.length <= MAX_VARIANTS) {
+    return { response, truncated: false };
+  }
+
+  const summary = response.summary.slice(0, MAX_VARIANTS);
+  const visibleVariants = new Set(
+    summary.map(row => row[QUERY_ENGINE_GROUP_BY])
+  );
+  return {
+    response: {
+      ...response,
+      summary,
+      data: response.data?.filter(row =>
+        visibleVariants.has(row[QUERY_ENGINE_GROUP_BY])
+      ),
+    },
+    truncated: true,
+  };
+}
+
+function formatEvaluationsJson(
+  flag: Flag,
+  response: MetricsQueryResponse,
+  startTime: Date,
+  endTime: Date,
+  granularity: Granularity,
+  truncated: boolean
+): string {
+  return `${JSON.stringify(
+    {
+      flag: flag.slug,
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      granularity,
+      truncated,
+      buckets: (response.data ?? []).map(row => ({
+        timestamp: row.timestamp,
+        variant: row[QUERY_ENGINE_GROUP_BY] ?? null,
+        evaluations: row[FLAG_EVALUATIONS_ROLLUP] ?? null,
+      })),
+    },
+    null,
+    2
+  )}\n`;
+}
+
+export default async function evaluations(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new FlagsEvaluationsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    evaluationsSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const { args, flags } = parsedArgs;
+  const [flagArgument] = args;
+  const projectName = getProjectNameFromFlags(flags);
+  const since = flags['--since'];
+  const until = flags['--until'];
+  const granularity = flags['--granularity'];
+
+  telemetry.trackCliArgumentFlag(flagArgument);
+  telemetry.trackCliOptionProject(projectName);
+  telemetry.trackCliOptionSince(since);
+  telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliOptionGranularity(granularity);
+  telemetry.trackCliFlagJson(flags['--json']);
+
+  const jsonOutput = flags['--json'] ?? false;
+
+  if (!flagArgument) {
+    return outputError(
+      client,
+      jsonOutput,
+      'MISSING_FLAG',
+      `Missing required argument: flag. Usage: ${getCommandName('flags evaluations <flag>')}`
+    );
+  }
+
+  if (granularity && !isFlagEvaluationsGranularity(granularity)) {
+    return outputError(
+      client,
+      jsonOutput,
+      'INVALID_GRANULARITY',
+      `Invalid granularity "${granularity}". Use one of: ${FLAG_EVALUATIONS_GRANULARITIES.join(', ')}.`
+    );
+  }
+
+  let startTime: Date;
+  let endTime: Date;
+  let resolvedGranularity: ReturnType<typeof computeGranularity>;
+  try {
+    ({ startTime, endTime } = resolveTimeRange(since, until));
+    if (startTime.getTime() >= endTime.getTime()) {
+      throw new Error('The start time must be before the end time.');
+    }
+    resolvedGranularity = computeGranularity(
+      endTime.getTime() - startTime.getTime(),
+      granularity
+    );
+    ({ startTime, endTime } = alignTimeRange(
+      startTime,
+      endTime,
+      resolvedGranularity.duration
+    ));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return outputError(client, jsonOutput, 'INVALID_TIME', message);
+  }
+
+  if (
+    !jsonOutput &&
+    resolvedGranularity.adjusted &&
+    resolvedGranularity.notice
+  ) {
+    output.log(`Notice: ${resolvedGranularity.notice}`);
+  }
+
+  let link: Awaited<ReturnType<typeof getLinkedFlagsProject>>;
+  try {
+    link = await getLinkedFlagsProject(client, projectName, {
+      projectNotFoundHandling: jsonOutput ? 'return' : 'report',
+    });
+  } catch (error) {
+    return handleCommandError(client, error, jsonOutput);
+  }
+  if (link.status === 'error') {
+    return jsonOutput
+      ? outputError(
+          client,
+          true,
+          'PROJECT_RESOLUTION_FAILED',
+          'Unable to resolve the requested Vercel project.'
+        )
+      : link.exitCode;
+  }
+  if (link.status === 'not_linked') {
+    const code = projectName ? 'PROJECT_NOT_FOUND' : 'NOT_LINKED';
+    const message = projectName
+      ? `Project "${projectName}" was not found in the current scope.`
+      : `Your codebase isn't linked to a project on Vercel. Pass --project <name>, or run ${getCommandName('link')} to link it.`;
+    return outputError(client, jsonOutput, code, message);
+  }
+
+  client.config.currentTeam =
+    link.org.type === 'team' ? link.org.id : undefined;
+
+  const { project, org } = link;
+  let flag: Flag;
+  try {
+    flag = await getFlag(client, project.id, flagArgument);
+  } catch (error) {
+    return handleCommandError(client, error, jsonOutput);
+  }
+
+  if (!jsonOutput) {
+    output.spinner('Querying flag evaluations...');
+  }
+
+  const scope: ProjectScope = {
+    type: 'project',
+    ownerId: org.id,
+    projectIds: [project.id],
+  };
+  let response: MetricsQueryResponse;
+  try {
+    const body = {
+      scope,
+      reason: 'observability_chart',
+      event: 'flagEvaluation',
+      rollups: {
+        [FLAG_EVALUATIONS_ROLLUP]: {
+          measure: 'flagEvaluations',
+          aggregation: 'sum',
+        },
+      },
+      orderBy: FLAG_EVALUATIONS_ROLLUP,
+      orderDirection: 'desc',
+      groupBy: [QUERY_ENGINE_GROUP_BY],
+      // Fetch one extra variant so output can disclose truncation reliably.
+      limit: MAX_VARIANTS + 1,
+      limitRanking: 'single_pass',
+      tailRollup: 'truncate',
+      summaryOnly: false,
+      filter: `flagKey eq '${escapeODataString(flag.slug)}'`,
+      granularity: resolvedGranularity.duration,
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+    };
+
+    response = await client.fetch<MetricsQueryResponse>(
+      getFlagEvaluationsApiUrl(org.id),
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+        useCurrentTeam: false,
+        bailOn429: true,
+      }
+    );
+  } catch (error) {
+    return handleMetricsQueryError(client, error, jsonOutput);
+  } finally {
+    if (!jsonOutput) {
+      output.stopSpinner();
+    }
+  }
+
+  const limited = limitEvaluationVariants(response);
+
+  if (jsonOutput) {
+    client.stdout.write(
+      formatEvaluationsJson(
+        flag,
+        limited.response,
+        startTime,
+        endTime,
+        resolvedGranularity.duration,
+        limited.truncated
+      )
+    );
+  } else {
+    if (limited.truncated) {
+      output.warn(
+        `Results are limited to the ${MAX_VARIANTS} most evaluated variants.`
+      );
+    }
+    client.stdout.write(
+      formatText(
+        {
+          ...limited.response,
+          data: limited.response.data?.map(row => ({
+            ...row,
+            [DISPLAY_GROUP_BY]: row[QUERY_ENGINE_GROUP_BY] ?? null,
+          })),
+        },
+        {
+          metric: FLAG_EVALUATIONS_METRIC,
+          metricUnit: 'count',
+          aggregation: FLAG_EVALUATIONS_AGGREGATION,
+          groupBy: [DISPLAY_GROUP_BY],
+          scope,
+          projectName: project.name,
+          teamName: org.slug,
+          periodStart: startTime.toISOString(),
+          periodEnd: endTime.toISOString(),
+          granularity: resolvedGranularity.duration,
+          presentation: {
+            compact: true,
+            formatGroupValue: (_field, value) =>
+              getVariantDisplayName(flag, value),
+          },
+        }
+      )
+    );
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/flags/evaluations.ts
+++ b/packages/cli/src/commands/flags/evaluations.ts
@@ -145,6 +145,9 @@ function formatEvaluationsJson(
   return `${JSON.stringify(
     {
       flag: flag.slug,
+      variants: Object.fromEntries(
+        flag.variants.map(({ id, value }) => [id, value])
+      ),
       startTime: startTime.toISOString(),
       endTime: endTime.toISOString(),
       granularity,
@@ -293,7 +296,7 @@ export default async function evaluations(
   try {
     const body = {
       scope,
-      reason: 'observability_chart',
+      reason: 'flag_evaluation_chart',
       event: 'flagEvaluation',
       rollups: {
         [FLAG_EVALUATIONS_ROLLUP]: {

--- a/packages/cli/src/commands/flags/index.ts
+++ b/packages/cli/src/commands/flags/index.ts
@@ -10,6 +10,7 @@ import { FlagsTelemetryClient } from '../../util/telemetry/commands/flags';
 import ls from './ls';
 import inspect from './inspect';
 import versions from './versions';
+import evaluations from './evaluations';
 import create from './add';
 import openFlag from './open';
 import update from './update';
@@ -28,6 +29,7 @@ import {
   listSubcommand,
   inspectSubcommand,
   versionsSubcommand,
+  evaluationsSubcommand,
   createSubcommand,
   openSubcommand,
   updateSubcommand,
@@ -51,6 +53,7 @@ const COMMAND_CONFIG = {
   ls: getCommandAliases(listSubcommand),
   inspect: getCommandAliases(inspectSubcommand),
   versions: getCommandAliases(versionsSubcommand),
+  evaluations: getCommandAliases(evaluationsSubcommand),
   create: getCommandAliases(createSubcommand),
   open: getCommandAliases(openSubcommand),
   update: getCommandAliases(updateSubcommand),
@@ -126,6 +129,14 @@ export default async function main(client: Client) {
     case 'versions':
       telemetry.trackCliSubcommandVersions(subcommandOriginal);
       return versions(client, needHelp ? [...args, '--help'] : args);
+    case 'evaluations':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('flags', subcommandOriginal);
+        printHelp(evaluationsSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandEvaluations(subcommandOriginal);
+      return evaluations(client, args);
     case 'open':
       if (needHelp) {
         telemetry.trackCliFlagHelp('flags', subcommandOriginal);

--- a/packages/cli/src/commands/flags/project.ts
+++ b/packages/cli/src/commands/flags/project.ts
@@ -1,5 +1,8 @@
 import type Client from '../../util/client';
-import { resolveProjectContext } from '../../util/projects/resolve-project-context';
+import {
+  resolveProjectContext,
+  type ResolveProjectContextOptions,
+} from '../../util/projects/resolve-project-context';
 
 export function getProjectNameFromFlags(flags: {
   [key: string]: unknown;
@@ -7,9 +10,14 @@ export function getProjectNameFromFlags(flags: {
   return flags['--project'] as string | undefined;
 }
 
-export function getLinkedFlagsProject(client: Client, projectName?: string) {
+export function getLinkedFlagsProject(
+  client: Client,
+  projectName?: string,
+  options?: Pick<ResolveProjectContextOptions, 'projectNotFoundHandling'>
+) {
   return resolveProjectContext({
     client,
     projectNameOrId: projectName,
+    projectNotFoundHandling: options?.projectNotFoundHandling,
   });
 }

--- a/packages/cli/src/commands/metrics/text-output.ts
+++ b/packages/cli/src/commands/metrics/text-output.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk';
+import stripAnsi from 'strip-ansi';
 import table from '../../util/output/table';
 import indent from '../../util/output/indent';
+import elapsed from '../../util/output/elapsed';
 import { getResolvedOrderMetadata, getRollupColumnName } from './output';
 import { toGranularityMsFromDuration } from './time-utils';
 import type {
@@ -47,6 +49,7 @@ interface SummaryTableOptions {
   aggregation: Aggregation;
   periodStart: Date;
   periodEnd: Date;
+  ansiAwareGroupValues?: boolean;
 }
 
 interface MetadataHeaderOptions {
@@ -65,6 +68,12 @@ interface MetadataHeaderOptions {
   teamName?: string;
   unit?: string;
   groupCount?: number;
+  compact?: boolean;
+}
+
+export interface TextOutputPresentation {
+  compact?: boolean;
+  formatGroupValue?: (field: string, value: string) => string;
 }
 
 export interface FormatTextOptions {
@@ -82,6 +91,7 @@ export interface FormatTextOptions {
   bucketTimezone?: string;
   orderBy?: OrderBy;
   orderDirection?: OrderDirection;
+  presentation?: TextOutputPresentation;
 }
 
 // Use a non-printable delimiter so group keys remain stable without colliding
@@ -156,6 +166,19 @@ function formatPeriodBound(input: string): string {
   }
   // Keep metadata period compact and deterministic at minute precision.
   return formatHumanMinute(date);
+}
+
+/** Formats the elapsed time between valid period bounds. */
+function formatPeriodSpan(startInput: string, endInput: string): string | null {
+  const start = Date.parse(startInput);
+  const end = Date.parse(endInput);
+  const durationMs = end - start;
+
+  if (!Number.isFinite(durationMs) || durationMs <= 0) {
+    return null;
+  }
+
+  return elapsed(durationMs);
 }
 
 /** Renders granularity objects in short form (e.g. 5m, 1h, 1d). */
@@ -606,11 +629,16 @@ const MAX_GROUP_VALUE_LENGTH = 60;
  * Example (maxLength=60):
  *   "/very/long/path/..." → "/very/long/pa…nd/of/path"
  */
-export function ellipsizeMiddle(str: string, maxLength: number): string {
-  if (str.length <= maxLength) return str;
+export function ellipsizeMiddle(
+  str: string,
+  maxLength: number,
+  useVisibleLength: boolean = false
+): string {
+  const comparable = useVisibleLength ? stripAnsi(str) : str;
+  if (comparable.length <= maxLength) return str;
   const endLength = Math.floor((maxLength - 1) / 2);
   const startLength = maxLength - 1 - endLength;
-  return `${str.slice(0, startLength)}…${str.slice(str.length - endLength)}`;
+  return `${comparable.slice(0, startLength)}…${comparable.slice(comparable.length - endLength)}`;
 }
 
 /**
@@ -702,17 +730,25 @@ export function generateSparkline(values: (number | null)[]): string {
 
 /** Builds aligned metadata header lines shown above results. */
 export function formatMetadataHeader(opts: MetadataHeaderOptions): string {
-  const rows: Array<{ key: string; value: string }> = [
-    {
+  const periodSpan = opts.compact
+    ? formatPeriodSpan(opts.periodStart, opts.periodEnd)
+    : null;
+  const rows: Array<{ key: string; value: string }> = [];
+
+  if (!opts.compact) {
+    rows.push({
       key: 'Metric',
       value: `${opts.metric} ${opts.aggregation}`,
-    },
+    });
+  }
+
+  rows.push(
     {
       // Period bounds are always UTC; annotate them so the boundary is
       // unambiguous when the Interval below reports a different
       // --bucket-timezone.
       key: 'Period',
-      value: `${formatPeriodBound(opts.periodStart)} to ${formatPeriodBound(opts.periodEnd)} (UTC)`,
+      value: `${formatPeriodBound(opts.periodStart)} to ${formatPeriodBound(opts.periodEnd)} (UTC)${periodSpan ? ` ${periodSpan}` : ''}`,
     },
     {
       // Period bounds are always UTC; the timezone only controls calendar
@@ -724,8 +760,8 @@ export function formatMetadataHeader(opts: MetadataHeaderOptions): string {
         'days' in opts.granularity
           ? `${formatGranularity(opts.granularity)} (${opts.bucketTimezone ?? 'UTC'})`
           : formatGranularity(opts.granularity),
-    },
-  ];
+    }
+  );
 
   // Whole-period deduplicated count from the API summary. Per-bucket uniques
   // cannot be summed, so this is the only correct period total for `unique`.
@@ -736,11 +772,11 @@ export function formatMetadataHeader(opts: MetadataHeaderOptions): string {
     });
   }
 
-  if (opts.filter) {
+  if (!opts.compact && opts.filter) {
     rows.push({ key: 'Filter', value: opts.filter });
   }
 
-  if (opts.orderBy && opts.orderDirection) {
+  if (!opts.compact && opts.orderBy && opts.orderDirection) {
     rows.push({
       key: 'Order By',
       value: `${opts.orderBy} ${opts.orderDirection}${
@@ -765,7 +801,7 @@ export function formatMetadataHeader(opts: MetadataHeaderOptions): string {
     rows.push({ key: 'Units', value: formatUnitLabel(opts.unit) });
   }
 
-  if (typeof opts.groupCount === 'number') {
+  if (!opts.compact && typeof opts.groupCount === 'number') {
     rows.push({ key: 'Groups', value: String(opts.groupCount) });
   }
 
@@ -783,7 +819,7 @@ export function formatSummaryTable(opts: SummaryTableOptions): string {
 
   for (const row of opts.rows) {
     const nextRow: string[] = row.groupValues.map(v =>
-      ellipsizeMiddle(v, MAX_GROUP_VALUE_LENGTH)
+      ellipsizeMiddle(v, MAX_GROUP_VALUE_LENGTH, opts.ansiAwareGroupValues)
     );
 
     if (row.stats.allMissing) {
@@ -824,43 +860,35 @@ export function formatSummaryTable(opts: SummaryTableOptions): string {
 export function formatSparklineSection(
   groupRows: string[][],
   sparklines: string[],
-  groupByFields: string[]
+  groupByFields: string[],
+  compact: boolean = false
 ): string {
-  const lines = ['sparklines:'];
-
   if (groupRows.length === 0) {
     const sparkline = sparklines[0];
-    if (sparkline) {
-      lines.push(indent(sparkline, 2));
-    }
-    return lines.join('\n');
+    const chart = sparkline ? indent(sparkline, 2) : '';
+    return compact ? chart : ['sparklines:', chart].filter(Boolean).join('\n');
   }
 
-  const rowsWithSparklines = groupRows.map((groupValues, index) => ({
-    groupValues,
-    sparkline: sparklines[index] ?? '',
-  }));
-
+  const header = [...groupByFields, compact ? '' : 'sparkline'];
   const rows = [
-    [...groupByFields, 'sparkline'].map(name => chalk.bold(chalk.cyan(name))),
-    ...rowsWithSparklines.map(({ groupValues, sparkline }) => [
-      ...groupValues.map(v => ellipsizeMiddle(v, MAX_GROUP_VALUE_LENGTH)),
-      sparkline,
+    header.map(name => chalk.bold(chalk.cyan(name))),
+    ...groupRows.map((groupValues, index) => [
+      ...groupValues.map(v =>
+        ellipsizeMiddle(v, MAX_GROUP_VALUE_LENGTH, compact)
+      ),
+      sparklines[index] ?? '',
     ]),
   ];
   const align: TableAlignment[] = groupByFields.map(() => 'r');
   align.push('l');
-  lines.push(
-    indent(
-      table(rows, {
-        align,
-        hsep: 2,
-      }),
-      2
-    )
+  const chart = indent(
+    table(rows, {
+      align,
+      hsep: 2,
+    }),
+    2
   );
-
-  return lines.join('\n');
+  return compact ? chart : `sparklines:\n${chart}`;
 }
 
 /**
@@ -952,6 +980,7 @@ export function formatText(
     teamName: opts.teamName,
     unit: displayUnit,
     groupCount: opts.groupBy.length > 0 ? groups.length : undefined,
+    compact: opts.presentation?.compact,
   });
 
   if (groups.length === 0) {
@@ -967,12 +996,16 @@ export function formatText(
     const points = series.get(key) ?? [];
     const values = points.map(point => point.value);
     const currentGroupValues = groupValues.get(key) ?? [];
+    const displayGroupValues = currentGroupValues.map((value, index) => {
+      const field = opts.groupBy[index];
+      return opts.presentation?.formatGroupValue?.(field, value) ?? value;
+    });
 
     summaryRows.push({
-      groupValues: currentGroupValues,
+      groupValues: displayGroupValues,
       stats: computeGroupStats(points),
     });
-    groupRows.push(currentGroupValues);
+    groupRows.push(displayGroupValues);
     sparklineRows.push(generateSparkline(values));
   }
 
@@ -983,13 +1016,15 @@ export function formatText(
     aggregation: opts.aggregation,
     periodStart: new Date(opts.periodStart),
     periodEnd: new Date(opts.periodEnd),
+    ansiAwareGroupValues: opts.presentation?.compact,
   });
 
   const groupedOutput = opts.groupBy.length > 0;
   const sparklineSection = formatSparklineSection(
     groupedOutput ? groupRows : [],
     sparklineRows,
-    opts.groupBy
+    opts.groupBy,
+    opts.presentation?.compact
   );
 
   const sections = [metadata, summaryTable, sparklineSection];

--- a/packages/cli/src/util/flags/print-flag-details.ts
+++ b/packages/cli/src/util/flags/print-flag-details.ts
@@ -11,13 +11,8 @@ import {
   formatFlagSplitWeights,
   formatFlagVariantSummary,
 } from './format-flag-outcome';
-import { formatVariantValue } from './resolve-variant';
-import type {
-  Flag,
-  FlagEnvironmentConfig,
-  FlagSettings,
-  FlagVariant,
-} from './types';
+import { formatVariantListSummary } from './resolve-variant';
+import type { Flag, FlagEnvironmentConfig, FlagSettings } from './types';
 
 interface PrintFlagDetailsOptions {
   flag: Flag;
@@ -223,13 +218,4 @@ function hasCustomConfigurationEnabled(
     envConfig.fallthrough.type === 'split' ||
     envConfig.fallthrough.type === 'rollout'
   );
-}
-
-function formatVariantListSummary(variant: FlagVariant): string {
-  const value = formatVariantValue(variant.value);
-  if (!variant.label) {
-    return value;
-  }
-
-  return `${value}: ${chalk.gray(variant.label)}`;
 }

--- a/packages/cli/src/util/flags/resolve-variant.ts
+++ b/packages/cli/src/util/flags/resolve-variant.ts
@@ -27,6 +27,19 @@ export function formatVariantForDisplay(variant: FlagVariant): string {
 }
 
 /**
+ * Formats a variant for list output, matching `flags inspect`.
+ * Shows the value first, followed by a muted label when available.
+ */
+export function formatVariantListSummary(variant: FlagVariant): string {
+  const value = formatVariantValue(variant.value);
+  if (!variant.label) {
+    return value;
+  }
+
+  return `${value}: ${chalk.gray(variant.label)}`;
+}
+
+/**
  * Formats a list of variants for error messages.
  */
 export function formatAvailableVariants(variants: FlagVariant[]): string {

--- a/packages/cli/src/util/projects/resolve-project-context.ts
+++ b/packages/cli/src/util/projects/resolve-project-context.ts
@@ -9,6 +9,14 @@ export interface ResolveProjectContextOptions {
   cwd?: string;
   projectNameOrId?: string;
   commandName?: string;
+  /**
+   * Controls who handles an unresolved explicit project. `report` emits the
+   * standard project-not-found error; `return` leaves the result as
+   * `not_linked` so the caller can provide its own output.
+   *
+   * @default 'report'
+   */
+  projectNotFoundHandling?: 'report' | 'return';
 }
 
 function getInvokingCommandFromArgv(argv: string[]): string {
@@ -31,6 +39,7 @@ export async function resolveProjectContext({
   cwd = client.cwd,
   projectNameOrId,
   commandName = '',
+  projectNotFoundHandling = 'report',
 }: ResolveProjectContextOptions): Promise<ProjectLinkResultWithOrgId> {
   const context = await getLinkedProject(client, {
     cwd,
@@ -39,7 +48,11 @@ export async function resolveProjectContext({
     scopeIsExplicit: detectExplicitScope(client),
   });
 
-  if (context.status === 'not_linked' && projectNameOrId) {
+  if (
+    context.status === 'not_linked' &&
+    projectNameOrId &&
+    projectNotFoundHandling === 'report'
+  ) {
     await printProjectNotFoundError(
       client,
       projectNameOrId,

--- a/packages/cli/src/util/telemetry/commands/flags/evaluations.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/evaluations.ts
@@ -1,0 +1,53 @@
+import { TelemetryClient } from '../..';
+import type { evaluationsSubcommand } from '../../../../commands/flags/command';
+import { isFlagEvaluationsGranularity } from '../../../../commands/flags/evaluations-config';
+import type { TelemetryMethods } from '../../types';
+
+export class FlagsEvaluationsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof evaluationsSubcommand>
+{
+  trackCliArgumentFlag(flag: string | undefined) {
+    if (flag) {
+      this.trackCliArgument({
+        arg: 'flag',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSince(since: string | undefined) {
+    if (since) {
+      this.trackCliOption({
+        option: 'since',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionUntil(until: string | undefined) {
+    if (until) {
+      this.trackCliOption({
+        option: 'until',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionGranularity(granularity: string | undefined) {
+    if (granularity) {
+      this.trackCliOption({
+        option: 'granularity',
+        value: isFlagEvaluationsGranularity(granularity)
+          ? granularity
+          : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/flags/index.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/index.ts
@@ -27,6 +27,13 @@ export class FlagsTelemetryClient
     });
   }
 
+  trackCliSubcommandEvaluations(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'evaluations',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandOpen(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'open',

--- a/packages/cli/test/unit/commands/flags/evaluations.test.ts
+++ b/packages/cli/test/unit/commands/flags/evaluations.test.ts
@@ -1,0 +1,577 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import stripAnsi from 'strip-ansi';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import flags from '../../../../src/commands/flags';
+import {
+  removeProjectLink,
+  setupUnitFixture,
+} from '../../../helpers/setup-unit-fixture';
+import { client } from '../../../mocks/client';
+import { defaultFlags, useFlags } from '../../../mocks/flags';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+const ROLLUP = 'vercel_flag_evaluation_flag_evaluations_sum';
+
+describe('flags evaluations', () => {
+  let postedBody: Record<string, unknown> | undefined;
+  let postedQuery: Record<string, unknown> | undefined;
+  let flagLookupFailure:
+    | { status: number; code: string; message: string }
+    | undefined;
+
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-flags-test',
+      name: 'vercel-flags-test',
+      accountId: 'team_dummy',
+    });
+    client.cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+    process.env.VERCEL_FLAG_EVALUATIONS_API_URL = new URL(
+      '/api/observability/metrics',
+      client.apiUrl
+    ).href;
+    postedBody = undefined;
+    postedQuery = undefined;
+    flagLookupFailure = undefined;
+    client.scenario.get(
+      '/v1/projects/:projectId/feature-flags/flags/:flagIdOrSlug',
+      (_req, res, next) => {
+        if (!flagLookupFailure) {
+          next?.();
+          return;
+        }
+        res.status(flagLookupFailure.status).json({
+          error: {
+            code: flagLookupFailure.code,
+            message: flagLookupFailure.message,
+          },
+        });
+      }
+    );
+    useFlags();
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_FLAG_EVALUATIONS_API_URL;
+  });
+
+  function useEvaluationsResponse({
+    data = [],
+    summary = [],
+  }: {
+    data?: Record<string, unknown>[];
+    summary?: Record<string, unknown>[];
+  } = {}) {
+    client.scenario.post('/api/observability/metrics', (req, res) => {
+      postedBody = req.body as Record<string, unknown>;
+      postedQuery = req.query as Record<string, unknown>;
+      res.json({
+        data,
+        summary,
+        statistics: { rowsRead: 42, bytesRead: 1024 },
+      });
+    });
+  }
+
+  it('queries and displays evaluations for the canonical flag slug', async () => {
+    useEvaluationsResponse({
+      data: [
+        {
+          timestamp: '2026-07-10T10:00:00.000Z',
+          flagVariant: 'off',
+          [ROLLUP]: 3,
+        },
+        {
+          timestamp: '2026-07-10T10:05:00.000Z',
+          flagVariant: 'off',
+          [ROLLUP]: 5,
+        },
+        {
+          timestamp: '2026-07-10T10:00:00.000Z',
+          flagVariant: 'on',
+          [ROLLUP]: 2,
+        },
+        {
+          timestamp: '2026-07-10T10:05:00.000Z',
+          flagVariant: '',
+          [ROLLUP]: 1,
+        },
+      ],
+      summary: [
+        { flagVariant: 'off', [ROLLUP]: 8 },
+        { flagVariant: 'on', [ROLLUP]: 2 },
+        { flagVariant: '', [ROLLUP]: 1 },
+      ],
+    });
+
+    client.setArgv(
+      'flags',
+      'evaluations',
+      defaultFlags[0].id,
+      '--since',
+      '2026-07-10T10:00:00.000Z',
+      '--until',
+      '2026-07-10T10:10:00.000Z',
+      '--granularity',
+      '5m'
+    );
+    const exitCode = await flags(client);
+
+    expect(exitCode).toBe(0);
+    expect(postedQuery).toMatchObject({ ownerId: 'team_dummy' });
+    expect(postedBody).toMatchObject({
+      scope: {
+        type: 'project',
+        ownerId: 'team_dummy',
+        projectIds: ['vercel-flags-test'],
+      },
+      reason: 'observability_chart',
+      event: 'flagEvaluation',
+      rollups: {
+        [ROLLUP]: {
+          measure: 'flagEvaluations',
+          aggregation: 'sum',
+        },
+      },
+      orderBy: ROLLUP,
+      orderDirection: 'desc',
+      groupBy: ['flagVariant'],
+      limit: 101,
+      limitRanking: 'single_pass',
+      tailRollup: 'truncate',
+      summaryOnly: false,
+      filter: "flagKey eq 'my-feature'",
+      granularity: { minutes: 5 },
+      startTime: '2026-07-10T10:00:00.000Z',
+      endTime: '2026-07-10T10:10:00.000Z',
+    });
+
+    const stdout = stripAnsi(client.stdout.getFullOutput());
+    expect(stdout).not.toContain('Metric:');
+    expect(stdout).not.toContain('Filter:');
+    expect(stdout).not.toContain('Order By:');
+    expect(stdout).toContain('Period:');
+    expect(stdout).toContain('(UTC) [10m]');
+    expect(stdout).toContain('Variants');
+    expect(stdout).not.toContain('flag_variant');
+    expect(stdout).toContain('false: Off');
+    expect(stdout).toContain('true: On');
+    expect(stdout).toContain('Default in Code');
+    expect(stdout).not.toContain('Chart:');
+    expect(stdout).not.toContain('  Chart');
+    expect(stdout).not.toContain('sparklines:');
+    expect(stdout).not.toContain('sparkline');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:evaluations', value: 'evaluations' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:since', value: '[REDACTED]' },
+      { key: 'option:until', value: '[REDACTED]' },
+      { key: 'option:granularity', value: '5m' },
+    ]);
+  });
+
+  it('aligns query bounds outward to granularity boundaries', async () => {
+    useEvaluationsResponse();
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--since',
+      '2026-07-10T09:03:27.123Z',
+      '--until',
+      '2026-07-10T10:03:27.123Z'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toBe(0);
+    expect(postedBody).toMatchObject({
+      granularity: { minutes: 1 },
+      startTime: '2026-07-10T09:03:00.000Z',
+      endTime: '2026-07-10T10:04:00.000Z',
+    });
+  });
+
+  it('outputs machine-readable JSON with exact bucket data', async () => {
+    useEvaluationsResponse({
+      data: [
+        {
+          timestamp: '2026-07-10T10:00:00.000Z',
+          flagVariant: 'off',
+          [ROLLUP]: 3,
+        },
+        {
+          timestamp: '2026-07-10T10:01:00.000Z',
+          flagVariant: '',
+          [ROLLUP]: 1,
+        },
+      ],
+      summary: [
+        { flagVariant: 'off', [ROLLUP]: 3 },
+        { flagVariant: '', [ROLLUP]: 1 },
+        ...Array.from({ length: 98 }, (_, index) => ({
+          flagVariant: `unused-${index}`,
+          [ROLLUP]: 0,
+        })),
+      ],
+    });
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--since',
+      '2026-07-10T10:00:00.000Z',
+      '--until',
+      '2026-07-10T11:00:00.000Z',
+      '--json'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(client.stdout.getFullOutput());
+    expect(json).toEqual({
+      flag: 'my-feature',
+      startTime: '2026-07-10T10:00:00.000Z',
+      endTime: '2026-07-10T11:00:00.000Z',
+      granularity: { minutes: 1 },
+      truncated: false,
+      buckets: [
+        {
+          timestamp: '2026-07-10T10:00:00.000Z',
+          variant: 'off',
+          evaluations: 3,
+        },
+        {
+          timestamp: '2026-07-10T10:01:00.000Z',
+          variant: '',
+          evaluations: 1,
+        },
+      ],
+    });
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Querying flag evaluations'
+    );
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:evaluations', value: 'evaluations' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:since', value: '[REDACTED]' },
+      { key: 'option:until', value: '[REDACTED]' },
+      { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+
+  it('discloses when variants are truncated and preserves response order', async () => {
+    const variants = Array.from(
+      { length: 101 },
+      (_, index) => `variant-${index}`
+    );
+    useEvaluationsResponse({
+      summary: variants.map((variant, index) => ({
+        flagVariant: variant,
+        [ROLLUP]: variants.length - index,
+      })),
+      data: ['variant-100', 'variant-99', 'variant-0'].map(
+        (variant, index) => ({
+          timestamp: '2026-07-10T10:00:00.000Z',
+          flagVariant: variant,
+          [ROLLUP]: index + 1,
+        })
+      ),
+    });
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--since',
+      '2026-07-10T10:00:00.000Z',
+      '--until',
+      '2026-07-10T11:00:00.000Z',
+      '--json'
+    );
+
+    expect(await flags(client)).toBe(0);
+
+    const json = JSON.parse(client.stdout.getFullOutput());
+    expect(json.truncated).toBe(true);
+    expect(
+      json.buckets.map((bucket: { variant: string }) => bucket.variant)
+    ).toEqual(['variant-99', 'variant-0']);
+    expect(json.buckets).not.toContainEqual(
+      expect.objectContaining({ variant: 'variant-100' })
+    );
+  });
+
+  it('warns when human-readable results omit additional variants', async () => {
+    useEvaluationsResponse({
+      summary: Array.from({ length: 101 }, (_, index) => ({
+        flagVariant: `variant-${index}`,
+        [ROLLUP]: 101 - index,
+      })),
+    });
+    client.setArgv('flags', 'evaluations', 'my-feature');
+
+    expect(await flags(client)).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Results are limited to the 100 most evaluated variants.'
+    );
+  });
+
+  it('prints a no-data result without failing', async () => {
+    useEvaluationsResponse();
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--since',
+      '2026-07-10T10:00:00.000Z',
+      '--until',
+      '2026-07-10T11:00:00.000Z'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stdout.getFullOutput()).toContain(
+      'No data found for this period.'
+    );
+  });
+
+  it('supports the evals alias and --project outside a linked directory', async () => {
+    useEvaluationsResponse();
+    const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+    removeProjectLink(cwd);
+    client.cwd = cwd;
+    client.setArgv(
+      'flags',
+      'evals',
+      'my-feature',
+      '--project',
+      'vercel-flags-test'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toBe(0);
+    expect(postedBody?.scope).toEqual({
+      type: 'project',
+      ownerId: 'team_dummy',
+      projectIds: ['vercel-flags-test'],
+    });
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:evaluations', value: 'evals' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:project', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('rejects invalid time ranges before querying', async () => {
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--since',
+      '2026-07-10T11:00:00.000Z',
+      '--until',
+      '2026-07-10T10:00:00.000Z'
+    );
+    expect(await flags(client)).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'The start time must be before the end time'
+    );
+    expect(postedBody).toBeUndefined();
+  });
+
+  it.each([
+    ['1m', { minutes: 1 }],
+    ['5m', { minutes: 5 }],
+    ['15m', { minutes: 15 }],
+    ['1h', { hours: 1 }],
+    ['4h', { hours: 4 }],
+    ['1d', { days: 1 }],
+  ])('accepts the supported %s granularity', async (value, duration) => {
+    useEvaluationsResponse();
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--granularity',
+      value
+    );
+
+    expect(await flags(client)).toBe(0);
+    expect(postedBody?.granularity).toEqual(duration);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:evaluations', value: 'evaluations' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:granularity', value },
+    ]);
+  });
+
+  it('rejects unsupported granularities locally and redacts them', async () => {
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--granularity',
+      '10m'
+    );
+
+    expect(await flags(client)).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Invalid granularity "10m". Use one of: 1m, 5m, 15m, 1h, 4h, 1d.'
+    );
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:evaluations', value: 'evaluations' },
+      { key: 'argument:flag', value: '[REDACTED]' },
+      { key: 'option:granularity', value: '[REDACTED]' },
+    ]);
+    expect(postedBody).toBeUndefined();
+  });
+
+  it('returns project resolution failures as valid JSON', async () => {
+    useUnknownProject();
+    const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+    removeProjectLink(cwd);
+    client.cwd = cwd;
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--project',
+      'no-such-project',
+      '--json'
+    );
+
+    expect(await flags(client)).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      error: {
+        code: 'PROJECT_NOT_FOUND',
+        message:
+          'Project "no-such-project" was not found in the current scope.',
+      },
+    });
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'If it lives in a different team'
+    );
+  });
+
+  it('returns an unlinked project error as valid JSON', async () => {
+    const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
+    removeProjectLink(cwd);
+    client.cwd = cwd;
+    client.setArgv('flags', 'evaluations', 'my-feature', '--json');
+
+    expect(await flags(client)).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      error: {
+        code: 'NOT_LINKED',
+        message:
+          "Your codebase isn't linked to a project on Vercel. Pass --project <name>, or run `vercel link` to link it.",
+      },
+    });
+  });
+
+  it('returns project resolution exceptions as valid JSON', async () => {
+    writeFileSync(join(client.cwd, '.vercel/project.json'), '{invalid');
+    client.setArgv('flags', 'evaluations', 'my-feature', '--json');
+
+    expect(await flags(client)).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      error: {
+        code: 'UNEXPECTED_ERROR',
+        message:
+          'Project Settings could not be retrieved. To link your project again, remove the ' +
+          `${join(client.cwd, '.vercel')} directory.`,
+      },
+    });
+  });
+
+  it('rejects a missing flag argument', async () => {
+    client.setArgv('flags', 'evaluations');
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Missing required argument: flag'
+    );
+  });
+
+  it('returns API failures as JSON errors', async () => {
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.status(403).json({
+        error: { code: 'forbidden', message: 'Not allowed' },
+      });
+    });
+    client.setArgv('flags', 'evaluations', 'my-feature', '--json');
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      error: {
+        code: 'FORBIDDEN',
+        message:
+          'You do not have permission to query metrics for this project/team.',
+      },
+    });
+  });
+
+  it('does not map flag lookup failures to metrics errors', async () => {
+    flagLookupFailure = {
+      status: 403,
+      code: 'flag_access_denied',
+      message: 'You cannot inspect this feature flag.',
+    };
+    client.setArgv('flags', 'evaluations', 'my-feature', '--json');
+
+    expect(await flags(client)).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      error: {
+        code: 'flag_access_denied',
+        message: 'You cannot inspect this feature flag.',
+      },
+    });
+    expect(client.stdout.getFullOutput()).not.toContain(
+      'permission to query metrics'
+    );
+    expect(postedBody).toBeUndefined();
+  });
+
+  describe('--help', () => {
+    it('prints help and tracks telemetry', async () => {
+      client.setArgv('flags', 'evaluations', '--help');
+
+      const exitCode = await flags(client);
+
+      expect(exitCode).toBe(2);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Display evaluation metrics for a feature flag'
+      );
+      expect(client.stderr.getFullOutput()).toContain('--since');
+      expect(client.stderr.getFullOutput()).toContain('--json');
+      expect(client.stderr.getFullOutput()).toContain(
+        '1m, 5m, 15m, 1h, 4h, 1d'
+      );
+      expect(client.stderr.getFullOutput()).not.toContain('--format');
+      expect(client.stderr.getFullOutput()).not.toContain('--group-by');
+      expect(client.stderr.getFullOutput()).not.toContain('--filter');
+      expect(client.stderr.getFullOutput()).not.toContain('--limit');
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'flags:evaluations' },
+      ]);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/flags/evaluations.test.ts
+++ b/packages/cli/test/unit/commands/flags/evaluations.test.ts
@@ -3,6 +3,7 @@ import stripAnsi from 'strip-ansi';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import flags from '../../../../src/commands/flags';
+import type { Flag } from '../../../../src/util/flags/types';
 import {
   removeProjectLink,
   setupUnitFixture,
@@ -18,6 +19,38 @@ import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
 const ROLLUP = 'vercel_flag_evaluation_flag_evaluations_sum';
+const evaluationFlags: Flag[] = [
+  ...defaultFlags,
+  {
+    ...defaultFlags[1],
+    id: 'flag_number789',
+    slug: 'number-feature',
+    kind: 'number',
+    variants: [
+      { id: 'default', value: 10, label: 'Small' },
+      { id: 'variant-a', value: 20, label: 'Large' },
+    ],
+  },
+  {
+    ...defaultFlags[1],
+    id: 'flag_json999',
+    slug: 'json-feature',
+    kind: 'json',
+    variants: [
+      {
+        id: 'default',
+        value: { theme: 'light', sidebar: false },
+        label: 'Light',
+      },
+      {
+        id: 'variant-a',
+        value: ['dark', 'compact'],
+        label: 'Dark',
+      },
+      { id: 'disabled', value: null, label: 'Disabled' },
+    ],
+  },
+];
 
 describe('flags evaluations', () => {
   let postedBody: Record<string, unknown> | undefined;
@@ -59,7 +92,7 @@ describe('flags evaluations', () => {
         });
       }
     );
-    useFlags();
+    useFlags(evaluationFlags);
   });
 
   afterEach(() => {
@@ -136,7 +169,7 @@ describe('flags evaluations', () => {
         ownerId: 'team_dummy',
         projectIds: ['vercel-flags-test'],
       },
-      reason: 'observability_chart',
+      reason: 'flag_evaluation_chart',
       event: 'flagEvaluation',
       rollups: {
         [ROLLUP]: {
@@ -243,6 +276,7 @@ describe('flags evaluations', () => {
     const json = JSON.parse(client.stdout.getFullOutput());
     expect(json).toEqual({
       flag: 'my-feature',
+      variants: { off: false, on: true },
       startTime: '2026-07-10T10:00:00.000Z',
       endTime: '2026-07-10T11:00:00.000Z',
       granularity: { minutes: 1 },
@@ -270,6 +304,54 @@ describe('flags evaluations', () => {
       { key: 'option:until', value: '[REDACTED]' },
       { key: 'flag:json', value: 'TRUE' },
     ]);
+  });
+
+  it.each([
+    {
+      kind: 'boolean',
+      flagSlug: 'my-feature',
+      expectedVariants: { off: false, on: true },
+    },
+    {
+      kind: 'string',
+      flagSlug: 'another-feature',
+      expectedVariants: { default: 'control', 'variant-a': 'variant-a' },
+    },
+    {
+      kind: 'number',
+      flagSlug: 'number-feature',
+      expectedVariants: { default: 10, 'variant-a': 20 },
+    },
+    {
+      kind: 'json',
+      flagSlug: 'json-feature',
+      expectedVariants: {
+        default: { theme: 'light', sidebar: false },
+        'variant-a': ['dark', 'compact'],
+        disabled: null,
+      },
+    },
+  ])('maps $kind variant IDs to raw values in JSON output', async ({
+    flagSlug,
+    expectedVariants,
+  }) => {
+    useEvaluationsResponse();
+    client.setArgv(
+      'flags',
+      'evaluations',
+      flagSlug,
+      '--since',
+      '2026-07-10T10:00:00.000Z',
+      '--until',
+      '2026-07-10T11:00:00.000Z',
+      '--json'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(client.stdout.getFullOutput());
+    expect(json.variants).toEqual(expectedVariants);
   });
 
   it('discloses when variants are truncated and preserves response order', async () => {

--- a/packages/cli/test/unit/commands/flags/index.test.ts
+++ b/packages/cli/test/unit/commands/flags/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import flags from '../../../../src/commands/flags';
 import * as ls from '../../../../src/commands/flags/ls';
 import * as openFlag from '../../../../src/commands/flags/open';
+import * as evaluationsFlag from '../../../../src/commands/flags/evaluations';
 import * as rolloutFlag from '../../../../src/commands/flags/rollout';
 import * as segmentsFlag from '../../../../src/commands/flags/segments';
 import * as splitFlag from '../../../../src/commands/flags/split';
@@ -12,6 +13,9 @@ import { client } from '../../../mocks/client';
 describe('flags', () => {
   const lsSpy = vi.spyOn(ls, 'default').mockResolvedValue(0);
   const openSpy = vi.spyOn(openFlag, 'default').mockResolvedValue(0);
+  const evaluationsSpy = vi
+    .spyOn(evaluationsFlag, 'default')
+    .mockResolvedValue(0);
   const rolloutSpy = vi.spyOn(rolloutFlag, 'default').mockResolvedValue(0);
   const segmentsSpy = vi.spyOn(segmentsFlag, 'segments').mockResolvedValue(0);
   const splitSpy = vi.spyOn(splitFlag, 'default').mockResolvedValue(0);
@@ -21,6 +25,7 @@ describe('flags', () => {
   afterEach(() => {
     lsSpy.mockClear();
     openSpy.mockClear();
+    evaluationsSpy.mockClear();
     rolloutSpy.mockClear();
     segmentsSpy.mockClear();
     splitSpy.mockClear();
@@ -69,6 +74,14 @@ describe('flags', () => {
     client.setArgv('flags', 'open', ...args);
     await flags(client);
     expect(openSpy).toHaveBeenCalledWith(client, args);
+  });
+
+  it('routes to evaluations subcommand', async () => {
+    const args: string[] = ['my-feature', '--since', '1h'];
+
+    client.setArgv('flags', 'evaluations', ...args);
+    await flags(client);
+    expect(evaluationsSpy).toHaveBeenCalledWith(client, args);
   });
 
   it('routes to update subcommand', async () => {

--- a/packages/cli/test/unit/commands/metrics/text-output.test.ts
+++ b/packages/cli/test/unit/commands/metrics/text-output.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
 import {
   getMeasureType,
@@ -155,6 +156,12 @@ describe('text-output', () => {
       // endLength=2, startLength=3
       expect(result).toBe('abc…ij');
       expect(result).toHaveLength(6);
+    });
+
+    it('should not split ANSI styling in visible-length mode', () => {
+      const result = ellipsizeMiddle(chalk.gray('a'.repeat(100)), 10, true);
+      expect(result).toBe('aaaaa…aaaa');
+      expect(stripAnsi(result)).toHaveLength(10);
     });
   });
 
@@ -368,7 +375,24 @@ describe('text-output', () => {
       // Sub-day intervals are timezone-independent, so no zone is shown.
       expect(metadata).not.toContain('Timezone:');
       expect(metadata).not.toContain('Europe/Paris');
-      expect(metadata).toContain('2026-02-19 10:00 to 2026-02-19 10:15');
+      expect(metadata).toContain('2026-02-19 10:00 to 2026-02-19 10:15 (UTC)');
+      expect(stripAnsi(metadata)).not.toContain('[15m]');
+    });
+
+    it('should show a compact elapsed span for bucket-aligned bounds', () => {
+      const metadata = formatMetadataHeader({
+        metric: 'vercel.request.count',
+        aggregation: 'sum',
+        periodStart: '2026-07-10T09:03:00.000Z',
+        periodEnd: '2026-07-10T10:04:00.000Z',
+        granularity: { minutes: 1 },
+        scope: projectScope,
+        compact: true,
+      });
+
+      expect(stripAnsi(metadata)).toContain(
+        'Period: 2026-07-10 09:03 to 2026-07-10 10:04 (UTC) [1h]'
+      );
     });
 
     it('should annotate day intervals with the bucket alignment timezone', () => {
@@ -420,6 +444,21 @@ describe('text-output', () => {
       expect(sparklineSection).toContain('shop-app');
       expect(sparklineSection).toContain('▁▂▃');
       expect(sparklineSection).toContain('█▇▆');
+    });
+
+    it('should omit sparkline labels in compact output', () => {
+      const sparklineSection = formatSparklineSection(
+        [['true: Enabled']],
+        ['▁▂▃'],
+        ['Variants'],
+        true
+      );
+
+      expect(sparklineSection).not.toContain('sparklines:');
+      expect(sparklineSection).not.toContain('sparkline');
+      expect(sparklineSection).toContain('Variants');
+      expect(sparklineSection).toContain('true: Enabled');
+      expect(sparklineSection).toContain('▁▂▃');
     });
   });
 
@@ -536,9 +575,60 @@ describe('text-output', () => {
       expect(output).toContain('projectName');
       expect(output).toContain('httpStatus');
       expect(output).toContain('sparklines:');
+      expect(output).toContain('sparkline');
+      expect(output).toContain('█');
       expect(output).toContain('my-app');
       expect(output).toContain('200');
       expect(output).toContain('500');
+    });
+
+    it('should apply compact presentation at render time without merging groups', () => {
+      const output = stripAnsi(
+        formatText(
+          {
+            data: [
+              {
+                timestamp: '2026-02-19T10:00:00.000Z',
+                Variants: 'variant-a',
+                vercel_flag_evaluation_count_sum: 1,
+              },
+              {
+                timestamp: '2026-02-19T10:00:00.000Z',
+                Variants: 'variant-b',
+                vercel_flag_evaluation_count_sum: 9,
+              },
+            ],
+            summary: [],
+            statistics: {},
+          },
+          {
+            metric: 'vercel.flag_evaluation.count',
+            metricUnit: 'count',
+            aggregation: 'sum',
+            groupBy: ['Variants'],
+            filter: "flag_key eq 'example'",
+            scope: projectScope,
+            periodStart: '2026-02-19T10:00:00.000Z',
+            periodEnd: '2026-02-19T10:05:00.000Z',
+            granularity: { minutes: 5 },
+            presentation: {
+              compact: true,
+              formatGroupValue: () => 'same display value',
+            },
+          }
+        )
+      );
+
+      expect(output).not.toContain('Metric:');
+      expect(output).not.toContain('Filter:');
+      expect(output).not.toContain('Groups:');
+      expect(output).not.toContain('Order By:');
+      expect(output).not.toContain('sparklines:');
+      expect(output).not.toContain('sparkline');
+      expect(output.match(/same display value/g)).toHaveLength(4);
+      expect(output.match(/Variants/g)).toHaveLength(2);
+      expect(output).toContain(' 1 ');
+      expect(output).toContain(' 9 ');
     });
 
     it('should keep fractional average for count sum output', () => {

--- a/packages/cli/test/unit/util/flags/resolve-variant.test.ts
+++ b/packages/cli/test/unit/util/flags/resolve-variant.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   resolveVariant,
   formatVariantForDisplay,
+  formatVariantListSummary,
   formatAvailableVariants,
 } from '../../../../src/util/flags/resolve-variant';
 import type { FlagVariant } from '../../../../src/util/flags/types';
@@ -167,6 +168,18 @@ describe('resolve-variant', () => {
     it('formats variant without label', () => {
       const result = formatVariantForDisplay(stringVariants[2]);
       expect(result).toBe('"off"');
+    });
+  });
+
+  describe('formatVariantListSummary', () => {
+    it('matches the value-first format used by flags inspect', () => {
+      const result = formatVariantListSummary(booleanVariants[0]);
+      expect(stripAnsi(result)).toBe('true: Enabled');
+      expect(result).toBe(`true: ${chalk.gray('Enabled')}`);
+    });
+
+    it('formats a variant without a label as its JSON value', () => {
+      expect(formatVariantListSummary(stringVariants[2])).toBe('"off"');
     });
   });
 


### PR DESCRIPTION
Add `vercel flags evaluations` for viewing compact, per-variant evaluation charts and bucket-level JSON data

Examples:

```bash
vercel flags evaluations my-feature
vercel flags evaluations my-feature --since 24h --granularity 1h
vercel flags evaluations my-feature --since 24h --json```