### PR TITLE
feat(cli): add vcr permissions commands

### DIFF
--- a/.changeset/eighty-donuts-tease.md
+++ b/.changeset/eighty-donuts-tease.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel vcr permissions` subcommands for managing which teams can pull images from a VCR repository: `vcr permissions <repository> ls` lists teams with access (by team slug), `add` and `rm` grant or revoke access for one or more teams (comma-separated team ids or slugs), and `clear` removes access for every team.

--- a/packages/cli/src/commands/vcr/command.ts
+++ b/packages/cli/src/commands/vcr/command.ts
@@ -7,6 +7,7 @@ import {
 } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
 import { imageAggregateCommand } from './image/command';
+import { permissionsAggregateCommand } from './permissions/command';
 import { tagsAggregateCommand } from './tags/command';
 
 const projectScopeOption = {
@@ -243,6 +244,7 @@ export const vcrCommand = {
     pushSubcommand,
     tagsAggregateCommand,
     imageAggregateCommand,
+    permissionsAggregateCommand,
   ],
   options: [],
   examples: [

--- a/packages/cli/src/commands/vcr/index.ts
+++ b/packages/cli/src/commands/vcr/index.ts
@@ -29,6 +29,14 @@ import {
   tagsLsSubcommand,
   tagsInspectSubcommand,
 } from './tags/command';
+import {
+  PERMISSIONS_ACTIONS,
+  permissionsAggregateCommand,
+  permissionsLsSubcommand,
+  permissionsAddSubcommand,
+  permissionsRmSubcommand,
+  permissionsClearSubcommand,
+} from './permissions/command';
 
 const COMMAND_CONFIG = {
   ls: getCommandAliases(listSubcommand),
@@ -40,6 +48,7 @@ const COMMAND_CONFIG = {
   push: getCommandAliases(pushSubcommand),
   tag: getCommandAliases(tagsAggregateCommand),
   image: getCommandAliases(imageAggregateCommand),
+  permissions: getCommandAliases(permissionsAggregateCommand),
 };
 
 export default async function vcr(client: Client): Promise<number> {
@@ -134,6 +143,40 @@ export default async function vcr(client: Client): Promise<number> {
         printHelp(imageAggregateCommand);
         return 2;
       }
+      case 'permissions': {
+        telemetry.trackCliFlagHelp('vcr', subcommandOriginal);
+        // Actions use `<repository> <action>` ordering, so the action may be
+        // the first or second positional (the repository may be omitted).
+        const nested = args.slice(0, 2);
+        const hasAction = (aliases: string[]) =>
+          nested.some(arg => arg !== undefined && aliases.includes(arg));
+        function printPermissionsActionHelp(command: Command): void {
+          output.print(
+            help(command, {
+              parent: { ...vcrCommand, name: 'vcr permissions repository' },
+              columns: client.stderr.columns,
+            })
+          );
+        }
+        if (hasAction(PERMISSIONS_ACTIONS.ls)) {
+          printPermissionsActionHelp(permissionsLsSubcommand);
+          return 2;
+        }
+        if (hasAction(PERMISSIONS_ACTIONS.add)) {
+          printPermissionsActionHelp(permissionsAddSubcommand);
+          return 2;
+        }
+        if (hasAction(PERMISSIONS_ACTIONS.rm)) {
+          printPermissionsActionHelp(permissionsRmSubcommand);
+          return 2;
+        }
+        if (hasAction(PERMISSIONS_ACTIONS.clear)) {
+          printPermissionsActionHelp(permissionsClearSubcommand);
+          return 2;
+        }
+        printHelp(permissionsAggregateCommand);
+        return 2;
+      }
       default:
         telemetry.trackCliFlagHelp('vcr', subcommandOriginal);
         output.print(help(vcrCommand, { columns: client.stderr.columns }));
@@ -169,6 +212,9 @@ export default async function vcr(client: Client): Promise<number> {
     case 'image':
       telemetry.trackCliSubcommandImage(subcommandOriginal);
       return (await import('./image')).default(client, args, telemetry);
+    case 'permissions':
+      telemetry.trackCliSubcommandPermissions(subcommandOriginal);
+      return (await import('./permissions')).default(client, args, telemetry);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(vcrCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/vcr/permissions/add.ts
+++ b/packages/cli/src/commands/vcr/permissions/add.ts
@@ -22,6 +22,10 @@ import type { RepositoryPermission, TeamOperationFailure } from './team-refs';
 
 const USAGE = 'vcr permissions <repository> add <team>[,<team>...]';
 
+type AddResult =
+  | { ok: true; team: string; permission: RepositoryPermission }
+  | { ok: false; team: string; failure: TeamOperationFailure };
+
 export default async function add(
   client: Client,
   argv: string[],
@@ -87,32 +91,54 @@ export default async function add(
   const added: RepositoryPermission[] = [];
   const failed: TeamOperationFailure[] = [];
 
-  for (const team of teamRefs) {
-    output.spinner(`Sharing ${repository} with ${team}...`);
-    try {
-      const result = await client.fetch<{ permission: RepositoryPermission }>(
-        path,
-        {
-          method: 'POST',
-          body: teamRefBody(team),
+  output.spinner(
+    `Sharing ${repository} with ${
+      teamRefs.length === 1 ? teamRefs[0] : `${teamRefs.length} teams`
+    }...`
+  );
+  let results;
+  try {
+    results = await Promise.all(
+      teamRefs.map(async (team): Promise<AddResult> => {
+        try {
+          const result = await client.fetch<{
+            permission: RepositoryPermission;
+          }>(path, {
+            method: 'POST',
+            body: teamRefBody(team),
+          });
+          return { ok: true, team, permission: result.permission };
+        } catch (err) {
+          if (!isAPIError(err)) {
+            throw err;
+          }
+          const message = err.serverMessage || `API error (${err.status}).`;
+          return {
+            ok: false,
+            team,
+            failure: { team, code: err.code || 'API_ERROR', message },
+          };
         }
-      );
-      output.stopSpinner();
+      })
+    );
+  } finally {
+    output.stopSpinner();
+  }
+
+  for (const result of results) {
+    if (result.ok) {
       added.push(result.permission);
       if (!fr.jsonOutput) {
         output.success(
-          `Shared ${repository} with ${result.permission?.teamSlug ?? team}`
+          `Shared ${repository} with ${result.permission?.teamSlug ?? result.team}`
         );
       }
-    } catch (err) {
-      output.stopSpinner();
-      if (!isAPIError(err)) {
-        throw err;
-      }
-      const message = err.serverMessage || `API error (${err.status}).`;
-      failed.push({ team, code: err.code || 'API_ERROR', message });
+    } else {
+      failed.push(result.failure);
       if (!fr.jsonOutput) {
-        output.error(`Failed to share ${repository} with ${team}: ${message}`);
+        output.error(
+          `Failed to share ${repository} with ${result.team}: ${result.failure.message}`
+        );
       }
     }
   }

--- a/packages/cli/src/commands/vcr/permissions/add.ts
+++ b/packages/cli/src/commands/vcr/permissions/add.ts
@@ -1,0 +1,141 @@
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import output from '../../../output-manager';
+import { isAPIError } from '../../../util/errors-ts';
+import { outputError } from '../../../util/command-validation';
+import {
+  buildCommandWithGlobalFlags,
+  outputAgentError,
+} from '../../../util/agent-output';
+import { AGENT_REASON } from '../../../util/agent-output-constants';
+import { packageName } from '../../../util/pkg-name';
+import type { VcrTelemetryClient } from '../../../util/telemetry/commands/vcr';
+import { permissionsAddSubcommand } from './command';
+import { resolveVcrScope } from '../utils/resolve-vcr-scope';
+import { validateVcrJsonOutput } from '../utils/validators';
+import { emitVcrArgParseError } from '../utils/errors';
+import { repositoryPermissionsPath } from '../utils/paths';
+import { parseTeamRefs, teamRefBody } from './team-refs';
+import type { RepositoryPermission, TeamOperationFailure } from './team-refs';
+
+const USAGE = 'vcr permissions <repository> add <team>[,<team>...]';
+
+export default async function add(
+  client: Client,
+  argv: string[],
+  telemetry: VcrTelemetryClient
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(permissionsAddSubcommand.options)
+    );
+  } catch (err) {
+    emitVcrArgParseError(client, err, USAGE);
+    printError(err);
+    return 1;
+  }
+
+  const fr = validateVcrJsonOutput(client, parsedArgs.flags);
+  if (typeof fr === 'number') {
+    return fr;
+  }
+
+  // Positional args are `<repository> add <team>...`.
+  const repository = parsedArgs.args[0];
+  const teamRefs = parseTeamRefs(parsedArgs.args.slice(2));
+  const project = parsedArgs.flags['--project'] as string | undefined;
+  telemetry.trackCliOptionProject(project);
+  telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
+
+  if (teamRefs.length === 0) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.MISSING_ARGUMENTS,
+        message: `Missing team. Example: ${packageName} vcr permissions ${repository} add team_1a2b3c4d`,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(client.argv, USAGE),
+            when: 'Replace <team> with a team id or slug (comma-separate multiple teams)',
+          },
+        ],
+      },
+      1
+    );
+    return outputError(
+      client,
+      fr.jsonOutput,
+      'MISSING_ARGUMENTS',
+      `Usage: \`vercel ${USAGE}\``
+    );
+  }
+
+  const scope = await resolveVcrScope(client, {
+    project,
+    jsonOutput: fr.jsonOutput,
+  });
+  if (typeof scope === 'number') {
+    return scope;
+  }
+
+  const path = repositoryPermissionsPath(scope, repository);
+  const added: RepositoryPermission[] = [];
+  const failed: TeamOperationFailure[] = [];
+
+  for (const team of teamRefs) {
+    output.spinner(`Sharing ${repository} with ${team}...`);
+    try {
+      const result = await client.fetch<{ permission: RepositoryPermission }>(
+        path,
+        {
+          method: 'POST',
+          body: teamRefBody(team),
+        }
+      );
+      output.stopSpinner();
+      added.push(result.permission);
+      if (!fr.jsonOutput) {
+        output.success(
+          `Shared ${repository} with ${result.permission?.teamSlug ?? team}`
+        );
+      }
+    } catch (err) {
+      output.stopSpinner();
+      if (!isAPIError(err)) {
+        throw err;
+      }
+      const message = err.serverMessage || `API error (${err.status}).`;
+      failed.push({ team, code: err.code || 'API_ERROR', message });
+      if (!fr.jsonOutput) {
+        output.error(`Failed to share ${repository} with ${team}: ${message}`);
+      }
+    }
+  }
+
+  if (failed.length > 0) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.API_ERROR,
+        message: `Failed to share ${repository} with ${failed
+          .map(f => `${f.team} (${f.message})`)
+          .join(', ')}`,
+      },
+      1
+    );
+  }
+
+  if (fr.jsonOutput) {
+    client.stdout.write(
+      `${JSON.stringify({ permissions: added, failed }, null, 2)}\n`
+    );
+  }
+
+  return failed.length > 0 ? 1 : 0;
+}

