### PR TITLE
fix(cli): crash after bare --help/--version when an update notification is pending

### DIFF
--- a/.changeset/guard-update-notification-client.md
+++ b/.changeset/guard-update-notification-client.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix a crash after `vercel --help`, `vercel --version`, and config-read errors when an update notification is pending: the update prompt dereferenced the CLI client before it was constructed on those early-return paths, printing "An unexpected error occurred!" and exiting 1. The update notification is now skipped when the client was never constructed.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1388,8 +1388,11 @@ main()
   .then(async exitCode => {
     // Skip the update notification after `vc upgrade`: the process still has
     // the pre-upgrade version in memory, so it would prompt the user to
-    // upgrade again right after the upgrade completed.
-    if (cachedLatest && resolvedCommandForUpdate !== 'upgrade') {
+    // upgrade again right after the upgrade completed. `client` is never
+    // assigned when main() returns before setup (bare `--help`, `--version`,
+    // and config-read errors), and the update flow dereferences it for
+    // config and prompts.
+    if (client && cachedLatest && resolvedCommandForUpdate !== 'upgrade') {
       const originalExitCode = typeof exitCode === 'number' ? exitCode : 0;
 
       // Await the fresh registry lookup to verify the exact version before


### PR DESCRIPTION
## Bug

Bare `vercel --help`, `vercel --version`, and config-read error paths return from `main()` before the shared `Client` is constructed (`let client: Client` at the top of `src/index.ts` is only assigned during full setup). The module-scope update check sets `cachedLatest` independently, so when an update notification is pending, the `main().then` update flow runs and dereferences the unassigned client:

- `canAutoUpdate(client, ...)` reads `client.config` (`src/util/updates.ts`)
- `promptAndUpgrade(client, ...)` uses `client.input.confirm`

→ TypeError → `.catch(handleUnexpected)` → "An unexpected error occurred!" + Sentry report + exit 1, after the command's real output already printed.

## Fix

Skip the update-notification block when `client` was never constructed. Any run that reaches command dispatch has `client` assigned, so command behavior is unchanged; the guard only affects paths that already returned before setup.

## Notes

Found while reviewing #17119 (not proceeding with that PR); this is the standalone pre-existing bug extracted from it. No feasible unit harness exists for `main()`'s post-run block — verified by code trace of the full chain (`cachedLatest` set at module scope → gate → `canAutoUpdate` → `client.config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)