### PR TITLE
[@vercel/connect] adding authorization mode override env var

### DIFF
--- a/.changeset/gold-pans-argue.md
+++ b/.changeset/gold-pans-argue.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Adding support for authorization mode override via env var.

--- a/packages/connect/src/authorization.ts
+++ b/packages/connect/src/authorization.ts
@@ -40,6 +40,9 @@ export interface ConnectAuthorizationResponse {
   };
 }
 
+const DETACHED_INTERACTIVE_AUTH_MODE = 'detached';
+const INTERACTIVE_AUTH_MODE_ENV = 'VERCEL_CONNECT_INTERACTIVE_AUTH_MODE';
+
 export async function startAuthorization(
   connector: string,
   params: ConnectTokenParams,
@@ -48,7 +51,9 @@ export async function startAuthorization(
   if (!connector) {
     throw new Error('connector is required');
   }
-  if (options?.callbackUrl !== undefined) {
+  const detachedInteractiveAuth =
+    process.env[INTERACTIVE_AUTH_MODE_ENV] === DETACHED_INTERACTIVE_AUTH_MODE;
+  if (!detachedInteractiveAuth && options?.callbackUrl !== undefined) {
     validateCallbackUrl(options.callbackUrl);
   }
   if (options?.webhook !== undefined) {
@@ -57,15 +62,19 @@ export async function startAuthorization(
 
   const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
   const endpoint = `https://api.vercel.com/v1/connect/authorize/${encodeURIComponent(connector)}`;
+  const deviceCode =
+    options?.deviceCode ?? (detachedInteractiveAuth ? true : undefined);
+  const returnUrl =
+    !detachedInteractiveAuth && options?.callbackUrl !== undefined
+      ? { returnUrl: options.callbackUrl }
+      : {};
 
   const body = {
     ...params,
-    ...(options?.callbackUrl !== undefined && {
-      returnUrl: options.callbackUrl,
-    }),
+    ...returnUrl,
     ...(options?.webhook !== undefined && { webhook: options.webhook }),
-    ...(options?.deviceCode !== undefined && {
-      deviceCode: options.deviceCode,
+    ...(deviceCode !== undefined && {
+      deviceCode,
     }),
     ...(options?.expiresInMs !== undefined && {
       expiresInMs: options.expiresInMs,

--- a/packages/connect/test/authorization.test.ts
+++ b/packages/connect/test/authorization.test.ts
@@ -21,6 +21,7 @@ describe('startAuthorization', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -51,6 +52,34 @@ describe('startAuthorization', () => {
     expect(JSON.parse(init.body as string)).toMatchObject({
       returnUrl: 'http://agent.localhost:3000/eve/v1/authorization/callback',
     });
+  });
+
+  it('uses detached device authorization when requested by environment', async () => {
+    vi.stubEnv('VERCEL_CONNECT_INTERACTIVE_AUTH_MODE', 'detached');
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        request: 'req_123',
+        verifier: 'verifier_123',
+        url: 'https://connect.vercel.com/authorize/req_123',
+        deviceCode: 'ABC123',
+      })
+    );
+
+    await expect(
+      startAuthorization(CONNECTOR, PARAMS, {
+        callbackUrl: 'http://example.com/connect/callback',
+      })
+    ).resolves.toMatchObject({
+      request: 'req_123',
+      verifier: 'verifier_123',
+      deviceCode: 'ABC123',
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      deviceCode: true,
+    });
+    expect(JSON.parse(init.body as string)).not.toHaveProperty('returnUrl');
   });
 
   it('rejects non-local http callback URLs', async () => {


### PR DESCRIPTION
Adding support for this `VERCEL_CONNECT_INTERACTIVE_AUTH_MODE` override env var. We want v0 to generate applications with the Connect SDK and enter detached mode inside the v0 preview without altering the generated code. 