### PR TITLE
[vercel] Precompile config validation to improve CLI startup

### DIFF
--- a/.changeset/faster-config-validation.md
+++ b/.changeset/faster-config-validation.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Precompile `vercel.json` validation to improve CLI startup performance.

--- a/packages/build-utils/src/max-duration.ts
+++ b/packages/build-utils/src/max-duration.ts
@@ -22,10 +22,11 @@ export const SKIP_MAX_DURATION_LIMIT_ENV = 'VERCEL_CLI_SKIP_MAX_DURATION_LIMIT';
 // TODO: Once `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` is fully rolled out and the
 // server-side limit is authoritative for everyone, drop the client-side upper
 // bound entirely: remove this env var, `getMaxDurationLimit`, the `maximum`
-// branch of `getMaxDurationSchema`, and the lazy per-limit validator machinery
-// in the CLI (`packages/cli/src/util/validate-config.ts`). The `vercel.json`
-// schema can then be compiled once again with no `maxDuration` maximum, and the
-// lower-bound/integer checks become the only client-side validation.
+// branch of `getMaxDurationSchema`, and the dynamic maximum handling in the CLI
+// (`packages/cli/scripts/precompile-config-validator.mjs` and
+// `packages/cli/src/util/config-validator.ts`). The `vercel.json` schema can
+// then be compiled with no `maxDuration` maximum, leaving only the lower-bound
+// and integer checks on the client.
 
 /**
  * Returns the client-side upper bound for `maxDuration` in seconds, or

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -11,6 +11,7 @@ import { compileDevTemplates } from './compile-templates.mjs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { esbuild, getDependencies } from '../../../utils/build.mjs';
+import { createConfigValidatorPlugin } from './precompile-config-validator.mjs';
 
 const repoRoot = new URL('../', import.meta.url);
 const cwd = process.cwd();
@@ -127,7 +128,7 @@ await esbuild({
   outdir: distDir,
   external: getDependencies(),
   banner,
-  plugins: [jsoncParserPlugin],
+  plugins: [jsoncParserPlugin, await createConfigValidatorPlugin()],
 });
 
 // Move priority command outputs to expected locations

--- a/packages/cli/scripts/precompile-config-validator.mjs
+++ b/packages/cli/scripts/precompile-config-validator.mjs
@@ -1,0 +1,146 @@
+import Ajv from 'ajv';
+import {
+  DEFAULT_MAX_DURATION_LIMIT,
+  SKIP_MAX_DURATION_LIMIT_ENV,
+} from '@vercel/build-utils';
+import { build as esbuild } from 'esbuild';
+import { tsImport } from 'tsx/esm/api';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const cliDir = fileURLToPath(new URL('..', import.meta.url));
+const outputPath = fileURLToPath(
+  new URL('../dist/chunks/config-validator.mjs', import.meta.url)
+);
+
+export async function createConfigValidatorPlugin() {
+  await generateConfigValidator();
+
+  return {
+    name: 'precompile-config-validator',
+    setup(build) {
+      let didResolve = false;
+      build.onResolve({ filter: /^\.\/config-validator$/ }, args => {
+        if (args.importer.endsWith('validate-config.ts')) {
+          didResolve = true;
+          return { path: './config-validator.mjs', external: true };
+        }
+      });
+      build.onEnd(result => {
+        if (result.errors.length === 0 && !didResolve) {
+          throw new Error('Build did not use the precompiled config validator');
+        }
+      });
+    },
+  };
+}
+
+export async function generateConfigValidator() {
+  const { buildVercelConfigSchema } = await tsImport(
+    '../src/util/validate-config.ts',
+    import.meta.url
+  );
+  const previousSkipMaxDuration = process.env[SKIP_MAX_DURATION_LIMIT_ENV];
+
+  let schema;
+  try {
+    delete process.env[SKIP_MAX_DURATION_LIMIT_ENV];
+    schema = buildVercelConfigSchema();
+  } finally {
+    if (previousSkipMaxDuration === undefined) {
+      delete process.env[SKIP_MAX_DURATION_LIMIT_ENV];
+    } else {
+      process.env[SKIP_MAX_DURATION_LIMIT_ENV] = previousSkipMaxDuration;
+    }
+  }
+
+  const validator = precompile(schema);
+  mkdirSync(fileURLToPath(new URL('../dist/chunks', import.meta.url)), {
+    recursive: true,
+  });
+  await esbuild({
+    stdin: {
+      contents: `
+        import { getMaxDurationLimit } from '@vercel/build-utils';
+        const validator = ${validator};
+        export function getConfigValidator() {
+          return validator;
+        }
+      `,
+      resolveDir: cliDir,
+    },
+    bundle: true,
+    external: ['@vercel/build-utils'],
+    format: 'esm',
+    minify: true,
+    outfile: outputPath,
+    platform: 'node',
+  });
+
+  return outputPath;
+}
+
+// Ajv 6 exposes generated source plus its closure values, rather than a
+// standalone module, so serialize both here.
+function precompile(schema) {
+  const ajv = new Ajv({ sourceCode: true });
+  const validate = ajv.compile(schema);
+  if (validate.refVal.length !== 1 || validate.refVal[0] !== validate) {
+    throw new Error('Unsupported referenced validator in vercel.json schema');
+  }
+
+  const patterns = validate.source.patterns
+    .map(
+      (pattern, index) =>
+        `const pattern${index} = new RegExp(${JSON.stringify(pattern)});`
+    )
+    .join('\n');
+  const defaults = validate.source.defaults
+    .map((value, index) => `const default${index} = ${JSON.stringify(value)};`)
+    .join('\n');
+
+  // Keep the environment-gated maximum dynamic without shipping two copies of
+  // this large validator. All uses of this limit in the schema are maxDuration.
+  const maximumCheck = ` > ${DEFAULT_MAX_DURATION_LIMIT}`;
+  const maximumChecks = validate.toString().split(maximumCheck).length - 1;
+  const schemaMaximums = countMaxDurationMaximums(schema);
+  if (maximumChecks !== schemaMaximums) {
+    throw new Error('Could not make maxDuration validation dynamic');
+  }
+  const validatorSource = validate
+    .toString()
+    .replaceAll(maximumCheck, ' > getMaxDurationLimit()');
+
+  return `(() => {
+    const formats = require('ajv/lib/compile/formats')();
+    const ucs2length = require('ajv/lib/compile/ucs2length');
+    const equal = require('ajv/lib/compile/equal');
+    const refVal = [];
+    ${patterns}
+    ${defaults}
+    const validate = (${validatorSource});
+    validate.schema = ${JSON.stringify(validate.schema)};
+    validate.errors = null;
+    return validate;
+  })()`;
+}
+
+function countMaxDurationMaximums(value, insideMaxDuration = false) {
+  if (!value || typeof value !== 'object') return 0;
+
+  let count = 0;
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'maximum' && child === DEFAULT_MAX_DURATION_LIMIT) {
+      if (!insideMaxDuration) {
+        throw new Error('Default maxDuration limit used by another schema');
+      }
+      count++;
+    } else {
+      count += countMaxDurationMaximums(
+        child,
+        insideMaxDuration || key === 'maxDuration'
+      );
+    }
+  }
+  return count;
+}

--- a/packages/cli/src/util/config-validator.ts
+++ b/packages/cli/src/util/config-validator.ts
@@ -1,0 +1,31 @@
+import Ajv from 'ajv';
+import { getMaxDurationLimit } from '@vercel/build-utils';
+
+type BuildSchema = () => object;
+
+const ajv = new Ajv();
+const validatorCacheByLimit = new Map<
+  number | 'skipped',
+  ReturnType<typeof ajv.compile>
+>();
+
+/**
+ * This lazy compiler supports direct source execution. The production build
+ * and Vitest replace it with a validator compiled during `scripts/build.mjs`.
+ *
+ * Keep selecting by the current limit at validation time: the environment
+ * variable may be set after this module is imported.
+ */
+export function getConfigValidator(buildSchema: BuildSchema) {
+  if (process.env.VITEST) {
+    throw new Error('Vitest must use the precompiled config validator');
+  }
+
+  const cacheKey = getMaxDurationLimit() ?? 'skipped';
+  let validate = validatorCacheByLimit.get(cacheKey);
+  if (!validate) {
+    validate = ajv.compile(buildSchema());
+    validatorCacheByLimit.set(cacheKey, validate);
+  }
+  return validate;
+}

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -1,4 +1,3 @@
-import Ajv from 'ajv';
 import {
   routesSchema,
   cleanUrlsSchema,
@@ -11,12 +10,12 @@ import type { VercelConfig } from './dev/types';
 import {
   getFunctionsSchema,
   buildsSchema,
-  getMaxDurationLimit,
   getMaxDurationSchema,
   NowBuildError,
   getPrettyError,
 } from '@vercel/build-utils';
 import { fileNameSymbol } from '@vercel/client';
+import { getConfigValidator } from './config-validator';
 
 const imagesSchema = {
   type: 'object',
@@ -572,7 +571,7 @@ const getServicesSchema = () => ({
   additionalProperties: getServicesServiceConfigSchema(),
 });
 
-function buildVercelConfigSchema() {
+export function buildVercelConfigSchema() {
   return {
     type: 'object',
     // These are not all possibilities because `vc dev`
@@ -598,38 +597,8 @@ function buildVercelConfigSchema() {
   };
 }
 
-const ajv = new Ajv();
-
-/**
- * The `maxDuration` upper bound is gated behind
- * `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` (see `getMaxDurationSchema`), which may be
- * set after this module is imported. Compiling the validator once at module load
- * would bake in whatever limit was active at import time and ignore the variable,
- * so instead we build and compile lazily, caching one validator per resolved
- * limit (bounded vs. skipped).
- *
- * TODO: This machinery exists only to honor the runtime
- * `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT` toggle. Once the flag is fully rolled out
- * and the client-side bound is dropped (see `max-duration.ts` in
- * `@vercel/build-utils`), revert to a single statically compiled validator.
- */
-const validatorCacheByLimit = new Map<
-  number | 'skipped',
-  ReturnType<typeof ajv.compile>
->();
-
-function getConfigValidator() {
-  const cacheKey = getMaxDurationLimit() ?? 'skipped';
-  let validate = validatorCacheByLimit.get(cacheKey);
-  if (!validate) {
-    validate = ajv.compile(buildVercelConfigSchema());
-    validatorCacheByLimit.set(cacheKey, validate);
-  }
-  return validate;
-}
-
 export function validateConfig(config: VercelConfig): NowBuildError | null {
-  const validate = getConfigValidator();
+  const validate = getConfigValidator(buildVercelConfigSchema);
   if (!validate(config)) {
     if (validate.errors && validate.errors[0]) {
       const error = validate.errors[0];

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -323,7 +323,7 @@ describe('validateConfig', () => {
 
     it('allows maxDuration above 1800s when set to "1" (defers to the server)', () => {
       process.env[ENV] = '1';
-      expect(validateConfig(configWith(1800))).toBeNull();
+      expect(validateConfig(configWith(1900))).toBeNull();
     });
 
     it('still enforces the lower bound and integer check when skipped', () => {

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -323,6 +323,7 @@ describe('validateConfig', () => {
 
     it('allows maxDuration above 1800s when set to "1" (defers to the server)', () => {
       process.env[ENV] = '1';
+      expect(validateConfig(configWith(1800))).toBeNull();
       expect(validateConfig(configWith(1900))).toBeNull();
     });
 

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -2,12 +2,19 @@ import { mergeConfig } from 'vite';
 import rootConfig from '../../vitest.config.mts';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
+import { generateConfigValidator } from './scripts/precompile-config-validator.mjs';
 
 // Get peer dependencies to externalize them (they may not be installed in CI)
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 const peerDeps = Object.keys(pkg.peerDependencies || {});
 
 export default mergeConfig(rootConfig, {
+  // Exercise the same precompiled validator that the production build ships.
+  resolve: {
+    alias: {
+      './config-validator': await generateConfigValidator(),
+    },
+  },
   test: {
     setupFiles: ['./vitest.setup.mts'],
   },


### PR DESCRIPTION
`vc build` currently compiles the full `vercel.json` Ajv schema on first use. In Vercel platform traces, that accounts for ~167ms inside `vc.doBuild` before the core build work happens.

This PR moves schema compilation to the CLI build step and uses the precompiled validator at runtime. Validation behaviour is unchanged, including the runtime `maxDuration` gate.

Note: this cost is not caused by the `maxDuration` rollout. That flag is why we previously needed separate lazily compiled validator variants, but removing it would still leave Ajv compiling the large schema at runtime. The expensive part is the compilation itself.

The existing `validateConfig` test suite automatically uses the same precompiled validator that production ships, so the new path gets the full existing coverage without duplicating tests. The e2e tests run the built CLI and therefore cover the production wiring too.


### Benchmarks

I compared the same uncached build in lhr1 using production (`dpl_C4Xig3NrN78CMZcJRteRQbVjiBW3`) and using this PR's CLI (`dpl_CiK7PYKeG9U7TgsrfMvdRPfDDFR1`). The unaccounted time inside `vc.doBuild` fell from ~167ms to effectively zero. Because this Ajv compilation happens during `vc build` startup before project-specific work, I’m reasonably confident this removes roughly 167ms from every build.

I also did a rough local benchmark. The results were a little noisy, but `vercel build` was around 40ms faster (roughly a 10% improvement, lower than on our build machines because my M3 Pro laptop is better).