### PR TITLE
fix(cli): improve upload failure error messages

### DIFF
--- a/.changeset/improve-upload-failure-errors.md
+++ b/.changeset/improve-upload-failure-errors.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve deploy upload failure messages for network timeouts, API gateway errors, and `api-upload` service failures with actionable retry guidance and archive suggestions.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -91,7 +91,10 @@ import { DeployTelemetryClient } from '../../util/telemetry/commands/deploy';
 import output from '../../output-manager';
 import { ensureLink } from '../../util/link/ensure-link';
 import { isOwnerLookupUnavailableLink } from '../../util/projects/link';
-import { UploadErrorMissingArchive } from '../../util/deploy/process-deployment';
+import {
+  UploadErrorMissingArchive,
+  UploadFailureError,
+} from '../../util/deploy/process-deployment';
 import { displayBuildLogsUntilFinalError } from '../../util/logs';
 import { determineAgent } from '@vercel/detect-agent';
 import { validateJsonOutput } from '../../util/output-format';
@@ -709,6 +712,11 @@ async function handleInitDeployment(
     }
 
     if (err instanceof UploadErrorMissingArchive) {
+      output.prettyError(err);
+      return 1;
+    }
+
+    if (err instanceof UploadFailureError) {
       output.prettyError(err);
       return 1;
     }
