### PR TITLE
[cli] Add --base-url flag and gateway compat endpoints to coding-agen…

### DIFF
--- a/.changeset/coding-agents-base-url.md
+++ b/.changeset/coding-agents-base-url.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+Add a `--base-url` flag to `vercel ai-gateway coding-agents setup` to point Codex and Claude Code at a different AI Gateway base URL (e.g. a preview deployment). When set, the value is written verbatim into each agent's config, so you own correctness when mixing API styles in one run.
+
+Codex and Claude Code now default to their gateway compatibility endpoints — `https://ai-gateway.vercel.sh/codex/v1` and `https://ai-gateway.vercel.sh/claude-code` (Anthropic style, no `/v1`) — instead of the generic gateway URLs. Claude Code's settings also set `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` so it discovers the gateway's model catalog. OpenCode and Pi are unaffected — they use their native gateway providers.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
@@ -101,6 +101,7 @@ export default async function codingAgentsSetup(
   const agentConfig = opts['--agent-config'] as string[] | undefined;
   const shellRcOverride = opts['--shell-rc'] as string | undefined;
   const applyMode = opts['--apply'] as string | undefined;
+  const baseUrl = opts['--base-url'] as string | undefined;
   const yes = opts['--yes'] as boolean | undefined;
 
   telemetry.trackCliOptionAgent(agentFlags as [string] | undefined);
@@ -118,6 +119,7 @@ export default async function codingAgentsSetup(
   telemetry.trackCliOptionAgentConfig(agentConfig);
   telemetry.trackCliOptionShellRc(shellRcOverride);
   telemetry.trackCliOptionApply(applyMode);
+  telemetry.trackCliOptionBaseUrl(baseUrl);
   telemetry.trackCliFlagYes(yes);
 
   const machine = shouldEmitNonInteractiveCommandError(client);
@@ -167,6 +169,14 @@ export default async function codingAgentsSetup(
       machine,
       AGENT_REASON.INVALID_ARGUMENTS,
       'The `--apply prompt` mode needs the macOS Keychain so the prompt never contains your plaintext key. Run on macOS without --no-keychain, or use `--apply edit`.'
+    );
+  }
+  if (baseUrl !== undefined && !isValidBaseUrl(baseUrl)) {
+    return failValidation(
+      client,
+      machine,
+      AGENT_REASON.INVALID_ARGUMENTS,
+      `Invalid --base-url "${baseUrl}". Must be an http(s) URL.`
     );
   }
   const flagExpiresAt =
@@ -370,12 +380,23 @@ export default async function codingAgentsSetup(
       }
     }
   }
