### PR TITLE
[cli] ai-gateway coding-agents: use apiKeyHelper for Claude Code Keychain setup

### DIFF
--- a/.changeset/claude-code-apikeyhelper.md
+++ b/.changeset/claude-code-apikeyhelper.md
@@ -1,0 +1,12 @@
+---
+'vercel': patch
+---
+
+ai-gateway coding-agents setup: configure Claude Code via `apiKeyHelper` in
+`settings.json` (Keychain mode) instead of exporting `ANTHROPIC_AUTH_TOKEN` from
+the shell rc. `ANTHROPIC_AUTH_TOKEN` outranks `apiKeyHelper` in Claude Code's
+credential precedence, so the old export silently disabled a user's own
+`apiKeyHelper`; it also leaked the token into every shell and child process.
+Resolving through `apiKeyHelper` keeps the token scoped to Claude Code's process
+and no longer overrides the user's configured auth. The secret still lives only
+in the macOS Keychain. Non-Keychain Claude Code and Codex are unchanged.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -2,17 +2,26 @@ import { join } from 'node:path';
 import type { CodingAgent, EnvExport } from '../types';
 import { mergeJson, pathExists } from '../config-files';
 import { GATEWAY_ANTHROPIC_BASE_URL } from '../gateway';
+import { keychainLookupCommand } from '../keychain';
 
 /**
  * Claude Code reads env vars from the `env` object in `~/.claude/settings.json`.
  * It speaks the gateway's Anthropic-compatible endpoint, so the base URL has NO
- * `/v1` (the Anthropic SDK appends `/v1/messages`). `ANTHROPIC_API_KEY` must be
- * emptied because it takes precedence over `ANTHROPIC_AUTH_TOKEN`.
+ * `/v1` (the Anthropic SDK appends `/v1/messages`).
  *
- * With Keychain enabled we keep the token out of `settings.json` and export
- * `ANTHROPIC_AUTH_TOKEN` from the shell rc (resolved from the Keychain) instead,
- * so the secret never lands in the config file. Claude Code then reads the token
- * from its inherited environment.
+ * With Keychain enabled we resolve the token through `apiKeyHelper` — a shell
+ * command Claude Code runs in-process (via `/bin/sh`), reading the key from its
+ * stdout — pointed at the Keychain lookup. The secret never lands in the config
+ * file, and the token stays scoped to Claude Code's process rather than leaking
+ * into every shell via a global export. `apiKeyHelper` sits at the bottom of
+ * Claude Code's credential precedence ladder (below `ANTHROPIC_AUTH_TOKEN` and
+ * `ANTHROPIC_API_KEY`), so we empty BOTH of those env vars in `settings.json` —
+ * otherwise a stray one in the user's environment would outrank the helper and
+ * the gateway routing would silently not take effect. Emptying them also stops
+ * this setup from silently overriding a user's own `apiKeyHelper`.
+ *
+ * Without Keychain the token is embedded directly as `ANTHROPIC_AUTH_TOKEN` in
+ * `settings.json` (still emptying `ANTHROPIC_API_KEY`, which outranks it).
  *
  * Docs: https://vercel.com/docs/ai-gateway/coding-agents/claude-code
  */
@@ -43,9 +52,14 @@ export const claudeCode: CodingAgent = {
       ANTHROPIC_BASE_URL: GATEWAY_ANTHROPIC_BASE_URL,
       ANTHROPIC_API_KEY: '',
     };
+    // Claude Code never touches the shell rc: it reads everything from
+    // settings.json (the token via `apiKeyHelper` under Keychain, or embedded
+    // directly otherwise), so no env exports are contributed.
     const envExports: EnvExport[] = [];
+    const patch: Record<string, unknown> = { env };
     if (ctx.useKeychain) {
-      envExports.push({ name: 'ANTHROPIC_AUTH_TOKEN', value: ctx.apiKey });
+      env.ANTHROPIC_AUTH_TOKEN = '';
+      patch.apiKeyHelper = keychainLookupCommand();
     } else {
       env.ANTHROPIC_AUTH_TOKEN = ctx.apiKey;
     }
