### PR TITLE
[cli] Detect global npm install when npm/node is managed by Homebrew

### DIFF
--- a/.changeset/proud-ways-fetch.md
+++ b/.changeset/proud-ways-fetch.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Detect and correctly upgrade global npm installs when npm is managed by Homebrew

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -140,6 +140,18 @@ function isGlobalByPath(installPath: string): boolean {
     return true;
   }
 
+  // Homebrew-managed node uses custom PREFIX
+  if (
+    installPath.includes(
+      ['', 'opt', 'homebrew', 'lib', 'node_modules', ''].join(sep)
+    ) ||
+    installPath.includes(
+      ['', '.linuxbrew', 'lib', 'node_modules', ''].join(sep)
+    )
+  ) {
+    return true;
+  }
+
   if (
     installPath.includes(['', 'yarn', 'global', 'node_modules', ''].join(sep))
   ) {

--- a/packages/cli/test/unit/util/get-update-command-detection.test.ts
+++ b/packages/cli/test/unit/util/get-update-command-detection.test.ts
@@ -56,6 +56,37 @@ describe('getUpdateCommandInfo install detection', () => {
       expect(info).toEqual({ command: 'npm i -g vercel@latest', global: true });
     });
 
+    it('detects a global npm install in Homebrew-managed npm PREFIX', async () => {
+      const originalArgv = process.argv;
+      process.argv = ['/usr/bin/node', '/some/bin/vercel'];
+      try {
+        const installPath = join(
+          sep,
+          'opt',
+          'homebrew',
+          'lib',
+          'node_modules',
+          'vercel',
+          'dist'
+        );
+        realpathMock.mockResolvedValueOnce(installPath);
+        mockExecFile.mockRejectedValue(new Error('not installed'));
+        scanParentDirsMock.mockResolvedValue({
+          cliType: 'npm',
+          lockfilePath: join(sep, 'project', 'package-lock.json'),
+        } as any);
+
+        const info = await getUpdateCommandInfo();
+
+        expect(info).toEqual({
+          command: 'npm i -g vercel@latest',
+          global: true,
+        });
+      } finally {
+        process.argv = originalArgv;
+      }
+    });
+
     it('detects a global pnpm install via the symlinked content-addressable store', async () => {
       const npmRoot = join(sep, 'npm-gnm');
       const pnpmRoot = join(sep, 'pnpm-gnm');


### PR DESCRIPTION
Supersedes previous attempt at https://github.com/vercel/vercel/pull/14487

CLI currently fails to detect npm global installs, when npm/node are managed by Homebrew.

This is because Homebrew [sets](https://github.com/Homebrew/homebrew-core/blob/99a428b33d5462818ad47bf00e3acf6a50a25cea/Formula/n/node.rb#L227) `prefix = <HOMEBRW_PREFIX>/lib/node_modules` in `<HOMEBREW_PREFIX>/lib/node_modules/npm/npmrc` when it installs `node`, which determines where global npm packages install to.

https://github.com/vercel/vercel/pull/16903 (now merged) made this global detection failure less annoying by having `vc`'s self-upgrade fall back to global instead of local upgrade command, but we should still explicitly detect npm global installations in Homebrew-managed npm, as Homebrew is a very common way of installing node & npm for developers.

Related Community thread, by me: https://community.vercel.com/t/why-vercel-cli-adds-itself-to-package-json-during-global-version-upgrades/37552/9
