### PR TITLE
[cli] Add `ai-gateway leaderboard models`

### DIFF
--- a/.changeset/ai-gateway-leaderboard-2-models.md
+++ b/.changeset/ai-gateway-leaderboard-2-models.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel ai-gateway leaderboard models`, exposing the AI Gateway models usage leaderboard from the CLI. Supports `--modality`, `--metric`, and `--date`, a pretty table in interactive terminals with JSON by default when piped, `--format table|json|csv`, and `--out` to write the payload to a file.

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -598,6 +598,78 @@ export const budgetsRemoveSubcommand = {
   ],
 } as const;
 
+const leaderboardFormatOption = {
+  name: 'format',
+  shorthand: 'F',
+  type: String,
+  argument: 'FORMAT',
+  deprecated: false,
+  description:
+    'Output format: table, json, or csv (default: table in a terminal, json otherwise)',
+} as const;
+
+const leaderboardOutOption = {
+  name: 'out',
+  shorthand: 'o',
+  type: String,
+  argument: 'FILE',
+  deprecated: false,
+  description:
+    'Write the payload to a file instead of stdout (defaults to json; use --format csv for CSV)',
+} as const;
+
+const leaderboardModalityOption = {
+  name: 'modality',
+  shorthand: null,
+  type: String,
+  argument: 'MODALITY',
+  deprecated: false,
+  description: 'Filter by modality: all, text, image, or video (default: all)',
+} as const;
+
+const leaderboardMetricOption = {
+  name: 'metric',
+  shorthand: null,
+  type: String,
+  argument: 'METRIC',
+  deprecated: false,
+  description:
+    'Metric for the table view: requests, tokens, spend, imageCount, or videoCount (default: requests)',
+} as const;
+
+const leaderboardDateOption = {
+  name: 'date',
+  shorthand: null,
+  type: String,
+  argument: 'YYYY-MM-DD',
+  deprecated: false,
+  description: 'Day to show in the table view (default: most recent)',
+} as const;
+
+export const leaderboardModelsSubcommand = {
+  name: 'models',
+  aliases: [],
+  description: 'Show the most-used models on AI Gateway',
+  arguments: [],
+  options: [
+    leaderboardModalityOption,
+    leaderboardMetricOption,
+    leaderboardDateOption,
+    leaderboardFormatOption,
+    leaderboardOutOption,
+  ],
+  examples: [
+    {
+      name: 'Show the top text models',
+      value: `${packageName} ai-gateway leaderboard models --modality text`,
+    },
+    {
+      name: 'Export the full model data as CSV',
+      value: `${packageName} ai-gateway leaderboard models --format csv --out models.csv`,
+    },
+  ],
+} as const;
+
 export const budgetsSubcommand = {
   name: 'budgets',
   aliases: [],
@@ -608,6 +680,17 @@ export const budgetsSubcommand = {
     budgetsListSubcommand,
     budgetsRemoveSubcommand,
   ],
+  options: [],
+  examples: [],
+} as const;
+
+export const leaderboardSubcommand = {
+  name: 'leaderboard',
+  aliases: ['leaderboards'],
+  description:
+    'Explore AI Gateway usage leaderboards (open, anonymized data under CC BY 4.0)',
+  arguments: [],
+  subcommands: [leaderboardModelsSubcommand],
   options: [],
   examples: [],
 } as const;
@@ -623,6 +706,7 @@ export const aiGatewayCommand = {
     rulesSubcommand,
     codingAgentsSubcommand,
     modelsSubcommand,
+    leaderboardSubcommand,
   ],
   options: [],
   examples: [],

--- a/packages/cli/src/commands/ai-gateway/index.ts
+++ b/packages/cli/src/commands/ai-gateway/index.ts
@@ -7,6 +7,7 @@ import budgets from './budgets';
 import rules from './rules';
 import codingAgents from './coding-agents';
 import models from './models';
+import leaderboard from './leaderboard';
 import {
   aiGatewayCommand,
   apiKeysSubcommand,
@@ -14,6 +15,7 @@ import {
   rulesSubcommand,
   codingAgentsSubcommand,
   modelsSubcommand,
+  leaderboardSubcommand,
 } from './command';
 import { help } from '../help';
 import { getCommandAliases } from '..';
@@ -27,6 +29,7 @@ const COMMAND_CONFIG = {
   rules: getCommandAliases(rulesSubcommand),
   'coding-agents': getCommandAliases(codingAgentsSubcommand),
   models: getCommandAliases(modelsSubcommand),
+  leaderboard: getCommandAliases(leaderboardSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -76,6 +79,9 @@ export default async function main(client: Client) {
     case 'models':
       telemetry.trackCliSubcommandModels(subcommandOriginal);
       return models(client);
+    case 'leaderboard':
+      telemetry.trackCliSubcommandLeaderboard(subcommandOriginal);
+      return leaderboard(client);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('ai-gateway', subcommandOriginal);

--- a/packages/cli/src/commands/ai-gateway/leaderboard-models.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-models.ts
@@ -1,0 +1,30 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { leaderboardModelsSubcommand } from './command';
+import { runTimeseriesLeaderboard } from './leaderboard-shared';
+import { AiGatewayLeaderboardModelsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-models';
+
+export default async function models(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLeaderboardModelsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardModelsSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  return runTimeseriesLeaderboard(client, parsedArgs.flags, telemetry, {
+    dataset: 'models',
+    entityLabel: 'model',
+    label: 'Top models',
+  });
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard.ts
@@ -1,0 +1,82 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import getSubcommand from '../../util/get-subcommand';
+import { type Command, help } from '../help';
+import models from './leaderboard-models';
+import { leaderboardSubcommand, leaderboardModelsSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { getCommandAliases } from '..';
+import { AiGatewayLeaderboardTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard';
+import { printError } from '../../util/error';
+
+const COMMAND_CONFIG = {
+  models: getCommandAliases(leaderboardModelsSubcommand),
+};
+
+export default async function leaderboard(client: Client) {
+  const telemetry = new AiGatewayLeaderboardTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardSubcommand.options
+  );
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const subArgs = parsedArgs.args.slice(2);
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    subArgs,
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('ai-gateway leaderboard', subcommandOriginal);
+    output.print(
+      help(leaderboardSubcommand, { columns: client.stderr.columns })
+    );
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        parent: leaderboardSubcommand,
+        columns: client.stderr.columns,
+      })
+    );
+  }
+
+  switch (subcommand) {
+    case 'models':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway leaderboard',
+          subcommandOriginal
+        );
+        printHelp(leaderboardModelsSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandModels(subcommandOriginal);
+      return models(client, args);
+    default:
+      output.error(getInvalidSubcommand(COMMAND_CONFIG));
+      output.print(
+        help(leaderboardSubcommand, { columns: client.stderr.columns })
+      );
+      return 2;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/index.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/index.ts
@@ -40,4 +40,11 @@ export class AiGatewayTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandLeaderboard(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'leaderboard',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-models.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-models.ts
@@ -1,0 +1,38 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardModelsSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardModelsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardModelsSubcommand>
+{
+  trackCliOptionModality(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'modality', value });
+    }
+  }
+
+  trackCliOptionMetric(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'metric', value });
+    }
+  }
+
+  trackCliOptionDate(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'date', value });
+    }
+  }
+
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'format', value });
+    }
+  }
+
+  trackCliOptionOut(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'out', value: this.redactedValue });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard.ts
@@ -1,0 +1,12 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardSubcommand>
+{
+  trackCliSubcommandModels(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'models', value: actual });
+  }
+}

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-models.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-models.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { unlinkSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+
+const sampleRows = [
+  {
+    date: '2026-05-18',
+    group: 'model',
+    name: 'Gemini 3 Flash',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 18.1487,
+  },
+  {
+    date: '2026-05-18',
+    group: 'model',
+    name: 'Claude Sonnet 4.6',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 4.1667,
+  },
+  {
+    date: '2026-05-17',
+    group: 'model',
+    name: 'Gemini 3 Flash',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 15.0,
+  },
+  {
+    date: '2026-05-18',
+    group: 'model',
+    name: 'Claude Opus 4.8',
+    metric: 'spend',
+    modality: 'all',
+    share_percent: 22.2,
+  },
+];
+
+const sampleCsv =
+  'date,group,name,metric,modality,share_percent\n2026-05-18,model,Gemini 3 Flash,requests,all,18.15\n';
+
+function useLeaderboard(opts: { rows?: unknown[]; csv?: string } = {}) {
+  let query: Record<string, string> | undefined;
+  client.scenario.get('/api/ai/leaderboard-export', (req, res) => {
+    query = req.query;
+    if (req.query.format === 'csv') {
+      res.setHeader('content-type', 'text/csv');
+      res.end(opts.csv ?? sampleCsv);
+      return;
+    }
+    res.json({
+      dataset: req.query.dataset,
+      modality: req.query.modality,
+      license: 'CC-BY-4.0',
+      license_url: 'https://creativecommons.org/licenses/by/4.0/',
+      rows: opts.rows ?? sampleRows,
+    });
+  });
+  return () => query;
+}
+
+describe('ai-gateway leaderboard models', () => {
+  beforeEach(() => {
+    process.env.VERCEL_LEADERBOARD_URL = client.apiUrl;
+
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = false;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_LEADERBOARD_URL;
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'leaderboard', 'models', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:leaderboard', value: 'leaderboard' },
+        { key: 'flag:help', value: 'ai-gateway leaderboard:models' },
+      ]);
+    });
+  });
+
+  it('outputs JSON by default in a non-TTY', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv('ai-gateway', 'leaderboard', 'models');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"dataset": "models"');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('renders a ranked table with --format table', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv('ai-gateway', 'leaderboard', 'models', '--format', 'table');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('Gemini 3 Flash');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('passes --modality through to the request', async () => {
+    useUser();
+    const getQuery = useLeaderboard();
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'models',
+      '--format',
+      'json',
+      '--modality',
+      'text'
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"rows"');
+    expect(await exitCodePromise).toBe(0);
+    expect(getQuery()?.modality).toBe('text');
+  });
+
+  it('filters the table to the chosen --metric', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'models',
+      '--format',
+      'table',
+      '--metric',
+      'spend'
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('Claude Opus 4.8');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('errors on a --date with no data', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'models',
+      '--format',
+      'table',
+      '--date',
+      '2000-01-01'
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('No data for 2000-01-01');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('passes format=csv through and prints it', async () => {
+    useUser();
+    const getQuery = useLeaderboard();
+    client.setArgv('ai-gateway', 'leaderboard', 'models', '--format', 'csv');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('share_percent');
+    expect(await exitCodePromise).toBe(0);
+    expect(getQuery()?.format).toBe('csv');
+  });
+
+  it('writes to a file with --out', async () => {
+    useUser();
+    useLeaderboard();
+    const out = join(tmpdir(), 'vercel-leaderboard-test.json');
+    if (existsSync(out)) unlinkSync(out);
+    client.setArgv('ai-gateway', 'leaderboard', 'models', '--out', out);
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('Wrote Top models');
+    expect(await exitCodePromise).toBe(0);
+    expect(existsSync(out)).toBe(true);
+    expect(readFileSync(out, 'utf8')).toContain('"dataset": "models"');
+    unlinkSync(out);
+  });
+
+  it('rejects --format table with --out', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'models',
+      '--format',
+      'table',
+      '--out',
+      join(tmpdir(), 'nope.txt')
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('Cannot write the table view');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('rejects an invalid --format', async () => {
+    useUser();
+    useLeaderboard();
+    client.setArgv('ai-gateway', 'leaderboard', 'models', '--format', 'xml');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('Invalid format');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('prompts for modality and metric in an interactive TTY', async () => {
+    useUser();
+    const getQuery = useLeaderboard();
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = true;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = true;
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce('image')
+      .mockResolvedValueOnce('spend');
+    client.input.select = selectMock as never;
+
+    client.setArgv('ai-gateway', 'leaderboard', 'models');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('Claude Opus 4.8');
+    expect(await exitCodePromise).toBe(0);
+    expect(selectMock).toHaveBeenCalledTimes(2);
+    expect(getQuery()?.modality).toBe('image');
+  });
+});


### PR DESCRIPTION
## Summary

Wires the `leaderboard` command group and its first subcommand, `models`, on top of the shared engine (#17152).

- `--modality all|text|image|video`, `--metric`, `--date` shape the view; `--format table|json|csv`; `--out` writes to a file.
- Pretty table in an interactive terminal, JSON when piped / non-interactive; CSV only on request. Interactive terminals prompt for omitted modality/metric.
- Per-subcommand help + telemetry, following the ai-gateway command family.

New unit suite (11 tests). **Stacked on** #17152. (Recreated from #17153, which a stacked-branch update falsely flipped to merged.)

▲ Created with [Vercel devbox](https://vercel.com/vercel/~/sandboxes/devboxes/2ylk0uyl04uih99ubpgl2boesp4h)