### PR TITLE
[connect] Add token exchange subject type

### DIFF
--- a/.changeset/bright-tokens-exchange.md
+++ b/.changeset/bright-tokens-exchange.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add token exchange subjects to `ConnectTokenParams`.

--- a/packages/connect/src/ai-sdk/index.ts
+++ b/packages/connect/src/ai-sdk/index.ts
@@ -61,6 +61,7 @@ export {
   NoValidTokenError,
   UserAuthorizationRequiredError,
   type ConnectErrorOptions,
+  type ConnectTokenExchangeSubject,
   type ConnectTokenParams,
   type ConnectTokenSubject,
   type ConnectVendorErrorPayload,

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -9,6 +9,7 @@ export {
   ConnectorInstallationRequiredError,
   type ConnectErrorOptions,
   type ConnectOptions,
+  type ConnectTokenExchangeSubject,
   type ConnectTokenParams,
   type ConnectTokenResponse,
   type ConnectTokenSubject,

--- a/packages/connect/src/mcp/connect-auth-provider.ts
+++ b/packages/connect/src/mcp/connect-auth-provider.ts
@@ -127,9 +127,9 @@ const EMPTY_CLIENT_METADATA: OAuthClientMetadata = {
  * @param connector Vercel Connect connector UID (e.g. `oauth/linear`)
  *   or opaque connector id.
  * @param params Token request parameters — always specify a
- *   `subject`; the three subject types
- *   (`'app'` / `'user'` / `'jwt-bearer'`) have distinct security
- *   semantics.
+ *   `subject`; the supported subject types
+ *   (`'app'` / `'user'` / `'jwt-bearer'` / `'token'`) have distinct
+ *   security semantics.
  * @param options Optional adapter behavior overrides.
  */
 export function connectAuthProvider(

--- a/packages/connect/src/mcp/index.ts
+++ b/packages/connect/src/mcp/index.ts
@@ -42,6 +42,7 @@ export {
   NoValidTokenError,
   UserAuthorizationRequiredError,
   type ConnectErrorOptions,
+  type ConnectTokenExchangeSubject,
   type ConnectTokenParams,
   type ConnectTokenSubject,
   type ConnectVendorErrorPayload,

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -1,12 +1,13 @@
 import { getVercelOidcToken } from '@vercel/oidc';
 import type { ConnectAuthorizationDetail } from './authorization-details.js';
 
-export type ConnectSubjectType = 'app' | 'user' | 'jwt-bearer';
+export type ConnectSubjectType = 'app' | 'user' | 'jwt-bearer' | 'token';
 
 export type ConnectTokenSubject =
   | ConnectAppTokenSubject
   | ConnectUserTokenSubject
-  | ConnectJwtBearerTokenSubject;
+  | ConnectJwtBearerTokenSubject
+  | ConnectTokenExchangeSubject;
 
 export interface ConnectAppTokenSubject {
   type: 'app';
@@ -26,6 +27,11 @@ export interface ConnectJwtBearerTokenSubject {
   /** Defaults to the connector's OAuth token endpoint. */
   aud?: string;
   additionalClaims?: Record<string, unknown>;
+}
+
+export interface ConnectTokenExchangeSubject {
+  type: 'token';
+  token: string;
 }
 
 export interface ConnectTokenParams {

--- a/packages/connect/test/authorization.test.ts
+++ b/packages/connect/test/authorization.test.ts
@@ -82,6 +82,35 @@ describe('startAuthorization', () => {
     expect(JSON.parse(init.body as string)).not.toHaveProperty('returnUrl');
   });
 
+  it('posts token exchange subjects on authorization requests', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        request: 'req_123',
+        verifier: 'verifier_123',
+        url: 'https://connect.vercel.com/authorize/req_123',
+      })
+    );
+
+    await startAuthorization(
+      CONNECTOR,
+      {
+        subject: {
+          type: 'token',
+          token: 'passport.jwt',
+        },
+      },
+      { vercelToken: 'vercel_token' }
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      subject: {
+        type: 'token',
+        token: 'passport.jwt',
+      },
+    });
+  });
+
   it('rejects non-local http callback URLs', async () => {
     await expect(
       startAuthorization(CONNECTOR, PARAMS, {

--- a/packages/connect/test/mcp/connect-auth-provider.types.test.ts
+++ b/packages/connect/test/mcp/connect-auth-provider.types.test.ts
@@ -38,5 +38,8 @@ describe('connectAuthProvider type compatibility', () => {
     connectAuthProvider('oauth/linear', {
       subject: { type: 'jwt-bearer', sub: 'subject_id' },
     });
+    connectAuthProvider('oauth/linear', {
+      subject: { type: 'token', token: 'passport.jwt' },
+    });
   });
 });

--- a/packages/connect/test/token.test.ts
+++ b/packages/connect/test/token.test.ts
@@ -171,6 +171,35 @@ describe('getTokenResponse cache', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('sends token exchange subjects and uses them for cache keying', async () => {
+    fetchMock.mockResolvedValue(tokenResponse('tok_passport'));
+
+    const first = await getTokenResponse('oauth/linear', {
+      subject: {
+        type: 'token',
+        token: 'passport.jwt',
+      },
+    });
+    const second = await getTokenResponse('oauth/linear', {
+      subject: {
+        type: 'token',
+        token: 'passport.jwt',
+      },
+    });
+
+    expect(first.token).toBe('tok_passport');
+    expect(second.token).toBe('tok_passport');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      subject: {
+        type: 'token',
+        token: 'passport.jwt',
+      },
+    });
+  });
+
   it('surfaces a revoked grant on re-check instead of serving the cached bearer', async () => {
     fetchMock.mockResolvedValueOnce(tokenResponse('tok_live'));
     const params = { subject: { type: 'user' as const, id: 'revoked' } };


### PR DESCRIPTION
## Summary

- Add `ConnectTokenExchangeSubject` to `ConnectTokenSubject` so `ConnectTokenParams.subject` accepts `{ type: "token", token: string }`.
- Forward token exchange subjects through `getTokenResponse()` and `startAuthorization()` request bodies.
- Re-export the new subject type from the root, MCP, and AI SDK entrypoints.

## SDK example

```ts
import { getToken } from "@vercel/connect";

const token = await getToken("oauth/linear", {
  subject: {
    type: "token",
    token: passportToken,
  },
});
```

`passportToken` should be a token preconfigured for Vercel Connect token exchange.

## Validation

- `pnpm --filter @vercel/connect typecheck`
- `pnpm --filter @vercel/connect test -- test/token.test.ts test/authorization.test.ts test/mcp/connect-auth-provider.types.test.ts`
