### PR TITLE
[build-utils] Add `partialPrerenderConfig` option to `Prerender`

### DIFF
--- a/.changeset/prerender-partial-prerender-config.md
+++ b/.changeset/prerender-partial-prerender-config.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Add `partialPrerenderConfig` option to `Prerender`. Builders set it per Partial Prerendering (PPR) route; `staticHint: true` indicates the page had no dynamic components detected at build time and should be opted out of async-shell-miss handling at the CDN.

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -1,4 +1,4 @@
-import type { File, HasField, Chain } from './types';
+import type { File, HasField, Chain, PartialPrerenderConfig } from './types';
 import { Lambda } from './lambda';
 
 function assertOptionalBoolean(
@@ -34,6 +34,7 @@ interface PrerenderOptions {
   hasFallback?: boolean;
   htmlSize?: number;
   isDynamicRoute?: boolean;
+  partialPrerenderConfig?: PartialPrerenderConfig;
 }
 
 export class Prerender {
@@ -90,6 +91,13 @@ export class Prerender {
    * rather than a concrete prerender.
    */
   public isDynamicRoute?: boolean;
+  /**
+   * Present when this route uses Partial Prerendering (PPR). `staticHint:
+   * true` means no dynamic components were detected at build time, so the
+   * page should be opted out of async-shell-miss handling at the CDN.
+   * `undefined` when the builder did not provide the signal.
+   */
+  public partialPrerenderConfig?: PartialPrerenderConfig;
 
   constructor({
     expiration,
@@ -113,6 +121,7 @@ export class Prerender {
     hasFallback,
     htmlSize,
     isDynamicRoute,
+    partialPrerenderConfig,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
@@ -315,6 +324,25 @@ export class Prerender {
       throw new Error(
         `The \`exposeErrBody\` argument for \`Prerender\` must be a boolean.`
       );
+    }
+
+    if (partialPrerenderConfig !== undefined) {
+      if (
+        partialPrerenderConfig === null ||
+        typeof partialPrerenderConfig !== 'object' ||
+        Array.isArray(partialPrerenderConfig)
+      ) {
+        throw new Error(
+          'The `partialPrerenderConfig` argument for `Prerender` must be an object.'
+        );
+      }
+
+      assertOptionalBoolean(
+        partialPrerenderConfig.staticHint,
+        'partialPrerenderConfig.staticHint'
+      );
+
+      this.partialPrerenderConfig = partialPrerenderConfig;
     }
 
     if (partialFallback === true) {

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -905,6 +905,19 @@ export interface Chain {
   headers: Record<string, string>;
 }
 
+/**
+ * Configuration for a Partial Prerendering (PPR) route.
+ */
+export interface PartialPrerenderConfig {
+  /**
+   * `true` when the page had no dynamic components detected at build time,
+   * hinting that the prerendered shell is fully static. Such pages should be
+   * opted out of async-shell-miss handling at the CDN so they keep MISS
+   * request collapsing and single invocations.
+   */
+  staticHint?: boolean;
+}
+
 interface TriggerEventBase {
   /** Name of the queue topic to consume from (REQUIRED) */
   topic: string;

--- a/packages/build-utils/test/unit.deserialize-build-output.test.ts
+++ b/packages/build-utils/test/unit.deserialize-build-output.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { describe, expect, it, vi } from 'vitest';
 import { Lambda } from '../src/lambda';
+import { Prerender } from '../src/prerender';
 import type {
   DeserializeBuildOutputConfig,
   DeserializeBuildOutputResult,
@@ -75,12 +76,17 @@ async function writeNodeFunction(outputDir: string, outputPath: string) {
   );
 }
 
-async function writePrerenderConfig(outputDir: string, outputPath: string) {
+async function writePrerenderConfig(
+  outputDir: string,
+  outputPath: string,
+  config: Record<string, unknown> = {}
+) {
   await fs.outputJSON(
     join(outputDir, 'functions', `${outputPath}.prerender-config.json`),
     {
       expiration: 60,
       fallback: null,
+      ...config,
     }
   );
 }
@@ -222,6 +228,57 @@ describe('deserializeBuildOutput()', () => {
       );
       expect(result.meta).toBeUndefined();
       expect(result.deploymentId).toBeUndefined();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it('round-trips partialPrerenderConfig through serialization', async () => {
+    const fixture = await createOutputFixture();
+
+    try {
+      await writeNodeFunction(fixture.outputDir, 'api/ppr-static');
+      await writeNodeFunction(fixture.outputDir, 'api/ppr-plain');
+
+      // Serialize the same way the CLI's `write-build-result.ts` does: the
+      // `Prerender` instance is spread into `.prerender-config.json`.
+      const prerender = new Prerender({
+        expiration: 60,
+        fallback: null,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        partialPrerenderConfig: { staticHint: true },
+      });
+      await writePrerenderConfig(fixture.outputDir, 'api/ppr-static', {
+        ...prerender,
+        lambda: undefined,
+        fallback: null,
+      });
+      await writePrerenderConfig(fixture.outputDir, 'api/ppr-plain');
+
+      const result = await deserializeBuildOutput<TestConfig>({
+        outputDir: fixture.outputDir,
+        repoRootPath: fixture.repoRootPath,
+        deserializeLambda: async () => createLambda('noop.handler'),
+        groupLambdas: async () => ({}),
+      });
+
+      const staticOutput =
+        result.output[getOutputKey(result.output, 'api/ppr-static')];
+      expect(staticOutput.type).toBe('Prerender');
+      if (staticOutput.type !== 'Prerender') {
+        throw new Error('Expected prerender output');
+      }
+      expect(staticOutput.partialPrerenderConfig).toEqual({
+        staticHint: true,
+      });
+
+      const plainOutput =
+        result.output[getOutputKey(result.output, 'api/ppr-plain')];
+      expect(plainOutput.type).toBe('Prerender');
+      if (plainOutput.type !== 'Prerender') {
+        throw new Error('Expected prerender output');
+      }
+      expect(plainOutput.partialPrerenderConfig).toBeUndefined();
     } finally {
       await fixture.cleanup();
     }

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -803,6 +803,85 @@ it('should validate htmlSize as a non-negative integer', async () => {
   );
 });
 
+it('should validate partialPrerenderConfig', async () => {
+  const staticShell = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    partialPrerenderConfig: { staticHint: true },
+  });
+  expect(staticShell.partialPrerenderConfig).toEqual({ staticHint: true });
+
+  const dynamicShell = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    partialPrerenderConfig: { staticHint: false },
+  });
+  expect(dynamicShell.partialPrerenderConfig).toEqual({ staticHint: false });
+
+  const noHint = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    partialPrerenderConfig: {},
+  });
+  expect(noHint.partialPrerenderConfig).toEqual({});
+
+  const unset = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+  });
+  expect(unset.partialPrerenderConfig).toBeUndefined();
+
+  expect(
+    () =>
+      new Prerender({
+        expiration: 1,
+        fallback: null,
+        group: 1,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        // @ts-expect-error - intentionally invalid to assert validation
+        partialPrerenderConfig: 'static',
+      })
+  ).toThrow(
+    'The `partialPrerenderConfig` argument for `Prerender` must be an object.'
+  );
+
+  expect(
+    () =>
+      new Prerender({
+        expiration: 1,
+        fallback: null,
+        group: 1,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        // @ts-expect-error - intentionally invalid to assert validation
+        partialPrerenderConfig: null,
+      })
+  ).toThrow(
+    'The `partialPrerenderConfig` argument for `Prerender` must be an object.'
+  );
+
+  expect(
+    () =>
+      new Prerender({
+        expiration: 1,
+        fallback: null,
+        group: 1,
+        bypassToken: 'some-long-bypass-token-to-make-it-work',
+        // @ts-expect-error - intentionally invalid to assert validation
+        partialPrerenderConfig: { staticHint: 'yes' },
+      })
+  ).toThrow(
+    'The `partialPrerenderConfig.staticHint` argument for `Prerender` must be a boolean'
+  );
+});
+
 it('should support passQuery correctly', async () => {
   new Prerender({
     expiration: 1,


### PR DESCRIPTION
## What

Adds a `partialPrerenderConfig` option to the `Prerender` output type in `@vercel/build-utils`:

```ts
partialPrerenderConfig?: {
  staticHint?: boolean;
}
```

- New `PartialPrerenderConfig` interface exported from `@vercel/build-utils` (defined in `types.ts` alongside `Chain`).
- Constructor validation consistent with neighboring fields: the value must be an object, and `staticHint` must be a boolean when present.
- The field round-trips through Build Output API serialization: the CLI's `write-build-result.ts` spreads the `Prerender` instance into `.prerender-config.json`, and `deserializeBuildOutput` spreads the parsed config back into the `Prerender` constructor, so no serializer changes were needed beyond the constructor plumbing (`SerializedPrerender` derives from the class and picks the field up automatically).

## Why
We want to be able to know when a PPR page is likely to be fully static at request time. Builders will set `partialPrerenderConfig` for every PPR (Partial Prerendering) route:

- `staticHint: true` means the page had no dynamic components detected at build time.

## Notes

- This PR only adds the field to `@vercel/build-utils` so it round-trips through serialization. The producer side is the `nextjs/adapter-vercel` adapter, which emits prebuilt Build Output API with `partialPrerenderConfig` set per PPR route — no `@vercel/next` builder change is planned. The deserialize-side fix in this PR is required regardless of producer: without the constructor plumbing, `deserializeBuildOutput` silently drops the field when reconstructing `Prerender` instances from `.prerender-config.json`.
- vercel/api will consume the new field via a `@vercel/build-utils` pin bump.

## Tests

- Constructor accepts `{ staticHint: true | false }` and `{}`, leaves it `undefined` when omitted, and rejects non-object values and non-boolean `staticHint`.
- Serialize→deserialize round trip (mirroring `write-build-result.ts`'s spread into `.prerender-config.json`) preserves `partialPrerenderConfig`, and instances without it are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
