### PR TITLE
[CLI] getting fix for broken vc env pull

### DIFF
--- a/.changeset/persist-stepup-refresh-token.md
+++ b/.changeset/persist-stepup-refresh-token.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Persist the rotated refresh token after the `vc env pull` step-up authentication. The step-up rotates the token pair server-side and revokes the previous refresh token, so keeping the old one caused subsequent step-ups to fail with `Device authorization request failed` and eventually forced a re-login.

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -458,6 +458,9 @@ async function pullEnvRecordsForEnvPull(
       userId: undefined,
       expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,
     });
+    if (tokens.refresh_token) {
+      client.updateAuthConfig({ refreshToken: tokens.refresh_token });
+    }
     client.persistAuthConfig();
 
     output.spinner('Downloading');

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -381,7 +381,7 @@ describe('env pull', () => {
     });
     expect(pullRequests).toBe(2);
     expect(client.authConfig.token).toBe('vca_new');
-    expect(client.authConfig.refreshToken).toBe('vcr_old');
+    expect(client.authConfig.refreshToken).toBe('vcr_new');
   });
 
   it('should handle pulling from Preview env vars', async () => {


### PR DESCRIPTION
This is addressing the issue Malte raised in the feedback CLI chanel:
```vc env pull
Vercel CLI 56.2.1 (Node.js 22.18.0)
> Overwriting existing .env.local file
> Downloading `development` environment variables for uncurated-tests/actor-polyfill
> Sensitive Environment Variables require fresh authentication.
Error: Device authorization request failed
Error: Challenge required
```