### PR TITLE
@vercel/connect: add experimental startInstallation API

### DIFF
--- a/.changeset/sharp-needles-serve.md
+++ b/.changeset/sharp-needles-serve.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add `experimental_startInstallation` for creating Vercel Connect installation requests.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -30,6 +30,22 @@ const token = await getToken(process.env.CONNECTOR_LINEAR!, {
 });
 ```
 
+To create an operator installation request for an app-scoped connector, use the
+experimental install helper:
+
+This feature is gated while experimental. Contact Vercel to enable access
+before using it.
+
+```ts
+import { experimental_startInstallation } from '@vercel/connect';
+
+const { url } = await experimental_startInstallation(
+  process.env.CONNECTOR_SLACK!,
+  {},
+  { returnUrl: 'https://example.com/settings/integrations' }
+);
+```
+
 ### Chat SDK
 
 Spread the helper into the matching `create*Adapter` factory. Each helper
@@ -123,4 +139,4 @@ import { connect } from '@vercel/connect/authjs';
 const providers = [connect({ connector: 'linear' })];
 ```
 
-See the source under `src/` for the full API (additional helpers like `revokeToken`, `getTokenResponse`, `startAuthorization`, typed error classes, and per-adapter options).
+See the source under `src/` for the full API (additional helpers like `revokeToken`, `getTokenResponse`, `startAuthorization`, `experimental_startInstallation`, typed error classes, and per-adapter options).

--- a/packages/connect/src/authorization.ts
+++ b/packages/connect/src/authorization.ts
@@ -1,4 +1,9 @@
 import { getVercelOidcToken } from '@vercel/oidc';
+import {
+  isDetachedInteractiveAuth,
+  validateCallbackUrl,
+  validateWebhookUrl,
+} from './internal/url-validation.js';
 import type { ConnectTokenParams } from './token.js';
 
 export interface ConnectAuthorizationOptions {
@@ -40,9 +45,6 @@ export interface ConnectAuthorizationResponse {
   };
 }
 
-const DETACHED_INTERACTIVE_AUTH_MODE = 'detached';
-const INTERACTIVE_AUTH_MODE_ENV = 'VERCEL_CONNECT_INTERACTIVE_AUTH_MODE';
-
 export async function startAuthorization(
   connector: string,
   params: ConnectTokenParams,
@@ -51,8 +53,7 @@ export async function startAuthorization(
   if (!connector) {
     throw new Error('connector is required');
   }
-  const detachedInteractiveAuth =
-    process.env[INTERACTIVE_AUTH_MODE_ENV] === DETACHED_INTERACTIVE_AUTH_MODE;
+  const detachedInteractiveAuth = isDetachedInteractiveAuth();
   if (!detachedInteractiveAuth && options?.callbackUrl !== undefined) {
     validateCallbackUrl(options.callbackUrl);
   }
@@ -103,40 +104,4 @@ export async function startAuthorization(
 
   const data: ConnectAuthorizationResponse = await response.json();
   return data;
-}
-
-function validateCallbackUrl(value: string): void {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw new Error(`Invalid callbackUrl: ${value}`);
-  }
-  if (url.protocol === 'https:') return;
-  if (url.protocol === 'http:' && isLocalHttpCallbackHostname(url.hostname)) {
-    return;
-  }
-  throw new Error(
-    `callbackUrl must be https://, http://localhost, or http://*.localhost, got: ${value}`
-  );
-}
-
-function isLocalHttpCallbackHostname(hostname: string): boolean {
-  return (
-    hostname === 'localhost' ||
-    hostname.endsWith('.localhost') ||
-    hostname === '127.0.0.1'
-  );
-}
-
-function validateWebhookUrl(value: string): void {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw new Error(`Invalid webhook URL: ${value}`);
-  }
-  if (url.protocol !== 'https:') {
-    throw new Error(`webhook must be https://, got: ${value}`);
-  }
 }

--- a/packages/connect/src/eve/connect-oauth.ts
+++ b/packages/connect/src/eve/connect-oauth.ts
@@ -4,10 +4,7 @@ import {
   type VerifyOidcConfig,
   verifyOidc,
 } from 'eve/channels/auth';
