### PR TITLE
[CLI] suppress deprecation warning for vc build and dev for binaries

### DIFF
--- a/.changeset/native-binary-dep0169-suppress.md
+++ b/.changeset/native-binary-dep0169-suppress.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Suppress DEP0169 `url.parse()` deprecation warnings in the native binary

--- a/packages/cli/pkg.js
+++ b/packages/cli/pkg.js
@@ -6,6 +6,17 @@ const [, , script] = process.argv;
 
 process.env.VERCEL_VC_NATIVE = '1';
 
+const defaultWarningListeners = process.listeners('warning');
+process.removeAllListeners('warning');
+process.on('warning', warning => {
+  if (warning.name === 'DeprecationWarning' && warning.code === 'DEP0169') {
+    return;
+  }
+  for (const listener of defaultWarningListeners) {
+    listener(warning);
+  }
+});
+
 // In the standalone binary, process.execPath points back to this binary.
 // Route internal worker invocations here so script paths are not parsed as CLI args.
 if (script && basename(script) === 'get-latest-worker.cjs') {


### PR DESCRIPTION
This suppresses the deprecation warning for binaries on vc dev and vc build