--- a/packages/cli/src/commands/vcr/permissions/add.ts
+++ b/packages/cli/src/commands/vcr/permissions/add.ts
@@ -1,3 +1,4 @@
+import Sema from 'async-sema';
 import type Client from '../../../util/client';
 import { parseArguments } from '../../../util/get-args';
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
@@ -17,7 +18,11 @@ import { resolveVcrScope } from '../utils/resolve-vcr-scope';
 import { validateVcrJsonOutput } from '../utils/validators';
 import { emitVcrArgParseError } from '../utils/errors';
 import { repositoryPermissionsPath } from '../utils/paths';
-import { parseTeamRefs, teamRefBody } from './team-refs';
+import {
+  MAX_CONCURRENT_REQUESTS,
+  parseTeamRefs,
+  teamRefBody,
+} from './team-refs';
 import type { RepositoryPermission, TeamOperationFailure } from './team-refs';
 
 const USAGE = 'vcr permissions <repository> add <team>[,<team>...]';
@@ -96,10 +101,12 @@ export default async function add(
       teamRefs.length === 1 ? teamRefs[0] : `${teamRefs.length} teams`
     }...`
   );
+  const sema = new Sema(MAX_CONCURRENT_REQUESTS);
   let results;
   try {
     results = await Promise.all(
       teamRefs.map(async (team): Promise<AddResult> => {
+        await sema.acquire();
         try {
           const result = await client.fetch<{
             permission: RepositoryPermission;
@@ -118,6 +125,8 @@ export default async function add(
             team,
             failure: { team, code: err.code || 'API_ERROR', message },
           };
+        } finally {
+          sema.release();
         }
       })
     );

--- a/packages/cli/src/commands/vcr/permissions/clear.ts
+++ b/packages/cli/src/commands/vcr/permissions/clear.ts
@@ -1,0 +1,112 @@
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import output from '../../../output-manager';
+import { isAPIError } from '../../../util/errors-ts';
+import {
+  buildCommandWithYes,
+  outputAgentError,
+} from '../../../util/agent-output';
+import { AGENT_REASON } from '../../../util/agent-output-constants';
+import type { VcrTelemetryClient } from '../../../util/telemetry/commands/vcr';
+import { permissionsClearSubcommand } from './command';
+import { resolveVcrScope } from '../utils/resolve-vcr-scope';
+import {
+  requireVcrRepository,
+  validateVcrJsonOutput,
+} from '../utils/validators';
+import { emitVcrArgParseError, handleVcrApiError } from '../utils/errors';
+import { repositoryPermissionsClearPath } from '../utils/paths';
+
+export default async function clear(
+  client: Client,
+  argv: string[],
+  telemetry: VcrTelemetryClient
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(permissionsClearSubcommand.options)
+    );
+  } catch (err) {
+    emitVcrArgParseError(client, err, 'vcr permissions <repository> clear');
+    printError(err);
+    return 1;
+  }
+
+  const fr = validateVcrJsonOutput(client, parsedArgs.flags);
+  if (typeof fr === 'number') {
+    return fr;
+  }
+
+  const repository = parsedArgs.args[0];
+  const project = parsedArgs.flags['--project'] as string | undefined;
+  const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
+  telemetry.trackCliOptionProject(project);
+  telemetry.trackCliFlagYes(parsedArgs.flags['--yes'] as boolean | undefined);
+  telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
+
+  const missingRepository = requireVcrRepository(
+    client,
+    repository,
+    fr.jsonOutput,
+    'vcr permissions <repository> clear'
+  );
+  if (typeof missingRepository === 'number') {
+    return missingRepository;
+  }
+
+  const scope = await resolveVcrScope(client, {
+    project,
+    jsonOutput: fr.jsonOutput,
+  });
+  if (typeof scope === 'number') {
+    return scope;
+  }
+
+  if (!skipConfirmation) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+        message:
+          'Clearing repository permissions removes access for every team. Re-run with --yes.',
+        next: [{ command: buildCommandWithYes(client.argv) }],
+      },
+      1
+    );
+    if (
+      !(await client.input.confirm(
+        `Remove access to ${repository} for all teams? They will no longer be able to pull its images.`,
+        false
+      ))
+    ) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  const path = repositoryPermissionsClearPath(scope, repository);
+  output.spinner('Clearing repository permissions...');
+  try {
+    await client.fetch(path, { method: 'DELETE' });
+    if (fr.jsonOutput) {
+      client.stdout.write(
+        `${JSON.stringify({ repository, cleared: true }, null, 2)}\n`
+      );
+    } else {
+      output.success(`Cleared repository permissions for ${repository}`);
+    }
+    return 0;
+  } catch (err) {
+    if (isAPIError(err)) {
+      return handleVcrApiError(client, err, fr.jsonOutput);
+    }
+    throw err;
+  } finally {
+    output.stopSpinner();
+  }
+}

--- a/packages/cli/src/commands/vcr/permissions/command.ts
+++ b/packages/cli/src/commands/vcr/permissions/command.ts
@@ -1,0 +1,170 @@
+import {
+  formatOption,
+  limitOption,
+  projectOption,
+  yesOption,
+} from '../../../util/arg-common';
+import { packageName } from '../../../util/pkg-name';
+
+/**
+ * Action aliases for the `vcr permissions <repository> <action>` group. Kept
+ * here (instead of `permissions/index.ts`) so the top-level `vcr` dispatcher
+ * can reuse it for `--help` routing without eagerly importing the router.
+ */
+export const PERMISSIONS_ACTIONS: Record<
+  'ls' | 'add' | 'rm' | 'clear',
+  string[]
+> = {
+  ls: ['ls', 'list'],
+  add: ['add'],
+  rm: ['rm', 'remove'],
+  clear: ['clear'],
+};
+
+const projectScopeOption = {
+  ...projectOption,
+  shorthand: 'p',
+  description: 'Project name or ID (defaults to the linked project).',
+} as const;
+
+const cursorOption = {
+  name: 'cursor',
+  shorthand: 'c',
+  type: String,
+  deprecated: false,
+  description: 'Cursor from a previous page to continue listing from',
+  argument: 'STRING',
+} as const;
+
+export const permissionsLsSubcommand = {
+  name: 'ls',
+  aliases: ['list'],
+  description: 'List teams with access to a repository',
+  arguments: [],
+  options: [projectScopeOption, limitOption, cursorOption, formatOption],
+  examples: [
+    {
+      name: 'List teams with access to a repository',
+      value: `${packageName} vcr permissions my-app ls`,
+    },
+    {
+      name: 'List teams with access as JSON',
+      value: `${packageName} vcr permissions my-app ls --format json`,
+    },
+  ],
+} as const;
+
+export const permissionsAddSubcommand = {
+  name: 'add',
+  aliases: [],
+  description: 'Give one or more teams access to pull images from a repository',
+  arguments: [
+    {
+      name: 'team',
+      required: true,
+      multiple: true,
+    },
+  ],
+  options: [projectScopeOption, formatOption],
+  examples: [
+    {
+      name: 'Share a repository with a team by id',
+      value: `${packageName} vcr permissions my-app add team_1a2b3c4d`,
+    },
+    {
+      name: 'Share a repository with a team by slug',
+      value: `${packageName} vcr permissions my-app add my-team`,
+    },
+    {
+      name: 'Share a repository with multiple teams',
+      value: `${packageName} vcr permissions my-app add team_1a2b3c4d,other-team`,
+    },
+  ],
+} as const;
+
+export const permissionsRmSubcommand = {
+  name: 'rm',
+  aliases: ['remove'],
+  description: "Remove one or more teams' access to a repository",
+  arguments: [
+    {
+      name: 'team',
+      required: true,
+      multiple: true,
+    },
+  ],
+  options: [projectScopeOption, formatOption],
+  examples: [
+    {
+      name: "Remove a team's access by id",
+      value: `${packageName} vcr permissions my-app rm team_1a2b3c4d`,
+    },
+    {
+      name: "Remove multiple teams' access",
+      value: `${packageName} vcr permissions my-app rm team_1a2b3c4d,other-team`,
+    },
+  ],
+} as const;
+
+export const permissionsClearSubcommand = {
+  name: 'clear',
+  aliases: [],
+  description: 'Remove access to a repository for every team',
+  arguments: [],
+  options: [projectScopeOption, yesOption, formatOption],
+  examples: [
+    {
+      name: 'Clear all repository permissions',
+      value: `${packageName} vcr permissions my-app clear`,
+    },
+    {
+      name: 'Clear all repository permissions without the confirmation prompt',
+      value: `${packageName} vcr permissions my-app clear --yes`,
+    },
+  ],
+} as const;
+
+/**
+ * Umbrella command used only for help output of the nested `vcr permissions`
+ * group. Unlike `vcr image`/`vcr tag`, the group uses
+ * `vcr permissions <repository> <action>` ordering, so the repository is an
+ * argument of the umbrella command itself. Routing happens in
+ * `permissions/index.ts`.
+ */
+export const permissionsAggregateCommand = {
+  name: 'permissions',
+  aliases: ['permission'],
+  description:
+    'Manage which teams can pull images from a container registry repository',
+  arguments: [
+    {
+      name: 'repository',
+      required: true,
+    },
+  ],
+  subcommands: [
+    permissionsLsSubcommand,
+    permissionsAddSubcommand,
+    permissionsRmSubcommand,
+    permissionsClearSubcommand,
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'List teams with access to a repository',
+      value: `${packageName} vcr permissions my-app ls`,
+    },
+    {
+      name: 'Share a repository with a team',
+      value: `${packageName} vcr permissions my-app add team_1a2b3c4d`,
+    },
+    {
+      name: "Remove a team's access to a repository",
+      value: `${packageName} vcr permissions my-app rm team_1a2b3c4d`,
+    },
+    {
+      name: 'Clear all repository permissions',
+      value: `${packageName} vcr permissions my-app clear`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/vcr/permissions/index.ts
+++ b/packages/cli/src/commands/vcr/permissions/index.ts
@@ -1,0 +1,98 @@
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import getSubcommand from '../../../util/get-subcommand';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import output from '../../../output-manager';
+import {
+  buildCommandWithGlobalFlags,
+  outputAgentError,
+} from '../../../util/agent-output';
+import { AGENT_REASON } from '../../../util/agent-output-constants';
+import type { VcrTelemetryClient } from '../../../util/telemetry/commands/vcr';
+import {
+  PERMISSIONS_ACTIONS,
+  permissionsLsSubcommand,
+  permissionsClearSubcommand,
+} from './command';
+
+const USAGE = 'vcr permissions <repository> <ls|add|rm|clear>';
+
+/**
+ * Flags accepted by any `vcr permissions` action. The router parses
+ * permissively with the full set so flag values (e.g. `--project my-app`) are
+ * not mistaken for positional arguments while locating the action word.
+ */
+const ROUTING_OPTIONS = [
+  ...permissionsLsSubcommand.options,
+  ...permissionsClearSubcommand.options,
+];
+
+export default async function permissions(
+  client: Client,
+  argv: string[],
+  telemetry: VcrTelemetryClient
+): Promise<number> {
+  // This group uses `vcr permissions <repository> <action>` ordering, so the
+  // action is the second positional argument rather than the first.
+  let positionals: string[];
+  try {
+    const parsed = parseArguments(
+      argv,
+      getFlagsSpecification(ROUTING_OPTIONS),
+      { permissive: true }
+    );
+    positionals = parsed.args;
+  } catch {
+    // A malformed flag: fall through with raw args so the strict per-action
+    // parse (or the unknown-action error below) reports it.
+    positionals = argv.filter(arg => !arg.startsWith('-'));
+  }
+
+  const repository = positionals[0];
+  const { subcommand } = getSubcommand(
+    positionals.slice(1),
+    PERMISSIONS_ACTIONS
+  );
+
+  if (!repository || subcommand == null) {
+    const message = !repository
+      ? `Missing repository. Usage: \`vercel ${USAGE}\`.`
+      : positionals.length < 2
+        ? `Please specify an action. Usage: \`vercel ${USAGE}\`.`
+        : `Unknown "vcr permissions" action "${positionals[1]}". Usage: \`vercel ${USAGE}\`.`;
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'vcr permissions --help'
+            ),
+            when: 'Show valid permissions actions',
+          },
+        ],
+      },
+      1
+    );
+    output.error(`${message} Run \`vercel vcr permissions --help\`.`);
+    return 1;
+  }
+
+  switch (subcommand) {
+    case 'ls':
+      return (await import('./ls')).default(client, argv, telemetry);
+    case 'add':
+      return (await import('./add')).default(client, argv, telemetry);
+    case 'rm':
+      return (await import('./rm')).default(client, argv, telemetry);
+    case 'clear':
+      return (await import('./clear')).default(client, argv, telemetry);
+    default:
+      output.error(`Unhandled permissions action: ${subcommand}`);
+      return 1;
+  }
+}

