### PR TITLE
[cli] Add `ai-gateway leaderboard` labs, apps, providers

### DIFF
--- a/.changeset/ai-gateway-leaderboard-3-ranked.md
+++ b/.changeset/ai-gateway-leaderboard-3-ranked.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel ai-gateway leaderboard labs`, `apps`, and `providers`, completing CLI parity with the AI Gateway leaderboard export endpoint. `labs` mirrors the `models` time series (`--modality`/`--metric`/`--date`); `apps` and `providers` render the ranked top lists. All support `--format table|json|csv` and `--out`.

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -684,13 +684,66 @@ export const budgetsSubcommand = {
   examples: [],
 } as const;
 
+export const leaderboardLabsSubcommand = {
+  name: 'labs',
+  aliases: [],
+  description: 'Show the most-used model creators (labs) on AI Gateway',
+  arguments: [],
+  options: [
+    leaderboardModalityOption,
+    leaderboardMetricOption,
+    leaderboardDateOption,
+    leaderboardFormatOption,
+    leaderboardOutOption,
+  ],
+  examples: [
+    {
+      name: 'Show the top labs by spend',
+      value: `${packageName} ai-gateway leaderboard labs --metric spend`,
+    },
+  ],
+} as const;
+
+export const leaderboardAppsSubcommand = {
+  name: 'apps',
+  aliases: [],
+  description: 'Show the top apps built on AI Gateway',
+  arguments: [],
+  options: [leaderboardFormatOption, leaderboardOutOption],
+  examples: [
+    {
+      name: 'Show the top apps',
+      value: `${packageName} ai-gateway leaderboard apps`,
+    },
+  ],
+} as const;
+
+export const leaderboardProvidersSubcommand = {
+  name: 'providers',
+  aliases: [],
+  description: 'Show the top inference providers on AI Gateway',
+  arguments: [],
+  options: [leaderboardFormatOption, leaderboardOutOption],
+  examples: [
+    {
+      name: 'Show the top providers as JSON',
+      value: `${packageName} ai-gateway leaderboard providers --format json`,
+    },
+  ],
+} as const;
+
 export const leaderboardSubcommand = {
   name: 'leaderboard',
   aliases: ['leaderboards'],
   description:
     'Explore AI Gateway usage leaderboards (open, anonymized data under CC BY 4.0)',
   arguments: [],
-  subcommands: [leaderboardModelsSubcommand],
+  subcommands: [
+    leaderboardModelsSubcommand,
+    leaderboardLabsSubcommand,
+    leaderboardAppsSubcommand,
+    leaderboardProvidersSubcommand,
+  ],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/ai-gateway/leaderboard-apps.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-apps.ts
@@ -1,0 +1,29 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { leaderboardAppsSubcommand } from './command';
+import { runRankedLeaderboard } from './leaderboard-shared';
+import { AiGatewayLeaderboardAppsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-apps';
+
+export default async function apps(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLeaderboardAppsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardAppsSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  return runRankedLeaderboard(client, parsedArgs.flags, telemetry, {
+    dataset: 'apps',
+    label: 'Top apps',
+  });
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard-apps.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-apps.ts
@@ -1,28 +1,14 @@
 import type Client from '../../util/client';
-import { parseArguments } from '../../util/get-args';
-import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/error';
 import { leaderboardAppsSubcommand } from './command';
-import { runRankedLeaderboard } from './leaderboard-shared';
+import { runLeaderboardSubcommand } from './leaderboard-shared';
 import { AiGatewayLeaderboardAppsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-apps';
 
 export default async function apps(client: Client, argv: string[]) {
-  const telemetry = new AiGatewayLeaderboardAppsTelemetryClient({
-    opts: { store: client.telemetryEventStore },
-  });
-
-  let parsedArgs;
-  const flagsSpecification = getFlagsSpecification(
-    leaderboardAppsSubcommand.options
-  );
-  try {
-    parsedArgs = parseArguments(argv, flagsSpecification);
-  } catch (error) {
-    printError(error);
-    return 1;
-  }
-
-  return runRankedLeaderboard(client, parsedArgs.flags, telemetry, {
+  return runLeaderboardSubcommand(client, argv, leaderboardAppsSubcommand, {
+    kind: 'ranked',
+    telemetry: new AiGatewayLeaderboardAppsTelemetryClient({
+      opts: { store: client.telemetryEventStore },
+    }),
     dataset: 'apps',
     label: 'Top apps',
   });

--- a/packages/cli/src/commands/ai-gateway/leaderboard-labs.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-labs.ts
@@ -1,28 +1,14 @@
 import type Client from '../../util/client';
-import { parseArguments } from '../../util/get-args';
-import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/error';
 import { leaderboardLabsSubcommand } from './command';
-import { runTimeseriesLeaderboard } from './leaderboard-shared';
+import { runLeaderboardSubcommand } from './leaderboard-shared';
 import { AiGatewayLeaderboardLabsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-labs';
 
 export default async function labs(client: Client, argv: string[]) {
-  const telemetry = new AiGatewayLeaderboardLabsTelemetryClient({
-    opts: { store: client.telemetryEventStore },
-  });
-
-  let parsedArgs;
-  const flagsSpecification = getFlagsSpecification(
-    leaderboardLabsSubcommand.options
-  );
-  try {
-    parsedArgs = parseArguments(argv, flagsSpecification);
-  } catch (error) {
-    printError(error);
-    return 1;
-  }
-
-  return runTimeseriesLeaderboard(client, parsedArgs.flags, telemetry, {
+  return runLeaderboardSubcommand(client, argv, leaderboardLabsSubcommand, {
+    kind: 'timeseries',
+    telemetry: new AiGatewayLeaderboardLabsTelemetryClient({
+      opts: { store: client.telemetryEventStore },
+    }),
     dataset: 'labs',
     entityLabel: 'lab',
     label: 'Top labs',

--- a/packages/cli/src/commands/ai-gateway/leaderboard-labs.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-labs.ts
@@ -1,0 +1,30 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { leaderboardLabsSubcommand } from './command';
+import { runTimeseriesLeaderboard } from './leaderboard-shared';
+import { AiGatewayLeaderboardLabsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-labs';
+
+export default async function labs(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLeaderboardLabsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardLabsSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  return runTimeseriesLeaderboard(client, parsedArgs.flags, telemetry, {
+    dataset: 'labs',
+    entityLabel: 'lab',
+    label: 'Top labs',
+  });
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard-models.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-models.ts
@@ -1,28 +1,14 @@
 import type Client from '../../util/client';
-import { parseArguments } from '../../util/get-args';
-import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/error';
 import { leaderboardModelsSubcommand } from './command';
-import { runTimeseriesLeaderboard } from './leaderboard-shared';
+import { runLeaderboardSubcommand } from './leaderboard-shared';
 import { AiGatewayLeaderboardModelsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-models';
 
 export default async function models(client: Client, argv: string[]) {
-  const telemetry = new AiGatewayLeaderboardModelsTelemetryClient({
-    opts: { store: client.telemetryEventStore },
-  });
-
-  let parsedArgs;
-  const flagsSpecification = getFlagsSpecification(
-    leaderboardModelsSubcommand.options
-  );
-  try {
-    parsedArgs = parseArguments(argv, flagsSpecification);
-  } catch (error) {
-    printError(error);
-    return 1;
-  }
-
-  return runTimeseriesLeaderboard(client, parsedArgs.flags, telemetry, {
+  return runLeaderboardSubcommand(client, argv, leaderboardModelsSubcommand, {
+    kind: 'timeseries',
+    telemetry: new AiGatewayLeaderboardModelsTelemetryClient({
+      opts: { store: client.telemetryEventStore },
+    }),
     dataset: 'models',
     entityLabel: 'model',
     label: 'Top models',

--- a/packages/cli/src/commands/ai-gateway/leaderboard-providers.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-providers.ts
@@ -1,29 +1,20 @@
 import type Client from '../../util/client';
-import { parseArguments } from '../../util/get-args';
-import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/error';
 import { leaderboardProvidersSubcommand } from './command';
-import { runRankedLeaderboard } from './leaderboard-shared';
+import { runLeaderboardSubcommand } from './leaderboard-shared';
 import { AiGatewayLeaderboardProvidersTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-providers';
 
 export default async function providers(client: Client, argv: string[]) {
-  const telemetry = new AiGatewayLeaderboardProvidersTelemetryClient({
-    opts: { store: client.telemetryEventStore },
-  });
-
-  let parsedArgs;
-  const flagsSpecification = getFlagsSpecification(
-    leaderboardProvidersSubcommand.options
+  return runLeaderboardSubcommand(
+    client,
+    argv,
+    leaderboardProvidersSubcommand,
+    {
+      kind: 'ranked',
+      telemetry: new AiGatewayLeaderboardProvidersTelemetryClient({
+        opts: { store: client.telemetryEventStore },
+      }),
+      dataset: 'providers',
+      label: 'Top providers',
+    }
   );
-  try {
-    parsedArgs = parseArguments(argv, flagsSpecification);
-  } catch (error) {
-    printError(error);
-    return 1;
-  }
-
-  return runRankedLeaderboard(client, parsedArgs.flags, telemetry, {
-    dataset: 'providers',
-    label: 'Top providers',
-  });
 }

--- a/packages/cli/src/commands/ai-gateway/leaderboard-providers.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-providers.ts
@@ -1,0 +1,29 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { leaderboardProvidersSubcommand } from './command';
+import { runRankedLeaderboard } from './leaderboard-shared';
+import { AiGatewayLeaderboardProvidersTelemetryClient } from '../../util/telemetry/commands/ai-gateway/leaderboard-providers';
+
+export default async function providers(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLeaderboardProvidersTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    leaderboardProvidersSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  return runRankedLeaderboard(client, parsedArgs.flags, telemetry, {
+    dataset: 'providers',
+    label: 'Top providers',
+  });
+}

--- a/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard-shared.ts
@@ -1,11 +1,16 @@
 import { writeFile } from 'node:fs/promises';
+import type { Spec } from 'arg';
 import chalk from 'chalk';
 import table from '../../util/output/table';
 import type Client from '../../util/client';
+import type { CommandOption } from '../help';
 import output from '../../output-manager';
 import stamp from '../../util/output/stamp';
 import { isAPIError } from '../../util/errors-ts';
 import { canPrompt } from '../../util/can-prompt';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
 import {
   fetchLeaderboard,
   fetchLeaderboardCsv,
@@ -399,4 +404,56 @@ function printLicense() {
   output.log(
     chalk.gray('Source: AI Gateway Leaderboard data, licensed under CC BY 4.0.')
   );
+}
+
+type LeaderboardVariant =
+  | ({ kind: 'timeseries'; telemetry: TimeseriesTelemetry } & {
+      dataset: 'models' | 'labs';
+      /** Column header for the entity, e.g. `model` or `lab`. */
+      entityLabel: string;
+      label: string;
+    })
+  | ({ kind: 'ranked'; telemetry: RankedTelemetry } & {
+      dataset: 'apps' | 'providers';
+      label: string;
+    });
+
+/**
+ * Single entry point for every leaderboard subcommand: parses argv against the
+ * subcommand's flag spec (with the shared error handling) and dispatches to
+ * the time-series or ranked engine, so the per-subcommand files stay
+ * declarative.
+ */
+export async function runLeaderboardSubcommand(
+  client: Client,
+  argv: string[],
+  subcommand: { options: readonly CommandOption[] },
+  variant: LeaderboardVariant
+): Promise<number> {
+  let parsedArgs;
+  // Over a broad `readonly CommandOption[]` the mapped spec type widens past
+  // what `arg` accepts; the runtime value is the same spec every subcommand
+  // builds for itself today.
+  const flagsSpecification = getFlagsSpecification(subcommand.options) as Spec;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  // The generic spec widens the parsed flag types; every leaderboard
+  // subcommand declares (a subset of) these flags.
+  const flags = parsedArgs.flags as LeaderboardFlags;
+
+  if (variant.kind === 'timeseries') {
+    return runTimeseriesLeaderboard(client, flags, variant.telemetry, {
+      dataset: variant.dataset,
+      entityLabel: variant.entityLabel,
+      label: variant.label,
+    });
+  }
+  return runRankedLeaderboard(client, flags, variant.telemetry, {
+    dataset: variant.dataset,
+    label: variant.label,
+  });
 }

--- a/packages/cli/src/commands/ai-gateway/leaderboard.ts
+++ b/packages/cli/src/commands/ai-gateway/leaderboard.ts
@@ -4,7 +4,16 @@ import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import getSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import models from './leaderboard-models';
-import { leaderboardSubcommand, leaderboardModelsSubcommand } from './command';
+import labs from './leaderboard-labs';
+import apps from './leaderboard-apps';
+import providers from './leaderboard-providers';
+import {
+  leaderboardSubcommand,
+  leaderboardModelsSubcommand,
+  leaderboardLabsSubcommand,
+  leaderboardAppsSubcommand,
+  leaderboardProvidersSubcommand,
+} from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
@@ -13,6 +22,9 @@ import { printError } from '../../util/error';
 
 const COMMAND_CONFIG = {
   models: getCommandAliases(leaderboardModelsSubcommand),
+  labs: getCommandAliases(leaderboardLabsSubcommand),
+  apps: getCommandAliases(leaderboardAppsSubcommand),
+  providers: getCommandAliases(leaderboardProvidersSubcommand),
 };
 
 export default async function leaderboard(client: Client) {
@@ -72,6 +84,39 @@ export default async function leaderboard(client: Client) {
       }
       telemetry.trackCliSubcommandModels(subcommandOriginal);
       return models(client, args);
+    case 'labs':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway leaderboard',
+          subcommandOriginal
+        );
+        printHelp(leaderboardLabsSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandLabs(subcommandOriginal);
+      return labs(client, args);
+    case 'apps':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway leaderboard',
+          subcommandOriginal
+        );
+        printHelp(leaderboardAppsSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandApps(subcommandOriginal);
+      return apps(client, args);
+    case 'providers':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp(
+          'ai-gateway leaderboard',
+          subcommandOriginal
+        );
+        printHelp(leaderboardProvidersSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandProviders(subcommandOriginal);
+      return providers(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-apps.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-apps.ts
@@ -1,0 +1,20 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardAppsSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardAppsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardAppsSubcommand>
+{
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'format', value });
+    }
+  }
+
+  trackCliOptionOut(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'out', value: this.redactedValue });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-labs.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-labs.ts
@@ -1,0 +1,38 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardLabsSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardLabsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardLabsSubcommand>
+{
+  trackCliOptionModality(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'modality', value });
+    }
+  }
+
+  trackCliOptionMetric(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'metric', value });
+    }
+  }
+
+  trackCliOptionDate(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'date', value });
+    }
+  }
+
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'format', value });
+    }
+  }
+
+  trackCliOptionOut(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'out', value: this.redactedValue });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-providers.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard-providers.ts
@@ -1,0 +1,20 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { leaderboardProvidersSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLeaderboardProvidersTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof leaderboardProvidersSubcommand>
+{
+  trackCliOptionFormat(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'format', value });
+    }
+  }
+
+  trackCliOptionOut(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({ option: 'out', value: this.redactedValue });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/leaderboard.ts
@@ -9,4 +9,16 @@ export class AiGatewayLeaderboardTelemetryClient
   trackCliSubcommandModels(actual: string) {
     this.trackCliSubcommand({ subcommand: 'models', value: actual });
   }
+
+  trackCliSubcommandLabs(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'labs', value: actual });
+  }
+
+  trackCliSubcommandApps(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'apps', value: actual });
+  }
+
+  trackCliSubcommandProviders(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'providers', value: actual });
+  }
 }

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-apps.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-apps.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+
+const appRows = [
+  {
+    rank: 1,
+    name: 'Kilo Code',
+    ranked_by: 'Token Volume',
+    url: 'https://kilocode.ai',
+    description: 'AI coding agent for VS Code',
+  },
+];
+
+function useApps() {
+  client.scenario.get('/api/ai/leaderboard-export', (_req, res) => {
+    res.json({
+      dataset: 'apps',
+      license: 'CC-BY-4.0',
+      license_url: 'https://creativecommons.org/licenses/by/4.0/',
+      rows: appRows,
+    });
+  });
+}
+
+describe('ai-gateway leaderboard apps', () => {
+  beforeEach(() => {
+    process.env.VERCEL_LEADERBOARD_URL = client.apiUrl;
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = false;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_LEADERBOARD_URL;
+  });
+
+  it('outputs JSON by default in a non-TTY', async () => {
+    useUser();
+    useApps();
+    client.setArgv('ai-gateway', 'leaderboard', 'apps');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"dataset": "apps"');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('renders a ranked table with --format table', async () => {
+    useUser();
+    useApps();
+    client.setArgv('ai-gateway', 'leaderboard', 'apps', '--format', 'table');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('Kilo Code');
+    expect(await exitCodePromise).toBe(0);
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-labs.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-labs.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+
+const labRows = [
+  {
+    date: '2026-05-18',
+    group: 'lab',
+    name: 'google',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 39.1981,
+  },
+  {
+    date: '2026-05-18',
+    group: 'lab',
+    name: 'anthropic',
+    metric: 'requests',
+    modality: 'all',
+    share_percent: 21.5,
+  },
+];
+
+function useLabs() {
+  let query: Record<string, string> | undefined;
+  client.scenario.get('/api/ai/leaderboard-export', (req, res) => {
+    query = req.query;
+    res.json({
+      dataset: 'labs',
+      modality: req.query.modality,
+      license: 'CC-BY-4.0',
+      license_url: 'https://creativecommons.org/licenses/by/4.0/',
+      rows: labRows,
+    });
+  });
+  return () => query;
+}
+
+describe('ai-gateway leaderboard labs', () => {
+  beforeEach(() => {
+    process.env.VERCEL_LEADERBOARD_URL = client.apiUrl;
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = false;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_LEADERBOARD_URL;
+  });
+
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'leaderboard', 'labs', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:leaderboard', value: 'leaderboard' },
+        { key: 'flag:help', value: 'ai-gateway leaderboard:labs' },
+      ]);
+    });
+  });
+
+  it('outputs JSON by default in a non-TTY', async () => {
+    useUser();
+    useLabs();
+    client.setArgv('ai-gateway', 'leaderboard', 'labs');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"dataset": "labs"');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('renders a ranked table with --format table', async () => {
+    useUser();
+    useLabs();
+    client.setArgv('ai-gateway', 'leaderboard', 'labs', '--format', 'table');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('google');
+    expect(await exitCodePromise).toBe(0);
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/leaderboard-providers.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/leaderboard-providers.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { unlinkSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+
+const rankedRows = [
+  {
+    rank: 1,
+    name: 'DeepSeek',
+    ranked_by: 'Token Volume',
+    url: 'https://deepseek.com',
+    description: 'AI research and deployment',
+  },
+  {
+    rank: 2,
+    name: 'Anthropic',
+    ranked_by: 'Token Volume',
+    url: 'https://anthropic.com',
+    description: 'AI safety and research company',
+  },
+];
+
+function useRanked(dataset: string) {
+  let query: Record<string, string> | undefined;
+  client.scenario.get('/api/ai/leaderboard-export', (req, res) => {
+    query = req.query;
+    if (req.query.format === 'csv') {
+      res.setHeader('content-type', 'text/csv');
+      res.end('rank,name\n1,DeepSeek\n');
+      return;
+    }
+    res.json({
+      dataset,
+      license: 'CC-BY-4.0',
+      license_url: 'https://creativecommons.org/licenses/by/4.0/',
+      rows: rankedRows,
+    });
+  });
+  return () => query;
+}
+
+describe('ai-gateway leaderboard providers', () => {
+  beforeEach(() => {
+    process.env.VERCEL_LEADERBOARD_URL = client.apiUrl;
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    (client.stdout as unknown as { isTTY: boolean }).isTTY = false;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_LEADERBOARD_URL;
+  });
+
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'leaderboard', 'providers', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:leaderboard', value: 'leaderboard' },
+        { key: 'flag:help', value: 'ai-gateway leaderboard:providers' },
+      ]);
+    });
+  });
+
+  it('outputs JSON by default in a non-TTY', async () => {
+    useUser();
+    const getQuery = useRanked('providers');
+    client.setArgv('ai-gateway', 'leaderboard', 'providers');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('"dataset": "providers"');
+    expect(await exitCodePromise).toBe(0);
+
+    expect(getQuery()?.modality).toBeUndefined();
+  });
+
+  it('renders a ranked table with --format table', async () => {
+    useUser();
+    useRanked('providers');
+    client.setArgv(
+      'ai-gateway',
+      'leaderboard',
+      'providers',
+      '--format',
+      'table'
+    );
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('DeepSeek');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('passes format=csv through', async () => {
+    useUser();
+    const getQuery = useRanked('providers');
+    client.setArgv('ai-gateway', 'leaderboard', 'providers', '--format', 'csv');
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stdout).toOutput('DeepSeek');
+    expect(await exitCodePromise).toBe(0);
+    expect(getQuery()?.format).toBe('csv');
+  });
+
+  it('writes to a file with --out', async () => {
+    useUser();
+    useRanked('providers');
+    const out = join(tmpdir(), 'vercel-leaderboard-providers.json');
+    if (existsSync(out)) unlinkSync(out);
+    client.setArgv('ai-gateway', 'leaderboard', 'providers', '--out', out);
+
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('Wrote Top providers');
+    expect(await exitCodePromise).toBe(0);
+    expect(readFileSync(out, 'utf8')).toContain('"dataset": "providers"');
+    unlinkSync(out);
+  });
+});


### PR DESCRIPTION
## Summary

Completes CLI parity with the leaderboard export endpoint.

- `labs` mirrors the `models` time series (`--modality`/`--metric`/`--date`).
- `apps` and `providers` render the ranked top lists (`--format` / `--out` only).
- All support `--format table|json|csv` and `--out`.

New unit suites for labs/apps/providers. **Stacked on** the models PR. (Recreated from #17154, falsely flipped to merged by a stacked-branch update.)

▲ Created with [Vercel devbox](https://vercel.com/vercel/~/sandboxes/devboxes/2ylk0uyl04uih99ubpgl2boesp4h)