+  if (
+    baseUrl &&
+    !machine &&
+    !agents.some(a => a.id === 'codex' || a.id === 'claude-code')
+  ) {
+    printWarning(
+      '--base-url has no effect for the selected agents; only Claude Code and Codex write a gateway base URL.'
+    );
+  }
+
   const previewPlan = await buildSetupPlan(agents, {
     apiKey: previewKey,
     home,
     useKeychain,
     overrides,
     shellRcOverride,
+    baseUrlOverride: baseUrl,
   });
 
   const changed = previewPlan.changes.filter(
@@ -406,6 +427,7 @@ export default async function codingAgentsSetup(
       useKeychain,
       overrides,
       shellRcOverride,
+      baseUrlOverride: baseUrl,
       home,
       alreadyConfigured,
       // With nothing consented there is nothing to rotate or reconfigure.
@@ -568,6 +590,7 @@ export default async function codingAgentsSetup(
     useKeychain,
     overrides,
     shellRcOverride,
+    baseUrlOverride: baseUrl,
   });
 
   if (applyAction === 'copy') {
@@ -708,6 +731,15 @@ function failConsent(
     output.error(message);
   }
   return 1;
+}
+
+function isValidBaseUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 function failValidation(

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -358,6 +358,15 @@ export const setupSubcommand = {
       description:
         'How to apply non-interactively: edit (write files, default) or prompt (emit an agent prompt on stdout; requires the macOS Keychain)',
     },
+    {
+      name: 'base-url',
+      shorthand: null,
+      type: String,
+      argument: 'URL',
+      deprecated: false,
+      description:
+        'Override the AI Gateway base URL written into agent configs (advanced; e.g. a preview deployment). Written verbatim.',
+    },
     yesOption,
   ],
   examples: [
@@ -380,6 +389,10 @@ export const setupSubcommand = {
     {
       name: 'Reuse an existing key and preview changes only',
       value: `${packageName} ai-gateway coding-agents setup --key <key> --dry-run`,
+    },
+    {
+      name: 'Point an agent at a different gateway base URL',
+      value: `${packageName} ai-gateway coding-agents setup --agent codex --base-url https://preview.ai-gateway.vercel.sh/v1`,
     },
   ],
 } as const;

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -1,7 +1,10 @@
 import { join } from 'node:path';
 import type { CodingAgent, EnvExport } from '../types';
 import { mergeJson, pathExists } from '../config-files';
-import { GATEWAY_ANTHROPIC_BASE_URL } from '../gateway';
+import {
+  GATEWAY_CLAUDE_CODE_BASE_URL,
+  resolveGatewayBaseUrl,
+} from '../gateway';
 
 /**
  * Claude Code reads env vars from the `env` object in `~/.claude/settings.json`.
@@ -40,8 +43,12 @@ export const claudeCode: CodingAgent = {
   buildPlan(ctx) {
     const path = this.configPath(ctx);
     const env: Record<string, string> = {
-      ANTHROPIC_BASE_URL: GATEWAY_ANTHROPIC_BASE_URL,
+      ANTHROPIC_BASE_URL: resolveGatewayBaseUrl(
+        ctx.baseUrlOverride,
+        GATEWAY_CLAUDE_CODE_BASE_URL
+      ),
       ANTHROPIC_API_KEY: '',
+      CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: '1',
     };
     const envExports: EnvExport[] = [];
     if (ctx.useKeychain) {

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
@@ -2,7 +2,11 @@ import { join } from 'node:path';
 import type { AgentWarning, CodingAgent } from '../types';
 import { mergeToml, pathExists } from '../config-files';
 import { isMacAppInstalled } from '../desktop-apps';
-import { GATEWAY_OPENAI_BASE_URL, GATEWAY_API_KEY_ENV } from '../gateway';
+import {
+  GATEWAY_CODEX_BASE_URL,
+  GATEWAY_API_KEY_ENV,
+  resolveGatewayBaseUrl,
+} from '../gateway';
 
 /** The Codex desktop app shares `~/.codex/config.toml` with the CLI. */
 const CODEX_DESKTOP_APP = 'Codex.app';
@@ -69,7 +73,10 @@ export const codex: CodingAgent = {
               model_providers: {
                 vercel: {
                   name: 'Vercel AI Gateway',
-                  base_url: GATEWAY_OPENAI_BASE_URL,
+                  base_url: resolveGatewayBaseUrl(
+                    ctx.baseUrlOverride,
+                    GATEWAY_CODEX_BASE_URL
+                  ),
                   env_key: GATEWAY_API_KEY_ENV,
                   wire_api: 'responses',
                 },

--- a/packages/cli/src/util/ai-gateway/coding-agents/gateway.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/gateway.ts
@@ -1,9 +1,22 @@
 export const GATEWAY_OPENAI_BASE_URL = 'https://ai-gateway.vercel.sh/v1';
 export const GATEWAY_ANTHROPIC_BASE_URL = 'https://ai-gateway.vercel.sh';
 
+export const GATEWAY_CODEX_BASE_URL = 'https://ai-gateway.vercel.sh/codex/v1';
+
+export const GATEWAY_CLAUDE_CODE_BASE_URL =
+  'https://ai-gateway.vercel.sh/claude-code';
+
 export const GATEWAY_API_KEY_ENV = 'AI_GATEWAY_API_KEY';
 
 export const KEY_PLACEHOLDER = '__AI_GATEWAY_API_KEY__';
+
+export function resolveGatewayBaseUrl(
+  override: string | undefined,
+  agentDefault: string
+): string {
+  const trimmed = override?.trim();
+  return trimmed ? trimmed : agentDefault;
+}
 
 export function maskSecret(secret: string): string {
   if (!secret) return secret;

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -23,6 +23,7 @@ export async function runMachine(args: {
   useKeychain: boolean;
   overrides?: Record<string, string>;
   shellRcOverride?: string;
+  baseUrlOverride?: string;
   home: string;
   alreadyConfigured: boolean;
   reconfigure: boolean;
@@ -171,6 +172,7 @@ export async function runMachine(args: {
     useKeychain,
     overrides: args.overrides,
     shellRcOverride: args.shellRcOverride,
+    baseUrlOverride: args.baseUrlOverride,
   });
 
   if (args.promptMode) {

--- a/packages/cli/src/util/ai-gateway/coding-agents/types.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/types.ts
@@ -4,6 +4,7 @@ export interface SetupContext {
   useKeychain?: boolean;
   overrides?: Record<string, string>;
   shellRcOverride?: string;
+  baseUrlOverride?: string;
 }
 
 export type FileFormat = 'json' | 'toml' | 'shell';

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/coding-agents-setup.ts
@@ -105,6 +105,12 @@ export class AiGatewayCodingAgentsSetupTelemetryClient
     }
   }
 
+  trackCliOptionBaseUrl(baseUrl: string | undefined) {
+    if (baseUrl) {
+      this.trackCliOption({ option: 'base-url', value: this.redactedValue });
+    }
+  }
+
   trackCliFlagYes(yes: boolean | undefined) {
     if (yes) {
       this.trackCliFlag('yes');

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -203,10 +203,11 @@ describe('ai-gateway coding-agents setup', () => {
 
       const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
       expect(settings.env.ANTHROPIC_BASE_URL).toBe(
-        'https://ai-gateway.vercel.sh'
+        'https://ai-gateway.vercel.sh/claude-code'
       );
       expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('vck_DummyKey0001');
       expect(settings.env.ANTHROPIC_API_KEY).toBe('');
+      expect(settings.env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY).toBe('1');
 
       const out = JSON.parse(client.stdout.getFullOutput());
       expect(out.status).toBe('ok');
@@ -240,7 +241,7 @@ describe('ai-gateway coding-agents setup', () => {
         // We never pin a default model — only the provider/URL/auth are set up.
         expect(toml.model).toBeUndefined();
         expect(toml.model_providers.vercel.base_url).toBe(
-          'https://ai-gateway.vercel.sh/v1'
+          'https://ai-gateway.vercel.sh/codex/v1'
         );
         expect(toml.model_providers.vercel.wire_api).toBe('responses');
         expect(toml.model_providers.vercel.env_key).toBe('AI_GATEWAY_API_KEY');
@@ -252,6 +253,74 @@ describe('ai-gateway coding-agents setup', () => {
         );
       }
     );
+
+    it('writes a --base-url override verbatim into the Codex config', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0002',
+        '--agent',
+        'codex',
+        '--base-url',
+        'https://preview.ai-gateway.vercel.sh/v1'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const toml = tomlParse(readFileSync(codexConfigPath(), 'utf8')) as any;
+      expect(toml.model_providers.vercel.base_url).toBe(
+        'https://preview.ai-gateway.vercel.sh/v1'
+      );
+    });
+
+    it('writes a --base-url override verbatim into Claude Code settings', async () => {
+      useUser();
+      client.nonInteractive = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0001',
+        '--agent',
+        'claude-code',
+        '--base-url',
+        'https://preview.ai-gateway.vercel.sh'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const settings = JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
+      expect(settings.env.ANTHROPIC_BASE_URL).toBe(
+        'https://preview.ai-gateway.vercel.sh'
+      );
+    });
+
+    it('rejects an invalid --base-url without writing config', async () => {
+      useUser();
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0002',
+        '--agent',
+        'codex',
+        '--base-url',
+        'not-a-url'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid --base-url');
+      expect(existsSync(codexConfigPath())).toBe(false);
+    });
 
     // Shell rc management is intentionally skipped on Windows.
     it.skipIf(process.platform === 'win32')(
@@ -1719,9 +1788,10 @@ describe('ai-gateway coding-agents setup', () => {
       expect(settings.env.FOO).toBe('bar');
       // …and the gateway keys land alongside them.
       expect(settings.env.ANTHROPIC_BASE_URL).toBe(
-        'https://ai-gateway.vercel.sh'
+        'https://ai-gateway.vercel.sh/claude-code'
       );
       expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('vck_MergeKey0001');
+      expect(settings.env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY).toBe('1');
     });
 
     it('keeps the existing file formatting; only the added keys change the file', async () => {


### PR DESCRIPTION
## Summary

Adds configurable AI Gateway base URLs to `vercel ai-gateway coding-agents setup`:

- **Per-agent compatibility endpoints (agent-owned defaults).** Codex now defaults to `https://ai-gateway.vercel.sh/codex/v1` (was the generic `/v1`) and Claude Code to `https://ai-gateway.vercel.sh/claude-code` (Anthropic style, no `/v1` — the SDK appends `/v1/messages`).
- **`--base-url` flag.** When set, the value is written **verbatim** into Codex and Claude Code configs, overriding the per-agent default (e.g. point a run at a preview deployment). Non-`http(s)` values are rejected. OpenCode and Pi are unchanged — they use their native `@ai-sdk/gateway` providers.
- **Claude Code model discovery.** Its `settings.json` `env` block now also sets `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` so it discovers the gateway's model catalog.

Precedence: `--base-url` (verbatim) → agent default → generic gateway URL.

## Example

```bash
vercel ai-gateway coding-agents setup --agent codex \
  --base-url https://preview.ai-gateway.vercel.sh/v1
```

Resulting Claude Code `settings.json`:

```json
{
  "env": {
    "ANTHROPIC_BASE_URL": "https://ai-gateway.vercel.sh/claude-code",
    "ANTHROPIC_API_KEY": "",
    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
    "ANTHROPIC_AUTH_TOKEN": "<key>"
  }
}
```

## Testing

- `pnpm vitest-run test/unit/commands/ai-gateway/coding-agents-setup.test.ts` — **112/112 pass**, including new tests for the verbatim override (Codex + Claude Code) and invalid-URL rejection, plus updated default-endpoint assertions.
- Type-check clean for the changed files; biome format + lint passed via pre-commit.

## Notes

- CLI-only change: the gateway backend must serve `/codex/v1` and `/claude-code` for these defaults to route.
- Because `--base-url` is written verbatim, selecting Codex **and** Claude Code together with a single `/v1`-suffixed URL writes `/v1` into Claude Code's config (wrong for the Anthropic style). A warning is emitted when `--base-url` has no effect for native-provider agents; there is no hard guard against mixing styles.

▲ Created with [Vercel devbox](https://vercel.com/vercel/~/sandboxes/devboxes/1ai8co7s82yt3wttx1n8rxntjbnl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
