### PR TITLE
[cli] Add ai-gateway api-keys list/inspect/remove subcommands

### DIFF
--- a/.changeset/ai-gateway-api-keys-list-inspect-remove.md
+++ b/.changeset/ai-gateway-api-keys-list-inspect-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel ai-gateway api-keys` list, inspect, and remove subcommands so API keys can be listed, inspected, and deleted from the CLI.

--- a/packages/cli/src/commands/ai-gateway/api-keys-inspect.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys-inspect.ts
@@ -1,0 +1,124 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import type Client from '../../util/client';
+import { getApiKey, type ApiKey } from '../../util/ai-gateway/api-keys';
+import { ensureTeam } from '../../util/ai-gateway/ensure-team';
+import output from '../../output-manager';
+import { AiGatewayApiKeysInspectTelemetryClient } from '../../util/telemetry/commands/ai-gateway/api-keys-inspect';
+import { inspectSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { renderResource } from '../../util/ai-gateway/output';
+
+export default async function inspect(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayApiKeysInspectTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(inspectSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+
+  const [id] = args;
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  if (!id) {
+    output.error(
+      `${getCommandName('ai-gateway api-keys inspect <id>')} expects an API key id.`
+    );
+    return 1;
+  }
+
+  if (!(await ensureTeam(client))) {
+    return 1;
+  }
+
+  return renderResource<ApiKey>(client, {
+    asJson: formatResult.jsonOutput,
+    spinnerText: 'Fetching API key',
+    fetch: () => getApiKey(client, id),
+    toJSON: apiKey => ({ apiKey }),
+    isEmpty: () => false,
+    emptyMessage: '',
+    header: apiKey => `API key ${chalk.bold(apiKey.name || apiKey.id)}`,
+    renderTable: printApiKeyDetails,
+  });
+}
+
+function dim(value: string) {
+  return chalk.gray(value);
+}
+
+function yesNo(value: boolean) {
+  return value ? 'yes' : 'no';
+}
+
+function printApiKeyDetails(apiKey: ApiKey) {
+  const rows: string[][] = [
+    ['id', apiKey.id],
+    ['name', apiKey.name || dim('–')],
+    ['key', apiKey.partialKey ? `…${apiKey.partialKey}` : dim('–')],
+    ['purpose', apiKey.purpose],
+    ['project', apiKey.projectId ?? dim('all projects')],
+    [
+      'created',
+      apiKey.createdAt ? new Date(apiKey.createdAt).toLocaleString() : dim('–'),
+    ],
+    [
+      'last used',
+      apiKey.activeAt
+        ? new Date(apiKey.activeAt).toLocaleString()
+        : dim('never'),
+    ],
+    [
+      'expires',
+      apiKey.expiresAt
+        ? new Date(apiKey.expiresAt).toLocaleString()
+        : dim('never'),
+    ],
+    ['created by', apiKey.createdBy || dim('–')],
+  ];
+
+  const quota = apiKey.quota;
+  if (quota) {
+    rows.push(
+      ['budget', `$${quota.limitAmount}`],
+      ['spend', `$${quota.currentSpend}`],
+      ['byok spend', `$${quota.currentByokSpend}`],
+      ['include byok', yesNo(quota.includeByokInQuota)],
+      ['refresh', quota.refreshPeriod],
+      [
+        'alerts',
+        quota.alertThresholds && quota.alertThresholds.length > 0
+          ? quota.alertThresholds.map(threshold => `${threshold}%`).join(', ')
+          : dim('none'),
+      ],
+      ['active', yesNo(quota.active)]
+    );
+  } else {
+    rows.push(['budget', dim('none')]);
+  }
+
+  return `${table(
+    rows.map(([label, value]) => [dim(label), value]),
+    { align: ['l', 'l'], hsep: 4 }
+  ).replace(/^/gm, '  ')}\n\n`;
+}

--- a/packages/cli/src/commands/ai-gateway/api-keys-list.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys-list.ts
@@ -1,0 +1,77 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import type Client from '../../util/client';
+import { listApiKeys, type ApiKey } from '../../util/ai-gateway/api-keys';
+import { ensureTeam } from '../../util/ai-gateway/ensure-team';
+import output from '../../output-manager';
+import { AiGatewayApiKeysListTelemetryClient } from '../../util/telemetry/commands/ai-gateway/api-keys-list';
+import { listSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { renderResource } from '../../util/ai-gateway/output';
+
+export default async function list(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayApiKeysListTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(listSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { flags: opts } = parsedArgs;
+
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  if (!(await ensureTeam(client))) {
+    return 1;
+  }
+
+  return renderResource<ApiKey[]>(client, {
+    asJson: formatResult.jsonOutput,
+    spinnerText: 'Fetching API keys',
+    fetch: () => listApiKeys(client),
+    toJSON: apiKeys => ({ apiKeys }),
+    isEmpty: apiKeys => apiKeys.length === 0,
+    emptyMessage: `No API keys found. Create one with ${getCommandName('ai-gateway api-keys create')}.`,
+    header: () => 'API keys',
+    renderTable: printApiKeysTable,
+  });
+}
+
+function printApiKeysTable(apiKeys: ApiKey[]) {
+  return `${table(
+    [
+      ['id', 'name', 'key', 'budget', 'spend', 'refresh', 'created'].map(
+        header => chalk.gray(header)
+      ),
+      ...apiKeys.map(apiKey => [
+        apiKey.id,
+        apiKey.name || chalk.gray('–'),
+        apiKey.partialKey ? `…${apiKey.partialKey}` : chalk.gray('–'),
+        apiKey.quota ? `$${apiKey.quota.limitAmount}` : chalk.gray('–'),
+        apiKey.quota ? `$${apiKey.quota.currentSpend}` : chalk.gray('–'),
+        apiKey.quota?.refreshPeriod ?? chalk.gray('–'),
+        apiKey.createdAt
+          ? new Date(apiKey.createdAt).toLocaleDateString()
+          : chalk.gray('–'),
+      ]),
+    ],
+    { align: ['l', 'l', 'l', 'l', 'l', 'l', 'l'], hsep: 4 }
+  ).replace(/^/gm, '  ')}\n\n`;
+}

--- a/packages/cli/src/commands/ai-gateway/api-keys-remove.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys-remove.ts
@@ -1,0 +1,99 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { deleteApiKey } from '../../util/ai-gateway/api-keys';
+import { ensureTeam } from '../../util/ai-gateway/ensure-team';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { AiGatewayApiKeysRemoveTelemetryClient } from '../../util/telemetry/commands/ai-gateway/api-keys-remove';
+import { removeSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+
+export default async function remove(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayApiKeysRemoveTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(removeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+
+  const [id] = args;
+  const yes = opts['--yes'] as boolean | undefined;
+
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliFlagYes(yes);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  if (!id) {
+    output.error(
+      `${getCommandName('ai-gateway api-keys rm <id>')} expects an API key id.`
+    );
+    return 1;
+  }
+
+  if (!(await ensureTeam(client))) {
+    return 1;
+  }
+
+  if (!yes) {
+    if (!client.stdin.isTTY) {
+      output.error('To remove in non-interactive mode, re-run with --yes.');
+      return 1;
+    }
+    const confirmed = await client.input.confirm(
+      `Remove API key ${chalk.bold(id)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  const removeStamp = stamp();
+  output.spinner('Removing API key');
+
+  try {
+    await deleteApiKey(client, id);
+    output.stopSpinner();
+    if (asJson) {
+      client.stdout.write(
+        `${JSON.stringify({ id, removed: true }, null, 2)}\n`
+      );
+    } else {
+      output.success(`API key ${chalk.bold(id)} removed ${removeStamp()}`);
+    }
+    return 0;
+  } catch (err: unknown) {
+    output.stopSpinner();
+    if (isAPIError(err) && err.status === 404) {
+      output.error(`API key "${id}" not found.`);
+      return 1;
+    }
+    if (isAPIError(err)) {
+      output.error(err.message);
+      return 1;
+    }
+    throw err;
+  }
+}