-
-declare const process:
-  | { readonly env?: Readonly<Record<string, string | undefined>> }
-  | undefined;
+import { readNonEmptyEnv } from '../internal/env.js';
 
 export const CONNECT_OAUTH_ISSUER = 'https://connect.vercel.com';
 
@@ -233,12 +230,6 @@ function buildClaimMatchers(
       : { installationId: opts.installationIds }),
     typ: ['at'],
   };
-}
-
-function readNonEmptyEnv(name: string): string | undefined {
-  const value =
-    typeof process === 'undefined' ? undefined : process.env?.[name]?.trim();
-  return value === undefined || value.length === 0 ? undefined : value;
 }
 
 function extractAudiences(payload: Record<string, unknown>): readonly string[] {

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -21,4 +21,11 @@ export {
   type ConnectAuthorizationResponse,
 } from './authorization.js';
 
+export {
+  experimental_startInstallation,
+  type ConnectInstallationOptions,
+  type ConnectInstallationParams,
+  type ConnectInstallationResponse,
+} from './installation.js';
+
 export type { ConnectAuthorizationDetail } from './authorization-details.js';

--- a/packages/connect/src/installation.ts
+++ b/packages/connect/src/installation.ts
@@ -1,0 +1,135 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+import type { ConnectTokenParams } from './token.js';
+import { createConnectErrorFromResponse } from './token.js';
+
+export type ConnectInstallationParams = Omit<ConnectTokenParams, 'subject'>;
+
+export interface ConnectInstallationOptions {
+  vercelToken?: string;
+  returnUrl?: string;
+  webhook?: string;
+  tenantId?: string;
+  deviceCode?: boolean;
+  expiresInMs?: number;
+}
+
+export interface ConnectInstallationResponse {
+  request: string;
+  verifier: string;
+  url: string;
+  deviceCode?: string;
+  expiresAt: number;
+  connector: {
+    /** Client id. */
+    id: string;
+    /** Client uid. */
+    uid: string;
+    /** Client type, eg. `oauth`, `salesforce`. */
+    type: string;
+    /** Resolved service id when known, eg. `salesforce`. */
+    service?: string;
+    /**
+     * Curated display name of the resolved service, eg. `Salesforce`,
+     * present when the service is known to Vercel Connect. Suited for
+     * end-user surfaces like "Sign in with {serviceName}".
+     */
+    serviceName?: string;
+    /** The connector's own (operator-given) name. */
+    name: string;
+  };
+}
+
+const DETACHED_INTERACTIVE_AUTH_MODE = 'detached';
+const INTERACTIVE_AUTH_MODE_ENV = 'VERCEL_CONNECT_INTERACTIVE_AUTH_MODE';
+
+/**
+ * Create an operator installation request for an app-scoped connector.
+ *
+ * @experimental This API is feature-gated while experimental. Contact Vercel
+ * to enable access before using it.
+ */
+export async function experimental_startInstallation(
+  connector: string,
+  params: ConnectInstallationParams = {},
+  options?: ConnectInstallationOptions
+): Promise<ConnectInstallationResponse> {
+  if (!connector) {
+    throw new Error('connector is required');
+  }
+
+  const detachedInteractiveAuth =
+    process.env[INTERACTIVE_AUTH_MODE_ENV] === DETACHED_INTERACTIVE_AUTH_MODE;
+
+  if (!detachedInteractiveAuth && options?.returnUrl !== undefined) {
+    validateReturnUrl(options.returnUrl);
+  }
+  if (options?.webhook !== undefined) {
+    validateWebhookUrl(options.webhook);
+  }
+
+  const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
+  const endpoint = `https://api.vercel.com/v1/connect/install/${encodeURIComponent(connector)}`;
+  const deviceCode =
+    options?.deviceCode ?? (detachedInteractiveAuth ? true : undefined);
+  const returnUrl =
+    !detachedInteractiveAuth && options?.returnUrl !== undefined
+      ? { returnUrl: options.returnUrl }
+      : {};
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${vercelToken}`,
+    },
+    body: JSON.stringify({
+      ...params,
+      ...returnUrl,
+      ...(options?.webhook !== undefined && { webhook: options.webhook }),
+      ...(options?.tenantId !== undefined && { tenantId: options.tenantId }),
+      ...(deviceCode !== undefined && { deviceCode }),
+      ...(options?.expiresInMs !== undefined && {
+        expiresInMs: options.expiresInMs,
+      }),
+    }),
+  });
+
+  if (!response.ok) {
+    throw await createConnectErrorFromResponse(
+      response,
+      'Failed to start installation'
+    );
+  }
+
+  const data: ConnectInstallationResponse = await response.json();
+  return data;
+}
+
+function validateReturnUrl(value: string): void {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Invalid returnUrl: ${value}`);
+  }
+  if (url.protocol === 'https:') return;
+  if (url.protocol === 'http:' && url.hostname === 'localhost') {
+    return;
+  }
+  throw new Error(
+    `returnUrl must be https:// or http://localhost, got: ${value}`
+  );
+}
+
+function validateWebhookUrl(value: string): void {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Invalid webhook URL: ${value}`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`webhook must be https://, got: ${value}`);
+  }
+}

