### PR TITLE
[python] Add [tool.vercel.fastapi.static] cdn opt-out flag.

### DIFF
--- a/.changeset/tall-socks-relax.md
+++ b/.changeset/tall-socks-relax.md
@@ -3,4 +3,4 @@
 '@vercel/python': minor
 ---
 
-Add [tool.vercel.fastapi] static_cdn opt-out flag.
+Add [tool.vercel.fastapi.static] cdn opt-out flag.

--- a/.changeset/tall-socks-relax.md
+++ b/.changeset/tall-socks-relax.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python-analysis': minor
+'@vercel/python': minor
+---
+
+Add [tool.vercel.fastapi] static_cdn opt-out flag.

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -123,6 +123,8 @@ export {
   PyProjectTomlSchema,
   ReadmeObjectSchema,
   ReadmeSchema,
+  PyProjectToolVercelFastapiSectionSchema,
+  PyProjectToolVercelSectionSchema,
 } from './manifest/pyproject/schema';
 
 // PyProject types (from source of truth)
@@ -139,6 +141,8 @@ export type {
   PyProjectToolSection,
   Readme,
   ReadmeObject,
+  PyProjectToolVercelFastapiSection,
+  PyProjectToolVercelSection,
 } from './manifest/pyproject/types';
 
 // UV config schemas

--- a/packages/python-analysis/src/index.ts
+++ b/packages/python-analysis/src/index.ts
@@ -124,6 +124,7 @@ export {
   ReadmeObjectSchema,
   ReadmeSchema,
   PyProjectToolVercelFastapiSectionSchema,
+  PyProjectToolVercelFastapiStaticSectionSchema,
   PyProjectToolVercelSectionSchema,
 } from './manifest/pyproject/schema';
 
@@ -142,6 +143,7 @@ export type {
   Readme,
   ReadmeObject,
   PyProjectToolVercelFastapiSection,
+  PyProjectToolVercelFastapiStaticSection,
   PyProjectToolVercelSection,
 } from './manifest/pyproject/types';
 