@@ -55,14 +69,13 @@ export const claudeCode: CodingAgent = {
           path,
           label: 'Claude Code settings',
           format: 'json',
-          transform: current => mergeJson(current, { env }),
+          transform: current => mergeJson(current, patch),
         },
       ],
       envExports,
       notes: ctx.useKeychain
         ? [
-            'The Anthropic auth token is read from your shell environment (Keychain-backed).',
-            'Open a new terminal so ANTHROPIC_AUTH_TOKEN is loaded, then restart Claude Code.',
+            'Claude Code reads your AI Gateway key from the macOS Keychain via apiKeyHelper in settings.json — no new terminal or restart needed.',
           ]
         : ['Restart Claude Code to pick up the new settings.'],
     };

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -9,20 +9,6 @@ import { keychainLookupCommand } from '../keychain';
  * It speaks the gateway's Anthropic-compatible endpoint, so the base URL has NO
  * `/v1` (the Anthropic SDK appends `/v1/messages`).
  *
- * With Keychain enabled we resolve the token through `apiKeyHelper` — a shell
- * command Claude Code runs in-process (via `/bin/sh`), reading the key from its
- * stdout — pointed at the Keychain lookup. The secret never lands in the config
- * file, and the token stays scoped to Claude Code's process rather than leaking
- * into every shell via a global export. `apiKeyHelper` sits at the bottom of
- * Claude Code's credential precedence ladder (below `ANTHROPIC_AUTH_TOKEN` and
- * `ANTHROPIC_API_KEY`), so we empty BOTH of those env vars in `settings.json` —
- * otherwise a stray one in the user's environment would outrank the helper and
- * the gateway routing would silently not take effect. Emptying them also stops
- * this setup from silently overriding a user's own `apiKeyHelper`.
- *
- * Without Keychain the token is embedded directly as `ANTHROPIC_AUTH_TOKEN` in
- * `settings.json` (still emptying `ANTHROPIC_API_KEY`, which outranks it).
- *
  * Docs: https://vercel.com/docs/ai-gateway/coding-agents/claude-code
  */
 /** Config dir: `$CLAUDE_CONFIG_DIR` (Claude Code's own override) or `~/.claude`. */
@@ -52,9 +38,6 @@ export const claudeCode: CodingAgent = {
       ANTHROPIC_BASE_URL: GATEWAY_ANTHROPIC_BASE_URL,
       ANTHROPIC_API_KEY: '',
     };
-    // Claude Code never touches the shell rc: it reads everything from
-    // settings.json (the token via `apiKeyHelper` under Keychain, or embedded
-    // directly otherwise), so no env exports are contributed.
     const envExports: EnvExport[] = [];
     const patch: Record<string, unknown> = { env };
     if (ctx.useKeychain) {

--- a/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
@@ -38,8 +38,17 @@ export function storeKeyInKeychain(key: string): boolean {
   }
 }
 
+/**
+ * The bare lookup command, with no shell substitution wrapping. Suitable as a
+ * value that is itself run by a shell — e.g. Claude Code's `apiKeyHelper`, which
+ * executes the string through `/bin/sh` and reads the key from its stdout.
+ */
+export function keychainLookupCommand(): string {
+  return `${SECURITY_BIN} find-generic-password -s '${KEYCHAIN_SERVICE}' -a '${KEYCHAIN_ACCOUNT}' -w 2>/dev/null`;
+}
+
 export function keychainLookup(opts: { fish?: boolean } = {}): string {
-  const cmd = `${SECURITY_BIN} find-generic-password -s '${KEYCHAIN_SERVICE}' -a '${KEYCHAIN_ACCOUNT}' -w 2>/dev/null`;
+  const cmd = keychainLookupCommand();
   return opts.fish ? `(${cmd})` : `$(${cmd})`;
 }
 

--- a/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
@@ -38,11 +38,6 @@ export function storeKeyInKeychain(key: string): boolean {
   }
 }
 
