### PR TITLE
[CLI] Add opt-in config for native binary trampoline

### DIFF
--- a/.changeset/native-binary-opt-in.md
+++ b/.changeset/native-binary-opt-in.md
@@ -3,4 +3,4 @@
 'vercel': patch
 ---
 
-Gate the native CLI binary trampoline behind an explicit opt-in. The native `@vercel/vc-native-*` binary is only spawned when the user opts in via `vercel upgrade --binary` (or the `useNativeBinary` global config flag); members of the `vercel` team are auto-opted-in. Adds a zod-free `@vercel/cli-config/paths` subpath so the opt-in flag can be read on the CLI startup hot path without loading zod.
+Gate the native CLI binary trampoline behind an explicit opt-in. The native `@vercel/vc-native-*` binary is only spawned when the user opts in via `vercel upgrade --binary` (or the `useNativeBinary` global config flag); members of the `vercel` team (by team membership) are auto-opted-in. Adds a zod-free `@vercel/cli-config/paths` subpath so the opt-in flag can be read on the CLI startup hot path without loading zod.

--- a/.changeset/native-binary-opt-in.md
+++ b/.changeset/native-binary-opt-in.md
@@ -1,0 +1,6 @@
+---
+'@vercel/cli-config': patch
+'vercel': patch
+---
+
+Gate the native CLI binary trampoline behind an explicit opt-in. The native `@vercel/vc-native-*` binary is only spawned when the user opts in via `vercel upgrade --binary` (or the `useNativeBinary` global config flag); members of the `vercel` team are auto-opted-in. Adds a zod-free `@vercel/cli-config/paths` subpath so the opt-in flag can be read on the CLI startup hot path without loading zod.

--- a/.changeset/native-binary-opt-in.md
+++ b/.changeset/native-binary-opt-in.md
@@ -3,4 +3,4 @@
 'vercel': patch
 ---
 
-Gate the native CLI binary trampoline behind an explicit opt-in. The native `@vercel/vc-native-*` binary is only spawned when the user opts in via `vercel upgrade --binary` (or the `useNativeBinary` global config flag); members of the `vercel` team (by team membership) are auto-opted-in. Adds a zod-free `@vercel/cli-config/paths` subpath so the opt-in flag can be read on the CLI startup hot path without loading zod.
+Gate the native CLI binary trampoline behind an explicit opt-in. The native `@vercel/vc-native-*` binary is only spawned when the user opts in via `vercel upgrade --enable-binary` (or the `useNativeBinary` global config flag); members of the `vercel` team are auto-opted-in when their teams are already loaded. Adds a zod-free `@vercel/cli-config/paths` subpath so the opt-in flag can be read on the CLI startup hot path without loading zod.

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -12,7 +12,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./paths": "./dist/paths.js"
   },
   "private": false,
   "files": [

--- a/packages/cli-config/src/cli-config.ts
+++ b/packages/cli-config/src/cli-config.ts
@@ -1,10 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { homedir } from 'node:os';
-import XDGAppPaths from 'xdg-app-paths';
 import { z } from 'zod';
 import { authConfigSchema, globalConfigSchema } from './schema';
 import type { AuthConfig, AuthFileConfig, GlobalConfig } from './types';
+import {
+  getAuthConfigFilePath,
+  getConfigFilePath,
+  getGlobalPathConfig,
+} from './paths';
+
+export { getAuthConfigFilePath, getConfigFilePath, getGlobalPathConfig };
 
 const DOCS_URL =
   'https://vercel.com/docs/projects/project-configuration/global-configuration';
@@ -114,38 +119,6 @@ export function writeConfigFile<S extends z.ZodType>(
     indent: 2,
     ...options,
   });
