### PR TITLE
[CLI] fixing infinite launcher from trampoline logic

### DIFF
--- a/.changeset/native-trampoline-loop-guard.md
+++ b/.changeset/native-trampoline-loop-guard.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix an infinite launcher loop when `vercel` and `@vercel/vc-native` are both installed globally. The launcher no longer resolves a native binary when already running inside one (`VERCEL_VC_NATIVE=1`), and only resolves the native package from its own install tree, ignoring `NODE_PATH`.

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -24,10 +24,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
 function resolveNative() {
+  // Already running inside the native binary — never trampoline again.
+  if (process.env.VERCEL_VC_NATIVE === '1') return null;
   const pkgName = `@vercel/vc-native-${process.platform}-${process.arch}`;
   const binName = process.platform === 'win32' ? 'vercel.exe' : 'vercel';
   try {
-    const dir = dirname(require.resolve(`${pkgName}/package.json`));
+    // Resolve only from this install's own tree, never from NODE_PATH.
+    const dir = dirname(
+      require.resolve(`${pkgName}/package.json`, { paths: [__dirname] })
+    );
     const a = join(dir, 'bin', binName);
     if (existsSync(a)) return a;
     const b = join(dir, binName);

--- a/packages/cli/test/unit/esm/native-trampoline.test.ts
+++ b/packages/cli/test/unit/esm/native-trampoline.test.ts
@@ -125,6 +125,48 @@ describe('dist/vc.js native resolution', () => {
   );
 
   it.runIf(process.platform !== 'win32')(
+    'does not trampoline again when VERCEL_VC_NATIVE=1 (loop guard)',
+    () => {
+      const { vcJs } = buildInstall({
+        platform: process.platform,
+        arch: process.arch,
+        body: '#!/bin/sh\necho NATIVE_RAN\nexit 7\n',
+      });
+      const r = spawnSync(process.execPath, [vcJs, '--version'], {
+        encoding: 'utf8',
+        env: { ...cleanEnv(), VERCEL_VC_NATIVE: '1' },
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe(cliVersion);
+      expect(r.stdout).not.toContain('NATIVE_RAN');
+    }
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'ignores a native package resolved via NODE_PATH',
+    () => {
+      const { vcJs } = buildInstall({
+        platform: process.platform,
+        arch: process.arch,
+      });
+      // A second install holds the native package; expose it via NODE_PATH.
+      const other = buildInstall({
+        platform: process.platform,
+        arch: process.arch,
+        body: '#!/bin/sh\necho NATIVE_RAN\nexit 7\n',
+      });
+      const r = spawnSync(process.execPath, [vcJs, '--version'], {
+        encoding: 'utf8',
+        env: { ...cleanEnv(), NODE_PATH: join(other.root, 'node_modules') },
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe(cliVersion);
+      expect(r.stdout).not.toContain('NATIVE_RAN');
+      expect(r.stderr).not.toContain('(native)');
+    }
+  );
+
+  it.runIf(process.platform !== 'win32')(
     'falls through to JS when the native binary is not executable',
     () => {
       const { vcJs } = buildInstall({


### PR DESCRIPTION
This fixes an issue with the trampoline logic where we were getting where we would find ourselves in an infinite loop between installers