--- a/packages/cli/src/commands/vcr/permissions/ls.ts
+++ b/packages/cli/src/commands/vcr/permissions/ls.ts
@@ -1,0 +1,156 @@
+import chalk from 'chalk';
+import type Client from '../../../util/client';
+import table from '../../../util/output/table';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import output from '../../../output-manager';
+import { isAPIError } from '../../../util/errors-ts';
+import {
+  outputError,
+  validateOptionalIntegerRange,
+} from '../../../util/command-validation';
+import { outputAgentError } from '../../../util/agent-output';
+import { AGENT_REASON } from '../../../util/agent-output-constants';
+import type { VcrTelemetryClient } from '../../../util/telemetry/commands/vcr';
+import { permissionsLsSubcommand } from './command';
+import { resolveVcrScope } from '../utils/resolve-vcr-scope';
+import { formatRelativeTime } from '../utils/format';
+import {
+  requireVcrRepository,
+  validateVcrJsonOutput,
+} from '../utils/validators';
+import { emitVcrArgParseError, handleVcrApiError } from '../utils/errors';
+import { repositoryPermissionsPath } from '../utils/paths';
+import type { RepositoryPermissionList } from './team-refs';
+
+function printPermissions(list: RepositoryPermissionList): void {
+  if (list.permissions.length === 0) {
+    output.log('This repository has not been shared with any teams.');
+    return;
+  }
+
+  const headers = ['Team', 'Added'].map(h => chalk.cyan(h));
+  const rows = [
+    headers,
+    ...list.permissions.map(permission => [
+      chalk.bold(permission.teamSlug),
+      formatRelativeTime(permission.createdAt),
+    ]),
+  ];
+
+  const tableOutput = table(rows, { hsep: 3 })
+    .split('\n')
+    .map(line => line.trimEnd())
+    .join('\n')
+    .replace(/^/gm, '  ');
+  output.print(`\n${tableOutput}\n`);
+
+  if (list.nextCursor) {
+    output.log(
+      `More results available. Re-run with \`--cursor ${list.nextCursor}\`.`
+    );
+  }
+}
+
+export default async function ls(
+  client: Client,
+  argv: string[],
+  telemetry: VcrTelemetryClient
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(permissionsLsSubcommand.options)
+    );
+  } catch (err) {
+    emitVcrArgParseError(
+      client,
+      err,
+      'vcr permissions <repository> ls --project <name-or-id>'
+    );
+    printError(err);
+    return 1;
+  }
+
+  const fr = validateVcrJsonOutput(client, parsedArgs.flags);
+  if (typeof fr === 'number') {
+    return fr;
+  }
+
+  const repository = parsedArgs.args[0];
+  const project = parsedArgs.flags['--project'] as string | undefined;
+  const cursor = parsedArgs.flags['--cursor'] as string | undefined;
+  const limitFlag = parsedArgs.flags['--limit'] as number | undefined;
+
+  telemetry.trackCliOptionProject(project);
+  telemetry.trackCliOptionLimit(limitFlag);
+  telemetry.trackCliOptionCursor(cursor);
+  telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
+
+  const missingRepository = requireVcrRepository(
+    client,
+    repository,
+    fr.jsonOutput,
+    'vcr permissions <repository> ls'
+  );
+  if (typeof missingRepository === 'number') {
+    return missingRepository;
+  }
+
+  const limitResult = validateOptionalIntegerRange(limitFlag, {
+    flag: '--limit',
+    min: 1,
+    max: 100,
+  });
+  if (!limitResult.valid) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: limitResult.message,
+      },
+      1
+    );
+    return outputError(
+      client,
+      fr.jsonOutput,
+      limitResult.code,
+      limitResult.message
+    );
+  }
+
+  const scope = await resolveVcrScope(client, {
+    project,
+    jsonOutput: fr.jsonOutput,
+  });
+  if (typeof scope === 'number') {
+    return scope;
+  }
+
+  const path = repositoryPermissionsPath(scope, repository, {
+    // A repository can be shared with at most 100 teams, so a full page
+    // always contains every permission.
+    limit: limitResult.value ?? 100,
+    cursor,
+  });
+  output.spinner('Fetching repository permissions...');
+  try {
+    const list = await client.fetch<RepositoryPermissionList>(path);
+    if (fr.jsonOutput) {
+      client.stdout.write(`${JSON.stringify(list, null, 2)}\n`);
+    } else {
+      printPermissions(list);
+    }
+    return 0;
+  } catch (err) {
+    if (isAPIError(err)) {
+      return handleVcrApiError(client, err, fr.jsonOutput);
+    }
+    throw err;
+  } finally {
+    output.stopSpinner();
+  }
+}