-/**
- * The bare lookup command, with no shell substitution wrapping. Suitable as a
- * value that is itself run by a shell — e.g. Claude Code's `apiKeyHelper`, which
- * executes the string through `/bin/sh` and reads the key from its stdout.
- */
 export function keychainLookupCommand(): string {
   return `${SECURITY_BIN} find-generic-password -s '${KEYCHAIN_SERVICE}' -a '${KEYCHAIN_ACCOUNT}' -w 2>/dev/null`;
 }

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -743,8 +743,6 @@ describe('ai-gateway coding-agents setup', () => {
         useKeychain: true,
       });
 
-      // Claude Code resolves the token in-process from the Keychain — no shell
-      // rc change, so the token can't leak into other processes.
       expect(plan.changes.some(c => c.format === 'shell')).toBe(false);
 
       const claude = plan.changes.find(c => c.label === 'Claude Code settings');
@@ -753,10 +751,8 @@ describe('ai-gateway coding-agents setup', () => {
         'https://ai-gateway.vercel.sh'
       );
       expect(settings.apiKeyHelper).toContain('security find-generic-password');
-      // Both higher-precedence env vars are emptied so the helper always wins.
       expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('');
       expect(settings.env.ANTHROPIC_API_KEY).toBe('');
-      // The secret itself never lands in the config — only the Keychain lookup.
       expect(claude?.next).not.toContain(secret);
     });
 