--- a/packages/connect/src/installation.ts
+++ b/packages/connect/src/installation.ts
@@ -1,4 +1,9 @@
 import { getVercelOidcToken } from '@vercel/oidc';
+import {
+  isDetachedInteractiveAuth,
+  validateCallbackUrl,
+  validateWebhookUrl,
+} from './internal/url-validation.js';
 import type { ConnectTokenParams } from './token.js';
 import { createConnectErrorFromResponse } from './token.js';
 
@@ -39,9 +44,6 @@ export interface ConnectInstallationResponse {
   };
 }
 
-const DETACHED_INTERACTIVE_AUTH_MODE = 'detached';
-const INTERACTIVE_AUTH_MODE_ENV = 'VERCEL_CONNECT_INTERACTIVE_AUTH_MODE';
-
 /**
  * Create an operator installation request for an app-scoped connector.
  *
@@ -57,11 +59,10 @@ export async function experimental_startInstallation(
     throw new Error('connector is required');
   }
 
-  const detachedInteractiveAuth =
-    process.env[INTERACTIVE_AUTH_MODE_ENV] === DETACHED_INTERACTIVE_AUTH_MODE;
+  const detachedInteractiveAuth = isDetachedInteractiveAuth();
 
   if (!detachedInteractiveAuth && options?.returnUrl !== undefined) {
-    validateReturnUrl(options.returnUrl);
+    validateCallbackUrl(options.returnUrl, 'returnUrl');
   }
   if (options?.webhook !== undefined) {
     validateWebhookUrl(options.webhook);
@@ -104,32 +105,4 @@ export async function experimental_startInstallation(
 
   const data: ConnectInstallationResponse = await response.json();
   return data;
-}
-
-function validateReturnUrl(value: string): void {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw new Error(`Invalid returnUrl: ${value}`);
-  }
-  if (url.protocol === 'https:') return;
-  if (url.protocol === 'http:' && url.hostname === 'localhost') {
-    return;
-  }
-  throw new Error(
-    `returnUrl must be https:// or http://localhost, got: ${value}`
-  );
-}
-
-function validateWebhookUrl(value: string): void {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw new Error(`Invalid webhook URL: ${value}`);
-  }
-  if (url.protocol !== 'https:') {
-    throw new Error(`webhook must be https://, got: ${value}`);
-  }
 }

--- a/packages/connect/src/internal/env.ts
+++ b/packages/connect/src/internal/env.ts
@@ -1,3 +1,7 @@
+declare const process:
+  | { readonly env?: Readonly<Record<string, string | undefined>> }
+  | undefined;
+
 export function readNonEmptyEnv(name: string): string | undefined {
   const value =
     typeof process === 'undefined' ? undefined : process.env?.[name]?.trim();

--- a/packages/connect/src/internal/env.ts
+++ b/packages/connect/src/internal/env.ts
@@ -1,0 +1,5 @@
+export function readNonEmptyEnv(name: string): string | undefined {
+  const value =
+    typeof process === 'undefined' ? undefined : process.env?.[name]?.trim();
+  return value === undefined || value.length === 0 ? undefined : value;
+}

--- a/packages/connect/src/internal/url-validation.ts
+++ b/packages/connect/src/internal/url-validation.ts
@@ -1,9 +1,12 @@
+import { readNonEmptyEnv } from './env.js';
+
 const DETACHED_INTERACTIVE_AUTH_MODE = 'detached';
 const INTERACTIVE_AUTH_MODE_ENV = 'VERCEL_CONNECT_INTERACTIVE_AUTH_MODE';
 
 export function isDetachedInteractiveAuth(): boolean {
   return (
-    process.env[INTERACTIVE_AUTH_MODE_ENV] === DETACHED_INTERACTIVE_AUTH_MODE
+    readNonEmptyEnv(INTERACTIVE_AUTH_MODE_ENV) ===
+    DETACHED_INTERACTIVE_AUTH_MODE
   );
 }
 

--- a/packages/connect/src/internal/url-validation.ts
+++ b/packages/connect/src/internal/url-validation.ts
@@ -1,0 +1,47 @@
+const DETACHED_INTERACTIVE_AUTH_MODE = 'detached';
+const INTERACTIVE_AUTH_MODE_ENV = 'VERCEL_CONNECT_INTERACTIVE_AUTH_MODE';
+
+export function isDetachedInteractiveAuth(): boolean {
+  return (
+    process.env[INTERACTIVE_AUTH_MODE_ENV] === DETACHED_INTERACTIVE_AUTH_MODE
+  );
+}
+
+export function validateCallbackUrl(
+  value: string,
+  label = 'callbackUrl'
+): void {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  if (url.protocol === 'https:') return;
+  if (url.protocol === 'http:' && isLocalHttpCallbackHostname(url.hostname)) {
+    return;
+  }
+  throw new Error(
+    `${label} must be https://, http://localhost, or http://*.localhost, got: ${value}`
+  );
+}
+
+export function validateWebhookUrl(value: string): void {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Invalid webhook URL: ${value}`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`webhook must be https://, got: ${value}`);
+  }
+}
+
+function isLocalHttpCallbackHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname === '127.0.0.1'
+  );
+}

--- a/packages/connect/test/installation.test.ts
+++ b/packages/connect/test/installation.test.ts
@@ -1,0 +1,184 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { experimental_startInstallation } from '../src/installation.js';
+import { ConnectError } from '../src/token.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn(),
+}));
+
+const CONNECTOR = 'oauth/linear';
+
+describe('experimental_startInstallation', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getVercelOidcToken).mockResolvedValue('oidc_token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates an installation request', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        request: 'sci_123',
+        verifier: 'verifier_123',
+        url: 'https://connect.vercel.com/install/sci_123',
+        expiresAt: 123456789,
+        connector: {
+          id: 'scl_123',
+          uid: 'oauth/linear',
+          type: 'oauth',
+          service: 'linear',
+          serviceName: 'Linear',
+          name: 'Linear',
+        },
+      })
+    );
+
+    await expect(
+      experimental_startInstallation(
+        CONNECTOR,
+        {
+          resources: ['workspace:acme'],
+          installationId: 'linear-installation',
+        },
+        {
+          vercelToken: 'vercel_token',
+          returnUrl: 'https://example.com/connect/install/return',
+          webhook: 'https://example.com/connect/install/webhook',
+          tenantId: 'tenant_123',
+          deviceCode: true,
+          expiresInMs: 60 * 60 * 1000,
+        }
+      )
+    ).resolves.toMatchObject({
+      request: 'sci_123',
+      verifier: 'verifier_123',
+      url: 'https://connect.vercel.com/install/sci_123',
+    });
+
+    expect(getVercelOidcToken).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://api.vercel.com/v1/connect/install/oauth%2Flinear'
+    );
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer vercel_token',
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      resources: ['workspace:acme'],
+      installationId: 'linear-installation',
+      returnUrl: 'https://example.com/connect/install/return',
+      webhook: 'https://example.com/connect/install/webhook',
+      tenantId: 'tenant_123',
+      deviceCode: true,
+      expiresInMs: 60 * 60 * 1000,
+    });
+  });
+
+  it('uses the Vercel OIDC token when no explicit token is provided', async () => {
+    fetchMock.mockResolvedValueOnce(installationResponse());
+
+    await experimental_startInstallation(CONNECTOR);
+
+    expect(getVercelOidcToken).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer oidc_token',
+    });
+  });
+
+  it('uses detached device authorization when requested by environment', async () => {
+    vi.stubEnv('VERCEL_CONNECT_INTERACTIVE_AUTH_MODE', 'detached');
+    fetchMock.mockResolvedValueOnce(
+      installationResponse({ deviceCode: 'ABC123' })
+    );
+
+    await expect(
+      experimental_startInstallation(CONNECTOR, undefined, {
+        returnUrl: 'http://example.com/connect/install/return',
+      })
+    ).resolves.toMatchObject({
+      deviceCode: 'ABC123',
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      deviceCode: true,
+    });
+  });
+
+  it('rejects non-local http return URLs', async () => {
+    await expect(
+      experimental_startInstallation(CONNECTOR, undefined, {
+        returnUrl: 'http://example.com/connect/install/return',
+      })
+    ).rejects.toThrow('returnUrl must be https:// or http://localhost');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('maps API errors through ConnectError', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: {
+            code: 'forbidden',
+            message: 'Missing permission to install connector',
+          },
+        },
+        { status: 403, statusText: 'Forbidden' }
+      )
+    );
+
+    const promise = experimental_startInstallation(CONNECTOR);
+
+    await expect(promise).rejects.toBeInstanceOf(ConnectError);
+    await expect(promise).rejects.toMatchObject({
+      code: 'forbidden',
+      status: 403,
+      statusText: 'Forbidden',
+      message: 'Missing permission to install connector',
+    });
+  });
+});
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+function installationResponse(
+  overrides: Partial<{
+    deviceCode: string;
+  }> = {}
+): Response {
+  return jsonResponse({
+    request: 'sci_123',
+    verifier: 'verifier_123',
+    url: 'https://connect.vercel.com/install/sci_123',
+    expiresAt: Date.now() + 60 * 60 * 1000,
+    connector: {
+      id: 'scl_123',
+      uid: 'oauth/linear',
+      type: 'oauth',
+      name: 'Linear',
+    },
+    ...overrides,
+  });
+}

--- a/packages/connect/test/installation.test.ts
+++ b/packages/connect/test/installation.test.ts
@@ -125,7 +125,9 @@ describe('experimental_startInstallation', () => {
       experimental_startInstallation(CONNECTOR, undefined, {
         returnUrl: 'http://example.com/connect/install/return',
       })
-    ).rejects.toThrow('returnUrl must be https:// or http://localhost');
+    ).rejects.toThrow(
+      'returnUrl must be https://, http://localhost, or http://*.localhost'
+    );
 
     expect(fetchMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- add `experimental_startInstallation` to create Connect installation requests through `POST /v1/connect/install/:connector`
- export typed params/options/response objects and map API failures through `ConnectError`
- document that the feature is gated while experimental and add a patch changeset

## SDK Example
```ts
import { experimental_startInstallation } from "@vercel/connect";

const { url } = await experimental_startInstallation(
  process.env.CONNECTOR_SLACK!,
  {},
  { returnUrl: "https://example.com/settings/integrations" }
);
```

## Verification
- `pnpm --filter @vercel/connect test`
- `pnpm --filter @vercel/connect typecheck`
- `pnpm exec prettier --check packages/connect/src/installation.ts packages/connect/src/index.ts packages/connect/test/installation.test.ts packages/connect/README.md .changeset/sharp-needles-serve.md`

fixes https://linear.app/vercel/issue/MKT-4078/support-anonymous-managed-slack-installation-flow