-}
-
-function isReadableDirectory(targetPath: string): boolean {
-  try {
-    return fs.lstatSync(targetPath).isDirectory();
-  } catch (_) {
-    // We don't care which kind of error occured, it isn't a readable directory anyway.
-    return false;
-  }
-}
-
-export function getGlobalPathConfig(): string {
-  const vercelDirectories = XDGAppPaths('com.vercel.cli').dataDirs();
-
-  const possibleConfigPaths = [
-    ...vercelDirectories, // latest vercel directory
-    path.join(homedir(), '.now'), // legacy config in user's home directory
-    ...XDGAppPaths('now').dataDirs(), // legacy XDG directory
-  ];
-
-  return (
-    possibleConfigPaths.find(configPath => isReadableDirectory(configPath)) ||
-    vercelDirectories[0]
-  );
-}
-
-export function getConfigFilePath(configDir: string): string {
-  return path.join(configDir, 'config.json');
-}
-
-export function getAuthConfigFilePath(configDir: string): string {
-  return path.join(configDir, 'auth.json');
 }
 
 export function readGlobalConfigFile(configPath: string): GlobalConfig {

--- a/packages/cli-config/src/paths.ts
+++ b/packages/cli-config/src/paths.ts
@@ -1,6 +1,5 @@
-// Zod-free path helpers for locating the global config directory/files. Kept
-// dependency-light so hot paths (e.g. the pre-CLI `vc.js` shim) can import it
-// without paying the ~40ms cost of loading zod and the config schemas.
+// Zod-free path helpers so hot paths (e.g. the `vc.js` shim) can locate and
+// read the global config without loading zod and the config schemas.
 import fs from 'node:fs';
 import path from 'node:path';
 import { homedir } from 'node:os';
@@ -10,7 +9,6 @@ function isReadableDirectory(targetPath: string): boolean {
   try {
     return fs.lstatSync(targetPath).isDirectory();
   } catch (_) {
-    // We don't care which kind of error occured, it isn't a readable directory anyway.
     return false;
   }
 }
@@ -38,9 +36,8 @@ export function getAuthConfigFilePath(configDir: string): string {
   return path.join(configDir, 'auth.json');
 }
 
-// Reads a single key from the global config file without schema validation.
-// For cheap feature-gate reads on hot paths; use `readGlobalConfigFile` when
-// you need the validated config.
+// Reads a single key from the global config file without schema validation,
+// for cheap feature-gate reads on hot paths.
 export function readGlobalConfigFlag(configPath: string, key: string): unknown {
   try {
     const content = fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, '');

--- a/packages/cli-config/src/paths.ts
+++ b/packages/cli-config/src/paths.ts
@@ -1,0 +1,55 @@
+// Zod-free path helpers for locating the global config directory/files. Kept
+// dependency-light so hot paths (e.g. the pre-CLI `vc.js` shim) can import it
+// without paying the ~40ms cost of loading zod and the config schemas.
+import fs from 'node:fs';
+import path from 'node:path';
+import { homedir } from 'node:os';
+import XDGAppPaths from 'xdg-app-paths';
+
+function isReadableDirectory(targetPath: string): boolean {
+  try {
+    return fs.lstatSync(targetPath).isDirectory();
+  } catch (_) {
+    // We don't care which kind of error occured, it isn't a readable directory anyway.
+    return false;
+  }
+}
+
+export function getGlobalPathConfig(): string {
+  const vercelDirectories = XDGAppPaths('com.vercel.cli').dataDirs();
+
+  const possibleConfigPaths = [
+    ...vercelDirectories, // latest vercel directory
+    path.join(homedir(), '.now'), // legacy config in user's home directory
+    ...XDGAppPaths('now').dataDirs(), // legacy XDG directory
+  ];
+
+  return (
+    possibleConfigPaths.find(configPath => isReadableDirectory(configPath)) ||
+    vercelDirectories[0]
+  );
+}
+
+export function getConfigFilePath(configDir: string): string {
+  return path.join(configDir, 'config.json');
+}
+
+export function getAuthConfigFilePath(configDir: string): string {
+  return path.join(configDir, 'auth.json');
+}
+
+// Reads a single key from the global config file without schema validation.
+// For cheap feature-gate reads on hot paths; use `readGlobalConfigFile` when
+// you need the validated config.
+export function readGlobalConfigFlag(configPath: string, key: string): unknown {
+  try {
+    const content = fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, '');
+    const parsed = JSON.parse(content);
+    if (parsed && typeof parsed === 'object') {
+      return (parsed as Record<string, unknown>)[key];
+    }
+  } catch {
+    // Missing/unreadable/invalid config is treated as "no value".
+  }
+  return undefined;
+}

--- a/packages/cli-config/src/schema.zod.ts
+++ b/packages/cli-config/src/schema.zod.ts
@@ -43,4 +43,5 @@ export const globalConfigSchema = z.object({
   telemetry: telemetryConfigSchema.optional(),
   guidance: guidanceConfigSchema.optional(),
   updates: updatesConfigSchema.optional(),
+  useNativeBinary: z.boolean().optional(),
 });

--- a/packages/cli-config/src/types.ts
+++ b/packages/cli-config/src/types.ts
@@ -55,4 +55,11 @@ export interface GlobalConfig {
   telemetry?: TelemetryConfig;
   guidance?: GuidanceConfig;
   updates?: UpdatesConfig;
+  /**
+   * Opt-in to running the native (compiled) Vercel CLI binary when a matching
+   * `@vercel/vc-native-*` package is installed. When unset or `false`, the CLI
+   * always runs as JavaScript even if a native binary is present. Members of
+   * the `vercel` team are auto-opted-in; opt out with `vercel upgrade --binary false`.
+   */
+  useNativeBinary?: boolean;
 }

--- a/packages/cli-config/src/types.ts
+++ b/packages/cli-config/src/types.ts
@@ -55,11 +55,6 @@ export interface GlobalConfig {
   telemetry?: TelemetryConfig;
   guidance?: GuidanceConfig;
   updates?: UpdatesConfig;
-  /**
-   * Opt-in to running the native (compiled) Vercel CLI binary when a matching
-   * `@vercel/vc-native-*` package is installed. When unset or `false`, the CLI
-   * always runs as JavaScript even if a native binary is present. Members of
-   * the `vercel` team are auto-opted-in; opt out with `vercel upgrade --binary false`.
-   */
+  /** Opt-in to running the native Vercel CLI binary when one is installed. */
   useNativeBinary?: boolean;
 }

--- a/packages/cli/src/commands/upgrade/command.ts
+++ b/packages/cli/src/commands/upgrade/command.ts
@@ -29,6 +29,16 @@ export const upgradeCommand = {
       description: 'Disable automatic CLI updates',
     },
     {
+      // Internal: opt in/out of the native CLI binary. Intentionally
+      // undocumented (no `description`) so it is omitted from `--help`, but
+      // still parseable: `--binary`, `--binary true`, `--binary false`.
+      name: 'binary',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      argument: 'BOOL',
+    },
+    {
       ...formatOption,
       description: 'Specify the output format (json) - implies --dry-run',
     },

--- a/packages/cli/src/commands/upgrade/command.ts
+++ b/packages/cli/src/commands/upgrade/command.ts
@@ -29,14 +29,18 @@ export const upgradeCommand = {
       description: 'Disable automatic CLI updates',
     },
     {
-      // Internal: opt in/out of the native CLI binary. Intentionally
-      // undocumented (no `description`) so it is omitted from `--help`, but
-      // still parseable: `--binary`, `--binary true`, `--binary false`.
-      name: 'binary',
+      // Internal: opt in/out of the native CLI binary. Undocumented (no
+      // `description`) so it is omitted from `--help`.
+      name: 'enable-binary',
       shorthand: null,
-      type: String,
+      type: Boolean,
       deprecated: false,
-      argument: 'BOOL',
+    },
+    {
+      name: 'disable-binary',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
     },
     {
       ...formatOption,

--- a/packages/cli/src/commands/upgrade/index.ts
+++ b/packages/cli/src/commands/upgrade/index.ts
@@ -13,27 +13,6 @@ import { UpgradeTelemetryClient } from '../../util/telemetry/commands/upgrade';
 import { isAutoUpdateEnabled, setAutoUpdate } from '../../util/updates';
 import { setUseNativeBinary } from '../../util/native-binary';
 
-// `--binary` accepts an optional boolean value. The `arg` parser has no notion
-// of optional-value flags, so normalize a valueless `--binary` to `--binary=true`.
-function normalizeBinaryFlag(argv: string[]): string[] {
-  const result: string[] = [];
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === '--binary') {
-      const next = argv[i + 1];
-      if (next !== undefined && !next.startsWith('-')) {
-        result.push(arg, next);
-        i++;
-      } else {
-        result.push('--binary=true');
-      }
-      continue;
-    }
-    result.push(arg);
-  }
-  return result;
-}
-
 export default async function upgrade(client: Client): Promise<number> {
   let parsedArgs = null;
 
@@ -47,10 +26,7 @@ export default async function upgrade(client: Client): Promise<number> {
 
   // Parse CLI args
   try {
-    parsedArgs = parseArguments(
-      normalizeBinaryFlag(client.argv.slice(2)),
-      flagsSpecification
-    );
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
   } catch (error) {
     printError(error);
     return 1;
@@ -65,7 +41,8 @@ export default async function upgrade(client: Client): Promise<number> {
   const dryRun = parsedArgs.flags['--dry-run'];
   const enableAuto = parsedArgs.flags['--enable-auto'];
   const disableAuto = parsedArgs.flags['--disable-auto'];
-  const binaryFlag = parsedArgs.flags['--binary'];
+  const enableBinary = parsedArgs.flags['--enable-binary'];
+  const disableBinary = parsedArgs.flags['--disable-binary'];
   const formatResult = validateJsonOutput(parsedArgs.flags);
   if (!formatResult.valid) {
     output.error(formatResult.error);
@@ -76,7 +53,8 @@ export default async function upgrade(client: Client): Promise<number> {
   telemetry.trackCliFlagDryRun(dryRun);
   telemetry.trackCliFlagEnableAuto(enableAuto);
   telemetry.trackCliFlagDisableAuto(disableAuto);
-  telemetry.trackCliOptionBinary(binaryFlag);
+  telemetry.trackCliFlagEnableBinary(enableBinary);
+  telemetry.trackCliFlagDisableBinary(disableBinary);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
   telemetry.trackCliFlagJson(parsedArgs.flags['--json']);
 
@@ -85,12 +63,13 @@ export default async function upgrade(client: Client): Promise<number> {
     return 1;
   }
 
-  if (binaryFlag !== undefined) {
-    if (binaryFlag !== 'true' && binaryFlag !== 'false') {
-      output.error('Invalid value for `--binary`. Expected `true` or `false`.');
-      return 1;
-    }
-    const enabled = binaryFlag === 'true';
+  if (enableBinary && disableBinary) {
+    output.error('Cannot use --enable-binary and --disable-binary together');
+    return 1;
+  }
+
+  if (enableBinary || disableBinary) {
+    const enabled = Boolean(enableBinary);
     setUseNativeBinary(client, enabled);
     output.success(
       `Native Vercel CLI binary ${enabled ? 'enabled' : 'disabled'}.`

--- a/packages/cli/src/commands/upgrade/index.ts
+++ b/packages/cli/src/commands/upgrade/index.ts
@@ -11,6 +11,28 @@ import pkg from '../../util/pkg';
 import type Client from '../../util/client';
 import { UpgradeTelemetryClient } from '../../util/telemetry/commands/upgrade';
 import { isAutoUpdateEnabled, setAutoUpdate } from '../../util/updates';
+import { setUseNativeBinary } from '../../util/native-binary';
+
+// `--binary` accepts an optional boolean value. The `arg` parser has no notion
+// of optional-value flags, so normalize a valueless `--binary` to `--binary=true`.
+function normalizeBinaryFlag(argv: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--binary') {
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('-')) {
+        result.push(arg, next);
+        i++;
+      } else {
+        result.push('--binary=true');
+      }
+      continue;
+    }
+    result.push(arg);
+  }
+  return result;
+}
 
 export default async function upgrade(client: Client): Promise<number> {
   let parsedArgs = null;
@@ -25,7 +47,10 @@ export default async function upgrade(client: Client): Promise<number> {
 
   // Parse CLI args
   try {
-    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+    parsedArgs = parseArguments(
+      normalizeBinaryFlag(client.argv.slice(2)),
+      flagsSpecification
+    );
   } catch (error) {
     printError(error);
     return 1;
@@ -40,6 +65,7 @@ export default async function upgrade(client: Client): Promise<number> {
   const dryRun = parsedArgs.flags['--dry-run'];
   const enableAuto = parsedArgs.flags['--enable-auto'];
   const disableAuto = parsedArgs.flags['--disable-auto'];
+  const binaryFlag = parsedArgs.flags['--binary'];
   const formatResult = validateJsonOutput(parsedArgs.flags);
   if (!formatResult.valid) {
     output.error(formatResult.error);
@@ -50,12 +76,26 @@ export default async function upgrade(client: Client): Promise<number> {
   telemetry.trackCliFlagDryRun(dryRun);
   telemetry.trackCliFlagEnableAuto(enableAuto);
   telemetry.trackCliFlagDisableAuto(disableAuto);
+  telemetry.trackCliOptionBinary(binaryFlag);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
   telemetry.trackCliFlagJson(parsedArgs.flags['--json']);
 
   if (enableAuto && disableAuto) {
     output.error('Cannot use --enable-auto and --disable-auto together');
     return 1;
+  }
+
+  if (binaryFlag !== undefined) {
+    if (binaryFlag !== 'true' && binaryFlag !== 'false') {
+      output.error('Invalid value for `--binary`. Expected `true` or `false`.');
+      return 1;
+    }
+    const enabled = binaryFlag === 'true';
+    setUseNativeBinary(client, enabled);
+    output.success(
+      `Native Vercel CLI binary ${enabled ? 'enabled' : 'disabled'}.`
+    );
+    return 0;
   }
 
   if (enableAuto || disableAuto) {

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -7,6 +7,7 @@ import { TeamDeleted } from './errors-ts';
 import { getLinkFromDir, getVercelDirectory } from './projects/link';
 import { getRepoLink, findProjectsFromPath } from './link/repo';
 import type { RepoProjectsConfig } from './link/repo';
+import { maybeAutoOptInNativeBinary } from './native-binary-auto-opt-in';
 import output from '../output-manager';
 
 export interface ScopeContext {
@@ -86,6 +87,11 @@ export default async function getScope(
     }
 
     contextName = team.slug;
+
+    // Members of the `vercel` team are auto-opted-in to the native binary the
+    // first time we resolve their team. This is a no-op once the user has an
+    // explicit preference (including having opted out via `upgrade --binary false`).
+    maybeAutoOptInNativeBinary(client, team.slug);
   }
 
   if (!opts.resolveLocalScope) {

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -89,11 +89,9 @@ export default async function getScope(
     contextName = team.slug;
   }
 
-  // Members of the `vercel` team are auto-opted-in to the native binary. This
-  // checks team membership (not the resolved scope) and is a no-op once the
-  // user has an explicit preference (including having opted out via
-  // `upgrade --binary false`), in which case no teams API call is made.
-  await maybeAutoOptInNativeBinary(client);
+  // Auto-opt-in `vercel` team members to the native binary when their teams
+  // are already loaded; never triggers its own request.
+  maybeAutoOptInNativeBinary(client);
 
   if (!opts.resolveLocalScope) {
     return { contextName, team, user };

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -87,12 +87,13 @@ export default async function getScope(
     }
 
     contextName = team.slug;
-
-    // Members of the `vercel` team are auto-opted-in to the native binary the
-    // first time we resolve their team. This is a no-op once the user has an
-    // explicit preference (including having opted out via `upgrade --binary false`).
-    maybeAutoOptInNativeBinary(client, team.slug);
   }
+
+  // Members of the `vercel` team are auto-opted-in to the native binary. This
+  // checks team membership (not the resolved scope) and is a no-op once the
+  // user has an explicit preference (including having opted out via
+  // `upgrade --binary false`), in which case no teams API call is made.
+  await maybeAutoOptInNativeBinary(client);
 
   if (!opts.resolveLocalScope) {
     return { contextName, team, user };

--- a/packages/cli/src/util/native-binary-auto-opt-in.ts
+++ b/packages/cli/src/util/native-binary-auto-opt-in.ts
@@ -4,40 +4,26 @@ import {
   hasNativeBinaryPreference,
   setUseNativeBinary,
 } from './native-binary';
-import getTeams from './teams/get-teams';
 import output from '../output-manager';
 
 /**
  * Auto-opt-in members of the `vercel` team to the native CLI binary.
  *
- * Membership is checked against every team the user belongs to (not just the
- * currently-selected scope), so a `vercel` member is opted in even while
- * operating on their personal scope or another team. Team slugs are globally
- * unique across the Vercel platform, so matching on the slug is stable without
- * hardcoding a team id.
- *
- * This only does any work — including the teams API call — when the user has no
- * explicit preference yet, so an opt-out via `vercel upgrade --binary false` is
- * always respected and users who already have a preference pay no extra cost.
- * It is best-effort: a failure to read teams or persist config must never break
- * the running command.
+ * Only acts on teams already loaded on the client, so it never issues its own
+ * API request. Runs only when the user has no explicit preference yet, so an
+ * opt-out is always respected and, once persisted, this never runs again.
  */
-export async function maybeAutoOptInNativeBinary(
-  client: Client
-): Promise<void> {
+export function maybeAutoOptInNativeBinary(client: Client): void {
   if (hasNativeBinaryPreference(client.config)) {
     return;
   }
 
-  try {
-    const teams = await getTeams(client);
-    const isMember = teams.some(
-      team => team.slug === NATIVE_BINARY_AUTO_OPT_IN_TEAM_SLUG
-    );
-    if (!isMember) {
-      return;
-    }
+  const teams = client.teams;
+  if (!teams?.some(team => team.slug === NATIVE_BINARY_AUTO_OPT_IN_TEAM_SLUG)) {
+    return;
+  }
 
+  try {
     setUseNativeBinary(client, true);
   } catch (error) {
     output.debug(

--- a/packages/cli/src/util/native-binary-auto-opt-in.ts
+++ b/packages/cli/src/util/native-binary-auto-opt-in.ts
@@ -4,30 +4,40 @@ import {
   hasNativeBinaryPreference,
   setUseNativeBinary,
 } from './native-binary';
+import getTeams from './teams/get-teams';
 import output from '../output-manager';
 
 /**
  * Auto-opt-in members of the `vercel` team to the native CLI binary.
  *
- * Team slugs are globally unique across the Vercel platform, so matching on
- * the slug is stable without hardcoding a team id. This only writes when the
- * user has no explicit preference yet, so an opt-out via
- * `vercel upgrade --binary false` is always respected. It is best-effort: a
- * failure to persist config must never break the running command.
+ * Membership is checked against every team the user belongs to (not just the
+ * currently-selected scope), so a `vercel` member is opted in even while
+ * operating on their personal scope or another team. Team slugs are globally
+ * unique across the Vercel platform, so matching on the slug is stable without
+ * hardcoding a team id.
+ *
+ * This only does any work — including the teams API call — when the user has no
+ * explicit preference yet, so an opt-out via `vercel upgrade --binary false` is
+ * always respected and users who already have a preference pay no extra cost.
+ * It is best-effort: a failure to read teams or persist config must never break
+ * the running command.
  */
-export function maybeAutoOptInNativeBinary(
-  client: Client,
-  teamSlug: string | undefined
-): void {
-  if (teamSlug !== NATIVE_BINARY_AUTO_OPT_IN_TEAM_SLUG) {
-    return;
-  }
-
+export async function maybeAutoOptInNativeBinary(
+  client: Client
+): Promise<void> {
   if (hasNativeBinaryPreference(client.config)) {
     return;
   }
 
   try {
+    const teams = await getTeams(client);
+    const isMember = teams.some(
+      team => team.slug === NATIVE_BINARY_AUTO_OPT_IN_TEAM_SLUG
+    );
+    if (!isMember) {
+      return;
+    }
+
     setUseNativeBinary(client, true);
   } catch (error) {
     output.debug(

--- a/packages/cli/src/util/native-binary-auto-opt-in.ts
+++ b/packages/cli/src/util/native-binary-auto-opt-in.ts
@@ -1,0 +1,39 @@
+import type Client from './client';
+import {
+  NATIVE_BINARY_AUTO_OPT_IN_TEAM_SLUG,
+  hasNativeBinaryPreference,
+  setUseNativeBinary,
+} from './native-binary';
+import output from '../output-manager';
+
+/**
+ * Auto-opt-in members of the `vercel` team to the native CLI binary.
+ *
+ * Team slugs are globally unique across the Vercel platform, so matching on
+ * the slug is stable without hardcoding a team id. This only writes when the
+ * user has no explicit preference yet, so an opt-out via
+ * `vercel upgrade --binary false` is always respected. It is best-effort: a
+ * failure to persist config must never break the running command.
+ */
+export function maybeAutoOptInNativeBinary(
+  client: Client,
+  teamSlug: string | undefined
+): void {
+  if (teamSlug !== NATIVE_BINARY_AUTO_OPT_IN_TEAM_SLUG) {
+    return;
+  }
+
+  if (hasNativeBinaryPreference(client.config)) {
+    return;
+  }
+
+  try {
+    setUseNativeBinary(client, true);
+  } catch (error) {
+    output.debug(
+      `Failed to auto-opt-in to the native binary: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}

--- a/packages/cli/src/util/native-binary.ts
+++ b/packages/cli/src/util/native-binary.ts
@@ -1,0 +1,27 @@
+import type { GlobalConfig } from '@vercel-internals/types';
+import type Client from './client';
+import { writeToConfigFile } from './config/files';
+
+/**
+ * Slug of the Vercel team whose members are auto-opted-in to the native
+ * binary. Team slugs are globally unique across the Vercel platform, so this
+ * is stable without hardcoding a team id into the source.
+ */
+export const NATIVE_BINARY_AUTO_OPT_IN_TEAM_SLUG = 'vercel';
+
+export function isNativeBinaryEnabled(config: GlobalConfig): boolean {
+  return config.useNativeBinary === true;
+}
+
+export function hasNativeBinaryPreference(config: GlobalConfig): boolean {
+  return typeof config.useNativeBinary === 'boolean';
+}
+
+export function setUseNativeBinary(client: Client, enabled: boolean): void {
+  client.config = {
+    ...client.config,
+    useNativeBinary: enabled,
+  };
+
+  writeToConfigFile(client.config);
+}

--- a/packages/cli/src/util/native-binary.ts
+++ b/packages/cli/src/util/native-binary.ts
@@ -2,11 +2,8 @@ import type { GlobalConfig } from '@vercel-internals/types';
 import type Client from './client';
 import { writeToConfigFile } from './config/files';
 
-/**
- * Slug of the Vercel team whose members are auto-opted-in to the native
- * binary. Team slugs are globally unique across the Vercel platform, so this
- * is stable without hardcoding a team id into the source.
- */
+// Slug of the team whose members are auto-opted-in. Slugs are globally unique,
+// so matching on it avoids hardcoding a team id.
 export const NATIVE_BINARY_AUTO_OPT_IN_TEAM_SLUG = 'vercel';
 
 export function isNativeBinaryEnabled(config: GlobalConfig): boolean {

--- a/packages/cli/src/util/telemetry/commands/upgrade/index.ts
+++ b/packages/cli/src/util/telemetry/commands/upgrade/index.ts
@@ -24,4 +24,13 @@ export class UpgradeTelemetryClient extends TelemetryClient {
       this.trackCliFlag('disable-auto');
     }
   }
+
+  trackCliOptionBinary(binary: string | undefined) {
+    if (binary === 'true' || binary === 'false') {
+      this.trackCliOption({
+        option: 'binary',
+        value: binary,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/upgrade/index.ts
+++ b/packages/cli/src/util/telemetry/commands/upgrade/index.ts
@@ -25,12 +25,15 @@ export class UpgradeTelemetryClient extends TelemetryClient {
     }
   }
 
-  trackCliOptionBinary(binary: string | undefined) {
-    if (binary === 'true' || binary === 'false') {
-      this.trackCliOption({
-        option: 'binary',
-        value: binary,
-      });
+  trackCliFlagEnableBinary(enableBinary: boolean | undefined) {
+    if (enableBinary) {
+      this.trackCliFlag('enable-binary');
+    }
+  }
+
+  trackCliFlagDisableBinary(disableBinary: boolean | undefined) {
+    if (disableBinary) {
+      this.trackCliFlag('disable-binary');
     }
   }
 }

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -10,13 +10,16 @@ try {
   }
 } catch {}
 
-// Native-first: spawn a @vercel/vc-native-{platform}-{arch} binary when
-// present and exit with its result, otherwise fall through to the JS CLI.
-// The native package is declared as an os/cpu-filtered optionalDependency
-// so at most one platform binary downloads per install.
+// Native-first: spawn a @vercel/vc-native-{platform}-{arch} binary when it's
+// present AND the user has opted in, otherwise fall through to the JS CLI.
+// The native package is declared as an os/cpu-filtered optionalDependency so
+// at most one platform binary downloads per install. Even when present, the
+// binary is only spawned when the user has opted in (`useNativeBinary` in the
+// global config, via `vercel upgrade --binary` or auto-enabled for the
+// `vercel` team); otherwise the CLI runs as JS.
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -44,9 +47,45 @@ function resolveNative() {
   }
 }
 
+// Read `--global-config`/`-Q` without loading the full CLI arg parser.
+function globalConfigDirFromArgv() {
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--global-config' || arg === '-Q') {
+      return argv[i + 1];
+    }
+    if (arg.startsWith('--global-config=')) {
+      return arg.slice('--global-config='.length);
+    }
+  }
+  return undefined;
+}
+
+// Any failure to read config is treated as "not opted in" so we never spawn a
+// binary the user didn't ask for.
+async function isNativeBinaryOptedIn() {
+  const envOverride = process.env.VERCEL_CLI_USE_NATIVE_BINARY;
+  if (envOverride === '1' || envOverride === 'true') return true;
+  if (envOverride === '0' || envOverride === 'false') return false;
+
+  try {
+    // Zod-free `paths` subpath avoids loading zod + schemas (~40ms) on this hot path.
+    const config = await import('@vercel/cli-config/paths');
+    const argDir = globalConfigDirFromArgv();
+    const configDir = argDir
+      ? resolve(process.cwd(), argDir)
+      : config.getGlobalPathConfig();
+    const configPath = config.getConfigFilePath(configDir);
+    return config.readGlobalConfigFlag(configPath, 'useNativeBinary') === true;
+  } catch {
+    return false;
+  }
+}
+
 const bin = resolveNative();
 
-if (bin) {
+if (bin && (await isNativeBinaryOptedIn())) {
   process.env.VERCEL_VC_NATIVE = '1';
   const r = spawnSync(bin, process.argv.slice(2), {
     stdio: 'inherit',

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -10,13 +10,8 @@ try {
   }
 } catch {}
 
-// Native-first: spawn a @vercel/vc-native-{platform}-{arch} binary when it's
-// present AND the user has opted in, otherwise fall through to the JS CLI.
-// The native package is declared as an os/cpu-filtered optionalDependency so
-// at most one platform binary downloads per install. Even when present, the
-// binary is only spawned when the user has opted in (`useNativeBinary` in the
-// global config, via `vercel upgrade --binary` or auto-enabled for the
-// `vercel` team); otherwise the CLI runs as JS.
+// Spawn the @vercel/vc-native-{platform}-{arch} binary when it's present and
+// the user has opted in (`useNativeBinary`); otherwise run the JS CLI.
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -62,15 +57,14 @@ function globalConfigDirFromArgv() {
   return undefined;
 }
 
-// Any failure to read config is treated as "not opted in" so we never spawn a
-// binary the user didn't ask for.
+// Any failure to read config counts as "not opted in".
 async function isNativeBinaryOptedIn() {
   const envOverride = process.env.VERCEL_CLI_USE_NATIVE_BINARY;
   if (envOverride === '1' || envOverride === 'true') return true;
   if (envOverride === '0' || envOverride === 'false') return false;
 
   try {
-    // Zod-free `paths` subpath avoids loading zod + schemas (~40ms) on this hot path.
+    // Zod-free subpath to avoid loading zod + schemas on this hot path.
     const config = await import('@vercel/cli-config/paths');
     const argDir = globalConfigDirFromArgv();
     const configDir = argDir

--- a/packages/cli/test/unit/commands/upgrade/index.test.ts
+++ b/packages/cli/test/unit/commands/upgrade/index.test.ts
@@ -188,9 +188,9 @@ describe('upgrade', () => {
     });
   });
 
-  describe('--binary', () => {
+  describe('--enable-binary', () => {
     it('opts in to the native binary in the global config', async () => {
-      client.setArgv('upgrade', '--binary');
+      client.setArgv('upgrade', '--enable-binary');
       const exitCode = await upgrade(client);
 
       expect(exitCode).toBe(0);
@@ -201,15 +201,17 @@ describe('upgrade', () => {
       await expect(client.stderr).toOutput('Native Vercel CLI binary enabled.');
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
-          key: 'option:binary',
-          value: 'true',
+          key: 'flag:enable-binary',
+          value: 'TRUE',
         },
       ]);
     });
+  });
 
-    it('opts out of the native binary with --binary false', async () => {
+  describe('--disable-binary', () => {
+    it('opts out of the native binary in the global config', async () => {
       client.config = { useNativeBinary: true };
-      client.setArgv('upgrade', '--binary', 'false');
+      client.setArgv('upgrade', '--disable-binary');
       const exitCode = await upgrade(client);
 
       expect(exitCode).toBe(0);
@@ -222,29 +224,21 @@ describe('upgrade', () => {
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
-          key: 'option:binary',
-          value: 'false',
+          key: 'flag:disable-binary',
+          value: 'TRUE',
         },
       ]);
     });
+  });
 
-    it('opts in with an explicit --binary true', async () => {
-      client.setArgv('upgrade', '--binary', 'true');
-      const exitCode = await upgrade(client);
+  it('rejects mutually exclusive binary flags', async () => {
+    client.setArgv('upgrade', '--enable-binary', '--disable-binary');
+    const result = await upgrade(client);
 
-      expect(exitCode).toBe(0);
-      expect(client.config.useNativeBinary).toBe(true);
-    });
-
-    it('rejects an invalid --binary value', async () => {
-      client.setArgv('upgrade', '--binary', 'maybe');
-      const exitCode = await upgrade(client);
-
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput(
-        'Invalid value for `--binary`. Expected `true` or `false`.'
-      );
-    });
+    expect(result).toBe(1);
+    await expect(client.stderr).toOutput(
+      'Cannot use --enable-binary and --disable-binary together'
+    );
   });
 
   it('rejects mutually exclusive auto-update flags', async () => {

--- a/packages/cli/test/unit/commands/upgrade/index.test.ts
+++ b/packages/cli/test/unit/commands/upgrade/index.test.ts
@@ -188,6 +188,65 @@ describe('upgrade', () => {
     });
   });
 
+  describe('--binary', () => {
+    it('opts in to the native binary in the global config', async () => {
+      client.setArgv('upgrade', '--binary');
+      const exitCode = await upgrade(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.config.useNativeBinary).toBe(true);
+      expect(writeConfigSpy).toHaveBeenCalledWith({
+        useNativeBinary: true,
+      });
+      await expect(client.stderr).toOutput('Native Vercel CLI binary enabled.');
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:binary',
+          value: 'true',
+        },
+      ]);
+    });
+
+    it('opts out of the native binary with --binary false', async () => {
+      client.config = { useNativeBinary: true };
+      client.setArgv('upgrade', '--binary', 'false');
+      const exitCode = await upgrade(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.config.useNativeBinary).toBe(false);
+      expect(writeConfigSpy).toHaveBeenCalledWith({
+        useNativeBinary: false,
+      });
+      await expect(client.stderr).toOutput(
+        'Native Vercel CLI binary disabled.'
+      );
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:binary',
+          value: 'false',
+        },
+      ]);
+    });
+
+    it('opts in with an explicit --binary true', async () => {
+      client.setArgv('upgrade', '--binary', 'true');
+      const exitCode = await upgrade(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.config.useNativeBinary).toBe(true);
+    });
+
+    it('rejects an invalid --binary value', async () => {
+      client.setArgv('upgrade', '--binary', 'maybe');
+      const exitCode = await upgrade(client);
+
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput(
+        'Invalid value for `--binary`. Expected `true` or `false`.'
+      );
+    });
+  });
+
   it('rejects mutually exclusive auto-update flags', async () => {
     client.setArgv('upgrade', '--enable-auto', '--disable-auto');
     const result = await upgrade(client);

--- a/packages/cli/test/unit/esm/native-trampoline.test.ts
+++ b/packages/cli/test/unit/esm/native-trampoline.test.ts
@@ -27,8 +27,10 @@ import { tmpdir } from 'node:os';
  * mirrors that topology so resolution behaves identically.
  *
  * When no native package is present the trampoline no-ops into JS. When a
- * fake native is installed as a sibling, the CLI spawns it and exits with
- * its exit code. Falling through to JS on EACCES must not leave
+ * fake native is installed as a sibling, the CLI spawns it and exits with its
+ * exit code — but only when the user has opted in (via the `useNativeBinary`
+ * global config or the VERCEL_CLI_USE_NATIVE_BINARY env override); otherwise
+ * it must fall through to JS. Falling through to JS on EACCES must not leave
  * VERCEL_VC_NATIVE=1 set (otherwise the version banner would claim
  * "(native)" while JS is running).
  */
@@ -92,6 +94,14 @@ function cleanEnv() {
   return out;
 }
 
+// Clean env plus an explicit native-binary opt-in / opt-out override.
+function optInEnv() {
+  return { ...cleanEnv(), VERCEL_CLI_USE_NATIVE_BINARY: '1' };
+}
+function optOutEnv() {
+  return { ...cleanEnv(), VERCEL_CLI_USE_NATIVE_BINARY: '0' };
+}
+
 describe('dist/vc.js native resolution', () => {
   it('no-ops to JS when no native package is installed', () => {
     const { vcJs } = buildInstall({
@@ -100,7 +110,7 @@ describe('dist/vc.js native resolution', () => {
     });
     const r = spawnSync(process.execPath, [vcJs, '--version'], {
       encoding: 'utf8',
-      env: cleanEnv(),
+      env: optInEnv(),
     });
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toBe(cliVersion);
@@ -108,7 +118,7 @@ describe('dist/vc.js native resolution', () => {
   });
 
   it.runIf(process.platform !== 'win32')(
-    'spawns the native binary and exits with its exit code',
+    'does NOT spawn the native binary when not opted in, even if present',
     () => {
       const { vcJs } = buildInstall({
         platform: process.platform,
@@ -117,7 +127,26 @@ describe('dist/vc.js native resolution', () => {
       });
       const r = spawnSync(process.execPath, [vcJs, '--version'], {
         encoding: 'utf8',
-        env: cleanEnv(),
+        env: optOutEnv(),
+      });
+      // Falls through to the JS --version fast path.
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe(cliVersion);
+      expect(r.stderr).not.toContain('(native)');
+    }
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'spawns the native binary and exits with its exit code when opted in',
+    () => {
+      const { vcJs } = buildInstall({
+        platform: process.platform,
+        arch: process.arch,
+        body: '#!/bin/sh\necho NATIVE_RAN\nexit 7\n',
+      });
+      const r = spawnSync(process.execPath, [vcJs, '--version'], {
+        encoding: 'utf8',
+        env: optInEnv(),
       });
       expect(r.status).toBe(7);
       expect(r.stdout.trim()).toBe('NATIVE_RAN');
@@ -134,7 +163,7 @@ describe('dist/vc.js native resolution', () => {
       });
       const r = spawnSync(process.execPath, [vcJs, '--version'], {
         encoding: 'utf8',
-        env: { ...cleanEnv(), VERCEL_VC_NATIVE: '1' },
+        env: { ...optInEnv(), VERCEL_VC_NATIVE: '1' },
       });
       expect(r.status).toBe(0);
       expect(r.stdout.trim()).toBe(cliVersion);
@@ -157,7 +186,7 @@ describe('dist/vc.js native resolution', () => {
       });
       const r = spawnSync(process.execPath, [vcJs, '--version'], {
         encoding: 'utf8',
-        env: { ...cleanEnv(), NODE_PATH: join(other.root, 'node_modules') },
+        env: { ...optInEnv(), NODE_PATH: join(other.root, 'node_modules') },
       });
       expect(r.status).toBe(0);
       expect(r.stdout.trim()).toBe(cliVersion);
@@ -177,7 +206,7 @@ describe('dist/vc.js native resolution', () => {
       });
       const r = spawnSync(process.execPath, [vcJs, '--version'], {
         encoding: 'utf8',
-        env: cleanEnv(),
+        env: optInEnv(),
       });
       // EACCES fall-through hits the JS --version fast path. Must not be
       // mislabeled as native — VERCEL_VC_NATIVE must be cleared on fallback.


### PR DESCRIPTION
## Summary

PR 1 of 2 for building native CLI binaries into the release flow. This PR adds the **opt-in gate** so the native `@vercel/vc-native-*` binary is never spawned unless the user explicitly opts in — a prerequisite before PR 2 wires `optionalDependencies` (which would otherwise make every install run the binary).

## Changes

- **Config:** add flat `useNativeBinary` key to the global config (`@vercel/cli-config`). Adds a zod-free `@vercel/cli-config/paths` subpath so `vc.js` can read the flag on the startup hot path without loading zod/schemas (~40ms saved).
- **Trampoline gate (`vc.js`):** only spawn the native binary when opted in — via the config flag or the `VERCEL_CLI_USE_NATIVE_BINARY` env override. Any failure to read config is treated as "not opted in", so we never spawn a binary the user didn't ask for. The `resolveNative()` check runs first and short-circuits, so there is no added cost when no native package is present.
- **`vercel upgrade --enable-binary | --disable-binary`:** toggles the opt-in, with telemetry.
- **Auto-opt-in:** members of the `vercel` team are auto-opted-in, matched by the globally-unique team slug (no hardcoded team id), and only when the user has no explicit preference (an opt-out via `--disable-binary` is always respected).
- **Tests:** trampoline gating (opt-in / opt-out) and the upgrade flag.

## Hot path note

The opt-in read only runs when a native binary is actually resolvable. Today (no `optionalDependencies`) that's never, so the gate costs ~0ms. Once PR 2 lands, the zod-free `paths` read is ~7ms (dominated by `xdg-app-paths`); can be inlined further in PR 2 if a startup benchmark shows it matters.

## Follow-up

PR 2: build binaries in the release flow, populate `optionalDependencies` before publishing `vercel`, and fail the publish if a binary build fails.