### PR TITLE
[connex] Resolve custom environments when attaching projects

### DIFF
--- a/.changeset/connex-custom-environments.md
+++ b/.changeset/connex-custom-environments.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Support attaching Connect connectors to project custom environments by slug or stable ID.

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -8,6 +8,10 @@ import { getLinkedProject } from '../../util/projects/link';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
 import { ProjectNotFound } from '../../util/errors-ts';
 import { envTargetChoices, isValidEnvTarget } from '../../util/env/env-target';
+import {
+  getCustomEnvironments,
+  pickCustomEnvironment,
+} from '../../util/target/get-custom-environments';
 import { normalizeRepeatableStringFilters } from '../../util/command-validation';
 import { sanitizeForTerminal } from '../../util/connex/sanitize';
 import { packageName } from '../../util/pkg-name';
@@ -25,6 +29,49 @@ import type {
 } from './types';
 
 const ALL_ENVS = ['production', 'preview', 'development'] as const;
+
+async function resolveRequestedEnvironments(
+  client: Client,
+  projectId: string,
+  projectName: string,
+  requestedEnvironments: string[]
+): Promise<string[] | undefined> {
+  if (requestedEnvironments.length === 0) {
+    return [...ALL_ENVS];
+  }
+
+  const customEnvironmentInputs = requestedEnvironments.filter(
+    environment => !isValidEnvTarget(environment)
+  );
+  const customEnvironments =
+    customEnvironmentInputs.length > 0
+      ? await getCustomEnvironments(client, projectId)
+      : [];
+  const resolvedEnvironments = new Set<string>();
+
+  for (const environment of requestedEnvironments) {
+    if (isValidEnvTarget(environment)) {
+      resolvedEnvironments.add(environment);
+      continue;
+    }
+
+    const customEnvironment = pickCustomEnvironment(
+      customEnvironments,
+      environment
+    );
+    if (!customEnvironment) {
+      output.error(
+        `Invalid environment ${chalk.bold(environment)} for project ${chalk.bold(projectName)}. Use ${envTargetChoices
+          .map(choice => choice.value)
+          .join(', ')}, or a custom environment slug or ID from that project.`
+      );
+      return undefined;
+    }
+    resolvedEnvironments.add(customEnvironment.id);
+  }
+
+  return [...resolvedEnvironments];
+}
 
 function envSetsEqual(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) {
@@ -79,22 +126,11 @@ export async function attach(
     return 1;
   }
 
-  // Validate environments. Empty → all three.
+  // Custom environment slugs are project-scoped, so resolve the project before
+  // validating these values. An omitted option still means all three built-ins.
   const requestedEnvsRaw = normalizeRepeatableStringFilters(
     flags['--environment']
   );
-  for (const env of requestedEnvsRaw) {
-    if (!isValidEnvTarget(env)) {
-      output.error(
-        `Invalid environment ${chalk.bold(env)}. Allowed values: ${envTargetChoices
-          .map(c => c.value)
-          .join(', ')}.`
-      );
-      return 1;
-    }
-  }
-  const environments =
-    requestedEnvsRaw.length > 0 ? requestedEnvsRaw : [...ALL_ENVS];
 
   // Resolve project — explicit --project takes priority over the linked one.
   let projectId: string;
@@ -143,6 +179,22 @@ export async function attach(
     }
     projectId = linked.project.id;
     projectName = sanitizeForTerminal(linked.project.name);
+  }
+
+  let environments: string[] | undefined;
+  try {
+    environments = await resolveRequestedEnvironments(
+      client,
+      projectId,
+      projectName,
+      requestedEnvsRaw
+    );
+  } catch (err: unknown) {
+    printError(err);
+    return 1;
+  }
+  if (!environments) {
+    return 1;
   }
 
   // Resolve client identity → canonical id + display name. The base GET

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -488,7 +488,7 @@ export const attachSubcommand = {
       argument: 'ENV',
       deprecated: false,
       description:
-        'Environments to enable. Repeatable and comma-separated (e.g. -e production -e preview, or -e production,preview). Defaults to all environments.',
+        'Environments to enable by system name, custom slug, or custom ID. Repeatable and comma-separated. Defaults to production, preview, and development.',
     },
     {
       ...projectOption,
@@ -529,12 +529,20 @@ export const attachSubcommand = {
   ],
   examples: [
     {
-      name: 'Attach the current project to a connector for all environments',
+      name: 'Attach the current project for all system environments',
       value: `${packageName} connect attach scl_abc123`,
     },
     {
       name: 'Restrict to specific environments',
       value: `${packageName} connect attach scl_abc123 -e production -e preview`,
+    },
+    {
+      name: 'Attach to a custom environment by slug',
+      value: `${packageName} connect attach scl_abc123 -e qa`,
+    },
+    {
+      name: 'Attach to a custom environment by stable ID',
+      value: `${packageName} connect attach scl_abc123 -e env_qa123`,
     },
     {
       name: 'Attach a different project by name',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -759,8 +759,8 @@ exports[`help command > connex help output snapshots > connex attach subcommand 
 
   Options:
 
-  -e,  --environment <ENV>        Environments to enable. Repeatable and comma-separated (e.g. -e production -e preview, or
-                                  -e production,preview). Defaults to all environments.                                    
+  -e,  --environment <ENV>        Environments to enable by system name, custom slug, or custom ID. Repeatable and         
+                                  comma-separated. Defaults to production, preview, and development.                       
   -F,  --format <FORMAT>          Specify the output format (json)                                                         
   -p,  --project <NAME_OR_ID>     Project name or ID (default: current linked project)                                     
        --trigger-branch <BRANCH>  Target a specific git branch for the trigger destination (default: production). Only     
@@ -788,13 +788,21 @@ exports[`help command > connex help output snapshots > connex attach subcommand 
 
   Examples:
 
-  - Attach the current project to a connector for all environments
+  - Attach the current project for all system environments
 
     $ vercel connect attach scl_abc123
 
   - Restrict to specific environments
 
     $ vercel connect attach scl_abc123 -e production -e preview
+
+  - Attach to a custom environment by slug
+
+    $ vercel connect attach scl_abc123 -e qa
+
+  - Attach to a custom environment by stable ID
+
+    $ vercel connect attach scl_abc123 -e env_qa123
 
   - Attach a different project by name
 

--- a/packages/cli/test/unit/commands/connex/attach.test.ts
+++ b/packages/cli/test/unit/commands/connex/attach.test.ts
@@ -30,7 +30,20 @@ describe('connex attach', () => {
     useUser();
     team = useTeam('team_test');
     client.config.currentTeam = team.id;
-    useProject({ ...defaultProject, id: PROJECT_ID, name: PROJECT_NAME });
+    useProject({
+      ...defaultProject,
+      id: PROJECT_ID,
+      name: PROJECT_NAME,
+      customEnvironments: [
+        {
+          id: 'env_qa123',
+          slug: 'qa',
+          type: 'preview',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
   });
 
   it('errors when no client argument is provided', async () => {
@@ -67,6 +80,179 @@ describe('connex attach', () => {
     const stderr = client.stderr.getFullOutput();
     expect(stderr).toContain('Invalid environment');
     expect(stderr).toContain('production, preview, development');
+    expect(stderr).toContain('custom environment slug or ID');
+  });
+
+  it('resolves a project custom environment slug to its stable ID', async () => {
+    await setupLinkedProject(team);
+    let postBody: { environments?: string[] } | undefined;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found' } });
+      }
+    );
+    client.scenario.post(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (req, res) => {
+        postBody = req.body;
+        res.json({});
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'attach',
+      'scl_abc123',
+      '-e',
+      'production,qa',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(postBody?.environments).toEqual(['production', 'env_qa123']);
+  });
+
+  it('accepts a stable custom environment ID belonging to the project', async () => {
+    await setupLinkedProject(team);
+    let postBody: { environments?: string[] } | undefined;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found' } });
+      }
+    );
+    client.scenario.post(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (req, res) => {
+        postBody = req.body;
+        res.json({});
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'attach',
+      'scl_abc123',
+      '-e',
+      'env_qa123',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(postBody?.environments).toEqual(['env_qa123']);
+  });
+
+  it('deduplicates built-in names, custom slugs, and their stable IDs', async () => {
+    await setupLinkedProject(team);
+    let postBody: { environments?: string[] } | undefined;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found' } });
+      }
+    );
+    client.scenario.post(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (req, res) => {
+        postBody = req.body;
+        res.json({});
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'attach',
+      'scl_abc123',
+      '-e',
+      'production,qa',
+      '-e',
+      'env_qa123,production',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(postBody?.environments).toEqual(['production', 'env_qa123']);
+  });
+
+  it('resolves a custom environment for an explicit --project', async () => {
+    client.cwd = setupTmpDir();
+    let postProjectId = '';
+    let postBody: { environments?: string[] } | undefined;
+
+    client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+      res.json({ id: 'scl_abc123', uid: 'slack/my-bot' });
+    });
+    client.scenario.get(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (_req, res) => {
+        res.statusCode = 404;
+        res.json({ error: { code: 'not_found' } });
+      }
+    );
+    client.scenario.post(
+      '/v1/connect/connectors/:clientId/projects/:projectId',
+      (req, res) => {
+        postProjectId = req.params.projectId;
+        postBody = req.body;
+        res.json({});
+      }
+    );
+
+    client.setArgv(
+      'connect',
+      'attach',
+      'scl_abc123',
+      '--project',
+      PROJECT_NAME,
+      '-e',
+      'qa',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(postProjectId).toBe(PROJECT_ID);
+    expect(postBody?.environments).toEqual(['env_qa123']);
+  });
+
+  it('rejects a custom environment ID belonging to another project', async () => {
+    await setupLinkedProject(team);
+    client.setArgv(
+      'connect',
+      'attach',
+      'scl_abc123',
+      '-e',
+      'env_other_project',
+      '--yes'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Invalid environment');
   });
 
   it('errors when no project is linked and --project is not provided', async () => {


### PR DESCRIPTION
## Summary

- let `vercel connect attach --environment` accept a project custom-environment slug or stable ID
- resolve custom inputs against the selected project and send stable `env_*` IDs to Connex
- reject unknown or wrong-project custom IDs and deduplicate aliases and repeated values
- preserve the existing Production, Preview, and Development default when the option is omitted
- document stable-ID input in command help and keep the required CLI changeset
- add coverage for alias deduplication and explicit `--project` resolution

Depends on the merged Connex API custom-environment stack:

1. https://github.com/vercel/api/pull/81164
2. https://github.com/vercel/api/pull/81165
3. https://github.com/vercel/api/pull/81166

## Test plan

- `pnpm turbo build --filter=vercel` — PASS (`39/39` tasks)
- `cd packages/cli && pnpm vitest run test/unit/commands/connex/attach.test.ts test/unit/commands/help.test.ts` — PASS (`2/2` files, `171/171` tests)
- Built `connect attach --help` — PASS (exit `0`; custom slug/ID documentation, defaults, and examples rendered)
- Explicit `--project vercel-ai-gateway-demo` matrix — PASS (omitted defaults, custom slug, stable ID, and repeatable/comma-separated deduplication)
- Linked `cli-test` matrix — PASS (`tonytest` slug and stable ID produced the same stable `env_*` receipt with no `--project`)
- Unknown project-scoped `env_*` — PASS (exit `1`; capture count unchanged, so no attachment POST)
- API safety boundary — PASS (deployed reads; `6/6` attachment POSTs captured locally, `0` unexpected routes, no deployed mutation)
- No `--triggers`, deletion, detach, or connector-removal scenarios were run

Related: [MKT-3999](https://linear.app/vercel/issue/MKT-3999)
