### PR TITLE
[cli] Add ai-gateway leaderboard commands

### DIFF
--- a/.changeset/ai-gateway-leaderboard.md
+++ b/.changeset/ai-gateway-leaderboard.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel ai-gateway leaderboard` with `models`, `labs`, `apps`, and `providers` subcommands, exposing the AI Gateway usage leaderboards from the CLI. Supports `--modality`, `--metric`, and `--date` for the model/lab time series, a pretty table in interactive terminals with JSON by default when piped, `--format table|json|csv`, and `--out` to write the payload to a file.

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -488,6 +488,142 @@ export const modelsSubcommand = {
   examples: [],
 } as const;
 
+const leaderboardFormatOption = {
+  name: 'format',
+  shorthand: 'F',
+  type: String,
+  argument: 'FORMAT',
+  deprecated: false,
+  description:
+    'Output format: table, json, or csv (default: table in a terminal, json otherwise)',
+} as const;
+
+const leaderboardOutOption = {
+  name: 'out',
+  shorthand: 'o',
+  type: String,
+  argument: 'FILE',
+  deprecated: false,
+  description:
+    'Write the payload to a file instead of stdout (defaults to json; use --format csv for CSV)',
+} as const;
+
+const leaderboardModalityOption = {
+  name: 'modality',
+  shorthand: null,
+  type: String,
+  argument: 'MODALITY',
+  deprecated: false,
+  description: 'Filter by modality: all, text, image, or video (default: all)',
+} as const;
+
+const leaderboardMetricOption = {
+  name: 'metric',
+  shorthand: null,
+  type: String,
+  argument: 'METRIC',
+  deprecated: false,
+  description:
+    'Metric for the table view: requests, tokens, spend, imageCount, or videoCount (default: requests)',
+} as const;
+
+const leaderboardDateOption = {
+  name: 'date',
+  shorthand: null,
+  type: String,
+  argument: 'YYYY-MM-DD',
+  deprecated: false,
+  description: 'Day to show in the table view (default: most recent)',
+} as const;
+
+export const leaderboardModelsSubcommand = {
+  name: 'models',
+  aliases: [],
+  description: 'Show the most-used models on AI Gateway',
+  arguments: [],
+  options: [
+    leaderboardModalityOption,
+    leaderboardMetricOption,
+    leaderboardDateOption,
+    leaderboardFormatOption,
+    leaderboardOutOption,
+  ],
+  examples: [
+    {
+      name: 'Show the top text models',
+      value: `${packageName} ai-gateway leaderboard models --modality text`,
+    },
+    {
+      name: 'Export the full model data as CSV',
+      value: `${packageName} ai-gateway leaderboard models --format csv --out models.csv`,
+    },
+  ],
+} as const;
+
+export const leaderboardLabsSubcommand = {
+  name: 'labs',
+  aliases: [],
+  description: 'Show the most-used model creators (labs) on AI Gateway',
+  arguments: [],
+  options: [
+    leaderboardModalityOption,
+    leaderboardMetricOption,
+    leaderboardDateOption,
+    leaderboardFormatOption,
+    leaderboardOutOption,
+  ],
+  examples: [
+    {
+      name: 'Show the top labs by spend',
+      value: `${packageName} ai-gateway leaderboard labs --metric spend`,
+    },
+  ],
+} as const;
+
+export const leaderboardAppsSubcommand = {
+  name: 'apps',
+  aliases: [],
+  description: 'Show the top apps built on AI Gateway',
+  arguments: [],
+  options: [leaderboardFormatOption, leaderboardOutOption],
+  examples: [
+    {
+      name: 'Show the top apps',
+      value: `${packageName} ai-gateway leaderboard apps`,
+    },
+  ],
+} as const;
+
+export const leaderboardProvidersSubcommand = {
+  name: 'providers',
+  aliases: [],
+  description: 'Show the top inference providers on AI Gateway',
+  arguments: [],
+  options: [leaderboardFormatOption, leaderboardOutOption],
+  examples: [
+    {
+      name: 'Show the top providers as JSON',
+      value: `${packageName} ai-gateway leaderboard providers --format json`,
+    },
+  ],
+} as const;
+
+export const leaderboardSubcommand = {
+  name: 'leaderboard',
+  aliases: ['leaderboards'],
+  description:
+    'Explore AI Gateway usage leaderboards (open, anonymized data under CC BY 4.0)',
+  arguments: [],
+  subcommands: [
+    leaderboardModelsSubcommand,
+    leaderboardLabsSubcommand,
+    leaderboardAppsSubcommand,
+    leaderboardProvidersSubcommand,
+  ],
+  options: [],
+  examples: [],
+} as const;
+
 export const aiGatewayCommand = {
   name: 'ai-gateway',
   aliases: [],
@@ -498,6 +634,7 @@ export const aiGatewayCommand = {
     rulesSubcommand,
     codingAgentsSubcommand,
     modelsSubcommand,
+    leaderboardSubcommand,
   ],
   options: [],
   examples: [],

--- a/packages/cli/src/commands/ai-gateway/index.ts
+++ b/packages/cli/src/commands/ai-gateway/index.ts
@@ -6,12 +6,14 @@ import apiKeys from './api-keys';
 import rules from './rules';
 import codingAgents from './coding-agents';
 import models from './models';
+import leaderboard from './leaderboard';
 import {
   aiGatewayCommand,
   apiKeysSubcommand,
   rulesSubcommand,
   codingAgentsSubcommand,
   modelsSubcommand,
+  leaderboardSubcommand,
 } from './command';
 import { help } from '../help';
 import { getCommandAliases } from '..';
@@ -24,6 +26,7 @@ const COMMAND_CONFIG = {
   rules: getCommandAliases(rulesSubcommand),
   'coding-agents': getCommandAliases(codingAgentsSubcommand),
   models: getCommandAliases(modelsSubcommand),
+  leaderboard: getCommandAliases(leaderboardSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -70,6 +73,9 @@ export default async function main(client: Client) {
     case 'models':
       telemetry.trackCliSubcommandModels(subcommandOriginal);
       return models(client);
+    case 'leaderboard':
+      telemetry.trackCliSubcommandLeaderboard(subcommandOriginal);
+      return leaderboard(client);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('ai-gateway', subcommandOriginal);

--- a/packages/cli/src/commands/ai-gateway/leaderboard-apps.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-apps.ts
@@ -1,0 +1,29 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { leaderboardAppsSubcommand } from './command';
+import { runRankedLeaderboard } from './leaderboard-shared';
+import { AiGatewayLeaderboardAppsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-apps';
+
+export default async function apps(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLeaderboardAppsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardAppsSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  return runRankedLeaderboard(client, parsedArgs.flags, telemetry, {
+    dataset: 'apps',
+    label: 'Top apps',
+  });
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard-labs.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-labs.ts
@@ -1,0 +1,30 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { leaderboardLabsSubcommand } from './command';
+import { runTimeseriesLeaderboard } from './leaderboard-shared';
+import { AiGatewayLeaderboardLabsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-labs';
+
+export default async function labs(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLeaderboardLabsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardLabsSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  return runTimeseriesLeaderboard(client, parsedArgs.flags, telemetry, {
+    dataset: 'labs',
+    entityLabel: 'lab',
+    label: 'Top labs',
+  });
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard-models.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-models.ts
@@ -1,0 +1,30 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { leaderboardModelsSubcommand } from './command';
+import { runTimeseriesLeaderboard } from './leaderboard-shared';
+import { AiGatewayLeaderboardModelsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-models';
+
+export default async function models(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLeaderboardModelsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardModelsSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  return runTimeseriesLeaderboard(client, parsedArgs.flags, telemetry, {
+    dataset: 'models',
+    entityLabel: 'model',
+    label: 'Top models',
+  });
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard-providers.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-providers.ts
@@ -1,0 +1,29 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { leaderboardProvidersSubcommand } from './command';
+import { runRankedLeaderboard } from './leaderboard-shared';
+import { AiGatewayLeaderboardProvidersTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-providers';
+
+export default async function providers(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLeaderboardProvidersTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardProvidersSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  return runRankedLeaderboard(client, parsedArgs.flags, telemetry, {
+    dataset: 'providers',
+    label: 'Top providers',
+  });
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
@@ -1,0 +1,394 @@
+import { writeFile } from 'node:fs/promises';
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import stamp from '../../util/output/stamp';
+import { isAPIError } from '../../util/errors-ts';
+import { canPrompt } from '../../util/flags/can-prompt';
+import {
+  fetchLeaderboard,
+  fetchLeaderboardCsv,
+  filterTimeseries,
+  latestDate,
+  availableDates,
+  LEADERBOARD_METRICS,
+  LEADERBOARD_MODALITIES,
+  type LeaderboardFormat,
+  type LeaderboardMetric,
+  type LeaderboardModality,
+  type LeaderboardRankedResponse,
+  type LeaderboardTimeseriesResponse,
+} from '../../util/ai-gateway/leaderboard';
+
+export interface TimeseriesTelemetry {
+  trackCliOptionModality(value?: string): void;
+  trackCliOptionMetric(value?: string): void;
+  trackCliOptionDate(value?: string): void;
+  trackCliOptionFormat(value?: string): void;
+  trackCliOptionOut(value?: string): void;
+}
+
+export interface RankedTelemetry {
+  trackCliOptionFormat(value?: string): void;
+  trackCliOptionOut(value?: string): void;
+}
+
+interface LeaderboardFlags {
+  '--format'?: string;
+  '--out'?: string;
+  '--modality'?: string;
+  '--metric'?: string;
+  '--date'?: string;
+}
+
+const dash = () => chalk.gray('–');
+
+/**
+ * Resolve the output representation. Explicit `--format` always wins; otherwise
+ * a real terminal gets the pretty table and everything else (pipes, CI,
+ * `--non-interactive`, `--out`) gets machine-readable JSON. CSV is opt-in only.
+ */
+function resolveFormat(
+  client: Client,
+  flags: LeaderboardFlags
+): { format: LeaderboardFormat } | { error: string } {
+  const raw = flags['--format'];
+  const out = flags['--out'];
+
+  if (raw !== undefined) {
+    const format = raw.toLowerCase();
+    if (format !== 'table' && format !== 'json' && format !== 'csv') {
+      return {
+        error: `Invalid format: "${raw}". Valid formats: table, json, csv`,
+      };
+    }
+    if (format === 'table' && out !== undefined) {
+      return {
+        error:
+          'Cannot write the table view to a file. Use --format json or --format csv with --out.',
+      };
+    }
+    return { format };
+  }
+
+  if (out !== undefined) {
+    return { format: 'json' };
+  }
+
+  const interactive = Boolean(client.stdout.isTTY) && !client.nonInteractive;
+  return { format: interactive ? 'table' : 'json' };
+}
+
+function parseEnum<T extends string>(
+  value: string | undefined,
+  allowed: readonly T[],
+  label: string
+): { value: T | undefined } | { error: string } {
+  if (value === undefined) {
+    return { value: undefined };
+  }
+  const normalized = value.toLowerCase() as T;
+  if (!allowed.includes(normalized)) {
+    return {
+      error: `Invalid ${label}: "${value}". Valid values: ${allowed.join(', ')}`,
+    };
+  }
+  return { value: normalized };
+}
+
+/** Fetch (json or raw csv) wrapped with the shared spinner + API-error flow. */
+async function fetchWithSpinner<T>(
+  fetch: () => Promise<T>,
+  spinnerText: string
+): Promise<{ data: T } | { exitCode: number }> {
+  output.spinner(spinnerText);
+  try {
+    const data = await fetch();
+    output.stopSpinner();
+    return { data };
+  } catch (err: unknown) {
+    output.stopSpinner();
+    if (isAPIError(err)) {
+      output.error(err.message);
+      return { exitCode: 1 };
+    }
+    throw err;
+  }
+}
+
+async function writeToFile(
+  client: Client,
+  out: string,
+  content: string,
+  label: string
+): Promise<number> {
+  const writeStamp = stamp();
+  try {
+    await writeFile(out, content);
+  } catch (err: unknown) {
+    output.error(
+      `Failed to write ${out}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return 1;
+  }
+  output.log(`Wrote ${label} to ${chalk.bold(out)} ${writeStamp()}`);
+  return 0;
+}
+
+/** Shared entry point for the `models` and `labs` (time-series) leaderboards. */
+export async function runTimeseriesLeaderboard(
+  client: Client,
+  flags: LeaderboardFlags,
+  telemetry: TimeseriesTelemetry,
+  config: {
+    dataset: 'models' | 'labs';
+    /** Column header for the entity, e.g. `model` or `lab`. */
+    entityLabel: string;
+    label: string;
+  }
+): Promise<number> {
+  telemetry.trackCliOptionModality(flags['--modality']);
+  telemetry.trackCliOptionMetric(flags['--metric']);
+  telemetry.trackCliOptionDate(flags['--date']);
+  telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliOptionOut(flags['--out']);
+
+  const formatResult = resolveFormat(client, flags);
+  if ('error' in formatResult) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const { format } = formatResult;
+
+  const modalityResult = parseEnum(
+    flags['--modality'],
+    LEADERBOARD_MODALITIES,
+    'modality'
+  );
+  if ('error' in modalityResult) {
+    output.error(modalityResult.error);
+    return 1;
+  }
+  const metricResult = parseEnum(
+    flags['--metric'],
+    LEADERBOARD_METRICS,
+    'metric'
+  );
+  if ('error' in metricResult) {
+    output.error(metricResult.error);
+    return 1;
+  }
+
+  let modality: LeaderboardModality | undefined = modalityResult.value;
+  let metric: LeaderboardMetric | undefined = metricResult.value;
+
+  // In an interactive terminal showing the table, let the user pick the
+  // dimensions they didn't pass. Machine output (json/csv/--out) never prompts.
+  if (format === 'table' && canPrompt(client)) {
+    if (modality === undefined) {
+      modality = await client.input.select<LeaderboardModality>({
+        message: 'Modality',
+        choices: LEADERBOARD_MODALITIES.map(value => ({ name: value, value })),
+        default: 'all',
+      });
+    }
+    if (metric === undefined) {
+      metric = await client.input.select<LeaderboardMetric>({
+        message: 'Metric',
+        choices: LEADERBOARD_METRICS.map(value => ({ name: value, value })),
+        default: 'requests',
+      });
+    }
+  }
+
+  const resolvedModality = modality ?? 'all';
+  const resolvedMetric = metric ?? 'requests';
+
+  // CSV is passed through verbatim; --modality still applies server-side.
+  if (format === 'csv') {
+    const result = await fetchWithSpinner(
+      () =>
+        fetchLeaderboardCsv(client, {
+          dataset: config.dataset,
+          modality: resolvedModality,
+        }),
+      `Fetching ${config.label}`
+    );
+    if ('exitCode' in result) return result.exitCode;
+    if (flags['--out'] !== undefined) {
+      return writeToFile(client, flags['--out'], result.data, config.label);
+    }
+    client.stdout.write(result.data);
+    return 0;
+  }
+
+  const result = await fetchWithSpinner(
+    () =>
+      fetchLeaderboard(client, {
+        dataset: config.dataset,
+        modality: resolvedModality,
+      }),
+    `Fetching ${config.label}`
+  );
+  if ('exitCode' in result) return result.exitCode;
+  const data = result.data;
+
+  if (format === 'json') {
+    const content = `${JSON.stringify(data, null, 2)}\n`;
+    if (flags['--out'] !== undefined) {
+      return writeToFile(client, flags['--out'], content, config.label);
+    }
+    client.stdout.write(content);
+    return 0;
+  }
+
+  // Table view: collapse to one metric on one day, ranked by share.
+  return renderTimeseriesTable(client, data, {
+    metric: resolvedMetric,
+    modality: resolvedModality,
+    date: flags['--date'],
+    entityLabel: config.entityLabel,
+    label: config.label,
+  });
+}
+
+function renderTimeseriesTable(
+  client: Client,
+  data: LeaderboardTimeseriesResponse,
+  options: {
+    metric: LeaderboardMetric;
+    modality: LeaderboardModality;
+    date?: string;
+    entityLabel: string;
+    label: string;
+  }
+): number {
+  const rows = data.rows ?? [];
+
+  if (options.date !== undefined && !rows.some(r => r.date === options.date)) {
+    const dates = availableDates(rows);
+    output.error(
+      `No data for ${options.date}.${dates.length ? ` Available dates: ${dates.slice(0, 5).join(', ')}${dates.length > 5 ? ', …' : ''}` : ''}`
+    );
+    return 1;
+  }
+
+  const filtered = filterTimeseries(rows, {
+    metric: options.metric,
+    date: options.date,
+  });
+
+  if (filtered.length === 0) {
+    output.log(`No ${options.label} data for ${options.metric}.`);
+    return 0;
+  }
+
+  const day = options.date ?? latestDate(rows);
+  output.log(
+    `${options.label} · ${chalk.bold(options.metric)} · ${options.modality} · ${day}`
+  );
+  client.stdout.write(
+    `${table(
+      [
+        ['#', options.entityLabel, 'share'].map(header => chalk.gray(header)),
+        ...filtered.map((row, index) => [
+          String(index + 1),
+          row.name,
+          `${row.share_percent.toFixed(2)}%`,
+        ]),
+      ],
+      { align: ['r', 'l', 'r'], hsep: 3 }
+    ).replace(/^/gm, '  ')}\n`
+  );
+  printLicense();
+  return 0;
+}
+
+/** Shared entry point for the `apps` and `providers` (ranked) leaderboards. */
+export async function runRankedLeaderboard(
+  client: Client,
+  flags: LeaderboardFlags,
+  telemetry: RankedTelemetry,
+  config: { dataset: 'apps' | 'providers'; label: string }
+): Promise<number> {
+  telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliOptionOut(flags['--out']);
+
+  const formatResult = resolveFormat(client, flags);
+  if ('error' in formatResult) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const { format } = formatResult;
+
+  if (format === 'csv') {
+    const result = await fetchWithSpinner(
+      () => fetchLeaderboardCsv(client, { dataset: config.dataset }),
+      `Fetching ${config.label}`
+    );
+    if ('exitCode' in result) return result.exitCode;
+    if (flags['--out'] !== undefined) {
+      return writeToFile(client, flags['--out'], result.data, config.label);
+    }
+    client.stdout.write(result.data);
+    return 0;
+  }
+
+  const result = await fetchWithSpinner(
+    () => fetchLeaderboard(client, { dataset: config.dataset }),
+    `Fetching ${config.label}`
+  );
+  if ('exitCode' in result) return result.exitCode;
+  const data = result.data;
+
+  if (format === 'json') {
+    const content = `${JSON.stringify(data, null, 2)}\n`;
+    if (flags['--out'] !== undefined) {
+      return writeToFile(client, flags['--out'], content, config.label);
+    }
+    client.stdout.write(content);
+    return 0;
+  }
+
+  return renderRankedTable(client, data, config.label);
+}
+
+function renderRankedTable(
+  client: Client,
+  data: LeaderboardRankedResponse,
+  label: string
+): number {
+  const rows = data.rows ?? [];
+  if (rows.length === 0) {
+    output.log(`No ${label} data.`);
+    return 0;
+  }
+
+  const lsStamp = stamp();
+  const rankedBy = rows[0]?.ranked_by;
+  output.log(
+    `${label}${rankedBy ? ` · ${chalk.bold(rankedBy)}` : ''} ${lsStamp()}`
+  );
+  client.stdout.write(
+    `${table(
+      [
+        ['#', 'name', 'description'].map(header => chalk.gray(header)),
+        ...rows.map(row => [
+          String(row.rank),
+          row.name,
+          row.description ? row.description : dash(),
+        ]),
+      ],
+      { align: ['r', 'l', 'l'], hsep: 3 }
+    ).replace(/^/gm, '  ')}\n`
+  );
+  printLicense();
+  return 0;
+}
+
+function printLicense() {
+  output.log(
+    chalk.gray('Source: AI Gateway Leaderboard data, licensed under CC BY 4.0.')
+  );
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard.ts
@@ -1,0 +1,127 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import getSubcommand from '../../util/get-subcommand';
+import { type Command, help } from '../help';
+import models from './leaderboard-models';
+import labs from './leaderboard-labs';
+import apps from './leaderboard-apps';
+import providers from './leaderboard-providers';
+import {
+  leaderboardSubcommand,
+  leaderboardModelsSubcommand,
+  leaderboardLabsSubcommand,
+  leaderboardAppsSubcommand,
+  leaderboardProvidersSubcommand,
+} from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { getCommandAliases } from '..';
+import { AiGatewayLeaderboardTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard';
+import { printError } from '../../util/error';
+
+const COMMAND_CONFIG = {
+  models: getCommandAliases(leaderboardModelsSubcommand),
+  labs: getCommandAliases(leaderboardLabsSubcommand),
+  apps: getCommandAliases(leaderboardAppsSubcommand),
+  providers: getCommandAliases(leaderboardProvidersSubcommand),
+};
+
+export default async function leaderboard(client: Client) {
+  const telemetry = new AiGatewayLeaderboardTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardSubcommand.options
+  );
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const subArgs = parsedArgs.args.slice(2);
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    subArgs,
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('ai-gateway leaderboard', subcommandOriginal);
+    output.print(
+      help(leaderboardSubcommand, { columns: client.stderr.columns })
+    );
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        parent: leaderboardSubcommand,
+        columns: client.stderr.columns,
+      })
+    );
+  }
+
+  switch (subcommand) {
+    case 'models':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway leaderboard',
+          subcommandOriginal
+        );
+        printHelp(leaderboardModelsSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandModels(subcommandOriginal);
+      return models(client, args);
+    case 'labs':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway leaderboard',
+          subcommandOriginal
+        );
+        printHelp(leaderboardLabsSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandLabs(subcommandOriginal);
+      return labs(client, args);
+    case 'apps':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway leaderboard',
+          subcommandOriginal
+        );
+        printHelp(leaderboardAppsSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandApps(subcommandOriginal);
+      return apps(client, args);
+    case 'providers':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway leaderboard',
+          subcommandOriginal
+        );
+        printHelp(leaderboardProvidersSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandProviders(subcommandOriginal);
+      return providers(client, args);
+    default:
+      output.error(getInvalidSubcommand(COMMAND_CONFIG));
+      output.print(
+        help(leaderboardSubcommand, { columns: client.stderr.columns })
+      );
+      return 2;
+  }
+}