--- a/packages/cli/src/commands/ai-gateway/api-keys.ts
+++ b/packages/cli/src/commands/ai-gateway/api-keys.ts
@@ -4,7 +4,16 @@ import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import getSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import create from './api-keys-create';
-import { apiKeysSubcommand, createSubcommand } from './command';
+import list from './api-keys-list';
+import inspect from './api-keys-inspect';
+import remove from './api-keys-remove';
+import {
+  apiKeysSubcommand,
+  createSubcommand,
+  listSubcommand,
+  inspectSubcommand,
+  removeSubcommand,
+} from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
@@ -13,6 +22,9 @@ import { printError } from '../../util/error';
 
 const COMMAND_CONFIG = {
   create: getCommandAliases(createSubcommand),
+  list: getCommandAliases(listSubcommand),
+  inspect: getCommandAliases(inspectSubcommand),
+  remove: getCommandAliases(removeSubcommand),
 };
 
 export default async function apiKeys(client: Client) {
@@ -65,6 +77,30 @@ export default async function apiKeys(client: Client) {
       }
       telemetry.trackCliSubcommandCreate(subcommandOriginal);
       return create(client, args);
+    case 'list':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('ai-gateway api-keys', subcommandOriginal);
+        printHelp(listSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return list(client, args);
+    case 'inspect':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('ai-gateway api-keys', subcommandOriginal);
+        printHelp(inspectSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandInspect(subcommandOriginal);
+      return inspect(client, args);
+    case 'remove':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('ai-gateway api-keys', subcommandOriginal);
+        printHelp(removeSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
+      return remove(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(apiKeysSubcommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -52,12 +52,59 @@ export const createSubcommand = {
   ],
 } as const;
 
+export const listSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List AI Gateway API keys',
+  arguments: [],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'List API keys',
+      value: `${packageName} ai-gateway api-keys ls`,
+    },
+  ],
+} as const;
+
+export const inspectSubcommand = {
+  name: 'inspect',
+  aliases: [],
+  description: 'Show details about an AI Gateway API key',
+  arguments: [{ name: 'id', required: true }],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'Inspect an API key',
+      value: `${packageName} ai-gateway api-keys inspect key_123`,
+    },
+  ],
+} as const;
+
+export const removeSubcommand = {
+  name: 'remove',
+  aliases: ['rm', 'delete'],
+  description: 'Remove an AI Gateway API key',
+  arguments: [{ name: 'id', required: true }],
+  options: [yesOption, formatOption],
+  examples: [
+    {
+      name: 'Remove an API key',
+      value: `${packageName} ai-gateway api-keys rm key_123`,
+    },
+  ],
+} as const;
+
 export const apiKeysSubcommand = {
   name: 'api-keys',
   aliases: [],
   description: 'Manage AI Gateway API keys',
   arguments: [],
-  subcommands: [createSubcommand],
+  subcommands: [
+    createSubcommand,
+    listSubcommand,
+    inspectSubcommand,
+    removeSubcommand,
+  ],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/util/ai-gateway/api-keys.ts
+++ b/packages/cli/src/util/ai-gateway/api-keys.ts
@@ -1,0 +1,69 @@
+import type Client from '../client';
+
+export type ApiKeyQuota = {
+  quotaEntityId: string;
+  limitAmount: number;
+  currentSpend: number;
+  currentByokSpend: number;
+  includeByokInQuota: boolean;
+  refreshPeriod: 'daily' | 'weekly' | 'monthly' | 'none';
+  active: boolean;
+  archived: boolean;
+  alertThresholds?: number[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ApiKey = {
+  id: string;
+  name: string;
+  partialKey: string;
+  teamId: string;
+  purpose: string;
+  projectId: string | null;
+  expiresAt: number | null;
+  activeAt: number;
+  createdAt: number;
+  createdBy: string;
+  leakedAt: number | null;
+  leakedUrl: string | null;
+  createdByAppId: string | null;
+  quota?: ApiKeyQuota;
+};
+
+type ListApiKeysResponse = {
+  apiKeys: ApiKey[];
+  pagination: {
+    count: number;
+    next: string | null;
+    prev: string | null;
+  };
+};
+
+export async function listApiKeys(client: Client): Promise<ApiKey[]> {
+  const { apiKeys } = await client.fetch<ListApiKeysResponse>(
+    '/v1/api-keys?purpose=ai-gateway',
+    { method: 'GET' }
+  );
+  return apiKeys ?? [];
+}
+
+export async function getApiKey(
+  client: Client,
+  apiKeyId: string
+): Promise<ApiKey> {
+  const { apiKey } = await client.fetch<{ apiKey: ApiKey }>(
+    `/v1/api-keys/${encodeURIComponent(apiKeyId)}`,
+    { method: 'GET' }
+  );
+  return apiKey;
+}
+
+export async function deleteApiKey(
+  client: Client,
+  apiKeyId: string
+): Promise<void> {
+  await client.fetch(`/v1/api-keys/${encodeURIComponent(apiKeyId)}`, {
+    method: 'DELETE',
+  });
+}

--- a/packages/cli/src/util/ai-gateway/ensure-team.ts
+++ b/packages/cli/src/util/ai-gateway/ensure-team.ts
@@ -9,14 +9,14 @@ export async function ensureTeam(client: Client): Promise<boolean> {
 
   if (!client.stdin.isTTY) {
     output.error(
-      'No team selected. Use `vercel --scope <team-slug> ai-gateway rules …` or run `vercel switch` first.'
+      'No team selected. Use `vercel --scope <team-slug> ai-gateway …` or run `vercel switch` first.'
     );
     return false;
   }
 
   const org = await selectOrg(
     client,
-    'Which team owns these AI Gateway rules?'
+    'Which team owns these AI Gateway resources?'
   );
   if (org.type === 'team') {
     client.config.currentTeam = org.id;
@@ -24,7 +24,7 @@ export async function ensureTeam(client: Client): Promise<boolean> {
   }
 
   output.error(
-    'AI Gateway rules are managed per team. Switch to a team scope and try again.'
+    'AI Gateway resources are managed per team. Switch to a team scope and try again.'
   );
   return false;
 }

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-inspect.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-inspect.ts
@@ -1,0 +1,20 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { inspectSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayApiKeysInspectTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof inspectSubcommand>
+{
+  trackCliArgumentId(id: string | undefined) {
+    if (id) {
+      this.trackCliArgument({ arg: 'id', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({ option: 'format', value: format });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-list.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-list.ts
@@ -1,0 +1,14 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { listSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayApiKeysListTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof listSubcommand>
+{
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({ option: 'format', value: format });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-remove.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys-remove.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { removeSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayApiKeysRemoveTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof removeSubcommand>
+{
+  trackCliArgumentId(id: string | undefined) {
+    if (id) {
+      this.trackCliArgument({ arg: 'id', value: this.redactedValue });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({ option: 'format', value: format });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/api-keys.ts
@@ -12,4 +12,25 @@ export class AiGatewayApiKeysTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/ai-gateway/api-keys-inspect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/api-keys-inspect.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+const sampleApiKey = {
+  id: 'key_1',
+  name: 'production',
+  partialKey: 't7V',
+  teamId: 'team_abc',
+  purpose: 'ai-gateway',
+  projectId: null,
+  expiresAt: null,
+  activeAt: 1700000000000,
+  createdAt: 1700000000000,
+  createdBy: 'user_1',
+  leakedAt: null,
+  leakedUrl: null,
+  createdByAppId: null,
+  quota: {
+    quotaEntityId: 'quota_1',
+    limitAmount: 500,
+    currentSpend: 42,
+    currentByokSpend: 0,
+    includeByokInQuota: false,
+    refreshPeriod: 'monthly',
+    active: true,
+    archived: false,
+    alertThresholds: [75, 100],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  },
+};
+
+function useGetApiKey(apiKey: unknown = sampleApiKey, id = 'key_1') {
+  client.scenario.get(`/v1/api-keys/${id}`, (_req, res) => {
+    res.json({ apiKey });
+  });
+}
+
+function useGetNotFound(id = 'missing') {
+  client.scenario.get(`/v1/api-keys/${id}`, (_req, res) => {
+    res
+      .status(404)
+      .json({ error: { code: 'not_found', message: 'API key not found.' } });
+  });
+}
+
+describe('ai-gateway api-keys inspect', () => {
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'api-keys', 'inspect', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:api-keys', value: 'api-keys' },
+        { key: 'flag:help', value: 'ai-gateway api-keys:inspect' },
+      ]);
+    });
+  });
+
+  it('shows details including quota', async () => {
+    const team = useTeam();
+    useUser();
+    useGetApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'inspect', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('budget');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('shows details for a key without a quota', async () => {
+    const team = useTeam();
+    useUser();
+    const { quota, ...noQuota } = sampleApiKey;
+    void quota;
+    useGetApiKey(noQuota);
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'inspect', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('production');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('requires an id', async () => {
+    useUser();
+    client.setArgv('ai-gateway', 'api-keys', 'inspect');
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('expects an API key id');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('reports a 404 as not found', async () => {
+    const team = useTeam();
+    useUser();
+    useGetNotFound();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'inspect', 'missing');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('API key not found');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    const team = useTeam();
+    useUser();
+    useGetApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv(
+      'ai-gateway',
+      'api-keys',
+      'inspect',
+      'key_1',
+      '--format',
+      'json'
+    );
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('"apiKey"');
+    expect(await exitCodePromise).toBe(0);
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/api-keys-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/api-keys-list.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+const sampleApiKey = {
+  id: 'key_1',
+  name: 'production',
+  partialKey: 't7V',
+  teamId: 'team_abc',
+  purpose: 'ai-gateway',
+  projectId: null,
+  expiresAt: null,
+  activeAt: 1700000000000,
+  createdAt: 1700000000000,
+  createdBy: 'user_1',
+  leakedAt: null,
+  leakedUrl: null,
+  createdByAppId: null,
+  quota: {
+    quotaEntityId: 'quota_1',
+    limitAmount: 500,
+    currentSpend: 42,
+    currentByokSpend: 0,
+    includeByokInQuota: false,
+    refreshPeriod: 'monthly',
+    active: true,
+    archived: false,
+    alertThresholds: [75, 100],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  },
+};
+
+function useListApiKeys(apiKeys: unknown[] = [sampleApiKey]) {
+  let query: unknown;
+  client.scenario.get('/v1/api-keys', (req, res) => {
+    query = req.query;
+    res.json({
+      apiKeys,
+      pagination: { count: apiKeys.length, next: null, prev: null },
+    });
+  });
+  return () => query;
+}
+
+describe('ai-gateway api-keys list', () => {
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'api-keys', 'list', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:api-keys', value: 'api-keys' },
+        { key: 'flag:help', value: 'ai-gateway api-keys:list' },
+      ]);
+    });
+  });
+
+  it('lists API keys in a table', async () => {
+    const team = useTeam();
+    useUser();
+    const getQuery = useListApiKeys();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('production');
+    expect(await exitCodePromise).toBe(0);
+    expect(getQuery()).toMatchObject({ purpose: 'ai-gateway' });
+  });
+
+  it('reports when there are no API keys', async () => {
+    const team = useTeam();
+    useUser();
+    useListApiKeys([]);
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'ls');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('No API keys found');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    const team = useTeam();
+    useUser();
+    useListApiKeys();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'list', '--format', 'json');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('"apiKeys"');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('fails without a team in non-interactive mode', async () => {
+    useUser();
+    client.config.currentTeam = undefined;
+    client.stdin.isTTY = false;
+    client.setArgv('ai-gateway', 'api-keys', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('No team selected');
+    expect(await exitCodePromise).toBe(1);
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/api-keys-remove.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/api-keys-remove.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+
+function useDeleteApiKey(id = 'key_1') {
+  client.scenario.delete(`/v1/api-keys/${id}`, (_req, res) => {
+    res.status(204).end();
+  });
+}
+
+function useDeleteNotFound(id = 'missing') {
+  client.scenario.delete(`/v1/api-keys/${id}`, (_req, res) => {
+    res
+      .status(404)
+      .json({ error: { code: 'not_found', message: 'API key not found.' } });
+  });
+}
+
+describe('ai-gateway api-keys remove', () => {
+  describe('--help', () => {
+    it('returns exit code 2', async () => {
+      client.setArgv('ai-gateway', 'api-keys', 'remove', '--help');
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:api-keys', value: 'api-keys' },
+        { key: 'flag:help', value: 'ai-gateway api-keys:remove' },
+      ]);
+    });
+  });
+
+  it('removes a key with --yes', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'key_1', '--yes');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('removed');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('removes a key via the delete alias', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'delete', 'key_1', '--yes');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('removed');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv(
+      'ai-gateway',
+      'api-keys',
+      'rm',
+      'key_1',
+      '--yes',
+      '--format',
+      'json'
+    );
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('"removed": true');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('requires an id', async () => {
+    useUser();
+    client.setArgv('ai-gateway', 'api-keys', 'rm', '--yes');
+    const exitCodePromise = aiGateway(client);
+    await expect(client.stderr).toOutput('expects an API key id');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('fails in non-interactive mode without --yes', async () => {
+    const team = useTeam();
+    useUser();
+    client.config.currentTeam = team.id;
+    client.stdin.isTTY = false;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('re-run with --yes');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('reports a 404 as not found', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteNotFound();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'missing', '--yes');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('API key "missing" not found');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('removes after interactive confirmation', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('Remove API key');
+    client.stdin.write('y\n');
+
+    await expect(client.stderr).toOutput('removed');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('cancels when confirmation is declined', async () => {
+    const team = useTeam();
+    useUser();
+    useDeleteApiKey();
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'api-keys', 'rm', 'key_1');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('Remove API key');
+    client.stdin.write('n\n');
+
+    await expect(client.stderr).toOutput('Canceled');
+    expect(await exitCodePromise).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

- The `vercel ai-gateway api-keys` command only wired up `create`, so users could mint keys from the CLI but had to leave it to list, inspect, or delete them. This closes that gap for the single-resource API-key endpoints.

## Summary

- Adds `api-keys list`/`ls`, `api-keys inspect <id>`, and `api-keys remove <id>`/`rm`/`delete`, mapping to `GET /v1/api-keys`, `GET /v1/api-keys/:id`, and `DELETE /v1/api-keys/:id`.
- Reuses the existing ai-gateway command-family rendering (`renderResource` + `table`), team gating (`ensureTeam`), and JSON output helpers — no new UI patterns.

## Validation

- New unit suites for list/inspect/remove.

## Notes

- Split out from #17134 (part 1 of 2). The `create` parity flags (`--expiration`, `--alert-thresholds`) land in the companion PR.

▲ Created with [Vercel devbox](https://vercel.com/vercel/~/sandboxes/devboxes/2mrpnc7ygwt5yteirsvh1fhge723)