### PR TITLE
[cli] Render root help from command registration metadata

### DIFF
--- a/.changeset/generated-root-help.md
+++ b/.changeset/generated-root-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Render root `vercel --help` from command registration metadata instead of hand-maintained text, so it can no longer list commands that don't exist or omit ones that do

--- a/packages/cli/src/commands/dev/command.ts
+++ b/packages/cli/src/commands/dev/command.ts
@@ -4,7 +4,7 @@ import { confirmOption, projectOption, yesOption } from '../../util/arg-common';
 export const devCommand = {
   name: 'dev',
   aliases: ['develop'],
-  description: `Starts the \`${packageName} dev\` server.`,
+  description: 'Start a local development server for your project.',
   arguments: [
     {
       name: 'dir',

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -65,7 +65,7 @@ import { webhooksCommand } from './webhooks/command';
 import type { Command } from './help';
 import output from '../output-manager';
 
-const commandsStructs = [
+export const commandsStructs = [
   agentCommand,
   agentRunsCommand,
   aiGatewayCommand,

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -65,7 +65,7 @@ import { webhooksCommand } from './webhooks/command';
 import type { Command } from './help';
 import output from '../output-manager';
 
-export const commandsStructs = [
+export const commandsStructs: Command[] = [
   agentCommand,
   agentRunsCommand,
   aiGatewayCommand,
@@ -128,7 +128,14 @@ export const commandsStructs = [
   vcrCommand,
   whoamiCommand,
   // added because we don't have a full help command
-  { name: 'help', aliases: [] },
+  {
+    name: 'help',
+    aliases: [],
+    description: 'Display help for a command',
+    arguments: [{ name: 'command', required: false }],
+    options: [],
+    examples: [],
+  },
 ];
 
 if (process.env.FF_GUIDANCE_MODE) {

--- a/packages/cli/src/commands/open/command.ts
+++ b/packages/cli/src/commands/open/command.ts
@@ -4,7 +4,7 @@ import { yesOption } from '../../util/arg-common';
 export const openCommand = {
   name: 'open',
   aliases: [],
-  description: 'Opens the current project in the Vercel Dashboard.',
+  description: 'Open the current project in the Vercel Dashboard.',
   arguments: [],
   options: [
     {

--- a/packages/cli/src/commands/telemetry/command.ts
+++ b/packages/cli/src/commands/telemetry/command.ts
@@ -1,7 +1,7 @@
 export const statusSubcommand = {
   name: 'status',
   aliases: [],
-  description: 'Shows whether telemetry collection is enabled or disabled',
+  description: 'Show whether telemetry collection is enabled or disabled',
   arguments: [],
   options: [],
   examples: [],
@@ -10,7 +10,7 @@ export const statusSubcommand = {
 export const enableSubcommand = {
   name: 'enable',
   aliases: [],
-  description: 'Enables telemetry collection',
+  description: 'Enable telemetry collection',
   arguments: [],
   options: [],
   examples: [],
@@ -29,7 +29,7 @@ export const flushSubcommand = {
 export const disableSubcommand = {
   name: 'disable',
   aliases: [],
-  description: 'Disables telemetry collection',
+  description: 'Disable telemetry collection',
   arguments: [],
   options: [],
   examples: [],
@@ -38,7 +38,7 @@ export const disableSubcommand = {
 export const telemetryCommand = {
   name: 'telemetry',
   aliases: [],
-  description: 'Allows you to enable or disable telemetry collection',
+  description: 'Enable or disable telemetry collection',
   arguments: [],
   subcommands: [
     enableSubcommand,

--- a/packages/cli/src/commands/upgrade/command.ts
+++ b/packages/cli/src/commands/upgrade/command.ts
@@ -4,7 +4,7 @@ import { packageName } from '../../util/pkg-name';
 export const upgradeCommand = {
   name: 'upgrade',
   aliases: [],
-  description: 'Upgrades the Vercel CLI to the latest version.',
+  description: 'Upgrade the Vercel CLI to the latest version.',
   arguments: [],
   options: [
     {

--- a/packages/cli/src/commands/whoami/command.ts
+++ b/packages/cli/src/commands/whoami/command.ts
@@ -4,7 +4,7 @@ import { formatOption } from '../../util/arg-common';
 export const whoamiCommand = {
   name: 'whoami',
   aliases: [],
-  description: 'Shows the username of the currently logged in user.',
+  description: 'Show the username of the currently logged in user.',
   arguments: [],
   options: [formatOption],
   examples: [

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,10 +1,158 @@
 import chalk from 'chalk';
+import { commandsStructs } from './commands';
+import { globalCommandOptions } from './util/arg-common';
+import type { Command } from './commands/help';
 
 // Hardcoded to avoid importing pkg.ts which pulls in more dependencies
 const packageName = 'vercel';
 const logo = '▲';
 
-export const help = () => `
+/**
+ * The command lines below are rendered from the same registration metadata
+ * the CLI routes with, so this help cannot list commands that do not exist
+ * or omit ones that do. Only the grouping is curated: anything registered
+ * but not named here is listed under "Advanced" automatically.
+ */
+const BASIC_COMMANDS = [
+  'deploy',
+  'build',
+  'cache',
+  'dev',
+  'env',
+  'git',
+  'help',
+  'init',
+  'inspect',
+  'install',
+  'integration',
+  'integration-resource',
+  'link',
+  'list',
+  'login',
+  'logout',
+  'open',
+  'promote',
+  'pull',
+  'redeploy',
+  'rollback',
+];
+
+const NAME_COLUMN = 21;
+const ARGS_COLUMN = 12;
+const MAX_DESCRIPTION = 78;
+
+type RootCommandEntry = Pick<Command, 'name' | 'aliases'> &
+  Partial<Pick<Command, 'description' | 'arguments' | 'subcommands'>> & {
+    hidden?: boolean;
+  };
+
+function firstSentence(text: string): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  const match = normalized.match(/^.*?[.!?](?=\s)/);
+  return match ? match[0] : normalized;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const cut = text.slice(0, max);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${cut.slice(0, lastSpace > 0 ? lastSpace : max)}…`;
+}
+
+function displayName(command: RootCommandEntry): string {
+  // Shortest first, matching the established `ls | list` convention.
+  return [command.name, ...command.aliases]
+    .slice()
+    .sort((a, b) => a.length - b.length || a.localeCompare(b))
+    .join(' | ');
+}
+
+function argsHint(command: RootCommandEntry): string {
+  if (command.name === 'help') return '[cmd]';
+  const first = command.arguments?.[0];
+  if (first) {
+    return first.required ? `<${first.name}>` : `[${first.name}]`;
+  }
+  return command.subcommands?.length ? '[cmd]' : '';
+}
+
+function description(command: RootCommandEntry): string {
+  if (command.name === 'help') {
+    return 'Display help for a command';
+  }
+  const text = truncate(
+    firstSentence(command.description ?? '').replace(/\.$/, ''),
+    MAX_DESCRIPTION
+  );
+  if (command.name === 'deploy') {
+    return `${text} ${chalk.bold('(default)')}`;
+  }
+  return text;
+}
+
+function pad(text: string, width: number): string {
+  return text.length >= width ? `${text} ` : text.padEnd(width);
+}
+
+function commandLine(command: RootCommandEntry): string {
+  return `      ${pad(displayName(command), NAME_COLUMN)}${pad(
+    argsHint(command),
+    ARGS_COLUMN
+  )}${description(command)}`;
+}
+
+function commandLines(): { basic: string[]; advanced: string[] } {
+  const visible = (commandsStructs as readonly RootCommandEntry[]).filter(
+    command => !command.hidden
+  );
+  const byName = new Map(visible.map(command => [command.name, command]));
+
+  const basic: string[] = [];
+  for (const name of BASIC_COMMANDS) {
+    const command = byName.get(name);
+    if (command) {
+      basic.push(commandLine(command));
+      byName.delete(name);
+    }
+  }
+
+  const advanced = [...byName.values()]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(commandLine);
+
+  return { basic, advanced };
+}
+
+function globalOptionLines(): string[] {
+  const lines: string[] = [];
+  for (const option of globalCommandOptions) {
+    // Undocumented options (no description) are omitted, matching help
+    // output for command options.
+    if (
+      option.deprecated ||
+      !('description' in option) ||
+      !option.description
+    ) {
+      continue;
+    }
+    const argument =
+      'argument' in option && option.argument
+        ? `=${chalk.bold.underline(option.argument)}`
+        : '';
+    const flags = [
+      option.shorthand ? `-${option.shorthand}` : null,
+      `--${option.name}${argument}`,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    lines.push(`    ${pad(flags, 31)}${option.description}`);
+  }
+  return lines;
+}
+
+export const help = () => {
+  const { basic, advanced } = commandLines();
+  return `
   ${chalk.bold(`${logo} ${packageName}`)} [options] <command | path>
 
   ${chalk.dim('For deploy command help, run `vercel deploy --help`')}
@@ -13,96 +161,15 @@ export const help = () => `
 
     ${chalk.dim('Basic')}
 
-      deploy               [path]      Performs a deployment ${chalk.bold(
-        '(default)'
-      )}
-      build                            Build the project locally into './vercel/output'
-      cache                [cmd]       Manages cache for your current Project
-      dev                              Start a local development server
-      env                              Manages the Environment Variables for your current Project
-      git                              Manage Git provider repository for your current Project
-      help                 [cmd]       Displays complete help for [cmd]
-      init                 [example]   Initialize an example project
-      inspect              [id]        Displays information related to a deployment
-      i | install          [name]      Install an integration from the Marketplace
-      integration          [cmd]       Manages your Marketplace integrations
-      ir | integration-resource [cmd]  Manages your Marketplace integration resources
-      link                 [path]      Link local directory to a Vercel Project
-      ls | list            [app]       Lists deployments
-      login                [email]     Logs into your account or creates a new one
-      logout                           Logs out of your account
-      open                             Opens the current project in the Vercel Dashboard
-      promote              [url|id]    Promote an existing deployment to current
-      pull                 [path]      Pull your Project Settings from the cloud
-      redeploy             [url|id]    Rebuild and deploy a previous deployment.
-      rollback             [url|id]    Quickly revert back to a previous deployment
-      switch               [scope]     Switches between different scopes
+${basic.join('\n')}
 
     ${chalk.dim('Advanced')}
 
-      activity                         List user activity events
-      agent                [init]      Generate AGENTS.md with Vercel best practices
-      ai-gateway           [cmd]       Manage AI Gateway resources
-      agent-runs           [cmd]       Inspect Agent Runs observability data
-      alerts                           List alerts for a project or team
-      alias                [cmd]       Manages your domain aliases
-      api                  [endpoint]  Make authenticated HTTP requests to the Vercel API [beta]
-      bisect                           Use binary search to find the deployment that introduced a bug
-      blob                 [cmd]       Manages your Blob stores and files
-      buy                  [cmd]       Purchase Vercel products for your team
-      certs                [cmd]       Manages your SSL certificates
-      connect              [cmd]       Manage connectors [beta]
-      contract                         Show contract information for billing periods
-      cron | crons         [cmd]       Manage cron jobs for a project [beta]
-      curl                 [path]      cURL requests to your linked project's deployment [beta]
-      deploy-hooks         [cmd]       Manage deploy hooks for Git-triggered builds
-      dns                  [name]      Manages your DNS records
-      domains              [name]      Manages your domain names
-      edge-config          [cmd]       Manage Edge Config stores
-      firewall             [cmd]       Manages Vercel Firewall configuration and custom rules
-      flags                [cmd]       Manage feature flags for a Vercel project
-      httpstat             path        Visualize HTTP timing statistics for deployments
-      logs                 [url]       Displays the logs for a deployment
-      metrics              <metric>    Queries observability metrics for your project or team
-      mcp                              Set up MCP agents and configuration
-      microfrontends                   Manages your microfrontends
-      oauth-apps           [cmd]       Register Vercel Apps (OAuth) and manage team installations
-      projects                         Manages your Projects
-      redirects            [cmd]       Manages redirects for your current Project
-      rm | remove          [id]        Removes a deployment
-      routes               [cmd]       Manages routing rules for your current Project
-      rr | rolling-release [cmd]       Manage rolling releases for gradual traffic shifting
-      sandbox                          Interact with Vercel Sandbox
-      skills               [query]     Discover agent skills relevant to your project
-      target               [cmd]       Manage custom environments for your Project
-      teams                            Manages your teams
-      telemetry            [cmd]       Enable or disable telemetry collection
-      tokens               [cmd]       Manage your personal Vercel authentication tokens
-      traces               [cmd]       Fetch and capture traces for your project's deployment
-      upgrade                          Upgrade the Vercel CLI to the latest version
-      usage                            Show billing usage for the current billing period
-      vcr                  [cmd]       Manages your Container Registry repositories and images
-      webhooks             [cmd]       Manages webhooks [beta]
-      whoami                           Shows the username of the currently logged in user
+${advanced.join('\n')}
 
   ${chalk.dim('Global Options:')}
 
-    -h, --help                     Output usage information
-    -v, --version                  Output the version number
-    --cwd                          Current working directory
-    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
-      'FILE'
-    )}   Path to the local ${'`vercel.json`'} file
-    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
-      'DIR'
-    )}    Path to the global ${'`.vercel`'} directory
-    -d, --debug                    Debug mode [off]
-    --no-color                     No color mode [off]
-    --non-interactive              Run without interactive prompts (default when agent detected)
-    -S, --scope                    Set a custom scope
-    -t ${chalk.underline('TOKEN')}, --token=${chalk.underline(
-      'TOKEN'
-    )}        Login token
+${globalOptionLines().join('\n')}
 
   ${chalk.dim('Examples:')}
 
@@ -124,3 +191,4 @@ export const help = () => `
 
     ${chalk.cyan(`$ ${packageName} help list`)}
 `;
+};

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -38,8 +38,7 @@ export const BASIC_COMMANDS = [
 ];
 
 const NAME_COLUMN = 21;
-const ARGS_COLUMN = 12;
-const MAX_DESCRIPTION = 78;
+const MAX_DESCRIPTION = 64;
 
 function firstSentence(text: string): string {
   const normalized = text.replace(/\s+/g, ' ').trim();
@@ -85,10 +84,10 @@ function pad(text: string, width: number): string {
   return text.length >= width ? `${text} ` : text.padEnd(width);
 }
 
-function commandLine(command: Command): string {
+function commandLine(command: Command, argsColumn: number): string {
   return `      ${pad(displayName(command), NAME_COLUMN)}${pad(
     argsHint(command),
-    ARGS_COLUMN
+    argsColumn
   )}${description(command)}`;
 }
 
@@ -96,20 +95,28 @@ function commandLines(): { basic: string[]; advanced: string[] } {
   const visible = commandsStructs.filter(command => !command.hidden);
   const byName = new Map(visible.map(command => [command.name, command]));
 
-  const basic: string[] = [];
+  // Size the hint column to the widest hint so metadata-derived
+  // placeholders (`[url|deploymentId]`) never push descriptions ragged.
+  const argsColumn =
+    Math.max(...visible.map(command => argsHint(command).length)) + 2;
+
+  const basic: Command[] = [];
   for (const name of BASIC_COMMANDS) {
     const command = byName.get(name);
     if (command) {
-      basic.push(commandLine(command));
+      basic.push(command);
       byName.delete(name);
     }
   }
 
-  const advanced = [...byName.values()]
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map(commandLine);
+  const advanced = [...byName.values()].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
 
-  return { basic, advanced };
+  return {
+    basic: basic.map(command => commandLine(command, argsColumn)),
+    advanced: advanced.map(command => commandLine(command, argsColumn)),
+  };
 }
 
 function globalOptionLines(): string[] {

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -13,7 +13,7 @@ const logo = '▲';
  * or omit ones that do. Only the grouping is curated: anything registered
  * but not named here is listed under "Advanced" automatically.
  */
-const BASIC_COMMANDS = [
+export const BASIC_COMMANDS = [
   'deploy',
   'build',
   'cache',
@@ -41,11 +41,6 @@ const NAME_COLUMN = 21;
 const ARGS_COLUMN = 12;
 const MAX_DESCRIPTION = 78;
 
-type RootCommandEntry = Pick<Command, 'name' | 'aliases'> &
-  Partial<Pick<Command, 'description' | 'arguments' | 'subcommands'>> & {
-    hidden?: boolean;
-  };
-
 function firstSentence(text: string): string {
   const normalized = text.replace(/\s+/g, ' ').trim();
   const match = normalized.match(/^.*?[.!?](?=\s)/);
@@ -59,7 +54,7 @@ function truncate(text: string, max: number): string {
   return `${cut.slice(0, lastSpace > 0 ? lastSpace : max)}…`;
 }
 
-function displayName(command: RootCommandEntry): string {
+function displayName(command: Command): string {
   // Shortest first, matching the established `ls | list` convention.
   return [command.name, ...command.aliases]
     .slice()
@@ -67,21 +62,17 @@ function displayName(command: RootCommandEntry): string {
     .join(' | ');
 }
 
-function argsHint(command: RootCommandEntry): string {
-  if (command.name === 'help') return '[cmd]';
-  const first = command.arguments?.[0];
+function argsHint(command: Command): string {
+  const first = command.arguments[0];
   if (first) {
     return first.required ? `<${first.name}>` : `[${first.name}]`;
   }
   return command.subcommands?.length ? '[cmd]' : '';
 }
 
-function description(command: RootCommandEntry): string {
-  if (command.name === 'help') {
-    return 'Display help for a command';
-  }
+function description(command: Command): string {
   const text = truncate(
-    firstSentence(command.description ?? '').replace(/\.$/, ''),
+    firstSentence(command.description).replace(/\.$/, ''),
     MAX_DESCRIPTION
   );
   if (command.name === 'deploy') {
@@ -94,7 +85,7 @@ function pad(text: string, width: number): string {
   return text.length >= width ? `${text} ` : text.padEnd(width);
 }
 
-function commandLine(command: RootCommandEntry): string {
+function commandLine(command: Command): string {
   return `      ${pad(displayName(command), NAME_COLUMN)}${pad(
     argsHint(command),
     ARGS_COLUMN
@@ -102,9 +93,7 @@ function commandLine(command: RootCommandEntry): string {
 }
 
 function commandLines(): { basic: string[]; advanced: string[] } {
-  const visible = (commandsStructs as readonly RootCommandEntry[]).filter(
-    command => !command.hidden
-  );
+  const visible = commandsStructs.filter(command => !command.hidden);
   const byName = new Map(visible.map(command => [command.name, command]));
 
   const basic: string[] = [];

--- a/packages/cli/src/util/output/index.ts
+++ b/packages/cli/src/util/output/index.ts
@@ -1,2 +1,2 @@
 export { Output } from './create-output';
-export { StopSpinner } from './wait';
+export type { StopSpinner } from './wait';

--- a/packages/cli/test/unit/commands/open/index.test.ts
+++ b/packages/cli/test/unit/commands/open/index.test.ts
@@ -43,7 +43,7 @@ describe('open', () => {
       const exitCode = await openCommand(client);
       expect(exitCode).toEqual(0);
       expect(client.getFullOutput()).toContain(
-        'Opens the current project in the Vercel Dashboard'
+        'Open the current project in the Vercel Dashboard'
       );
     });
   });

--- a/packages/cli/test/unit/commands/root-help.test.ts
+++ b/packages/cli/test/unit/commands/root-help.test.ts
@@ -1,10 +1,39 @@
 import { describe, expect, it } from 'vitest';
 import { help } from '../../../src/help';
+import { commandsStructs } from '../../../src/commands';
 
 describe('root help output', () => {
-  it('lists the agent-runs command', () => {
-    expect(help()).toContain(
-      'agent-runs           [cmd]       Inspect Agent Runs observability data'
-    );
+  const output = help();
+
+  it('lists every registered visible command', () => {
+    for (const command of commandsStructs) {
+      if ('hidden' in command && command.hidden) continue;
+      expect(output).toContain(` ${command.name} `);
+    }
+  });
+
+  it('does not list unregistered commands', () => {
+    // Previously drifted in as hand-maintained text (never a real command).
+    expect(output).not.toContain('oauth-apps');
+  });
+
+  it('lists the agent-runs command with its metadata description', () => {
+    expect(output).toMatch(/agent-runs\s+\[cmd\]\s+Inspect Agent Runs/);
+  });
+
+  it('renders aliases and the default marker', () => {
+    expect(output).toContain('rr | rolling-release');
+    expect(output).toContain('(default)');
+  });
+
+  it('renders global options from shared metadata', () => {
+    expect(output).toContain('--non-interactive');
+    expect(output).toMatch(/-t, --token/);
+  });
+
+  it('keeps groups and examples', () => {
+    expect(output).toContain('Basic');
+    expect(output).toContain('Advanced');
+    expect(output).toContain('$ vercel help list');
   });
 });

--- a/packages/cli/test/unit/commands/root-help.test.ts
+++ b/packages/cli/test/unit/commands/root-help.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { help } from '../../../src/help';
+import { BASIC_COMMANDS, help } from '../../../src/help';
 import { commandsStructs } from '../../../src/commands';
 
 describe('root help output', () => {
   const output = help();
+
+  it('curated grouping only names registered commands', () => {
+    // Guards against renames/removals leaving stale entries in the
+    // hand-maintained grouping list (the lines themselves are generated).
+    const registered = new Set(commandsStructs.map(command => command.name));
+    for (const name of BASIC_COMMANDS) {
+      expect(registered.has(name), `BASIC_COMMANDS entry "${name}"`).toBe(true);
+    }
+  });
 
   it('lists every registered visible command', () => {
     for (const command of commandsStructs) {


### PR DESCRIPTION
## `vercel --help`, before → after

**Before** (hand-maintained static text — note `oauth-apps`, which is not a registered command):

```
      deploy               [path]      Performs a deployment (default)
      cache                [cmd]       Manages cache for your current Project
      help                 [cmd]       Displays complete help for [cmd]
      ...
      mcp                              Set up MCP agents and configuration
      microfrontends                   Manages your microfrontends
      oauth-apps           [cmd]       Register Vercel Apps (OAuth) and manage team installations
      projects                         Manages your Projects
      ...
```

**After** (rendered from command registration metadata):

```
      deploy               [project-path]       Deploy your project to Vercel (default)
      cache                [cmd]                Manage cache for a Project
      help                 [command]            Display help for a command
      ...
      mcp                                       Set up MCP agents and configuration for Vercel integration
      mf | microfrontends  [cmd]                Manage microfrontends groups that compose multiple projects…
      project | projects   [cmd]                Manage your Vercel projects
      ...
```

<details>
<summary>Full output — before</summary>

```

  ▲ vercel [options] <command | path>

  For deploy command help, run `vercel deploy --help`

  Commands:

    Basic

      deploy               [path]      Performs a deployment (default)
      build                            Build the project locally into './vercel/output'
      cache                [cmd]       Manages cache for your current Project
      dev                              Start a local development server
      env                              Manages the Environment Variables for your current Project
      git                              Manage Git provider repository for your current Project
      help                 [cmd]       Displays complete help for [cmd]
      init                 [example]   Initialize an example project
      inspect              [id]        Displays information related to a deployment
      i | install          [name]      Install an integration from the Marketplace
      integration          [cmd]       Manages your Marketplace integrations
      ir | integration-resource [cmd]  Manages your Marketplace integration resources
      link                 [path]      Link local directory to a Vercel Project
      ls | list            [app]       Lists deployments
      login                [email]     Logs into your account or creates a new one
      logout                           Logs out of your account
      open                             Opens the current project in the Vercel Dashboard
      promote              [url|id]    Promote an existing deployment to current
      pull                 [path]      Pull your Project Settings from the cloud
      redeploy             [url|id]    Rebuild and deploy a previous deployment.
      rollback             [url|id]    Quickly revert back to a previous deployment
      switch               [scope]     Switches between different scopes

    Advanced

      activity                         List user activity events
      agent                [init]      Generate AGENTS.md with Vercel best practices
      ai-gateway           [cmd]       Manage AI Gateway resources
      agent-runs           [cmd]       Inspect Agent Runs observability data
      alerts                           List alerts for a project or team
      alias                [cmd]       Manages your domain aliases
      api                  [endpoint]  Make authenticated HTTP requests to the Vercel API [beta]
      bisect                           Use binary search to find the deployment that introduced a bug
      blob                 [cmd]       Manages your Blob stores and files
      buy                  [cmd]       Purchase Vercel products for your team
      certs                [cmd]       Manages your SSL certificates
      connect              [cmd]       Manage connectors [beta]
      contract                         Show contract information for billing periods
      cron | crons         [cmd]       Manage cron jobs for a project [beta]
      curl                 [path]      cURL requests to your linked project's deployment [beta]
      deploy-hooks         [cmd]       Manage deploy hooks for Git-triggered builds
      dns                  [name]      Manages your DNS records
      domains              [name]      Manages your domain names
      edge-config          [cmd]       Manage Edge Config stores
      firewall             [cmd]       Manages Vercel Firewall configuration and custom rules
      flags                [cmd]       Manage feature flags for a Vercel project
      httpstat             path        Visualize HTTP timing statistics for deployments
      logs                 [url]       Displays the logs for a deployment
      metrics              <metric>    Queries observability metrics for your project or team
      mcp                              Set up MCP agents and configuration
      microfrontends                   Manages your microfrontends
      oauth-apps           [cmd]       Register Vercel Apps (OAuth) and manage team installations
      projects                         Manages your Projects
      redirects            [cmd]       Manages redirects for your current Project
      rm | remove          [id]        Removes a deployment
      routes               [cmd]       Manages routing rules for your current Project
      rr | rolling-release [cmd]       Manage rolling releases for gradual traffic shifting
      sandbox                          Interact with Vercel Sandbox
      skills               [query]     Discover agent skills relevant to your project
      target               [cmd]       Manage custom environments for your Project
      teams                            Manages your teams
      telemetry            [cmd]       Enable or disable telemetry collection
      tokens               [cmd]       Manage your personal Vercel authentication tokens
      traces               [cmd]       Fetch and capture traces for your project's deployment
      upgrade                          Upgrade the Vercel CLI to the latest version
      usage                            Show billing usage for the current billing period
      vcr                  [cmd]       Manages your Container Registry repositories and images
      webhooks             [cmd]       Manages webhooks [beta]
      whoami                           Shows the username of the currently logged in user

  Global Options:

    -h, --help                     Output usage information
    -v, --version                  Output the version number
    --cwd                          Current working directory
    -A FILE, --local-config=FILE   Path to the local `vercel.json` file
    -Q DIR, --global-config=DIR    Path to the global `.vercel` directory
    -d, --debug                    Debug mode [off]
    --no-color                     No color mode [off]
    --non-interactive              Run without interactive prompts (default when agent detected)
    -S, --scope                    Set a custom scope
    -t TOKEN, --token=TOKEN        Login token

  Examples:

  – Deploy the current directory

    $ vercel

  – Deploy a custom path

    $ vercel /usr/src/project

  – Deploy with Environment Variables

    $ vercel -e NODE_ENV=production

  – Show the usage information for the sub command `list`

    $ vercel help list
```

</details>

<details>
<summary>Full output — after</summary>

```

  ▲ vercel [options] <command | path>

  For deploy command help, run `vercel deploy --help`

  Commands:

    Basic

      deploy               [project-path]       Deploy your project to Vercel (default)
      build                                     Build the project
      cache                [cmd]                Manage cache for a Project
      dev | develop        [dir]                Start a local development server for your project
      env                  [cmd]                Interact with Environment Variables for a Project
      git                  [cmd]                Manage your Git repository connection to the current Project
      help                 [command]            Display help for a command
      init                 [example]            Initialize example Vercel Projects
      inspect              <url|deploymentId>   Show information about a deployment
      i | install          <integration>        Install an integration from the marketplace (alias for…
      integration          [cmd]                Manage marketplace integrations
      ir | integration-resource [cmd]                Manage marketplace integration resources (alias for `vercel…
      link                 [cmd]                Link a local directory to a Vercel project
      ls | list            [app]                List deployments
      login                [email or team id]   Sign in to your Vercel account
      logout                                    Sign out the currently authenticated user
      open                                      Open the current project in the Vercel Dashboard
      promote              <url|deploymentId>   Promote an existing Deployment to current
      pull                 [project-path]       Pull latest environment variables and project settings from…
      redeploy             [url|deploymentId]   Rebuild and deploy a previous deployment
      rollback             <url|deploymentId>   Quickly revert back to a previous deployment

    Advanced

      activity             [cmd]                List user activity events
      agent                [init]               Generate an AGENTS.md file with Vercel deployment best practices
      agent-runs           [cmd]                Inspect Agent Runs observability data
      ai-gateway           [cmd]                Manage AI Gateway resources
      alerts               [cmd]                List alert groups, inspect a group, or manage alert rules (see…
      ln | alias | aliases [cmd]                Interact with deployment aliases
      api                  [endpoint]           Make authenticated HTTP requests to the Vercel API
      bisect                                    Bisect the current project interactively or via an automated…
      blob                 [cmd]                Interact with Vercel Blob
      buy                  [cmd]                Purchase Vercel products for your team
      cert | certs         [cmd]                Interact with SSL certificates
      connect              [cmd]                Manage connectors (Beta)
      contract                                  Show contract information for all billing periods
      cron | crons         [cmd]                Manage cron jobs for a project
      curl                 <path>               Execute curl with automatic deployment URL and protection bypass
      deploy-hook | deploy-hooks [cmd]                Manage deploy hooks for Git-triggered builds
      dns                  [cmd]                Interact with DNS entries for a project
      domain | domains     [cmd]                Manage domains
      edge-config          [cmd]                Manage Edge Config stores (dashboard API parity)
      firewall             [cmd]                Manage your project's firewall rules, IP blocks, and system…
      flags                [cmd]                Manage feature flags for a Vercel project
      httpstat             <path>               Execute httpstat with automatic deployment URL and protection…
      log | logs           [url|deploymentId]   Display request logs for a project
      mcp                                       Set up MCP agents and configuration for Vercel integration
      metrics              [metric-id]          Query observability metrics for your Vercel project or team
      mf | microfrontends  [cmd]                Manage microfrontends groups that compose multiple projects…
      project | projects   [cmd]                Manage your Vercel projects
      redirect | redirects [cmd]                Manage redirects for a project
      rm | remove          <name|deploymentId>  Remove deployment(s) by project name or deployment ID
      rr | rolling-release [cmd]                Rolling releases gradually shift traffic to a new deployment in…
      routes               [cmd]                Manage routing rules for a project
      sandbox                                   Interact with Vercel Sandbox
      skills               [query]              Discover agent skills relevant to your project
      target | targets     [cmd]                Manage your Vercel Project's "targets" (custom environments)
      team | teams | switch [cmd]                Manage Teams under your Vercel account
      telemetry            [cmd]                Enable or disable telemetry collection
      tokens               [cmd]                Manage your personal Vercel authentication tokens
      traces               [requestId]          Fetch traces captured for a Vercel project
      upgrade                                   Upgrade the Vercel CLI to the latest version
      usage                                     Show billing usage (MIUs and costs) for the current billing…
      vcr                  [cmd]                Manage Vercel Container Registry repositories and images (see…
      webhook | webhooks   [cmd]                Manage webhooks
      whoami                                    Show the username of the currently logged in user

  Global Options:

    -h, --help                     Output usage information
    -v, --version                  Output the version number
    --cwd=DIR                      Sets the current working directory for a single run of a command
    -A, --local-config=FILE        Path to the local `vercel.json` file
    -Q, --global-config=DIR        Path to the global `.vercel` directory
    -d, --debug                    Debug mode (default off)
    --no-color                     No color mode (default off)
    --non-interactive              Run without interactive prompts; when an agent is detected this is the default
    -S, --scope                    Set a custom scope
    -t, --token=TOKEN              Login token

  Examples:

  – Deploy the current directory

    $ vercel

  – Deploy a custom path

    $ vercel /usr/src/project

  – Deploy with Environment Variables

    $ vercel -e NODE_ENV=production

  – Show the usage information for the sub command `list`

    $ vercel help list
```

</details>

## Changes

- Root help command lines and global options now render from `commandsStructs` / `globalCommandOptions` — the same metadata the CLI routes with. It can no longer list commands that don't exist or omit ones that do.
- Only the Basic/Advanced **grouping** stays curated; anything registered but unlisted lands in Advanced automatically. A test asserts every curated name is registered, so renames/removals fail CI.
- `commandsStructs` is typed `Command[]` and exported; the `help` stub is now a full `Command` (`vercel help [command]`), removing special cases.
- Aliases display shortest-first (`ls | list`); argument hints come from each command's declared positionals; descriptions are the first sentence of command metadata (word-boundary truncated).
- Fixes `export { StopSpinner }` → `export type` in `util/output/index.ts` (a type re-exported as a value, which breaks per-file ESM consumers).
- No routing, parsing, or exit-code changes. Descends from the drift found in #17160.

## Known deltas (intentional, disclosed)

- **`[beta]` tags**: the old text hand-tagged five commands `[beta]`; metadata only carries it where the command's own description says so (e.g. `connect`). If per-command stage labels matter, the right fix is a `stage`/`beta` field on `Command` metadata — follow-up.
- **Copy is now metadata-verbatim**, which surfaced pre-existing copy-rule violations in a few descriptions ("Allows you to enable or disable…", "Starts the…"). Fixed at the source in this PR (dev, open, whoami, upgrade, telemetry family) — the corrections improve `vercel <command> --help` too.
- `switch` is no longer a separate row; it renders as an alias on `team | teams | switch`.

## Tests

`test/unit/commands/root-help.test.ts` (7 tests): every registered visible command appears, `oauth-apps` does not, curated grouping names are registered, aliases/`(default)`/global options render from metadata. Type-check and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