--- a/packages/cli/src/commands/vcr/permissions/rm.ts
+++ b/packages/cli/src/commands/vcr/permissions/rm.ts
@@ -22,6 +22,10 @@ import type { TeamOperationFailure } from './team-refs';
 
 const USAGE = 'vcr permissions <repository> rm <team>[,<team>...]';
 
+type RmResult =
+  | { ok: true; team: string }
+  | { ok: false; team: string; failure: TeamOperationFailure };
+
 export default async function rm(
   client: Client,
   argv: string[],
@@ -90,29 +94,50 @@ export default async function rm(
   const removed: string[] = [];
   const failed: TeamOperationFailure[] = [];
 
-  for (const team of teamRefs) {
-    output.spinner(`Removing access to ${repository} for ${team}...`);
-    try {
-      await client.fetch(path, {
-        method: 'DELETE',
-        body: teamRefBody(team),
-      });
-      output.stopSpinner();
-      removed.push(team);
-      if (!fr.jsonOutput) {
-        output.success(`Removed access to ${repository} for ${team}`);
-      }
-    } catch (err) {
-      output.stopSpinner();
-      if (!isAPIError(err)) {
-        throw err;
-      }
-      const message = err.serverMessage || `API error (${err.status}).`;
-      failed.push({ team, code: err.code || 'API_ERROR', message });
+  output.spinner(
+    `Removing access to ${repository} for ${
+      teamRefs.length === 1 ? teamRefs[0] : `${teamRefs.length} teams`
+    }...`
+  );
+  let results;
+  try {
+    results = await Promise.all(
+      teamRefs.map(async (team): Promise<RmResult> => {
+        try {
+          await client.fetch(path, {
+            method: 'DELETE',
+            body: teamRefBody(team),
+          });
+          return { ok: true, team };
+        } catch (err) {
+          if (!isAPIError(err)) {
+            throw err;
+          }
+          const message = err.serverMessage || `API error (${err.status}).`;
+          return {
+            ok: false,
+            team,
+            failure: { team, code: err.code || 'API_ERROR', message },
+          };
+        }
+      })
+    );
+  } finally {
+    output.stopSpinner();
+  }
+
+  for (const result of results) {
+    if (!result.ok) {
+      failed.push(result.failure);
       if (!fr.jsonOutput) {
         output.error(
-          `Failed to remove access to ${repository} for ${team}: ${message}`
+          `Failed to remove access to ${repository} for ${result.team}: ${result.failure.message}`
         );
+      }
+    } else {
+      removed.push(result.team);
+      if (!fr.jsonOutput) {
+        output.success(`Removed access to ${repository} for ${result.team}`);
       }
     }
   }

--- a/packages/cli/src/commands/vcr/permissions/rm.ts
+++ b/packages/cli/src/commands/vcr/permissions/rm.ts
@@ -1,3 +1,4 @@
+import Sema from 'async-sema';
 import type Client from '../../../util/client';
 import { parseArguments } from '../../../util/get-args';
 import { getFlagsSpecification } from '../../../util/get-flags-specification';
@@ -17,7 +18,11 @@ import { resolveVcrScope } from '../utils/resolve-vcr-scope';
 import { validateVcrJsonOutput } from '../utils/validators';
 import { emitVcrArgParseError } from '../utils/errors';
 import { repositoryPermissionsPath } from '../utils/paths';
-import { parseTeamRefs, teamRefBody } from './team-refs';
+import {
+  MAX_CONCURRENT_REQUESTS,
+  parseTeamRefs,
+  teamRefBody,
+} from './team-refs';
 import type { TeamOperationFailure } from './team-refs';
 
 const USAGE = 'vcr permissions <repository> rm <team>[,<team>...]';
@@ -99,10 +104,12 @@ export default async function rm(
       teamRefs.length === 1 ? teamRefs[0] : `${teamRefs.length} teams`
     }...`
   );
+  const sema = new Sema(MAX_CONCURRENT_REQUESTS);
   let results;
   try {
     results = await Promise.all(
       teamRefs.map(async (team): Promise<RmResult> => {
+        await sema.acquire();
         try {
           await client.fetch(path, {
             method: 'DELETE',
@@ -119,6 +126,8 @@ export default async function rm(
             team,
             failure: { team, code: err.code || 'API_ERROR', message },
           };
+        } finally {
+          sema.release();
         }
       })
     );

--- a/packages/cli/src/commands/vcr/permissions/rm.ts
+++ b/packages/cli/src/commands/vcr/permissions/rm.ts
@@ -1,0 +1,139 @@
+import type Client from '../../../util/client';
+import { parseArguments } from '../../../util/get-args';
+import { getFlagsSpecification } from '../../../util/get-flags-specification';
+import { printError } from '../../../util/error';
+import output from '../../../output-manager';
+import { isAPIError } from '../../../util/errors-ts';
+import { outputError } from '../../../util/command-validation';
+import {
+  buildCommandWithGlobalFlags,
+  outputAgentError,
+} from '../../../util/agent-output';
+import { AGENT_REASON } from '../../../util/agent-output-constants';
+import { packageName } from '../../../util/pkg-name';
+import type { VcrTelemetryClient } from '../../../util/telemetry/commands/vcr';
+import { permissionsRmSubcommand } from './command';
+import { resolveVcrScope } from '../utils/resolve-vcr-scope';
+import { validateVcrJsonOutput } from '../utils/validators';
+import { emitVcrArgParseError } from '../utils/errors';
+import { repositoryPermissionsPath } from '../utils/paths';
+import { parseTeamRefs, teamRefBody } from './team-refs';
+import type { TeamOperationFailure } from './team-refs';
+
+const USAGE = 'vcr permissions <repository> rm <team>[,<team>...]';
+
+export default async function rm(
+  client: Client,
+  argv: string[],
+  telemetry: VcrTelemetryClient
+): Promise<number> {
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(permissionsRmSubcommand.options)
+    );
+  } catch (err) {
+    emitVcrArgParseError(client, err, USAGE);
+    printError(err);
+    return 1;
+  }
+
+  const fr = validateVcrJsonOutput(client, parsedArgs.flags);
+  if (typeof fr === 'number') {
+    return fr;
+  }
+
+  // Positional args are `<repository> rm <team>...`.
+  const repository = parsedArgs.args[0];
+  const teamRefs = parseTeamRefs(parsedArgs.args.slice(2));
+  const project = parsedArgs.flags['--project'] as string | undefined;
+  telemetry.trackCliOptionProject(project);
+  telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
+
+  if (teamRefs.length === 0) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.MISSING_ARGUMENTS,
+        message: `Missing team. Example: ${packageName} vcr permissions ${repository} rm team_1a2b3c4d`,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              `vcr permissions ${repository} ls`
+            ),
+            when: 'List teams with access to pick one to remove',
+          },
+        ],
+      },
+      1
+    );
+    return outputError(
+      client,
+      fr.jsonOutput,
+      'MISSING_ARGUMENTS',
+      `Usage: \`vercel ${USAGE}\``
+    );
+  }
+
+  const scope = await resolveVcrScope(client, {
+    project,
+    jsonOutput: fr.jsonOutput,
+  });
+  if (typeof scope === 'number') {
+    return scope;
+  }
+
+  const path = repositoryPermissionsPath(scope, repository);
+  const removed: string[] = [];
+  const failed: TeamOperationFailure[] = [];
+
+  for (const team of teamRefs) {
+    output.spinner(`Removing access to ${repository} for ${team}...`);
+    try {
+      await client.fetch(path, {
+        method: 'DELETE',
+        body: teamRefBody(team),
+      });
+      output.stopSpinner();
+      removed.push(team);
+      if (!fr.jsonOutput) {
+        output.success(`Removed access to ${repository} for ${team}`);
+      }
+    } catch (err) {
+      output.stopSpinner();
+      if (!isAPIError(err)) {
+        throw err;
+      }
+      const message = err.serverMessage || `API error (${err.status}).`;
+      failed.push({ team, code: err.code || 'API_ERROR', message });
+      if (!fr.jsonOutput) {
+        output.error(
+          `Failed to remove access to ${repository} for ${team}: ${message}`
+        );
+      }
+    }
+  }
+
+  if (failed.length > 0) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.API_ERROR,
+        message: `Failed to remove access to ${repository} for ${failed
+          .map(f => `${f.team} (${f.message})`)
+          .join(', ')}`,
+      },
+      1
+    );
+  }
+
+  if (fr.jsonOutput) {
+    client.stdout.write(`${JSON.stringify({ removed, failed }, null, 2)}\n`);
+  }
+
+  return failed.length > 0 ? 1 : 0;
+}

