### PR TITLE
[CLI] listing all builders as peer deps

### DIFF
--- a/.changeset/builder-peer-pins.md
+++ b/.changeset/builder-peer-pins.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Declare builders as optional `peerDependencies` and use the declared versions to pin dynamic Builder installs: bare specs install the version this CLI release was published with instead of `latest`, stale `.vercel/builders` copies are reinstalled, `@vercel/build-utils` is pinned to the CLI's own version, and post-install resolution failures now report a per-Builder reason instead of "Something went wrong!". Explicit Builder version pins are unchanged and always win. Builders remain in `dependencies`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -79,6 +79,86 @@
     "undici": "5.29.0",
     "zod": "4.1.11"
   },
+  "peerDependencies": {
+    "@vercel/backends": "workspace:*",
+    "@vercel/container": "workspace:*",
+    "@vercel/elysia": "workspace:*",
+    "@vercel/express": "workspace:*",
+    "@vercel/fastify": "workspace:*",
+    "@vercel/go": "workspace:*",
+    "@vercel/h3": "workspace:*",
+    "@vercel/hono": "workspace:*",
+    "@vercel/hydrogen": "workspace:*",
+    "@vercel/koa": "workspace:*",
+    "@vercel/nestjs": "workspace:*",
+    "@vercel/next": "workspace:*",
+    "@vercel/node": "workspace:*",
+    "@vercel/python": "workspace:*",
+    "@vercel/redwood": "workspace:*",
+    "@vercel/remix-builder": "workspace:*",
+    "@vercel/ruby": "workspace:*",
+    "@vercel/rust": "workspace:*",
+    "@vercel/static-build": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@vercel/backends": {
+      "optional": true
+    },
+    "@vercel/container": {
+      "optional": true
+    },
+    "@vercel/elysia": {
+      "optional": true
+    },
+    "@vercel/express": {
+      "optional": true
+    },
+    "@vercel/fastify": {
+      "optional": true
+    },
+    "@vercel/go": {
+      "optional": true
+    },
+    "@vercel/h3": {
+      "optional": true
+    },
+    "@vercel/hono": {
+      "optional": true
+    },
+    "@vercel/hydrogen": {
+      "optional": true
+    },
+    "@vercel/koa": {
+      "optional": true
+    },
+    "@vercel/nestjs": {
+      "optional": true
+    },
+    "@vercel/next": {
+      "optional": true
+    },
+    "@vercel/node": {
+      "optional": true
+    },
+    "@vercel/python": {
+      "optional": true
+    },
+    "@vercel/redwood": {
+      "optional": true
+    },
+    "@vercel/remix-builder": {
+      "optional": true
+    },
+    "@vercel/ruby": {
+      "optional": true
+    },
+    "@vercel/rust": {
+      "optional": true
+    },
+    "@vercel/static-build": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@edge-runtime/node-utils": "2.3.0",
     "@inquirer/checkbox": "2.2.2",

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -1,5 +1,5 @@
 import npa from 'npm-package-arg';
-import { satisfies } from 'semver';
+import { satisfies, validRange } from 'semver';
 import { dirname, join } from 'path';
 import { createRequire } from 'module';
 import { readJSON } from 'fs-extra';
@@ -15,6 +15,7 @@ import * as staticBuilder from './static-builder';
 import { VERCEL_DIR } from '../projects/link';
 import { isErrnoException } from '@vercel/error-utils';
 import output from '../../output-manager';