@@ -1628,6 +1636,32 @@ async function handleDefaultDeploy(
             {
               status: AGENT_STATUS.ERROR,
               reason: 'missing_archive',
+              message: err.message,
+              next: [
+                {
+                  command: withGlobalFlags(client, 'deploy'),
+                  when: 'retry deploy',
+                },
+              ],
+            },
+            null,
+            2
+          )}\n`
+        );
+        return 1;
+      } else {
+        output.prettyError(err);
+        return 1;
+      }
+    }
+
+    if (err instanceof UploadFailureError) {
+      if (client.nonInteractive) {
+        client.stdout.write(
+          `${JSON.stringify(
+            {
+              status: AGENT_STATUS.ERROR,
+              reason: 'upload_failed',
               message: err.message,
               next: [
                 {

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -348,6 +348,13 @@ export default async function processDeployment({
           }
         }
 
+        const uploadFailureError = formatUploadFailureError(event.payload, {
+          archive,
+        });
+        if (uploadFailureError) {
+          throw uploadFailureError;
+        }
+
         const error = await now.handleDeploymentError(event.payload, {
           env,
         });
@@ -390,8 +397,121 @@ export default async function processDeployment({
 export const archiveSuggestionText =
   'Try using `--archive=tgz` to limit the amount of files you upload.';
 
+const uploadDocsLink = 'https://vercel.com/docs/cli/deploy#archive';
+const statusPageLink = 'https://www.vercel-status.com/';
+
 export class UploadErrorMissingArchive extends Error {
-  link = 'https://vercel.com/docs/cli/deploy#archive';
+  link = uploadDocsLink;
+}
+
+export class UploadFailureError extends Error {
+  link = uploadDocsLink;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (isErrorLike(error)) {
+    return error.message || '';
+  }
+
+  return String(error);
+}
+
+function isUploadNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const { message } = error;
+
+  if (
+    message.includes('ETIMEDOUT') ||
+    message.includes('ECONNREFUSED') ||
+    message.includes('ENOTFOUND') ||
+    message.includes('ECONNRESET') ||
+    message.includes('EAI_FAIL') ||
+    message.includes('socket hang up') ||
+    message.includes('network socket disconnected') ||
+    /fetch failed/i.test(message)
+  ) {
+    return true;
+  }
+
+  return isUploadNetworkError((error as { cause?: unknown }).cause);
+}
+
+function isUploadGatewayError(message: string): boolean {
+  return (
+    /invalid json response body/i.test(message) ||
+    /Unexpected token ['"]</i.test(message) ||
+    /upstream timed out/i.test(message) ||
+    /operation timed out/i.test(message)
+  );
+}
+
+function isUploadServiceError(error: unknown): boolean {
+  if (!isErrorLike(error)) {
+    return false;
+  }
+
+  if (
+    'errorName' in error &&
+    typeof error.errorName === 'string' &&
+    error.errorName.startsWith('api-upload-')
+  ) {
+    return true;
+  }
+
+  return /\/v2\/files/i.test(getErrorMessage(error));
+}
+
+export function formatUploadFailureError(
+  error: unknown,
+  { archive }: { archive?: ArchiveFormat } = {}
+): UploadFailureError | undefined {
+  const message = getErrorMessage(error);
+
+  if (!message) {
+    return;
+  }
+
+  const isNetwork = isUploadNetworkError(error);
+  const isGateway = isUploadGatewayError(message);
+  const isService = isUploadServiceError(error);
+
+  if (!isNetwork && !isGateway && !isService) {
+    return;
+  }
+
+  const lines = ['Failed to upload deployment files to Vercel.'];
+
+  if (isNetwork) {
+    lines.push(
+      'The connection timed out or was interrupted after multiple retries.'
+    );
+  } else if (isGateway) {
+    lines.push(
+      'The upload API returned an unexpected response. This can happen when the upload service is under heavy load or temporarily unavailable.'
+    );
+  } else {
+    lines.push(message);
+  }
+
+  lines.push('Retry the deployment in a few minutes.');
+  lines.push(
+    `If the problem persists, check ${statusPageLink} for ongoing incidents.`
+  );
+
+  if (!archive) {
+    lines.push(archiveSuggestionText);
+  }
+
+  const formatted = new UploadFailureError(lines.join('\n'));
+
+  if (isGateway) {
+    formatted.link = statusPageLink;
+  }
+
+  return formatted;
 }
 
 export function handleErrorSolvableWithArchive(error: unknown) {

--- a/packages/cli/test/unit/util/deploy/process-deployment.test.ts
+++ b/packages/cli/test/unit/util/deploy/process-deployment.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   handleErrorSolvableWithArchive,
+  formatUploadFailureError,
   archiveSuggestionText,
   UploadErrorMissingArchive,
+  UploadFailureError,
 } from '../../../../src/util/deploy/process-deployment';
 
 describe('processDeployment()', () => {
@@ -79,6 +81,58 @@ describe('processDeployment()', () => {
           code: 'too_many_files',
         })
       ).not.toBeInstanceOf(UploadErrorMissingArchive);
+    });
+  });
+
+  describe('formatUploadFailureError()', () => {
+    it('should return a network timeout error', () => {
+      const result = formatUploadFailureError(
+        new Error('connect ETIMEDOUT 52.0.0.0:443')
+      );
+
+      expect(result).toBeInstanceOf(UploadFailureError);
+      expect(result?.message).toContain(
+        'Failed to upload deployment files to Vercel.'
+      );
+      expect(result?.message).toContain('timed out or was interrupted');
+      expect(result?.message).toContain(archiveSuggestionText);
+    });
+
+    it('should return a fetch failed error from nested cause', () => {
+      const result = formatUploadFailureError(
+        new Error('fetch failed', {
+          cause: new Error('connect ETIMEDOUT'),
+        })
+      );
+
+      expect(result).toBeInstanceOf(UploadFailureError);
+      expect(result?.message).toContain('timed out or was interrupted');
+    });
+
+    it('should return a gateway error for invalid JSON responses', () => {
+      const result = formatUploadFailureError(
+        new Error(
+          `invalid json response body at https://api.vercel.com/v2/files reason: Unexpected token '<'`
+        )
+      );
+
+      expect(result).toBeInstanceOf(UploadFailureError);
+      expect(result?.message).toContain('unexpected response');
+      expect(result?.link).toBe('https://www.vercel-status.com/');
+    });
+
+    it('should omit archive suggestion when archive is set', () => {
+      const result = formatUploadFailureError(new Error('fetch failed'), {
+        archive: 'tgz',
+      });
+
+      expect(result?.message).not.toContain(archiveSuggestionText);
+    });
+
+    it('should return undefined for unrelated errors', () => {
+      expect(
+        formatUploadFailureError(new Error('Project not found'))
+      ).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `formatUploadFailureError` to translate cryptic deploy upload failures into actionable CLI output
- Handle network timeouts (`ETIMEDOUT`, `fetch failed`), API gateway HTML/JSON parse errors, and `api-upload` service errors seen during INC-5076
- Surface retry guidance, status page link, and `--archive=tgz` suggestion (when not already archiving)

Fixes VOC-1970.

## Test plan
- [x] `pnpm vitest run test/unit/util/deploy/process-deployment.test.ts`
- [ ] Deploy a project while simulating upload timeout and confirm improved error copy
- [ ] Confirm existing archive/rate-limit errors still show `UploadErrorMissingArchive`


Made with [Cursor](https://cursor.com)