--- a/packages/cli/src/commands/vcr/permissions/team-refs.ts
+++ b/packages/cli/src/commands/vcr/permissions/team-refs.ts
@@ -1,0 +1,51 @@
+/**
+ * A single repository permission grant as returned by the
+ * `/v1/vcr/repository/:idOrName/permissions` endpoints.
+ */
+export interface RepositoryPermission {
+  repositoryId: string;
+  teamId: string;
+  teamSlug: string;
+  createdAt: string;
+}
+
+export interface RepositoryPermissionList {
+  permissions: RepositoryPermission[];
+  nextCursor?: string;
+}
+
+/** A failed add/remove operation for a single team reference. */
+export interface TeamOperationFailure {
+  team: string;
+  code: string;
+  message: string;
+}
+
+/**
+ * Parses team references from positional arguments. Each argument may contain
+ * a single team id/slug or a comma-separated list (`team_123,my-team`).
+ * Duplicates are removed while preserving order.
+ */
+export function parseTeamRefs(args: string[]): string[] {
+  const refs: string[] = [];
+  for (const arg of args) {
+    for (const piece of arg.split(',')) {
+      const ref = piece.trim();
+      if (ref && !refs.includes(ref)) {
+        refs.push(ref);
+      }
+    }
+  }
+  return refs;
+}
+
+/**
+ * Builds the request body for a permission mutation. Team ids are detected by
+ * the `team_` prefix; everything else is treated as a team slug (mirrors the
+ * dashboard behavior).
+ */
+export function teamRefBody(
+  ref: string
+): { teamId: string } | { teamSlug: string } {
+  return ref.startsWith('team_') ? { teamId: ref } : { teamSlug: ref };
+}

--- a/packages/cli/src/commands/vcr/permissions/team-refs.ts
+++ b/packages/cli/src/commands/vcr/permissions/team-refs.ts
@@ -21,6 +21,8 @@ export interface TeamOperationFailure {
   message: string;
 }
 
