### PR TITLE
[cli] Add AI Gateway leaderboard export client + shared render engine

### DIFF
--- a/.changeset/ai-gateway-leaderboard-1-engine.md
+++ b/.changeset/ai-gateway-leaderboard-1-engine.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Internal: add the AI Gateway leaderboard export client (`util/ai-gateway/leaderboard.ts`) and the shared CLI rendering engine (fetch, format resolution, table rendering, file output) used by the forthcoming `ai-gateway leaderboard` subcommands. No user-facing change yet.

--- a/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
@@ -80,7 +80,14 @@ function resolveFormat(
   return { format: interactive ? 'table' : 'json' };
 }
 
-function parseEnum<T extends string>(
+/**
+ * Case-insensitive enum parse that returns the canonical allowed value, so
+ * camelCase members like `imageCount` match `--metric imagecount` (and any
+ * other casing) instead of being rejected by a lowercased comparison.
+ *
+ * Exported for unit tests.
+ */
+export function parseEnum<T extends string>(
   value: string | undefined,
   allowed: readonly T[],
   label: string
@@ -88,13 +95,14 @@ function parseEnum<T extends string>(
   if (value === undefined) {
     return { value: undefined };
   }
-  const normalized = value.toLowerCase() as T;
-  if (!allowed.includes(normalized)) {
+  const normalized = value.toLowerCase();
+  const match = allowed.find(member => member.toLowerCase() === normalized);
+  if (match === undefined) {
     return {
       error: `Invalid ${label}: "${value}". Valid values: ${allowed.join(', ')}`,
     };
   }
-  return { value: normalized };
+  return { value: match };
 }
 
 /** Fetch (json or raw csv) wrapped with the shared spinner + API-error flow. */

--- a/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
@@ -5,7 +5,7 @@ import type Client from '../../util/client';
 import output from '../../output-manager';
 import stamp from '../../util/output/stamp';
 import { isAPIError } from '../../util/errors-ts';
-import { canPrompt } from '../../util/flags/can-prompt';
+import { canPrompt } from '../../util/can-prompt';
 import {
   fetchLeaderboard,
   fetchLeaderboardCsv,

--- a/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
@@ -1,0 +1,394 @@
+import { writeFile } from 'node:fs/promises';
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import stamp from '../../util/output/stamp';
+import { isAPIError } from '../../util/errors-ts';
+import { canPrompt } from '../../util/flags/can-prompt';
+import {
+  fetchLeaderboard,
+  fetchLeaderboardCsv,
+  filterTimeseries,
+  latestDate,
+  availableDates,
+  LEADERBOARD_METRICS,
+  LEADERBOARD_MODALITIES,
+  type LeaderboardFormat,
+  type LeaderboardMetric,
+  type LeaderboardModality,
+  type LeaderboardRankedResponse,
+  type LeaderboardTimeseriesResponse,
+} from '../../util/ai-gateway/leaderboard';
+
+export interface TimeseriesTelemetry {
+  trackCliOptionModality(value?: string): void;
+  trackCliOptionMetric(value?: string): void;
+  trackCliOptionDate(value?: string): void;
+  trackCliOptionFormat(value?: string): void;
+  trackCliOptionOut(value?: string): void;
+}
+
+export interface RankedTelemetry {
+  trackCliOptionFormat(value?: string): void;
+  trackCliOptionOut(value?: string): void;
+}
+
+interface LeaderboardFlags {
+  '--format'?: string;
+  '--out'?: string;
+  '--modality'?: string;
+  '--metric'?: string;
+  '--date'?: string;
+}
+
+const dash = () => chalk.gray('–');
+
+/**
+ * Resolve the output representation. Explicit `--format` always wins; otherwise
+ * a real terminal gets the pretty table and everything else (pipes, CI,
+ * `--non-interactive`, `--out`) gets machine-readable JSON. CSV is opt-in only.
+ */
+function resolveFormat(
+  client: Client,
+  flags: LeaderboardFlags
+): { format: LeaderboardFormat } | { error: string } {
+  const raw = flags['--format'];
+  const out = flags['--out'];
+
+  if (raw !== undefined) {
+    const format = raw.toLowerCase();
+    if (format !== 'table' && format !== 'json' && format !== 'csv') {
+      return {
+        error: `Invalid format: "${raw}". Valid formats: table, json, csv`,
+      };
+    }
+    if (format === 'table' && out !== undefined) {
+      return {
+        error:
+          'Cannot write the table view to a file. Use --format json or --format csv with --out.',
+      };
+    }
+    return { format };
+  }
+
+  if (out !== undefined) {
+    return { format: 'json' };
+  }
+
+  const interactive = Boolean(client.stdout.isTTY) && !client.nonInteractive;
+  return { format: interactive ? 'table' : 'json' };
+}
+
+function parseEnum<T extends string>(
+  value: string | undefined,
+  allowed: readonly T[],
+  label: string
+): { value: T | undefined } | { error: string } {
+  if (value === undefined) {
+    return { value: undefined };
+  }
+  const normalized = value.toLowerCase() as T;
+  if (!allowed.includes(normalized)) {
+    return {
+      error: `Invalid ${label}: "${value}". Valid values: ${allowed.join(', ')}`,
+    };
+  }
+  return { value: normalized };
+}
+
+/** Fetch (json or raw csv) wrapped with the shared spinner + API-error flow. */
+async function fetchWithSpinner<T>(
+  fetch: () => Promise<T>,
+  spinnerText: string
+): Promise<{ data: T } | { exitCode: number }> {
+  output.spinner(spinnerText);
+  try {
+    const data = await fetch();
+    output.stopSpinner();
+    return { data };
+  } catch (err: unknown) {
+    output.stopSpinner();
+    if (isAPIError(err)) {
+      output.error(err.message);
+      return { exitCode: 1 };
+    }
+    throw err;
+  }
+}
+
+async function writeToFile(
+  client: Client,
+  out: string,
+  content: string,
+  label: string
+): Promise<number> {
+  const writeStamp = stamp();
+  try {
+    await writeFile(out, content);
+  } catch (err: unknown) {
+    output.error(
+      `Failed to write ${out}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return 1;
+  }
+  output.log(`Wrote ${label} to ${chalk.bold(out)} ${writeStamp()}`);
+  return 0;
+}
+
+/** Shared entry point for the `models` and `labs` (time-series) leaderboards. */
+export async function runTimeseriesLeaderboard(
+  client: Client,
+  flags: LeaderboardFlags,
+  telemetry: TimeseriesTelemetry,
+  config: {
+    dataset: 'models' | 'labs';
+    /** Column header for the entity, e.g. `model` or `lab`. */
+    entityLabel: string;
+    label: string;
+  }
+): Promise<number> {
+  telemetry.trackCliOptionModality(flags['--modality']);
+  telemetry.trackCliOptionMetric(flags['--metric']);
+  telemetry.trackCliOptionDate(flags['--date']);
+  telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliOptionOut(flags['--out']);
+
+  const formatResult = resolveFormat(client, flags);
+  if ('error' in formatResult) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const { format } = formatResult;
+
+  const modalityResult = parseEnum(
+    flags['--modality'],
+    LEADERBOARD_MODALITIES,
+    'modality'
+  );
+  if ('error' in modalityResult) {
+    output.error(modalityResult.error);
+    return 1;
+  }
+  const metricResult = parseEnum(
+    flags['--metric'],
+    LEADERBOARD_METRICS,
+    'metric'
+  );
+  if ('error' in metricResult) {
+    output.error(metricResult.error);
+    return 1;
+  }
+
+  let modality: LeaderboardModality | undefined = modalityResult.value;
+  let metric: LeaderboardMetric | undefined = metricResult.value;
+
+  // In an interactive terminal showing the table, let the user pick the
+  // dimensions they didn't pass. Machine output (json/csv/--out) never prompts.
+  if (format === 'table' && canPrompt(client)) {
+    if (modality === undefined) {
+      modality = await client.input.select<LeaderboardModality>({
+        message: 'Modality',
+        choices: LEADERBOARD_MODALITIES.map(value => ({ name: value, value })),
+        default: 'all',
+      });
+    }
+    if (metric === undefined) {
+      metric = await client.input.select<LeaderboardMetric>({
+        message: 'Metric',
+        choices: LEADERBOARD_METRICS.map(value => ({ name: value, value })),
+        default: 'requests',
+      });
+    }
+  }
+
+  const resolvedModality = modality ?? 'all';
+  const resolvedMetric = metric ?? 'requests';
+
+  // CSV is passed through verbatim; --modality still applies server-side.
+  if (format === 'csv') {
+    const result = await fetchWithSpinner(
+      () =>
+        fetchLeaderboardCsv(client, {
+          dataset: config.dataset,
+          modality: resolvedModality,
+        }),
+      `Fetching ${config.label}`
+    );
+    if ('exitCode' in result) return result.exitCode;
+    if (flags['--out'] !== undefined) {
+      return writeToFile(client, flags['--out'], result.data, config.label);
+    }
+    client.stdout.write(result.data);
+    return 0;
+  }
+
+  const result = await fetchWithSpinner(
+    () =>
+      fetchLeaderboard(client, {
+        dataset: config.dataset,
+        modality: resolvedModality,
+      }),
+    `Fetching ${config.label}`
+  );
+  if ('exitCode' in result) return result.exitCode;
+  const data = result.data;
+
+  if (format === 'json') {
+    const content = `${JSON.stringify(data, null, 2)}\n`;
+    if (flags['--out'] !== undefined) {
+      return writeToFile(client, flags['--out'], content, config.label);
+    }
+    client.stdout.write(content);
+    return 0;
+  }
+
+  // Table view: collapse to one metric on one day, ranked by share.
+  return renderTimeseriesTable(client, data, {
+    metric: resolvedMetric,
+    modality: resolvedModality,
+    date: flags['--date'],
+    entityLabel: config.entityLabel,
+    label: config.label,
+  });
+}
+
+function renderTimeseriesTable(
+  client: Client,
+  data: LeaderboardTimeseriesResponse,
+  options: {
+    metric: LeaderboardMetric;
+    modality: LeaderboardModality;
+    date?: string;
+    entityLabel: string;
+    label: string;
+  }
+): number {
+  const rows = data.rows ?? [];
+
+  if (options.date !== undefined && !rows.some(r => r.date === options.date)) {
+    const dates = availableDates(rows);
+    output.error(
+      `No data for ${options.date}.${dates.length ? ` Available dates: ${dates.slice(0, 5).join(', ')}${dates.length > 5 ? ', …' : ''}` : ''}`
+    );
+    return 1;
+  }
+
+  const filtered = filterTimeseries(rows, {
+    metric: options.metric,
+    date: options.date,
+  });
+
+  if (filtered.length === 0) {
+    output.log(`No ${options.label} data for ${options.metric}.`);
+    return 0;
+  }
+
+  const day = options.date ?? latestDate(rows);
+  output.log(
+    `${options.label} · ${chalk.bold(options.metric)} · ${options.modality} · ${day}`
+  );
+  client.stdout.write(
+    `${table(
+      [
+        ['#', options.entityLabel, 'share'].map(header => chalk.gray(header)),
+        ...filtered.map((row, index) => [
+          String(index + 1),
+          row.name,
+          `${row.share_percent.toFixed(2)}%`,
+        ]),
+      ],
+      { align: ['r', 'l', 'r'], hsep: 3 }
+    ).replace(/^/gm, '  ')}\n`
+  );
+  printLicense();
+  return 0;
+}
+
+/** Shared entry point for the `apps` and `providers` (ranked) leaderboards. */
+export async function runRankedLeaderboard(
+  client: Client,
+  flags: LeaderboardFlags,
+  telemetry: RankedTelemetry,
+  config: { dataset: 'apps' | 'providers'; label: string }
+): Promise<number> {
+  telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliOptionOut(flags['--out']);
+
+  const formatResult = resolveFormat(client, flags);
+  if ('error' in formatResult) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const { format } = formatResult;
+
+  if (format === 'csv') {
+    const result = await fetchWithSpinner(
+      () => fetchLeaderboardCsv(client, { dataset: config.dataset }),
+      `Fetching ${config.label}`
+    );
+    if ('exitCode' in result) return result.exitCode;
+    if (flags['--out'] !== undefined) {
+      return writeToFile(client, flags['--out'], result.data, config.label);
+    }
+    client.stdout.write(result.data);
+    return 0;
+  }
+
+  const result = await fetchWithSpinner(
+    () => fetchLeaderboard(client, { dataset: config.dataset }),
+    `Fetching ${config.label}`
+  );
+  if ('exitCode' in result) return result.exitCode;
+  const data = result.data;
+
+  if (format === 'json') {
+    const content = `${JSON.stringify(data, null, 2)}\n`;
+    if (flags['--out'] !== undefined) {
+      return writeToFile(client, flags['--out'], content, config.label);
+    }
+    client.stdout.write(content);
+    return 0;
+  }
+
+  return renderRankedTable(client, data, config.label);
+}
+
+function renderRankedTable(
+  client: Client,
+  data: LeaderboardRankedResponse,
+  label: string
+): number {
+  const rows = data.rows ?? [];
+  if (rows.length === 0) {
+    output.log(`No ${label} data.`);
+    return 0;
+  }
+
+  const lsStamp = stamp();
+  const rankedBy = rows[0]?.ranked_by;
+  output.log(
+    `${label}${rankedBy ? ` · ${chalk.bold(rankedBy)}` : ''} ${lsStamp()}`
+  );
+  client.stdout.write(
+    `${table(
+      [
+        ['#', 'name', 'description'].map(header => chalk.gray(header)),
+        ...rows.map(row => [
+          String(row.rank),
+          row.name,
+          row.description ? row.description : dash(),
+        ]),
+      ],
+      { align: ['r', 'l', 'l'], hsep: 3 }
+    ).replace(/^/gm, '  ')}\n`
+  );
+  printLicense();
+  return 0;
+}
+
+function printLicense() {
+  output.log(
+    chalk.gray('Source: AI Gateway Leaderboard data, licensed under CC BY 4.0.')
+  );
+}

--- a/packages/cli/src/util/ai-gateway/leaderboard.ts
+++ b/packages/cli/src/util/ai-gateway/leaderboard.ts
@@ -1,0 +1,157 @@
+import type Client from '../client';
+
+// The leaderboards are served from vercel.com, not the AI Gateway host or the
+// api host. Passing an absolute URL to client.fetch bypasses the default api
+// host (new URL(url, apiUrl)). Overridable so tests can route it through the
+// mock server, mirroring VERCEL_AI_GATEWAY_URL in ./models.
+const DEFAULT_LEADERBOARD_BASE = 'https://vercel.com';
+
+export type LeaderboardDataset = 'models' | 'labs' | 'apps' | 'providers';
+export type LeaderboardModality = 'all' | 'text' | 'image' | 'video';
+export type LeaderboardMetric =
+  | 'requests'
+  | 'tokens'
+  | 'spend'
+  | 'imageCount'
+  | 'videoCount';
+/** How the result is rendered. `json`/`csv` are the raw export payload. */
+export type LeaderboardFormat = 'table' | 'json' | 'csv';
+
+export const LEADERBOARD_DATASETS: readonly LeaderboardDataset[] = [
+  'models',
+  'labs',
+  'apps',
+  'providers',
+];
+export const LEADERBOARD_MODALITIES: readonly LeaderboardModality[] = [
+  'all',
+  'text',
+  'image',
+  'video',
+];
+export const LEADERBOARD_METRICS: readonly LeaderboardMetric[] = [
+  'requests',
+  'tokens',
+  'spend',
+  'imageCount',
+  'videoCount',
+];
+
+/** `models` and `labs`: one entity's share of one metric on one day. */
+export type LeaderboardTimeseriesRow = {
+  date: string;
+  group: 'model' | 'lab';
+  name: string;
+  metric: LeaderboardMetric;
+  modality: LeaderboardModality;
+  share_percent: number;
+};
+
+/** `apps` and `providers`: one ranked entity. */
+export type LeaderboardRankedRow = {
+  rank: number;
+  name: string;
+  ranked_by: string;
+  url: string;
+  description: string;
+};
+
+type LeaderboardResponseBase = {
+  dataset: LeaderboardDataset;
+  license: string;
+  license_url: string;
+};
+
+export type LeaderboardTimeseriesResponse = LeaderboardResponseBase & {
+  dataset: 'models' | 'labs';
+  modality: LeaderboardModality;
+  rows: LeaderboardTimeseriesRow[];
+};
+
+export type LeaderboardRankedResponse = LeaderboardResponseBase & {
+  dataset: 'apps' | 'providers';
+  rows: LeaderboardRankedRow[];
+};
+
+export interface LeaderboardQuery {
+  dataset: LeaderboardDataset;
+  /** Only meaningful for `models`/`labs`; omitted otherwise. */
+  modality?: LeaderboardModality;
+}
+
+function leaderboardBase(): string {
+  return process.env.VERCEL_LEADERBOARD_URL ?? DEFAULT_LEADERBOARD_BASE;
+}
+
+function buildUrl(query: LeaderboardQuery, format: 'json' | 'csv'): string {
+  const params = new URLSearchParams();
+  params.set('dataset', query.dataset);
+  if (query.modality) {
+    params.set('modality', query.modality);
+  }
+  params.set('format', format);
+  return `${leaderboardBase()}/api/ai/leaderboard-export?${params.toString()}`;
+}
+
+/** Fetch the leaderboard as the structured JSON export payload. */
+export async function fetchLeaderboard(
+  client: Client,
+  query: LeaderboardQuery & { dataset: 'models' | 'labs' }
+): Promise<LeaderboardTimeseriesResponse>;
+export async function fetchLeaderboard(
+  client: Client,
+  query: LeaderboardQuery & { dataset: 'apps' | 'providers' }
+): Promise<LeaderboardRankedResponse>;
+export async function fetchLeaderboard(
+  client: Client,
+  query: LeaderboardQuery
+): Promise<LeaderboardTimeseriesResponse | LeaderboardRankedResponse> {
+  return client.fetch(buildUrl(query, 'json'), { method: 'GET' });
+}
+
+/** Fetch the leaderboard as the raw CSV export, passed through verbatim. */
+export async function fetchLeaderboardCsv(
+  client: Client,
+  query: LeaderboardQuery
+): Promise<string> {
+  const res = await client.fetch(buildUrl(query, 'csv'), {
+    method: 'GET',
+    json: false,
+  });
+  return res.text();
+}
+
+/** The most recent day present in a time-series result, or undefined. */
+export function latestDate(
+  rows: LeaderboardTimeseriesRow[]
+): string | undefined {
+  let max: string | undefined;
+  for (const row of rows) {
+    if (max === undefined || row.date > max) {
+      max = row.date;
+    }
+  }
+  return max;
+}
+
+/** Distinct dates present, most recent first (for error hints). */
+export function availableDates(rows: LeaderboardTimeseriesRow[]): string[] {
+  return Array.from(new Set(rows.map(r => r.date))).sort((a, b) =>
+    a < b ? 1 : a > b ? -1 : 0
+  );
+}
+
+/**
+ * Collapse the full time-series (every day × metric) to the rows shown in the
+ * human table: a single metric on a single day, ranked by share descending.
+ * Modality is already applied server-side. Defaults to the latest day.
+ */
+export function filterTimeseries(
+  rows: LeaderboardTimeseriesRow[],
+  options: { metric: LeaderboardMetric; date?: string }
+): LeaderboardTimeseriesRow[] {
+  const day = options.date ?? latestDate(rows);
+  return rows
+    .filter(row => row.metric === options.metric && row.date === day)
+    .sort((a, b) => b.share_percent - a.share_percent);
+}

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-shared.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-shared.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnum } from '../../../../src/commands/ai-gateway/leaderboard-shared';
+import { LEADERBOARD_METRICS } from '../../../../src/util/ai-gateway/leaderboard';
+
+describe('ai-gateway leaderboard-shared parseEnum', () => {
+  it('accepts camelCase members regardless of input casing', () => {
+    expect(parseEnum('imageCount', LEADERBOARD_METRICS, 'metric')).toEqual({
+      value: 'imageCount',
+    });
+    expect(parseEnum('imagecount', LEADERBOARD_METRICS, 'metric')).toEqual({
+      value: 'imageCount',
+    });
+    expect(parseEnum('VIDEOCOUNT', LEADERBOARD_METRICS, 'metric')).toEqual({
+      value: 'videoCount',
+    });
+  });
+
+  it('accepts lowercase members case-insensitively', () => {
+    expect(parseEnum('Requests', LEADERBOARD_METRICS, 'metric')).toEqual({
+      value: 'requests',
+    });
+  });
+
+  it('passes undefined through', () => {
+    expect(parseEnum(undefined, LEADERBOARD_METRICS, 'metric')).toEqual({
+      value: undefined,
+    });
+  });
+
+  it('rejects unknown values with the valid list', () => {
+    expect(parseEnum('bogus', LEADERBOARD_METRICS, 'metric')).toEqual({
+      error: `Invalid metric: "bogus". Valid values: ${LEADERBOARD_METRICS.join(', ')}`,
+    });
+  });
+});

--- a/packages/cli/test/unit/util/ai-gateway/leaderboard.test.ts
+++ b/packages/cli/test/unit/util/ai-gateway/leaderboard.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  latestDate,
+  availableDates,
+  filterTimeseries,
+  type LeaderboardTimeseriesRow,
+} from '../../../../src/util/ai-gateway/leaderboard';
+
+const rows = [
+  ['2026-05-17', 'A', 'requests', 10],
+  ['2026-05-18', 'A', 'requests', 30],
+  ['2026-05-18', 'B', 'requests', 50],
+  ['2026-05-18', 'C', 'spend', 99],
+].map(
+  ([date, name, metric, share_percent]) =>
+    ({
+      date,
+      name,
+      metric,
+      share_percent,
+      group: 'model',
+      modality: 'all',
+    }) as LeaderboardTimeseriesRow
+);
+
+describe('ai-gateway leaderboard util', () => {
+  it('latestDate / availableDates read the day axis', () => {
+    expect(latestDate(rows)).toBe('2026-05-18');
+    expect(latestDate([])).toBeUndefined();
+    expect(availableDates(rows)).toEqual(['2026-05-18', '2026-05-17']);
+  });
+
+  it('filterTimeseries picks one metric on one day, ranked by share', () => {
+    expect(
+      filterTimeseries(rows, { metric: 'requests' }).map(r => r.name)
+    ).toEqual(['B', 'A']);
+    expect(
+      filterTimeseries(rows, { metric: 'requests', date: '2026-05-17' }).map(
+        r => r.name
+      )
+    ).toEqual(['A']);
+  });
+});


### PR DESCRIPTION
## Why

Groundwork for `vercel ai-gateway leaderboard` (split out of a larger change to keep each PR reviewable). This PR adds the data + rendering layer only; the user-facing subcommands land in stacked follow-ups.

## Summary

- `util/ai-gateway/leaderboard.ts`: typed client for `GET /api/ai/leaderboard-export` (JSON + raw CSV), plus latest-day / metric filtering helpers.
- `leaderboard-shared.ts`: the shared command engine — TTY-aware format resolution, spinner + API-error handling, ranked/time-series table rendering, and `--out` file writing.
- Unit test for the pure filtering helpers.

**Stacked:** base is `ai-gateway-api-keys-crud` (#17134). Followed by `models` then `labs`/`apps`/`providers`.

▲ Created with [Vercel devbox](https://vercel.com/vercel/~/sandboxes/devboxes/2ylk0uyl04uih99ubpgl2boesp4h)