--- a/packages/cli/src/util/ai-gateway/leaderboard.ts
+++ b/packages/cli/src/util/ai-gateway/leaderboard.ts
@@ -1,0 +1,157 @@
+import type Client from '../client';
+
+// The leaderboards are served from vercel.com, not the AI Gateway host or the
+// api host. Passing an absolute URL to client.fetch bypasses the default api
+// host (new URL(url, apiUrl)). Overridable so tests can route it through the
+// mock server, mirroring VERCEL_AI_GATEWAY_URL in ./models.
+const DEFAULT_LEADERBOARD_BASE = 'https://vercel.com';
+
+export type LeaderboardDataset = 'models' | 'labs' | 'apps' | 'providers';
+export type LeaderboardModality = 'all' | 'text' | 'image' | 'video';
+export type LeaderboardMetric =
+  | 'requests'
+  | 'tokens'
+  | 'spend'
+  | 'imageCount'
+  | 'videoCount';
+/** How the result is rendered. `json`/`csv` are the raw export payload. */
+export type LeaderboardFormat = 'table' | 'json' | 'csv';
+
+export const LEADERBOARD_DATASETS: readonly LeaderboardDataset[] = [
+  'models',
+  'labs',
+  'apps',
+  'providers',
+];
+export const LEADERBOARD_MODALITIES: readonly LeaderboardModality[] = [
+  'all',
+  'text',
+  'image',
+  'video',
+];
+export const LEADERBOARD_METRICS: readonly LeaderboardMetric[] = [
+  'requests',
+  'tokens',
+  'spend',
+  'imageCount',
+  'videoCount',
+];
+
+/** `models` and `labs`: one entity's share of one metric on one day. */
+export type LeaderboardTimeseriesRow = {
+  date: string;
+  group: 'model' | 'lab';
+  name: string;
+  metric: LeaderboardMetric;
+  modality: LeaderboardModality;
+  share_percent: number;
+};
+
+/** `apps` and `providers`: one ranked entity. */
+export type LeaderboardRankedRow = {
+  rank: number;
+  name: string;
+  ranked_by: string;
+  url: string;
+  description: string;
+};
+
+type LeaderboardResponseBase = {
+  dataset: LeaderboardDataset;
+  license: string;
+  license_url: string;
+};
+
+export type LeaderboardTimeseriesResponse = LeaderboardResponseBase & {
+  dataset: 'models' | 'labs';
+  modality: LeaderboardModality;
+  rows: LeaderboardTimeseriesRow[];
+};
+
+export type LeaderboardRankedResponse = LeaderboardResponseBase & {
+  dataset: 'apps' | 'providers';
+  rows: LeaderboardRankedRow[];
+};
+
+export interface LeaderboardQuery {
+  dataset: LeaderboardDataset;
+  /** Only meaningful for `models`/`labs`; omitted otherwise. */
+  modality?: LeaderboardModality;
+}
+
+function leaderboardBase(): string {
+  return process.env.VERCEL_LEADERBOARD_URL ?? DEFAULT_LEADERBOARD_BASE;
+}
+
+function buildUrl(query: LeaderboardQuery, format: 'json' | 'csv'): string {
+  const params = new URLSearchParams();
+  params.set('dataset', query.dataset);
+  if (query.modality) {
+    params.set('modality', query.modality);
+  }
+  params.set('format', format);
+  return `${leaderboardBase()}/api/ai/leaderboard-export?${params.toString()}`;
+}
+
+/** Fetch the leaderboard as the structured JSON export payload. */
+export async function fetchLeaderboard(
+  client: Client,
+  query: LeaderboardQuery & { dataset: 'models' | 'labs' }
+): Promise<LeaderboardTimeseriesResponse>;
+export async function fetchLeaderboard(
+  client: Client,
+  query: LeaderboardQuery & { dataset: 'apps' | 'providers' }
+): Promise<LeaderboardRankedResponse>;
+export async function fetchLeaderboard(
+  client: Client,
+  query: LeaderboardQuery
+): Promise<LeaderboardTimeseriesResponse | LeaderboardRankedResponse> {
+  return client.fetch(buildUrl(query, 'json'), { method: 'GET' });
+}
+
+/** Fetch the leaderboard as the raw CSV export, passed through verbatim. */
+export async function fetchLeaderboardCsv(
+  client: Client,
+  query: LeaderboardQuery
+): Promise<string> {
+  const res = await client.fetch(buildUrl(query, 'csv'), {
+    method: 'GET',
+    json: false,
+  });
+  return res.text();
+}
+
+/** The most recent day present in a time-series result, or undefined. */
+export function latestDate(
+  rows: LeaderboardTimeseriesRow[]
+): string | undefined {
+  let max: string | undefined;
+  for (const row of rows) {
+    if (max === undefined || row.date > max) {
+      max = row.date;
+    }
+  }
+  return max;
+}
+
+/** Distinct dates present, most recent first (for error hints). */
+export function availableDates(rows: LeaderboardTimeseriesRow[]): string[] {
+  return Array.from(new Set(rows.map(r => r.date))).sort((a, b) =>
+    a < b ? 1 : a > b ? -1 : 0
+  );
+}
+
+/**
+ * Collapse the full time-series (every day × metric) to the rows shown in the
+ * human table: a single metric on a single day, ranked by share descending.
+ * Modality is already applied server-side. Defaults to the latest day.
+ */
+export function filterTimeseries(
+  rows: LeaderboardTimeseriesRow[],
+  options: { metric: LeaderboardMetric; date?: string }
+): LeaderboardTimeseriesRow[] {
+  const day = options.date ?? latestDate(rows);
+  return rows
+    .filter(row => row.metric === options.metric && row.date === day)
+    .sort((a, b) => b.share_percent - a.share_percent);
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/index.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/index.ts
@@ -33,4 +33,11 @@ export class AiGatewayTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandLeaderboard(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'leaderboard',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-apps.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-apps.ts
@@ -1,0 +1,20 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardAppsSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardAppsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardAppsSubcommand>
+{
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'format', value });
+    }
+  }
+
+  trackCliOptionOut(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'out', value: this.redactedValue });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-labs.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-labs.ts
@@ -1,0 +1,38 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardLabsSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardLabsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardLabsSubcommand>
+{
+  trackCliOptionModality(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'modality', value });
+    }
+  }
+
+  trackCliOptionMetric(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'metric', value });
+    }
+  }
+
+  trackCliOptionDate(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'date', value });
+    }
+  }
+
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'format', value });
+    }
+  }
+
+  trackCliOptionOut(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'out', value: this.redactedValue });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-models.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-models.ts
@@ -1,0 +1,38 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardModelsSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardModelsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardModelsSubcommand>
+{
+  trackCliOptionModality(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'modality', value });
+    }
+  }
+
+  trackCliOptionMetric(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'metric', value });
+    }
+  }
+
+  trackCliOptionDate(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'date', value });
+    }
+  }
+
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'format', value });
+    }
+  }
+
+  trackCliOptionOut(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'out', value: this.redactedValue });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-providers.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-providers.ts
@@ -1,0 +1,20 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardProvidersSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardProvidersTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardProvidersSubcommand>
+{
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'format', value });
+    }
+  }
+
+  trackCliOptionOut(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'out', value: this.redactedValue });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard.ts
@@ -1,0 +1,24 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardSubcommand>
+{
+  trackCliSubcommandModels(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'models', value: actual });
+  }
+
+  trackCliSubcommandLabs(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'labs', value: actual });
+  }
+
+  trackCliSubcommandApps(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'apps', value: actual });
+  }
+
+  trackCliSubcommandProviders(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'providers', value: actual });
+  }
+}

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-apps.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-apps.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+
+const appRows = [
+  {
+    rank: 1,
+    name: 'Kilo Code',
+    ranked_by: 'Token Volume',
+    url: 'https://kilocode.ai',
+    description: 'AI coding agent for VS Code',
+  },
+];
+
+function useApps() {
+  client.scenario.get('/api/ai/leaderboard-export', (_req, res) => {
+    res.json({
+      dataset: 'apps',
+      license: 'CC-BY-4.0',
+      license_url: 'https://creativecommons.org/licenses/by/4.0/',
+      rows: appRows,
+    });
+  });
+}
+
+describe('ai-gateway leaderboard apps', () => {
+  beforeEach(() => {
+    process.env.VERCEL_LEADERBOARD_URL = client.apiUrl;
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = false;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_LEADERBOARD_URL;
+  });
+
+  it('outputs JSON by default in a non-TTY', async () => {
+    useUser();
+    useApps();
+    client.setArgv('ai-gateway', 'leaderboard', 'apps');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"dataset": "apps"');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('renders a ranked table with --format table', async () => {
+    useUser();
+    useApps();
+    client.setArgv('ai-gateway', 'leaderboard', 'apps', '--format', 'table');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('Kilo Code');
+    expect(await exitCodePromise).toBe(0);
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-labs.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-labs.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+
+const labRows = [
+  {
+    date: '2026-05-18',
+    group: 'lab',
+    name: 'google',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 39.1981,
+  },
+  {
+    date: '2026-05-18',
+    group: 'lab',
+    name: 'anthropic',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 21.5,
+  },
+];
+
+function useLabs() {
+  let query: Record<string, string> | undefined;
+  client.scenario.get('/api/ai/leaderboard-export', (req, res) => {
+    query = req.query;
+    res.json({
+      dataset: 'labs',
+      modality: req.query.modality,
+      license: 'CC-BY-4.0',
+      license_url: 'https://creativecommons.org/licenses/by/4.0/',
+      rows: labRows,
+    });
+  });
+  return () => query;
+}
+
+describe('ai-gateway leaderboard labs', () => {
+  beforeEach(() => {
+    process.env.VERCEL_LEADERBOARD_URL = client.apiUrl;
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = false;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_LEADERBOARD_URL;
+  });
+
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'leaderboard', 'labs', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:leaderboard', value: 'leaderboard' },
+        { key: 'flag:help', value: 'ai-gateway leaderboard:labs' },
+      ]);
+    });
+  });
+
+  it('outputs JSON by default in a non-TTY', async () => {
+    useUser();
+    useLabs();
+    client.setArgv('ai-gateway', 'leaderboard', 'labs');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"dataset": "labs"');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('renders a ranked table with --format table', async () => {
+    useUser();
+    useLabs();
+    client.setArgv('ai-gateway', 'leaderboard', 'labs', '--format', 'table');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('google');
+    expect(await exitCodePromise).toBe(0);
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-models.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-models.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { unlinkSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+
+const sampleRows = [
+  {
+    date: '2026-05-18',
+    group: 'model',
+    name: 'Gemini 3 Flash',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 18.1487,
+  },
+  {
+    date: '2026-05-18',
+    group: 'model',
+    name: 'Claude Sonnet 4.6',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 4.1667,
+  },
+  {
+    date: '2026-05-17',
+    group: 'model',
+    name: 'Gemini 3 Flash',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 15.0,
+  },
+  {
+    date: '2026-05-18',
+    group: 'model',
+    name: 'Claude Opus 4.8',
+    metric: 'spend',
+    modality: 'all',
+    share_percent: 22.2,
+  },
+];
+
+const sampleCsv =
+  'date,group,name,metric,modality,share_percent\n2026-05-18,model,Gemini 3 Flash,requests,all,18.15\n';
+
+function useLeaderboard(opts: { rows?: unknown[]; csv?: string } = {}) {
+  let query: Record<string, string> | undefined;
+  client.scenario.get('/api/ai/leaderboard-export', (req, res) => {
+    query = req.query;
+    if (req.query.format === 'csv') {
+      res.setHeader('content-type', 'text/csv');
+      res.end(opts.csv ?? sampleCsv);
+      return;
+    }
+    res.json({
+      dataset: req.query.dataset,
+      modality: req.query.modality,
+      license: 'CC-BY-4.0',
+      license_url: 'https://creativecommons.org/licenses/by/4.0/',
+      rows: opts.rows ?? sampleRows,
+    });
+  });
+  return () => query;
+}
+
+describe('ai-gateway leaderboard models', () => {
+  beforeEach(() => {
+    // Route the public vercel.com host through the mock server.
+    process.env.VERCEL_LEADERBOARD_URL = client.apiUrl;
+    // Suppress interactive prompts unless a test opts in.
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = false;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_LEADERBOARD_URL;
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'leaderboard', 'models', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:leaderboard', value: 'leaderboard' },
+        { key: 'flag:help', value: 'ai-gateway leaderboard:models' },
+      ]);
+    });
+  });
+
+  it('outputs JSON by default in a non-TTY', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv('ai-gateway', 'leaderboard', 'models');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"dataset": "models"');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('renders a ranked table with --format table', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv('ai-gateway', 'leaderboard', 'models', '--format', 'table');
+
+    const exitCodePromise = aiGateway(client);
+    // Latest day + requests metric, ranked by share.
+    await expect(client.stdout).toOutput('Gemini 3 Flash');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('passes --modality through to the request', async () => {
+    useUser();
+    const getQuery = useLeaderboard();
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'models',
+      '--format',
+      'json',
+      '--modality',
+      'text'
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"rows"');
+    expect(await exitCodePromise).toBe(0);
+    expect(getQuery()?.modality).toBe('text');
+  });
+
+  it('filters the table to the chosen --metric', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'models',
+      '--format',
+      'table',
+      '--metric',
+      'spend'
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('Claude Opus 4.8');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('errors on a --date with no data', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'models',
+      '--format',
+      'table',
+      '--date',
+      '2000-01-01'
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('No data for 2000-01-01');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('passes format=csv through and prints it', async () => {
+    useUser();
+    const getQuery = useLeaderboard();
+    client.setArgv('ai-gateway', 'leaderboard', 'models', '--format', 'csv');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('share_percent');
+    expect(await exitCodePromise).toBe(0);
+    expect(getQuery()?.format).toBe('csv');
+  });
+
+  it('writes to a file with --out', async () => {
+    useUser();
+    useLeaderboard();
+    const out = join(tmpdir(), 'vercel-leaderboard-test.json');
+    if (existsSync(out)) unlinkSync(out);
+    client.setArgv('ai-gateway', 'leaderboard', 'models', '--out', out);
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('Wrote Top models');
+    expect(await exitCodePromise).toBe(0);
+    expect(existsSync(out)).toBe(true);
+    expect(readFileSync(out, 'utf8')).toContain('"dataset": "models"');
+    unlinkSync(out);
+  });
+
+  it('rejects --format table with --out', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'models',
+      '--format',
+      'table',
+      '--out',
+      join(tmpdir(), 'nope.txt')
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('Cannot write the table view');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('rejects an invalid --format', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv('ai-gateway', 'leaderboard', 'models', '--format', 'xml');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('Invalid format');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('prompts for modality and metric in an interactive TTY', async () => {
+    useUser();
+    const getQuery = useLeaderboard();
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = true;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = true;
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce('image')
+      .mockResolvedValueOnce('spend');
+    client.input.select = selectMock as never;
+
+    client.setArgv('ai-gateway', 'leaderboard', 'models');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('Claude Opus 4.8');
+    expect(await exitCodePromise).toBe(0);
+    expect(selectMock).toHaveBeenCalledTimes(2);
+    expect(getQuery()?.modality).toBe('image');
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-providers.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-providers.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { unlinkSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+
+const rankedRows = [
+  {
+    rank: 1,
+    name: 'DeepSeek',
+    ranked_by: 'Token Volume',
+    url: 'https://deepseek.com',
+    description: 'AI research and deployment',
+  },
+  {
+    rank: 2,
+    name: 'Anthropic',
+    ranked_by: 'Token Volume',
+    url: 'https://anthropic.com',
+    description: 'AI safety and research company',
+  },
+];
+
+function useRanked(dataset: string) {
+  let query: Record<string, string> | undefined;
+  client.scenario.get('/api/ai/leaderboard-export', (req, res) => {
+    query = req.query;
+    if (req.query.format === 'csv') {
+      res.setHeader('content-type', 'text/csv');
+      res.end('rank,name\n1,DeepSeek\n');
+      return;
+    }
+    res.json({
+      dataset,
+      license: 'CC-BY-4.0',
+      license_url: 'https://creativecommons.org/licenses/by/4.0/',
+      rows: rankedRows,
+    });
+  });
+  return () => query;
+}
+
+describe('ai-gateway leaderboard providers', () => {
+  beforeEach(() => {
+    process.env.VERCEL_LEADERBOARD_URL = client.apiUrl;
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = false;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_LEADERBOARD_URL;
+  });
+
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'leaderboard', 'providers', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:leaderboard', value: 'leaderboard' },
+        { key: 'flag:help', value: 'ai-gateway leaderboard:providers' },
+      ]);
+    });
+  });
+
+  it('outputs JSON by default in a non-TTY', async () => {
+    useUser();
+    const getQuery = useRanked('providers');
+    client.setArgv('ai-gateway', 'leaderboard', 'providers');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"dataset": "providers"');
+    expect(await exitCodePromise).toBe(0);
+    // Ranked datasets do not send a modality param.
+    expect(getQuery()?.modality).toBeUndefined();
+  });
+
+  it('renders a ranked table with --format table', async () => {
+    useUser();
+    useRanked('providers');
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'providers',
+      '--format',
+      'table'
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('DeepSeek');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('passes format=csv through', async () => {
+    useUser();
+    const getQuery = useRanked('providers');
+    client.setArgv('ai-gateway', 'leaderboard', 'providers', '--format', 'csv');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('DeepSeek');
+    expect(await exitCodePromise).toBe(0);
+    expect(getQuery()?.format).toBe('csv');
+  });
+
+  it('writes to a file with --out', async () => {
+    useUser();
+    useRanked('providers');
+    const out = join(tmpdir(), 'vercel-leaderboard-providers.json');
+    if (existsSync(out)) unlinkSync(out);
+    client.setArgv('ai-gateway', 'leaderboard', 'providers', '--out', out);
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('Wrote Top providers');
+    expect(await exitCodePromise).toBe(0);
+    expect(readFileSync(out, 'utf8')).toContain('"dataset": "providers"');
+    unlinkSync(out);
+  });
+});


### PR DESCRIPTION
## Why

The AI Gateway [leaderboards](https://vercel.com/docs/ai-gateway/leaderboards) expose open, anonymized usage data (most-used models, labs, apps, and providers) via `GET /api/ai/leaderboard-export`. This surfaces that data in the CLI with full parity to the export endpoint.

## Summary

- Adds `vercel ai-gateway leaderboard` with `models`, `labs`, `apps`, and `providers` subcommands (group alias `leaderboards`).
- **Time-series datasets** (`models`/`labs`): `--modality all|text|image|video` (server-side), plus `--metric` and `--date` to shape the table view client-side.
- **Ranked datasets** (`apps`/`providers`): just `--format` / `--out` — modality/metric/date don't apply and aren't shown in their `--help`.
- **`--format table|json|csv`**: pretty table in an interactive terminal, JSON when piped / non-interactive / `--out`; CSV only when explicitly requested.
- **`--out <file>`**: writes the payload to a file (JSON by default, CSV with `--format csv`); `--format table --out` is rejected.
- Interactive terminals prompt for omitted `--modality`/`--metric` via inquirer; pipes and CI never prompt.
- Reuses the ai-gateway command-family conventions (per-subcommand help, telemetry, `table` rendering).

## Validation

- New unit suites for all four subcommands (21 tests) covering json/csv/table/`--out`/modality/metric/date, the TTY prompt path, and error cases. Full ai-gateway suite passes (196 tests). Leaderboard source type-checks clean.

▲ Created with [Vercel devbox](https://vercel.com/vercel/~/sandboxes/devboxes/2ylk0uyl04uih99ubpgl2boesp4h)