### PR TITLE
Update undici version to 6.24.0 in package-lock.json

### DIFF
--- a/packages/hydrogen/test/fixtures/hello-world-ts/package-lock.json
+++ b/packages/hydrogen/test/fixtures/hello-world-ts/package-lock.json
@@ -6805,7 +6805,7 @@
       "integrity": "sha512-IT3q0lPvtkqQ8toHQN/BkOi4VIqoqheqM1FnkNWT9y0G8B3xJhwnoKBu5OHx8zHDOvveQzfKuFowJ0VSARiIDg=="
     },
     "node_modules/undici": {
-      "version": "5.6.0",
+      "version": "6.24.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.6.0.tgz",
       "integrity": "sha512-mc+8SY1fXubTrdx4CXDkeFFGV8lI3Tq4I/70U1V8Z6g4iscGII0uLO7CPnDt56bXEbvaKwo2T2+VrteWbZiXiQ==",
       "engines": {
@@ -12087,7 +12087,7 @@
       "integrity": "sha512-IT3q0lPvtkqQ8toHQN/BkOi4VIqoqheqM1FnkNWT9y0G8B3xJhwnoKBu5OHx8zHDOvveQzfKuFowJ0VSARiIDg=="
     },
     "undici": {
-      "version": "5.6.0",
+      "version": "6.24.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.6.0.tgz",
       "integrity": "sha512-mc+8SY1fXubTrdx4CXDkeFFGV8lI3Tq4I/70U1V8Z6g4iscGII0uLO7CPnDt56bXEbvaKwo2T2+VrteWbZiXiQ=="
     },


### PR DESCRIPTION
Description
The undici WebSocket client is vulnerable to a denial-of-service attack via unbounded memory consumption during permessage-deflate decompression. When a WebSocket connection negotiates the permessage-deflate extension, the client decompresses incoming compressed frames without enforcing any limit on the decompressed data size. A malicious WebSocket server can send a small compressed frame (a "decompression bomb") that expands to an extremely large size in memory, causing the Node.js process to exhaust available memory and crash or become unresponsive.

The vulnerability exists in the PerMessageDeflate.decompress() method, which accumulates all decompressed chunks in memory and concatenates them into a single Buffer without checking whether the total size exceeds a safe threshold.



Impact

- Remote denial of service against any Node.js application using undici's WebSocket client
- A single compressed WebSocket frame of ~6 MB can decompress to ~1 GB or more
- Memory exhaustion occurs in native/external memory, bypassing V8 heap limits
- No application-level mitigation is possible as decompression occurs before message delivery