--- a/packages/python-analysis/src/manifest/pyproject/schema.ts
+++ b/packages/python-analysis/src/manifest/pyproject/schema.ts
@@ -20,6 +20,8 @@ import {
   pyProjectToolSectionSchema as generatedPyProjectToolSectionSchema,
   readmeObjectSchema as generatedReadmeObjectSchema,
   readmeSchema as generatedReadmeSchema,
+  pyProjectToolVercelFastapiSectionSchema as generatedPyProjectToolVercelFastapiSectionSchema,
+  pyProjectToolVercelSectionSchema as generatedPyProjectToolVercelSectionSchema,
 } from './schema.zod';
 
 import type {
@@ -33,6 +35,8 @@ import type {
   PyProjectToolSection,
   Readme,
   ReadmeObject,
+  PyProjectToolVercelFastapiSection,
+  PyProjectToolVercelSection,
 } from './types';
 
 /**
@@ -82,6 +86,18 @@ export const PyProjectDependencyGroupsSchema =
   generatedPyProjectDependencyGroupsSchema as z.ZodType<PyProjectDependencyGroups>;
 
 /**
+ * Schema for [tool.vercel] section.
+ */
+export const PyProjectToolVercelSectionSchema =
+  generatedPyProjectToolVercelSectionSchema as z.ZodType<PyProjectToolVercelSection>;
+
+/**
+ * Schema for [tool.vercel.fastapi] section.
+ */
+export const PyProjectToolVercelFastapiSectionSchema =
+  generatedPyProjectToolVercelFastapiSectionSchema as z.ZodType<PyProjectToolVercelFastapiSection>;
+
+/**
  * Schema for [tool.FOO] section.
  */
 export const PyProjectToolSectionSchema =
@@ -90,5 +106,6 @@ export const PyProjectToolSectionSchema =
 /**
  * Schema for a pyproject.toml file.
  */
-export const PyProjectTomlSchema =
-  generatedPyProjectTomlSchema.passthrough() as z.ZodType<PyProjectToml>;
+export const PyProjectTomlSchema = generatedPyProjectTomlSchema
+  .extend({ tool: PyProjectToolSectionSchema.optional() })
+  .passthrough() as z.ZodType<PyProjectToml>;

--- a/packages/python-analysis/src/manifest/pyproject/schema.ts
+++ b/packages/python-analysis/src/manifest/pyproject/schema.ts
@@ -21,6 +21,7 @@ import {
   readmeObjectSchema as generatedReadmeObjectSchema,
   readmeSchema as generatedReadmeSchema,
   pyProjectToolVercelFastapiSectionSchema as generatedPyProjectToolVercelFastapiSectionSchema,
+  pyProjectToolVercelFastapiStaticSectionSchema as generatedPyProjectToolVercelFastapiStaticSectionSchema,
   pyProjectToolVercelSectionSchema as generatedPyProjectToolVercelSectionSchema,
 } from './schema.zod';
 
@@ -36,6 +37,7 @@ import type {
   Readme,
   ReadmeObject,
   PyProjectToolVercelFastapiSection,
+  PyProjectToolVercelFastapiStaticSection,
   PyProjectToolVercelSection,
 } from './types';
 
@@ -96,6 +98,12 @@ export const PyProjectToolVercelSectionSchema =
  */
 export const PyProjectToolVercelFastapiSectionSchema =
   generatedPyProjectToolVercelFastapiSectionSchema as z.ZodType<PyProjectToolVercelFastapiSection>;
+
+/**
+ * Schema for [tool.vercel.fastapi.static] section.
+ */
+export const PyProjectToolVercelFastapiStaticSectionSchema =
+  generatedPyProjectToolVercelFastapiStaticSectionSchema as z.ZodType<PyProjectToolVercelFastapiStaticSection>;
 
 /**
  * Schema for [tool.FOO] section.

--- a/packages/python-analysis/src/manifest/pyproject/schema.zod.ts
+++ b/packages/python-analysis/src/manifest/pyproject/schema.zod.ts
@@ -60,8 +60,17 @@ export const pyProjectDependencyGroupsSchema = z.record(
   z.array(dependencyGroupEntrySchema)
 );
 
+export const pyProjectToolVercelFastapiSectionSchema = z.object({
+  static_cdn: z.boolean().optional(),
+});
+
+export const pyProjectToolVercelSectionSchema = z.object({
+  fastapi: pyProjectToolVercelFastapiSectionSchema.optional(),
+});
+
 export const pyProjectToolSectionSchema = z.object({
   uv: uvConfigSchema.optional(),
+  vercel: pyProjectToolVercelSectionSchema.optional(),
 });
 
 export const pyProjectTomlSchema = z.object({

--- a/packages/python-analysis/src/manifest/pyproject/schema.zod.ts
+++ b/packages/python-analysis/src/manifest/pyproject/schema.zod.ts
@@ -60,8 +60,12 @@ export const pyProjectDependencyGroupsSchema = z.record(
   z.array(dependencyGroupEntrySchema)
 );
 
+export const pyProjectToolVercelFastapiStaticSectionSchema = z.object({
+  cdn: z.boolean().optional(),
+});
+
 export const pyProjectToolVercelFastapiSectionSchema = z.object({
-  static_cdn: z.boolean().optional(),
+  static: pyProjectToolVercelFastapiStaticSectionSchema.optional(),
 });
 
 export const pyProjectToolVercelSectionSchema = z.object({

--- a/packages/python-analysis/src/manifest/pyproject/types.ts
+++ b/packages/python-analysis/src/manifest/pyproject/types.ts
@@ -107,7 +107,14 @@ export interface PyProjectToolVercelSection {
  * [tool.vercel.fastapi] section.
  */
 export interface PyProjectToolVercelFastapiSection {
-  static_cdn?: boolean;
+  static?: PyProjectToolVercelFastapiStaticSection;
+}
+
+/**
+ * [tool.vercel.fastapi.static] section.
+ */
+export interface PyProjectToolVercelFastapiStaticSection {
+  cdn?: boolean;
 }
 
 /**

--- a/packages/python-analysis/src/manifest/pyproject/types.ts
+++ b/packages/python-analysis/src/manifest/pyproject/types.ts
@@ -97,11 +97,26 @@ export type DependencyGroupEntry = string | DependencyGroupInclude;
 export type PyProjectDependencyGroups = Record<string, DependencyGroupEntry[]>;
 
 /**
+ * [tool.vercel] section.
+ */
+export interface PyProjectToolVercelSection {
+  fastapi?: PyProjectToolVercelFastapiSection;
+}
+
+/**
+ * [tool.vercel.fastapi] section.
+ */
+export interface PyProjectToolVercelFastapiSection {
+  static_cdn?: boolean;
+}
+
+/**
  * [tool.FOO] section.
  * @passthrough
  */
 export interface PyProjectToolSection {
   uv?: UvConfig;
+  vercel?: PyProjectToolVercelSection;
 }
 
 /**

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -480,10 +480,10 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
       return;
     }
 
-    const staticCdn = pyprojectData?.tool?.vercel?.fastapi?.static_cdn;
+    const staticCdn = pyprojectData?.tool?.vercel?.fastapi?.static?.cdn;
     if (staticCdn === false) {
       debug(
-        'FastAPI: static_cdn = false in pyproject.toml, skipping CDN collection'
+        'FastAPI: static.cdn = false in pyproject.toml, skipping CDN collection'
       );
       return;
     }

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -84,7 +84,11 @@ import {
   runFastAPICollectStatic,
   type FastAPICollectStaticResult,
 } from './fastapi';
-import { containsTopLevelCallable } from '@vercel/python-analysis';
+import {
+  containsTopLevelCallable,
+  type PyProjectToml,
+  type PyProjectToolSection,
+} from '@vercel/python-analysis';
 import {
   collectAppBytecodeFiles,
   collectAppPrefixBytecodeFiles,
@@ -332,12 +336,21 @@ export async function addCollectedVendorBytecode({
   return capacity - selectedInfo.totalSize;
 }
 
+type VercelToolSection = PyProjectToolSection & {
+  vercel?: {
+    fastapi?: {
+      static_cdn?: unknown;
+    };
+  };
+};
+
 interface FrameworkHookContext {
   pythonEnv: NodeJS.ProcessEnv;
   workPath: string;
   venvPath?: string;
   entrypoint: string | undefined;
   detected: DetectedPythonEntrypoint | undefined;
+  pyprojectData?: PyProjectToml;
 }
 
 interface FrameworkHookResult {
@@ -452,6 +465,7 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
     detected,
     workPath,
     venvPath,
+    pyprojectData,
   }): Promise<FastAPIFrameworkHookResult | void> => {
     if (!detected?.entrypoint || !workPath || !venvPath) {
       debug(
@@ -471,6 +485,23 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
     if (cdnEnv !== '1' && cdnEnv !== 'true') {
       debug(
         'FastAPI: VERCEL_FASTAPI_STATIC_CDN not set, skipping static CDN collection'
+      );
+      return;
+    }
+
+    const staticCdn = (pyprojectData?.tool as VercelToolSection | undefined)
+      ?.vercel?.fastapi?.static_cdn;
+    if (staticCdn !== undefined && typeof staticCdn !== 'boolean') {
+      throw new NowBuildError({
+        code: 'PYTHON_INVALID_STATIC_CDN_CONFIG',
+        message:
+          `"tool.vercel.fastapi.static_cdn" in pyproject.toml must be a boolean ` +
+          `(true or false), got ${JSON.stringify(staticCdn)}.`,
+      });
+    }
+    if (staticCdn === false) {
+      debug(
+        'FastAPI: static_cdn = false in pyproject.toml, skipping CDN collection'
       );
       return;
     }
@@ -1093,6 +1124,7 @@ export const build: BuildVX = async ({
     venvPath,
     entrypoint,
     detected,
+    pyprojectData: pythonPackage.manifest?.data,
   });
 
   // Collect the resolved entrypoint from detection or hook, preferring the

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -87,7 +87,6 @@ import {
 import {
   containsTopLevelCallable,
   type PyProjectToml,
-  type PyProjectToolSection,
 } from '@vercel/python-analysis';
 import {
   collectAppBytecodeFiles,
@@ -336,14 +335,6 @@ export async function addCollectedVendorBytecode({
   return capacity - selectedInfo.totalSize;
 }
 
-type VercelToolSection = PyProjectToolSection & {
-  vercel?: {
-    fastapi?: {
-      static_cdn?: unknown;
-    };
-  };
-};
-
 interface FrameworkHookContext {
   pythonEnv: NodeJS.ProcessEnv;
   workPath: string;
@@ -489,16 +480,7 @@ const frameworkHooks: Partial<Record<PythonFramework, FrameworkHook>> = {
       return;
     }
 
-    const staticCdn = (pyprojectData?.tool as VercelToolSection | undefined)
-      ?.vercel?.fastapi?.static_cdn;
-    if (staticCdn !== undefined && typeof staticCdn !== 'boolean') {
-      throw new NowBuildError({
-        code: 'PYTHON_INVALID_STATIC_CDN_CONFIG',
-        message:
-          `"tool.vercel.fastapi.static_cdn" in pyproject.toml must be a boolean ` +
-          `(true or false), got ${JSON.stringify(staticCdn)}.`,
-      });
-    }
+    const staticCdn = pyprojectData?.tool?.vercel?.fastapi?.static_cdn;
     if (staticCdn === false) {
       debug(
         'FastAPI: static_cdn = false in pyproject.toml, skipping CDN collection'

--- a/packages/python/test/fixtures/70-fastapi-static-disabled/pyproject.toml
+++ b/packages/python/test/fixtures/70-fastapi-static-disabled/pyproject.toml
@@ -3,3 +3,6 @@ name = "app"
 version = "0.1.0"
 dependencies = [ "fastapi==0.139.0" ]
 requires-python = "~=3.12.0"
+
+[tool.vercel.fastapi]
+static_cdn = false

--- a/packages/python/test/fixtures/70-fastapi-static-disabled/pyproject.toml
+++ b/packages/python/test/fixtures/70-fastapi-static-disabled/pyproject.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 dependencies = [ "fastapi==0.139.0" ]
 requires-python = "~=3.12.0"
 
-[tool.vercel.fastapi]
-static_cdn = false
+[tool.vercel.fastapi.static]
+cdn = false


### PR DESCRIPTION
 Followup to https://github.com/vercel/vercel/pull/16880

Projects can now set `tool.vercel.fastapi.static.cdn = false` in `pyproject.toml` to disable FastAPI static CDN collection on a per-project basis:

 ```toml
   [tool.vercel.fastapi.static]
   cdn = false
 ```

 The `VERCEL_FASTAPI_STATIC_CDN` env var still gates the feature globally.