+import cliPkg from '../pkg';
 import { installBuilders } from './install-builders';
 
 export interface BuilderWithPkg {
@@ -42,6 +43,44 @@ type ResolveBuildersResult =
 // Get a real `require()` reference that esbuild won't mutate
 const require_ = createRequire(__filename);
 
+// Builder versions this CLI release was published with, from its
+// `peerDependencies` (`workspace:*` in the monorepo, so a no-op in dev)
+let builderPins: Map<string, string> | undefined;
+
+function getBuilderPins(): Map<string, string> {
+  if (!builderPins) {
+    builderPins = new Map();
+    const peerDependencies: Record<string, string> =
+      (cliPkg as { peerDependencies?: Record<string, string> })
+        .peerDependencies ?? {};
+    for (const [name, version] of Object.entries(peerDependencies)) {
+      if (validRange(version)) {
+        builderPins.set(name, version);
+      }
+    }
+  }
+  return builderPins;
+}
+
+function isBareSpec(parsed: ReturnType<typeof npa>): boolean {
+  return parsed.type === 'tag' && parsed.rawSpec === '';
+}
+
+function pinBuilderSpecs(specs: Set<string>): Map<string, string> {
+  const pins = getBuilderPins();
+  const pinnedSpecs = new Map<string, string>();
+  for (const spec of specs) {
+    const parsed = npa(spec);
+    if (parsed.name && isBareSpec(parsed)) {
+      const version = pins.get(parsed.name);
+      if (version) {
+        pinnedSpecs.set(spec, `${parsed.name}@${version}`);
+      }
+    }
+  }
+  return pinnedSpecs;
+}
+
 /**
  * Imports the specified Vercel Builders, installing any missing ones
  * into `.vercel/builders` if necessary.
@@ -57,9 +96,10 @@ export async function importBuilders(
 
   if ('buildersToAdd' in importResult) {
     const { buildersToAdd, installReasons } = importResult;
+    const pinnedSpecs = pinBuilderSpecs(buildersToAdd);
     const installResult = await installBuilders(
       buildersDir,
-      buildersToAdd,
+      new Set(Array.from(buildersToAdd, spec => pinnedSpecs.get(spec) ?? spec)),
       span,
       installReasons
     );
@@ -71,7 +111,19 @@ export async function importBuilders(
     );
 
     if ('buildersToAdd' in importResult) {
-      throw new Error('Something went wrong!');
+      const { buildersToAdd: failed, installReasons: reasons } = importResult;
+      const failures = Array.from(failed, spec => {
+        const reason = reasons.get(spec);
+        return reason ? `${spec} (${reason})` : spec;
+      });
+      const err = new Error(
+        `Failed to load Builders after installing them: ${failures.join(
+          ', '
+        )}. Retry the build. If the failure persists, contact Vercel Support.`
+      );
+      (err as any).link =
+        'https://vercel.link/builder-dependencies-install-failed';
+      throw err;
     }
   }
 
@@ -170,6 +222,21 @@ async function resolveBuilders(
         throw new Error(
           `\`package.json\` for "${name}" does not contain a "version" field`
         );
+      }
+
+      const peerVersion = getBuilderPins().get(name);
+      if (
+        isBareSpec(parsed) &&
+        peerVersion &&
+        pkgPath.startsWith(buildersDir) &&
+        !satisfies(builderPkg.version, peerVersion)
+      ) {
+        output.debug(
+          `Cached "${name}@${builderPkg.version}" does not satisfy "${peerVersion}"`
+        );
+        buildersToAdd.add(spec);
+        installReasons.set(spec, 'peer-version-mismatch');
+        continue;
       }
 
       if (parsed.type === 'version' && parsed.rawSpec !== builderPkg.version) {

--- a/packages/cli/src/util/build/install-builders.ts
+++ b/packages/cli/src/util/build/install-builders.ts
@@ -1,9 +1,11 @@
 import { URL } from 'url';
 import plural from 'pluralize';
 import { join } from 'path';
+import { validRange } from 'semver';
 import { mkdirp, outputJSON, symlink } from 'fs-extra';
 import type { PackageJson, Span } from '@vercel/build-utils';
 import execa from 'execa';
+import cliPkg from '../pkg';
 import readJSONFile from '../read-json-file';
 import { CantParseJSONFile } from '../errors-ts';
 import { isErrnoException, isError } from '@vercel/error-utils';
@@ -51,10 +53,16 @@ async function untracedInstallBuilders(
       buildersToAdd
     ).join(', ')}`
   );
+  const buildUtilsVersion = cliPkg.dependencies?.['@vercel/build-utils'];
+  const buildUtilsSpec =
+    buildUtilsVersion && validRange(buildUtilsVersion)
+      ? `@vercel/build-utils@${buildUtilsVersion}`
+      : '@vercel/build-utils';
+
   try {
     const { stderr } = await execa(
       'npm',
-      ['install', '@vercel/build-utils', ...buildersToAdd],
+      ['install', buildUtilsSpec, ...buildersToAdd],
       {
         cwd: buildersDir,
         stdio: 'pipe',

--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -19,6 +19,21 @@ vi.mock('../../../../src/util/build/install-builders', async importOriginal => {
     ),
   };
 });
+
+vi.mock('../../../../src/util/pkg', async importOriginal => {
+  const actual = await (
+    importOriginal as () => Promise<{ default: Record<string, unknown> }>
+  )();
+  return {
+    default: {
+      ...actual.default,
+      peerDependencies: {
+        ...(actual.default.peerDependencies as Record<string, string>),
+        'fake-pinned-builder': '2.0.0',
+      },
+    },
+  };
+});
 import vercelNodePkg from '@vercel/node/package.json';
 import { vi } from 'vitest';
 import { isWindows } from '../../../helpers/is-windows';
@@ -320,5 +335,117 @@ describe('importBuilders()', () => {
     } finally {
       await remove(cwd);
     }
+  });
+
+  const pkgName = 'fake-pinned-builder';
+
+  function mockInstallWritingVersion(version: string) {
+    vi.mocked(installBuildersModule.installBuilders).mockImplementationOnce(
+      async dir => {
+        await outputJSON(join(dir, 'node_modules', pkgName, 'package.json'), {
+          name: pkgName,
+          version,
+          main: 'index.js',
+        });
+        await writeFile(
+          join(dir, 'node_modules', pkgName, 'index.js'),
+          `exports.version = 3; exports.build = async function() { return { output: {} }; };`
+        );
+        return new Map();
+      }
+    );
+  }
+
+  it('should install the peer-declared version for bare specs', async () => {
+    const spec = pkgName;
+    const cwd = await getWriteableDirectory();
+    const buildersDir = join(cwd, '.vercel', 'builders');
+
+    mockInstallWritingVersion('2.0.0');
+    try {
+      const builders = await importBuilders(new Set([spec]), cwd);
+      expect(installBuildersModule.installBuilders).toHaveBeenCalledWith(
+        buildersDir,
+        new Set(['fake-pinned-builder@2.0.0']),
+        undefined,
+        new Map([[spec, 'not-installed']])
+      );
+      expect(builders.get(spec)?.pkg.version).toBe('2.0.0');
+    } finally {
+      await remove(cwd);
+    }
+  });
+
+  it('should install the explicit pin when it differs from the peer-declared version', async () => {
+    const spec = 'fake-pinned-builder@1.0.0';
+    const cwd = await getWriteableDirectory();
+    const buildersDir = join(cwd, '.vercel', 'builders');
+
+    mockInstallWritingVersion('1.0.0');
+    try {
+      const builders = await importBuilders(new Set([spec]), cwd);
+      expect(installBuildersModule.installBuilders).toHaveBeenCalledWith(
+        buildersDir,
+        new Set(['fake-pinned-builder@1.0.0']),
+        undefined,
+        new Map([[spec, 'not-installed']])
+      );
+      expect(builders.get(spec)?.pkg.version).toBe('1.0.0');
+    } finally {
+      await remove(cwd);
+    }
+  });
+
+  it('should reinstall a cached bare-spec Builder that no longer matches the peer-declared version', async () => {
+    const spec = pkgName;
+    const cwd = await getWriteableDirectory();
+    const buildersDir = join(cwd, '.vercel', 'builders');
+    const builderModuleDir = join(buildersDir, 'node_modules', pkgName);
+
+    await outputJSON(join(builderModuleDir, 'package.json'), {
+      name: pkgName,
+      version: '1.5.0',
+      main: 'index.js',
+    });
+
+    mockInstallWritingVersion('2.0.0');
+    try {
+      const builders = await importBuilders(new Set([spec]), cwd);
+      expect(installBuildersModule.installBuilders).toHaveBeenCalledWith(
+        buildersDir,
+        new Set(['fake-pinned-builder@2.0.0']),
+        undefined,
+        new Map([[spec, 'peer-version-mismatch']])
+      );
+      expect(builders.get(spec)?.pkg.version).toBe('2.0.0');
+    } finally {
+      await remove(cwd);
+    }
+  });
+
+  it('should throw a descriptive error when the installed version still does not resolve', async () => {
+    const spec = 'fake-pinned-builder@3.0.0';
+    const cwd = await getWriteableDirectory();
+
+    // Install "succeeds" but yields a different version than the pin
+    mockInstallWritingVersion('2.0.0');
+    let err: Error | undefined;
+    try {
+      await importBuilders(new Set([spec]), cwd);
+    } catch (_err: unknown) {
+      err = _err as Error;
+    } finally {
+      await remove(cwd);
+    }
+
+    if (!err) {
+      throw new Error('Expected `err` to be defined');
+    }
+    expect(err.message).toContain(
+      'Failed to load Builders after installing them: fake-pinned-builder@3.0.0 (version-mismatch)'
+    );
+    expect((err as any).link).toEqual(
+      'https://vercel.link/builder-dependencies-install-failed'
+    );
   });
 });


### PR DESCRIPTION
This adds builders as peer deps in the third phase of removing builders from the CLI entirely - starting and making sure this works in the build container 