### PR TITLE
fix(cli): verify installed version after vc upgrade instead of trusting pre-resolved target

### DIFF
--- a/.changeset/vc-upgrade-verify-version.md
+++ b/.changeset/vc-upgrade-verify-version.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fixed `vc upgrade` reporting a successful version bump that didn't actually take effect. The upgrade command now re-reads the installed version from disk after the install completes and reports the version that was actually installed, rather than the version it resolved before the install. When the installer exits successfully but the on-disk version is unchanged (e.g. a second global install shadows the updated one), it now warns honestly instead of claiming success.

--- a/packages/cli/src/util/upgrade-version.ts
+++ b/packages/cli/src/util/upgrade-version.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import output from '../output-manager';
+
+/**
+ * Re-reads the CLI's installed version from disk, bypassing the in-memory
+ * `getPackageJSON` cache. Returns `undefined` on read/parse failure.
+ *
+ * Only meaningful for JS installs — native binaries embed package.json in a
+ * VFS snapshot that never changes.
+ *
+ * Isolated in its own module so tests can mock the disk read.
+ */
+export function getInstalledVersion(): string | undefined {
+  try {
+    // Walk up to the package root, mirroring getPackageJSON().
+    let dir = dirname(
+      typeof __dirname !== 'undefined'
+        ? __dirname
+        : fileURLToPath(import.meta.url)
+    );
+    let packageJsonPath = join(dir, 'package.json');
+    while (!existsSync(packageJsonPath)) {
+      const parent = dirname(dir);
+      if (parent === dir) return undefined; // reached filesystem root
+      dir = parent;
+      packageJsonPath = join(dir, 'package.json');
+    }
+    const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return typeof manifest?.version === 'string' ? manifest.version : undefined;
+  } catch (error) {
+    output.debug(
+      `Failed to re-read the installed CLI version: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return undefined;
+  }
+}

--- a/packages/cli/src/util/upgrade.ts
+++ b/packages/cli/src/util/upgrade.ts
@@ -2,6 +2,8 @@ import { spawn, execFile } from 'child_process';
 import { tmpdir } from 'os';
 import semver from 'semver';
 import { getUpdateCommandInfo } from './get-update-command';
+import { isNativeBinaryInstall } from './native-install';
+import { getInstalledVersion } from './upgrade-version';
 import pkg from './pkg';
 import output from '../output-manager';
 import { progress } from './output/progress';
@@ -117,8 +119,6 @@ export async function executeUpgrade(targetVersion?: string): Promise<number> {
 
   const cwd = global ? tmpdir() : process.cwd();
 
-  // The version currently running, captured before the install overwrites it.
-  // This is what `vc --version` reports, for both Node.js and native binary.
   const versionBefore = pkg.version;
 
   let resolvedTargetVersion = targetVersion;
@@ -194,6 +194,43 @@ export async function executeUpgrade(targetVersion?: string): Promise<number> {
       renderUpgradeProgress(totalSteps, totalSteps);
       output.stopSpinner();
 
+      // The installer may exit 0 yet not update the running CLI (e.g. a second
+      // global install shadows the updated one). Re-read the on-disk version to
+      // report what actually got installed. Native binaries embed package.json
+      // in a VFS snapshot, so skip the check there and trust the exit code.
+      const nativeInstall = isNativeBinaryInstall();
+      const installedVersion = nativeInstall
+        ? undefined
+        : getInstalledVersion();
+
+      if (
+        installedVersion &&
+        semver.valid(installedVersion) &&
+        semver.valid(versionBefore) &&
+        semver.neq(installedVersion, versionBefore)
+      ) {
+        output.success(
+          `Vercel CLI has been upgraded to v${installedVersion} successfully!`
+        );
+        resolve(0);
+        return;
+      }
+
+      // The on-disk version is unchanged — the upgrade didn't reach the
+      // active CLI. Surface this honestly instead of claiming success.
+      if (installedVersion && !nativeInstall) {
+        output.warn(
+          `The upgrade completed, but the active Vercel CLI is still v${versionBefore}. ` +
+            `Another install may be shadowing the updated one on your PATH.`
+        );
+        output.log(
+          `Verify with \`vc --version\`, or reinstall with: ${updateCommand}`
+        );
+        resolve(0);
+        return;
+      }
+
+      // Native install, or the on-disk version was unreadable.
       if (resolvedTargetVersion) {
         output.success(
           `Vercel CLI has been upgraded to v${resolvedTargetVersion} successfully!`

--- a/packages/cli/test/unit/util/upgrade.test.ts
+++ b/packages/cli/test/unit/util/upgrade.test.ts
@@ -5,6 +5,8 @@ import { spawn, execFile } from 'child_process';
 import output from '../../../src/output-manager';
 import { executeUpgrade } from '../../../src/util/upgrade';
 import { getUpdateCommandInfo } from '../../../src/util/get-update-command';
+import { isNativeBinaryInstall } from '../../../src/util/native-install';
+import { getInstalledVersion } from '../../../src/util/upgrade-version';
 import pkg from '../../../src/util/pkg';
 
 // Mock child_process
@@ -23,6 +25,7 @@ vi.mock('../../../src/output-manager', () => ({
     print: vi.fn(),
     spinner: vi.fn(),
     stopSpinner: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -33,10 +36,24 @@ vi.mock('../../../src/util/get-update-command', () => ({
     .mockResolvedValue({ command: 'npm i -g vercel@latest', global: true }),
 }));
 
+// Mock native-install so tests control whether the JS-vs-native verification
+// path runs, independent of the real process environment.
+vi.mock('../../../src/util/native-install', () => ({
+  isNativeBinaryInstall: vi.fn(() => false),
+}));
+
+// Mock the post-install disk read so tests can simulate whether the upgrade
+// actually changed the installed version, without touching the real fs.
+vi.mock('../../../src/util/upgrade-version', () => ({
+  getInstalledVersion: vi.fn(() => undefined),
+}));
+
 const spawnMock = vi.mocked(spawn);
 const execFileMock = vi.mocked(execFile);
 const outputMock = vi.mocked(output);
 const getUpdateCommandInfoMock = vi.mocked(getUpdateCommandInfo);
+const isNativeBinaryInstallMock = vi.mocked(isNativeBinaryInstall);
+const getInstalledVersionMock = vi.mocked(getInstalledVersion);
 
 // Makes the package manager's `latest` lookup resolve to `version`.
 function mockLatestVersion(version: string) {
@@ -67,6 +84,11 @@ describe('executeUpgrade', () => {
       callback(new Error('command not found'));
       return {} as any;
     }) as any);
+    // Defaults: JS install (not native), and the post-install disk read is
+    // unobservable so the generic "still on v<before>" notice is used unless a
+    // test opts into a concrete installed version.
+    isNativeBinaryInstallMock.mockReturnValue(false);
+    getInstalledVersionMock.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -461,5 +483,94 @@ describe('executeUpgrade', () => {
     expect(outputMock.debug).toHaveBeenCalledWith(
       `Executing: npm i -g vercel@latest (cwd: ${tmpdir()})`
     );
+  });
+
+  it('reports the on-disk version when the install actually upgraded the CLI', async () => {
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as any);
+    mockLatestVersion('999.0.0');
+    getInstalledVersionMock.mockReturnValue('999.0.0');
+
+    const exitCodePromise = executeUpgrade();
+    await tick();
+
+    mockProcess.emit('close', 0);
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(outputMock.success).toHaveBeenCalledWith(
+      'Vercel CLI has been upgraded to v999.0.0 successfully!'
+    );
+  });
+
+  it('warns when the installer exits 0 but the on-disk version is unchanged', async () => {
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as any);
+    mockLatestVersion('999.0.0');
+    getInstalledVersionMock.mockReturnValue(pkg.version);
+
+    const exitCodePromise = executeUpgrade();
+    await tick();
+
+    mockProcess.emit('close', 0);
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(outputMock.success).not.toHaveBeenCalled();
+    expect(outputMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `The upgrade completed, but the active Vercel CLI is still v${pkg.version}.`
+      )
+    );
+    expect(outputMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining('shadowing the updated one on your PATH.')
+    );
+    expect(outputMock.log).toHaveBeenCalledWith(
+      expect.stringContaining('Verify with `vc --version`')
+    );
+  });
+
+  it('reports the resolved target version for a successful native upgrade', async () => {
+    isNativeBinaryInstallMock.mockReturnValue(true);
+    getUpdateCommandInfoMock.mockResolvedValueOnce({
+      command: 'npm i -g @vercel/vc-native@latest --force',
+      global: true,
+    });
+    mockLatestVersion('999.0.0');
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as any);
+
+    const exitCodePromise = executeUpgrade();
+    await tick();
+
+    mockProcess.emit('close', 0);
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    // Native installs can't verify on disk (VFS snapshot), so the resolved
+    // target version is trusted.
+    expect(outputMock.success).toHaveBeenCalledWith(
+      'Vercel CLI has been upgraded to v999.0.0 successfully!'
+    );
+    expect(outputMock.warn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the resolved target when the on-disk version is unreadable', async () => {
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as any);
+    mockLatestVersion('999.0.0');
+    getInstalledVersionMock.mockReturnValue(undefined);
+
+    const exitCodePromise = executeUpgrade();
+    await tick();
+
+    mockProcess.emit('close', 0);
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(outputMock.success).toHaveBeenCalledWith(
+      'Vercel CLI has been upgraded to v999.0.0 successfully!'
+    );
+    expect(outputMock.warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

`vc upgrade` reported the version it resolved *before* the install, not the version that actually got installed. When the package manager exited 0 but didn't reach the running CLI (e.g. a second global install shadowing the updated one, or the upgrade targeting a different package than the one on `PATH`), it falsely claimed success — the "upgraded to v56.2 but `vc` still shows v54.18" report.

There is no "min release age" holdback mechanism in the codebase; the misleading message was the bug.

## What changed

After a successful install, `executeUpgrade` now re-reads the installed version from disk and compares it to the pre-install version:

- **Changed** → reports the *actual* installed version (not the pre-resolved target).
- **Unchanged** → warns honestly: *"The upgrade completed, but the active Vercel CLI is still vX. Another install may be shadowing the updated one on your PATH"* + guidance, instead of claiming success.
- **Native install** → skips the disk check (the binary embeds `package.json` in a VFS snapshot that never changes) and trusts the exit code + resolved target, preserving existing behavior.
- **Unreadable on disk** → falls back to the old resolved-target/generic message.

The disk re-read lives in a new `upgrade-version.ts` module so tests can mock it without mocking all of `fs`.

## Out of scope

The deeper install-target mismatch for native-spawned JS installs (`VERCEL_VC_NATIVE=1` → `npm i -g @vercel/vc-native`) is a separate, larger change to `getUpdateCommandInfo`. This PR makes the symptom honest — users get an accurate warning instead of a false success — without changing install routing.

## Test plan

- [x] `test/unit/util/upgrade.test.ts` — 20 passed (16 existing + 4 new)
- [x] `test/unit/util/get-update-command.test.ts` + `test/unit/commands/upgrade/index.test.ts` — 22 passed
- [x] `tsc --noEmit` — no errors in changed files
- [x] prettier / biome pre-commit hooks passed

New test cases:
- reports the on-disk version when the install actually upgraded the CLI
- warns when the installer exits 0 but the on-disk version is unchanged
- reports the resolved target version for a successful native upgrade
- falls back to the resolved target when the on-disk version is unreadable