@@ -2642,9 +2638,6 @@ describe('ai-gateway coding-agents setup', () => {
           true
         );
 
-        // A single shared shell block. Codex and OpenCode both want
-        // AI_GATEWAY_API_KEY — it's exported once (deduped). Claude Code does
-        // NOT touch the shell in keychain mode; it resolves via apiKeyHelper.
         const shells = plan.changes.filter(c => c.format === 'shell');
         expect(shells).toHaveLength(1);
         const gateway = shells[0].next?.match(/AI_GATEWAY_API_KEY/g) ?? [];

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -735,32 +735,50 @@ describe('ai-gateway coding-agents setup', () => {
       expect(keychainLookup()).toContain('security find-generic-password');
     });
 
-    // Keychain-backed shell exports only exist on macOS (no shell rc on Windows).
-    it.skipIf(process.platform === 'win32')(
-      'keeps the secret out of the configs and reads it from the shell',
-      async () => {
-        const secret = 'vck_KeychainSecret321';
-        const plan = await buildSetupPlan([claudeCode], {
-          apiKey: secret,
-          home,
-          useKeychain: true,
-        });
+    it('resolves Claude Code via apiKeyHelper and never touches the shell', async () => {
+      const secret = 'vck_KeychainSecret321';
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: secret,
+        home,
+        useKeychain: true,
+      });
 
-        // The env-based agent resolves its var from the Keychain at runtime.
-        const shell = plan.changes.find(c => c.format === 'shell');
-        expect(shell?.next).toContain('security find-generic-password');
-        expect(shell?.next).toContain('export ANTHROPIC_AUTH_TOKEN=');
-        expect(shell?.next).not.toContain(secret);
+      // Claude Code resolves the token in-process from the Keychain — no shell
+      // rc change, so the token can't leak into other processes.
+      expect(plan.changes.some(c => c.format === 'shell')).toBe(false);
 
-        // Claude's token is no longer embedded in settings.json.
-        const claude = plan.changes.find(
-          c => c.label === 'Claude Code settings'
-        );
-        expect(claude?.next).toContain('ANTHROPIC_BASE_URL');
-        expect(claude?.next).not.toContain('ANTHROPIC_AUTH_TOKEN');
-        expect(claude?.next).not.toContain(secret);
-      }
-    );
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      const settings = JSON.parse(claude?.next ?? '{}');
+      expect(settings.env.ANTHROPIC_BASE_URL).toBe(
+        'https://ai-gateway.vercel.sh'
+      );
+      expect(settings.apiKeyHelper).toContain('security find-generic-password');
+      // Both higher-precedence env vars are emptied so the helper always wins.
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('');
+      expect(settings.env.ANTHROPIC_API_KEY).toBe('');
+      // The secret itself never lands in the config — only the Keychain lookup.
+      expect(claude?.next).not.toContain(secret);
+    });
+
+    it('overwrites a pre-existing apiKeyHelper in keychain mode', async () => {
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        claudeSettingsPath(),
+        JSON.stringify({ apiKeyHelper: '/usr/local/bin/my-own-helper.sh' }),
+        'utf8'
+      );
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: 'vck_KeychainSecret654',
+        home,
+        useKeychain: true,
+      });
+
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      expect(claude?.status).toBe('update');
+      const settings = JSON.parse(claude?.next ?? '{}');
+      expect(settings.apiKeyHelper).toContain('security find-generic-password');
+      expect(settings.apiKeyHelper).not.toContain('my-own-helper');
+    });
 
     it('embeds the key directly when keychain is off', async () => {
       const secret = 'vck_PlainSecret654';
@@ -2625,13 +2643,19 @@ describe('ai-gateway coding-agents setup', () => {
         );
 
         // A single shared shell block. Codex and OpenCode both want
-        // AI_GATEWAY_API_KEY — it's exported once (deduped) — and Claude Code
-        // contributes ANTHROPIC_AUTH_TOKEN.
+        // AI_GATEWAY_API_KEY — it's exported once (deduped). Claude Code does
+        // NOT touch the shell in keychain mode; it resolves via apiKeyHelper.
         const shells = plan.changes.filter(c => c.format === 'shell');
         expect(shells).toHaveLength(1);
         const gateway = shells[0].next?.match(/AI_GATEWAY_API_KEY/g) ?? [];
         expect(gateway).toHaveLength(1);
-        expect(shells[0].next).toContain('ANTHROPIC_AUTH_TOKEN');
+        expect(shells[0].next).not.toContain('ANTHROPIC_AUTH_TOKEN');
+        const claude = plan.changes.find(
+          c => c.label === 'Claude Code settings'
+        );
+        expect(JSON.parse(claude?.next ?? '{}').apiKeyHelper).toContain(
+          'security find-generic-password'
+        );
       }
     );
 


### PR DESCRIPTION
## Problem

On macOS with the Keychain path (default), `vercel ai-gateway coding-agents setup` configures **Claude Code** by exporting from the shell rc:

```sh
export ANTHROPIC_AUTH_TOKEN="$(/usr/bin/security find-generic-password -s 'Vercel AI Gateway' -a 'vercel-ai-gateway' -w 2>/dev/null)"
```

This results in **Broad runtime exposure.** A global shell export lands the token in every interactive shell and every child process, versus `apiKeyHelper`, which keeps the token in Claude Code's own process memory (cached per `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`).

## Fix

For the `claude-code` agent in Keychain mode, write `apiKeyHelper` into `~/.claude/settings.json` (pointing at the same `security find-generic-password` lookup) instead of exporting `ANTHROPIC_AUTH_TOKEN` from the shell rc.

- The secret still lives only in the macOS Keychain — the config file holds a lookup command, not the key.
- The token is scoped to Claude Code's process instead of leaking into every shell.
- `apiKeyHelper` sits at the bottom of the precedence ladder, so it never shadows a user's own higher-precedence credential.
- Both higher-precedence env vars (`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`) are emptied in `settings.json` so a stray one in the environment can't outrank the helper and silently break gateway routing.

Verified against the Claude Code docs: `apiKeyHelper` is a top-level `settings.json` key run through `/bin/sh`, its stdout is sent as both `X-Api-Key` and `Authorization: Bearer`, and it reloads live (no restart/new terminal needed).

## Testing

- `pnpm test test/unit/commands/ai-gateway/coding-agents-setup.test.ts` → **110/110 pass**. Rewrote the Claude Code keychain assertions (apiKeyHelper present, both env tokens empty, secret absent, no shell change), added a test that a pre-existing foreign `apiKeyHelper` is overwritten, and updated the multi-agent shared-shell-block test.
- Keychain is macOS-only, so the real `security` + `claude` auth flow was not exercised on the Linux devbox; the plan builder output was verified directly.