+export const MAX_CONCURRENT_REQUESTS = 10;
+
 /**
  * Parses team references from positional arguments. Each argument may contain
  * a single team id/slug or a comma-separated list (`team_123,my-team`).

--- a/packages/cli/src/commands/vcr/utils/paths.ts
+++ b/packages/cli/src/commands/vcr/utils/paths.ts
@@ -84,3 +84,25 @@ export function repositoryTagPath(
 ): string {
   return `/v1/vcr/repository/${encodeURIComponent(idOrName)}/tags/${encodeURIComponent(tag)}?${baseQuery(scope).toString()}`;
 }
+
+export function repositoryPermissionsPath(
+  scope: VcrScope,
+  idOrName: string,
+  opts: { limit?: number; cursor?: string } = {}
+): string {
+  const query = baseQuery(scope);
+  if (opts.limit !== undefined) {
+    query.set('limit', String(opts.limit));
+  }
+  if (opts.cursor) {
+    query.set('cursor', opts.cursor);
+  }
+  return `/v1/vcr/repository/${encodeURIComponent(idOrName)}/permissions?${query.toString()}`;
+}
+
+export function repositoryPermissionsClearPath(
+  scope: VcrScope,
+  idOrName: string
+): string {
+  return `/v1/vcr/repository/${encodeURIComponent(idOrName)}/permissions/all?${baseQuery(scope).toString()}`;
+}

--- a/packages/cli/src/util/telemetry/commands/vcr/index.ts
+++ b/packages/cli/src/util/telemetry/commands/vcr/index.ts
@@ -110,6 +110,13 @@ export class VcrTelemetryClient
     });
   }
 
+  trackCliSubcommandPermissions(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'permissions',
+      value: actual,
+    });
+  }
+
   trackCliOptionLimit(value: number | undefined) {
     if (typeof value === 'number') {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/vcr/permissions-add.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions-add.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import vcr from '../../../../src/commands/vcr';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+
+let tmpDir: string;
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_vcr',
+      name: 'vcr-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+function permissionFor(body: { teamId?: string; teamSlug?: string }) {
+  return {
+    repositoryId: 'repo_1',
+    teamId: body.teamId ?? 'team_resolved',
+    teamSlug: body.teamSlug ?? 'resolved-team',
+    createdAt: '2026-06-30T10:00:00.000Z',
+  };
+}
+
+describe('vcr permissions add', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    tmpDir = setupTmpDir('vercel-vcr-permissions-add');
+    client.cwd = tmpDir;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shares a repository with a team by id', async () => {
+    const bodies: any[] = [];
+    client.scenario.post(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        expect(req.query.projectId).toBe('prj_vcr');
+        bodies.push(req.body);
+        res.json({ permission: permissionFor(req.body) });
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'add', 'team_12345');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(bodies).toEqual([{ teamId: 'team_12345' }]);
+    expect(client.stderr.getFullOutput()).toContain('Shared my-app with');
+  });
+
+  it('shares a repository with a team by slug', async () => {
+    const bodies: any[] = [];
+    client.scenario.post(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        bodies.push(req.body);
+        res.json({ permission: permissionFor(req.body) });
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'add', 'other-team');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(bodies).toEqual([{ teamSlug: 'other-team' }]);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Shared my-app with other-team'
+    );
+  });
+
+  it('shares a repository with multiple comma-separated teams', async () => {
+    const bodies: any[] = [];
+    client.scenario.post(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        bodies.push(req.body);
+        res.json({ permission: permissionFor(req.body) });
+      }
+    );
+
+    client.setArgv(
+      'vcr',
+      'permissions',
+      'my-app',
+      'add',
+      'team_12345,other-team'
+    );
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(bodies).toEqual([
+      { teamId: 'team_12345' },
+      { teamSlug: 'other-team' },
+    ]);
+  });
+
+  it('accepts multiple team arguments', async () => {
+    const bodies: any[] = [];
+    client.scenario.post(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        bodies.push(req.body);
+        res.json({ permission: permissionFor(req.body) });
+      }
+    );
+
+    client.setArgv(
+      'vcr',
+      'permissions',
+      'my-app',
+      'add',
+      'team_12345',
+      'other-team'
+    );
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(bodies).toHaveLength(2);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    client.scenario.post(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        res.json({ permission: permissionFor(req.body) });
+      }
+    );
+
+    client.setArgv(
+      'vcr',
+      'permissions',
+      'my-app',
+      'add',
+      'team_12345',
+      '--format',
+      'json'
+    );
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.permissions).toHaveLength(1);
+    expect(parsed.permissions[0].teamId).toBe('team_12345');
+    expect(parsed.failed).toEqual([]);
+  });
+
+  it('continues after a failed team and exits 1', async () => {
+    client.scenario.post(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        if (req.body.teamId === 'team_missing') {
+          res.status(400).json({
+            error: {
+              code: 'team_not_found',
+              message: 'The team to share the repository with does not exist.',
+            },
+          });
+          return;
+        }
+        res.json({ permission: permissionFor(req.body) });
+      }
+    );
+
+    client.setArgv(
+      'vcr',
+      'permissions',
+      'my-app',
+      'add',
+      'team_missing,other-team'
+    );
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('Failed to share my-app with team_missing');
+    expect(output).toContain('Shared my-app with other-team');
+  });
+
+  it('errors when the team argument is missing', async () => {
+    client.setArgv('vcr', 'permissions', 'my-app', 'add');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'vcr permissions <repository> add'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/vcr/permissions-add.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions-add.test.ts
@@ -203,6 +203,29 @@ describe('vcr permissions add', () => {
     expect(output).toContain('Shared my-app with other-team');
   });
 
+  it('caps concurrent requests at 10', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    client.scenario.post(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        setTimeout(() => {
+          inFlight--;
+          res.json({ permission: permissionFor(req.body) });
+        }, 5);
+      }
+    );
+
+    const teams = Array.from({ length: 25 }, (_, i) => `team-${i}`).join(',');
+    client.setArgv('vcr', 'permissions', 'my-app', 'add', teams);
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(10);
+  });
+
   it('treats a 2xx response without a permission body as success', async () => {
     client.scenario.post(
       '/v1/vcr/repository/my-app/permissions',

--- a/packages/cli/test/unit/commands/vcr/permissions-add.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions-add.test.ts
@@ -203,6 +203,22 @@ describe('vcr permissions add', () => {
     expect(output).toContain('Shared my-app with other-team');
   });
 
+  it('treats a 2xx response without a permission body as success', async () => {
+    client.scenario.post(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        res.json({});
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'add', 'team_12345');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('Shared my-app with team_12345');
+    expect(output).not.toContain('Failed to share');
+  });
+
   it('errors when the team argument is missing', async () => {
     client.setArgv('vcr', 'permissions', 'my-app', 'add');
     const exitCode = await vcr(client);

--- a/packages/cli/test/unit/commands/vcr/permissions-clear.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions-clear.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import vcr from '../../../../src/commands/vcr';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+
+let tmpDir: string;
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_vcr',
+      name: 'vcr-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+describe('vcr permissions clear', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    tmpDir = setupTmpDir('vercel-vcr-permissions-clear');
+    client.cwd = tmpDir;
+    client.input.confirm = vi.fn().mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clears all permissions with --yes', async () => {
+    let method = '';
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions/all',
+      (req, res) => {
+        method = req.method;
+        expect(req.query.projectId).toBe('prj_vcr');
+        res.status(204).end();
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'clear', '--yes');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(method).toBe('DELETE');
+    expect(client.stderr.getFullOutput()).toContain(
+      'Cleared repository permissions for my-app'
+    );
+  });
+
+  it('tracks subcommand invocation', async () => {
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions/all',
+      (_req, res) => {
+        res.status(204).end();
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'clear', '--yes');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:permissions',
+        value: 'permissions',
+      },
+      {
+        key: 'flag:yes',
+        value: 'TRUE',
+      },
+    ]);
+  });
+
+  it('prompts for confirmation when --yes is omitted', async () => {
+    const confirmMock = vi.fn().mockResolvedValue(false);
+    client.input.confirm = confirmMock;
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'clear');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(confirmMock).toHaveBeenCalled();
+    expect(client.stderr.getFullOutput()).toContain('Canceled');
+  });
+
+  it('outputs JSON with --format json', async () => {
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions/all',
+      (_req, res) => {
+        res.status(204).end();
+      }
+    );
+
+    client.setArgv(
+      'vcr',
+      'permissions',
+      'my-app',
+      'clear',
+      '--yes',
+      '--format',
+      'json'
+    );
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed).toEqual({ repository: 'my-app', cleared: true });
+  });
+
+  it('errors when the API returns a 404', async () => {
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions/all',
+      (_req, res) => {
+        res.status(404).json({
+          error: { code: 'not_found', message: 'VCR Repository not found.' },
+        });
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'clear', '--yes');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/packages/cli/test/unit/commands/vcr/permissions-ls.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions-ls.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import vcr from '../../../../src/commands/vcr';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+
+let tmpDir: string;
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_vcr',
+      name: 'vcr-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+describe('vcr permissions ls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    tmpDir = setupTmpDir('vercel-vcr-permissions-ls');
+    client.cwd = tmpDir;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists teams with access using the team slug', async () => {
+    client.scenario.get('/v1/vcr/repository/my-app/permissions', (req, res) => {
+      expect(req.query.projectId).toBe('prj_vcr');
+      expect(req.query.limit).toBe('100');
+      res.json({
+        permissions: [
+          {
+            repositoryId: 'repo_1',
+            teamId: 'team_other',
+            teamSlug: 'other-team',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      });
+    });
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'ls');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('other-team');
+    expect(output).not.toContain('team_other');
+  });
+
+  it('supports the list alias', async () => {
+    client.scenario.get(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        res.json({ permissions: [] });
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'list');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'This repository has not been shared with any teams.'
+    );
+  });
+
+  it('tracks subcommand invocation', async () => {
+    client.scenario.get(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        res.json({ permissions: [] });
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'ls');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:permissions',
+        value: 'permissions',
+      },
+    ]);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    client.scenario.get(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        res.json({
+          permissions: [
+            {
+              repositoryId: 'repo_1',
+              teamId: 'team_other',
+              teamSlug: 'other-team',
+              createdAt: '2026-06-30T10:00:00.000Z',
+            },
+          ],
+        });
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'ls', '--format', 'json');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.permissions).toHaveLength(1);
+    expect(parsed.permissions[0].teamSlug).toBe('other-team');
+  });
+
+  it('passes a custom limit through', async () => {
+    let limit = '';
+    client.scenario.get('/v1/vcr/repository/my-app/permissions', (req, res) => {
+      limit = String(req.query.limit);
+      res.json({ permissions: [] });
+    });
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'ls', '--limit', '5');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(limit).toBe('5');
+  });
+
+  it('errors when the API returns a 404', async () => {
+    client.scenario.get(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        res.status(404).json({
+          error: { code: 'not_found', message: 'VCR Repository not found.' },
+        });
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'ls');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/packages/cli/test/unit/commands/vcr/permissions-rm.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions-rm.test.ts
@@ -114,6 +114,29 @@ describe('vcr permissions rm', () => {
     ]);
   });
 
+  it('caps concurrent requests at 10', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        setTimeout(() => {
+          inFlight--;
+          res.status(204).end();
+        }, 5);
+      }
+    );
+
+    const teams = Array.from({ length: 25 }, (_, i) => `team-${i}`).join(',');
+    client.setArgv('vcr', 'permissions', 'my-app', 'rm', teams);
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(10);
+  });
+
   it('supports the remove alias', async () => {
     client.scenario.delete(
       '/v1/vcr/repository/my-app/permissions',

--- a/packages/cli/test/unit/commands/vcr/permissions-rm.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions-rm.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import vcr from '../../../../src/commands/vcr';
+import * as linkModule from '../../../../src/util/projects/link';
+import * as getScopeModule from '../../../../src/util/get-scope';
+
+vi.mock('../../../../src/util/projects/link');
+vi.mock('../../../../src/util/get-scope');
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+const mockedGetScope = vi.mocked(getScopeModule.default);
+
+let tmpDir: string;
+
+function mockLinkedProject() {
+  mockedGetLinkedProject.mockResolvedValue({
+    status: 'linked',
+    project: {
+      id: 'prj_vcr',
+      name: 'vcr-project',
+      accountId: 'team_dummy',
+      updatedAt: Date.now(),
+      createdAt: Date.now(),
+    },
+    org: {
+      id: 'team_dummy',
+      slug: 'my-team',
+      type: 'team',
+    },
+  } as any);
+}
+
+function mockTeamScope() {
+  mockedGetScope.mockResolvedValue({
+    contextName: 'my-team',
+    team: { id: 'team_dummy', slug: 'my-team' } as any,
+    user: { id: 'user_dummy' } as any,
+  } as any);
+}
+
+describe('vcr permissions rm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    mockLinkedProject();
+    mockTeamScope();
+    tmpDir = setupTmpDir('vercel-vcr-permissions-rm');
+    client.cwd = tmpDir;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("removes a team's access by id", async () => {
+    const bodies: any[] = [];
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        expect(req.query.projectId).toBe('prj_vcr');
+        bodies.push(req.body);
+        res.status(204).end();
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'rm', 'team_12345');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(bodies).toEqual([{ teamId: 'team_12345' }]);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Removed access to my-app for team_12345'
+    );
+  });
+
+  it("removes a team's access by slug", async () => {
+    const bodies: any[] = [];
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        bodies.push(req.body);
+        res.status(204).end();
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'rm', 'other-team');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(bodies).toEqual([{ teamSlug: 'other-team' }]);
+  });
+
+  it('removes multiple comma-separated teams', async () => {
+    const bodies: any[] = [];
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions',
+      (req, res) => {
+        bodies.push(req.body);
+        res.status(204).end();
+      }
+    );
+
+    client.setArgv(
+      'vcr',
+      'permissions',
+      'my-app',
+      'rm',
+      'team_12345,other-team'
+    );
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    expect(bodies).toEqual([
+      { teamId: 'team_12345' },
+      { teamSlug: 'other-team' },
+    ]);
+  });
+
+  it('supports the remove alias', async () => {
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        res.status(204).end();
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'remove', 'team_12345');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+  });
+
+  it('outputs JSON with --format json', async () => {
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        res.status(204).end();
+      }
+    );
+
+    client.setArgv(
+      'vcr',
+      'permissions',
+      'my-app',
+      'rm',
+      'team_12345',
+      '--format',
+      'json'
+    );
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.removed).toEqual(['team_12345']);
+    expect(parsed.failed).toEqual([]);
+  });
+
+  it('exits 1 when the repository is not shared with the team', async () => {
+    client.scenario.delete(
+      '/v1/vcr/repository/my-app/permissions',
+      (_req, res) => {
+        res.status(404).json({
+          error: {
+            code: 'not_found',
+            message: 'The repository is not shared with this team.',
+          },
+        });
+      }
+    );
+
+    client.setArgv('vcr', 'permissions', 'my-app', 'rm', 'team_12345');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'The repository is not shared with this team.'
+    );
+  });
+
+  it('errors when the team argument is missing', async () => {
+    client.setArgv('vcr', 'permissions', 'my-app', 'rm');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'vcr permissions <repository> rm'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/vcr/permissions.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import vcr from '../../../../src/commands/vcr';
+import { client } from '../../../mocks/client';
+
+describe('vcr permissions', () => {
+  it('errors when invoked without a repository or action', async () => {
+    client.setArgv('vcr', 'permissions');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Missing repository');
+  });
+
+  it('errors when the action is missing', async () => {
+    client.setArgv('vcr', 'permissions', 'my-app');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Please specify an action');
+  });
+
+  it('errors on an unknown action', async () => {
+    client.setArgv('vcr', 'permissions', 'my-app', 'bogus');
+    const exitCode = await vcr(client);
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Unknown "vcr permissions" action "bogus"'
+    );
+  });
+
+  describe('--help', () => {
+    it('shows group help and tracks telemetry', async () => {
+      client.setArgv('vcr', 'permissions', '--help');
+      const exitCode = await vcr(client);
+      expect(exitCode).toBe(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'vcr:permissions',
+        },
+      ]);
+    });
+
+    it('shows action help when the repository is present', async () => {
+      client.setArgv('vcr', 'permissions', 'my-app', 'add', '--help');
+      const exitCode = await vcr(client);
+      expect(exitCode).toBe(2);
+      expect(client.stderr.getFullOutput()).toContain(
+        'vcr permissions my-app add team_1a2b3c4d'
+      );
+    });
+
+    it('shows action help when the repository is omitted', async () => {
+      client.setArgv('vcr', 'permissions', 'ls', '--help');
+      const exitCode = await vcr(client);
+      expect(exitCode).toBe(2);
+      expect(client.stderr.getFullOutput()).toContain(
+        'vcr permissions my-app ls'
+      );
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/vcr/permissions/team-refs.test.ts
+++ b/packages/cli/test/unit/commands/vcr/permissions/team-refs.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseTeamRefs,
+  teamRefBody,
+} from '../../../../../src/commands/vcr/permissions/team-refs';
+
+describe('parseTeamRefs', () => {
+  it('returns an empty list for no arguments', () => {
+    expect(parseTeamRefs([])).toEqual([]);
+  });
+
+  it('parses a single team reference', () => {
+    expect(parseTeamRefs(['team_123'])).toEqual(['team_123']);
+  });
+
+  it('splits comma-separated references within one argument', () => {
+    expect(parseTeamRefs(['team_123,my-team'])).toEqual([
+      'team_123',
+      'my-team',
+    ]);
+  });
+
+  it('collects references across multiple arguments', () => {
+    expect(parseTeamRefs(['team_123', 'my-team'])).toEqual([
+      'team_123',
+      'my-team',
+    ]);
+  });
+
+  it('mixes comma-separated and positional references', () => {
+    expect(parseTeamRefs(['team_123,my-team', 'other-team'])).toEqual([
+      'team_123',
+      'my-team',
+      'other-team',
+    ]);
+  });
+
+  it('trims whitespace around references', () => {
+    expect(parseTeamRefs([' team_123 , my-team '])).toEqual([
+      'team_123',
+      'my-team',
+    ]);
+  });
+
+  it('ignores empty pieces from stray commas', () => {
+    expect(parseTeamRefs(['team_123,,my-team,', ','])).toEqual([
+      'team_123',
+      'my-team',
+    ]);
+  });
+
+  it('removes duplicates while preserving first-seen order', () => {
+    expect(
+      parseTeamRefs(['team_123,my-team', 'team_123', 'my-team,other-team'])
+    ).toEqual(['team_123', 'my-team', 'other-team']);
+  });
+});
+
+describe('teamRefBody', () => {
+  it('treats refs with a team_ prefix as team ids', () => {
+    expect(teamRefBody('team_123')).toEqual({ teamId: 'team_123' });
+  });
+
+  it('treats other refs as team slugs', () => {
+    expect(teamRefBody('my-team')).toEqual({ teamSlug: 'my-team' });
+  });
+
+  it('only detects the team_ prefix at the start of the ref', () => {
+    expect(teamRefBody('my-team_123')).toEqual({ teamSlug: 'my-team_123' });
+  });
+});

--- a/packages/cli/test/unit/commands/vcr/utils/paths.test.ts
+++ b/packages/cli/test/unit/commands/vcr/utils/paths.test.ts
@@ -4,6 +4,8 @@ import {
   repositoriesPath,
   repositoryImagesPath,
   repositoryPath,
+  repositoryPermissionsClearPath,
+  repositoryPermissionsPath,
   repositoryTagPath,
   repositoryTagsPath,
 } from '../../../../../src/commands/vcr/utils/paths';
@@ -106,6 +108,42 @@ describe('repositoryTagPath', () => {
   it('url-encodes the repository name and tag', () => {
     expect(repositoryTagPath(scope, 'my app', 'v1.0/beta')).toBe(
       '/v1/vcr/repository/my%20app/tags/v1.0%2Fbeta?teamId=team_dummy&projectId=prj_vcr'
+    );
+  });
+});
+
+describe('repositoryPermissionsPath', () => {
+  it('builds the permissions path for a repository', () => {
+    expect(repositoryPermissionsPath(scope, 'my-app')).toBe(
+      '/v1/vcr/repository/my-app/permissions?teamId=team_dummy&projectId=prj_vcr'
+    );
+  });
+
+  it('includes limit and cursor when provided', () => {
+    expect(
+      repositoryPermissionsPath(scope, 'my-app', { limit: 20, cursor: 'abc' })
+    ).toBe(
+      '/v1/vcr/repository/my-app/permissions?teamId=team_dummy&projectId=prj_vcr&limit=20&cursor=abc'
+    );
+  });
+
+  it('url-encodes the repository name', () => {
+    expect(repositoryPermissionsPath(scope, 'my app')).toBe(
+      '/v1/vcr/repository/my%20app/permissions?teamId=team_dummy&projectId=prj_vcr'
+    );
+  });
+});
+
+describe('repositoryPermissionsClearPath', () => {
+  it('builds the clear-all permissions path for a repository', () => {
+    expect(repositoryPermissionsClearPath(scope, 'my-app')).toBe(
+      '/v1/vcr/repository/my-app/permissions/all?teamId=team_dummy&projectId=prj_vcr'
+    );
+  });
+
+  it('url-encodes the repository name', () => {
+    expect(repositoryPermissionsClearPath(scope, 'my app')).toBe(
+      '/v1/vcr/repository/my%20app/permissions/all?teamId=team_dummy&projectId=prj_vcr'
     );
   });
 });


### PR DESCRIPTION
Add support for managing permissions to a repository from the CLI


# Usage
```
vercel vcr permissions <repository> ls                      # list teams with access (shows team slug)
vercel vcr permissions <repository> add team_12345          # grant access by team id / slug
vercel vcr permissions <repository> add my-team,other-team  # comma-separated ids/slugs
vercel vcr permissions <repository> rm team_12345,my-team   # revoke access
vercel vcr permissions <repository> clear [--yes]           # remove all access (confirmed)
```


# Examples

```
~/coding/sandbox-test 9.71s
12:29:28 [I]   ❯ node ~/coding/vercel/packages/cli/dist/vc.js vcr permissions grok ls
Vercel CLI 56.5.0 (Node.js 22.20.0)
> This repository has not been shared with any teams.

~/coding/sandbox-test
12:30:02 [I]   ❯ node ~/coding/vercel/packages/cli/dist/vc.js vcr permissions grok add vtest314-hive
Vercel CLI 56.5.0 (Node.js 22.20.0)
> Success! Shared grok with vtest314-hive

~/coding/sandbox-test
12:30:43 [I]   ❯ node ~/coding/vercel/packages/cli/dist/vc.js vcr permissions grok ls
Vercel CLI 56.5.0 (Node.js 22.20.0)

  Team            Added
  vtest314-hive   5s ago

~/coding/sandbox-test
12:30:47 [I]   ❯ node ~/coding/vercel/packages/cli/dist/vc.js vcr permissions grok clear
Vercel CLI 56.5.0 (Node.js 22.20.0)
? Remove access to grok for all teams? They will no longer be able to pull its images. yes
> Success! Cleared repository permissions for grok

```