### PR TITLE
[backends][node] apply request path transforms for rewrites

### DIFF
--- a/.changeset/backend-framework-rewrite-path.md
+++ b/.changeset/backend-framework-rewrite-path.md
@@ -1,0 +1,14 @@
+---
+'@vercel/build-utils': minor
+'@vercel/backends': minor
+'@vercel/express': minor
+'@vercel/hono': minor
+'@vercel/h3': minor
+'@vercel/koa': minor
+'@vercel/nestjs': minor
+'@vercel/fastify': minor
+'@vercel/elysia': minor
+'vercel': patch
+---
+
+Expose the resolved rewrite destination as the request path observed by Node backend framework applications (express, hono, h3, koa, nestjs, fastify, elysia) and the unified backends builder, and warn affected backend projects about the behavior change.

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -378,11 +378,18 @@ export const build: BuildV2 = async args => {
             // Copy the resolved (post-rewrite) path into the runtime request
             // before dispatching the shared framework Lambda so application
             // routing observes the rewrite rather than the original path.
+            //
+            // The catch-all capture group only matches the segment *after* the
+            // service route prefix, so include the prefix here to reconstruct
+            // the full resolved path. The runtime shim
+            // (VERCEL_SERVICE_ROUTE_PREFIX_STRIP) remains the single place that
+            // strips the mount prefix, avoiding a double-strip when the suffix
+            // itself begins with the prefix segment.
             transforms: [
               {
                 type: 'request.path' as const,
                 op: 'set' as const,
-                args: '/$1',
+                args: serviceRoutePrefix ? `${serviceRoutePrefix}/$1` : '/$1',
               },
             ],
           },

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -375,6 +375,16 @@ export const build: BuildV2 = async args => {
           {
             src: getServiceCatchallSource(serviceRoutePrefix),
             dest: serviceFunctionPath ?? '/',
+            // Copy the resolved (post-rewrite) path into the runtime request
+            // before dispatching the shared framework Lambda so application
+            // routing observes the rewrite rather than the original path.
+            transforms: [
+              {
+                type: 'request.path' as const,
+                op: 'set' as const,
+                args: '/$1',
+              },
+            ],
           },
         ];
 

--- a/packages/backends/src/introspection/index.ts
+++ b/packages/backends/src/introspection/index.ts
@@ -217,6 +217,15 @@ export const introspectApp = async (args: {
     {
       src: '/(.*)',
       dest: '/',
+      // Expose the resolved (post-rewrite) path to the framework Lambda so
+      // application routing observes the rewritten destination.
+      transforms: [
+        {
+          type: 'request.path' as const,
+          op: 'set' as const,
+          args: '/$1',
+        },
+      ],
     },
   ];
 
@@ -246,6 +255,15 @@ const defaultResult = (args: {
       {
         src: '/(.*)',
         dest: '/',
+        // Expose the resolved (post-rewrite) path to the framework Lambda so
+        // application routing observes the rewritten destination.
+        transforms: [
+          {
+            type: 'request.path' as const,
+            op: 'set' as const,
+            args: '/$1',
+          },
+        ],
       },
     ],
     framework: getFramework(args),

--- a/packages/backends/test/fixtures/01-express-index-ts-esm/routes.json
+++ b/packages/backends/test/fixtures/01-express-index-ts-esm/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/02-express-index-ts-cjs/routes.json
+++ b/packages/backends/test/fixtures/02-express-index-ts-cjs/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/03-express-views-pug/routes.json
+++ b/packages/backends/test/fixtures/03-express-views-pug/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/04-hono-index-ts-esm/routes.json
+++ b/packages/backends/test/fixtures/04-hono-index-ts-esm/routes.json
@@ -18,6 +18,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/05-hono-index-ts-cjs/routes.json
+++ b/packages/backends/test/fixtures/05-hono-index-ts-cjs/routes.json
@@ -18,6 +18,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/06-hono-relative-import/routes.json
+++ b/packages/backends/test/fixtures/06-hono-relative-import/routes.json
@@ -25,6 +25,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/07-hono-ts-paths-import/routes.json
+++ b/packages/backends/test/fixtures/07-hono-ts-paths-import/routes.json
@@ -25,6 +25,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/08-elysia/routes.json
+++ b/packages/backends/test/fixtures/08-elysia/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/09-nestjs-with-build-command/routes.json
+++ b/packages/backends/test/fixtures/09-nestjs-with-build-command/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/10-nestjs-no-build-command/routes.json
+++ b/packages/backends/test/fixtures/10-nestjs-no-build-command/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/11-express-v5-cjs/routes.json
+++ b/packages/backends/test/fixtures/11-express-v5-cjs/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/12-express-v5-mts/routes.json
+++ b/packages/backends/test/fixtures/12-express-v5-mts/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/12-hono-index-ts-esm-cjs-interop/routes.json
+++ b/packages/backends/test/fixtures/12-hono-index-ts-esm-cjs-interop/routes.json
@@ -11,6 +11,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/13-hono-ts-esm-cjs-interop-2/routes.json
+++ b/packages/backends/test/fixtures/13-hono-ts-esm-cjs-interop-2/routes.json
@@ -11,6 +11,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/14-hono-esm-cjs-interop-3/routes.json
+++ b/packages/backends/test/fixtures/14-hono-esm-cjs-interop-3/routes.json
@@ -11,6 +11,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/15-hono-sharp-native-bindings/routes.json
+++ b/packages/backends/test/fixtures/15-hono-sharp-native-bindings/routes.json
@@ -18,6 +18,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/16-hono-node-rs-xxhash/routes.json
+++ b/packages/backends/test/fixtures/16-hono-node-rs-xxhash/routes.json
@@ -11,6 +11,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/17-turborepo-hono-monorepo/routes.json
+++ b/packages/backends/test/fixtures/17-turborepo-hono-monorepo/routes.json
@@ -11,6 +11,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/18-include-exclude-files/routes.json
+++ b/packages/backends/test/fixtures/18-include-exclude-files/routes.json
@@ -11,6 +11,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/19-generic-node-server/routes.json
+++ b/packages/backends/test/fixtures/19-generic-node-server/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/20-cron-default-export/routes.json
+++ b/packages/backends/test/fixtures/20-cron-default-export/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/21-elysia-vercel-repro/routes.json
+++ b/packages/backends/test/fixtures/21-elysia-vercel-repro/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/fixtures/22-hono-argon2-pnpm/routes.json
+++ b/packages/backends/test/fixtures/22-hono-argon2-pnpm/routes.json
@@ -4,6 +4,13 @@
   },
   {
     "src": "/(.*)",
-    "dest": "/"
+    "dest": "/",
+    "transforms": [
+      {
+        "type": "request.path",
+        "op": "set",
+        "args": "/$1"
+      }
+    ]
   }
 ]

--- a/packages/backends/test/unit.test.ts
+++ b/packages/backends/test/unit.test.ts
@@ -610,6 +610,45 @@ it('prefixes emitted service route sources with routePrefix', async () => {
   expect(lambda.environment.VERCEL_SERVICE_ROUTE_PREFIX_STRIP).toBe('1');
 }, 30000);
 
+it('emits a prefixed request.path transform so the runtime shim strips once', async () => {
+  const fixtureName = '01-express-index-ts-esm';
+  const fixtureSource = join(__dirname, 'fixtures', fixtureName);
+  const { workDir } = await getWorkDir(fixtureName, fixtureSource);
+
+  const result = (await build({
+    files: {},
+    workPath: workDir,
+    config: {
+      ...defaultConfig,
+      routePrefix: 'api/js',
+      serviceName: 'js-api',
+    },
+    meta,
+    entrypoint: 'package.json',
+    repoRootPath: workDir,
+  })) as BuildResultV2Typical;
+
+  // The catch-all capture group only matches the segment after the prefix, so
+  // the transform must re-include the prefix. The runtime shim then performs
+  // the single prefix strip, avoiding a double-strip when the suffix begins
+  // with the prefix segment (e.g. `/api/js/api/js/...`).
+  expect(result.routes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        src: '^/api/js(?:/(.*))?$',
+        dest: '/_svc/js-api/index',
+        transforms: [
+          {
+            type: 'request.path',
+            op: 'set',
+            args: '/api/js/$1',
+          },
+        ],
+      }),
+    ])
+  );
+}, 30000);
+
 it('does not double-prefix routes already authored with routePrefix', async () => {
   const fixtureName = '04-hono-index-ts-esm';
   const fixtureSource = join(__dirname, 'fixtures', fixtureName);

--- a/packages/build-utils/src/generate-node-builder-functions.ts
+++ b/packages/build-utils/src/generate-node-builder-functions.ts
@@ -65,6 +65,27 @@ export function generateNodeBuilderFunctions(
       slug: frameworkName,
       version,
     };
+    // Mirror the framework `defaultRoutes` catch-all, but copy the resolved
+    // (post-rewrite) path into the runtime request via a `request.path`
+    // transform so application routing observes the rewritten destination.
+    // Only emit when the node build did not already produce routes (e.g.
+    // middleware) so we don't clobber that behavior.
+    if (!res.routes) {
+      res.routes = [
+        { handle: 'filesystem' },
+        {
+          src: '/(.*)',
+          dest: '/',
+          transforms: [
+            {
+              type: 'request.path' as const,
+              op: 'set' as const,
+              args: '/$1',
+            },
+          ],
+        },
+      ];
+    }
     return res;
   };
 

--- a/packages/cli/src/util/build/backend-rewrite-warning.ts
+++ b/packages/cli/src/util/build/backend-rewrite-warning.ts
@@ -1,4 +1,8 @@
-import { isPythonFramework, type Builder } from '@vercel/build-utils';
+import {
+  isNodeBackendFramework,
+  isPythonFramework,
+  type Builder,
+} from '@vercel/build-utils';
 import type { Rewrite } from '@vercel/routing-utils';
 
 export const BACKEND_REWRITE_BEHAVIOR_WARNING =
@@ -14,6 +18,12 @@ function hasInternalPathRewrite(rewrites: Rewrite[] | undefined): boolean {
   );
 }
 
+function isBackendRewriteFramework(
+  framework: string | null | undefined
+): boolean {
+  return isPythonFramework(framework) || isNodeBackendFramework(framework);
+}
+
 export function hasBackendRewriteBehaviorChange({
   projectRewrites,
   builders,
@@ -24,7 +34,7 @@ export function hasBackendRewriteBehaviorChange({
   return (
     hasInternalPathRewrite(projectRewrites) &&
     (builders ?? []).some(builder =>
-      isPythonFramework(builder.config?.framework)
+      isBackendRewriteFramework(builder.config?.framework)
     )
   );
 }

--- a/packages/cli/test/unit/util/build/backend-rewrite-warning.test.ts
+++ b/packages/cli/test/unit/util/build/backend-rewrite-warning.test.ts
@@ -14,22 +14,31 @@ function builder(framework: string, use = '@vercel/static-build'): Builder {
 }
 
 describe('backend rewrite behavior warning', () => {
-  it.each([
-    'fastapi',
-    'flask',
-    'django',
-    'python',
-    'fasthtml',
-  ])('warns for an internal rewrite in a %s project', framework => {
-    expect(
-      hasBackendRewriteBehaviorChange({
-        projectRewrites: [{ source: '/old', destination: '/new' }],
-        builders: [builder(framework)],
-      })
-    ).toBe(true);
-  });
+  it.each(['fastapi', 'flask', 'django', 'python', 'fasthtml'])(
+    'warns for an internal rewrite in a %s (Python) project',
+    framework => {
+      expect(
+        hasBackendRewriteBehaviorChange({
+          projectRewrites: [{ source: '/old', destination: '/new' }],
+          builders: [builder(framework)],
+        })
+      ).toBe(true);
+    }
+  );
 
-  it('does not infer Python from the builder package', () => {
+  it.each(['express', 'hono', 'h3', 'koa', 'nestjs', 'fastify', 'elysia'])(
+    'warns for an internal rewrite in a %s (Node backend) project',
+    framework => {
+      expect(
+        hasBackendRewriteBehaviorChange({
+          projectRewrites: [{ source: '/old', destination: '/new' }],
+          builders: [builder(framework)],
+        })
+      ).toBe(true);
+    }
+  );
+
+  it('does not infer the framework from the builder package', () => {
     expect(
       hasBackendRewriteBehaviorChange({
         projectRewrites: [{ source: '/old', destination: '/new' }],
@@ -38,13 +47,16 @@ describe('backend rewrite behavior warning', () => {
     ).toBe(false);
   });
 
-  it('does not warn for other frameworks or external rewrites', () => {
+  it('does not warn for non-backend frameworks', () => {
     expect(
       hasBackendRewriteBehaviorChange({
         projectRewrites: [{ source: '/old', destination: '/new' }],
-        builders: [builder('express', '@vercel/express')],
+        builders: [builder('nextjs')],
       })
     ).toBe(false);
+  });
+
+  it('does not warn for external rewrites', () => {
     expect(
       hasBackendRewriteBehaviorChange({
         projectRewrites: [
@@ -72,13 +84,29 @@ describe('backend rewrite behavior warning', () => {
     ).toBe(false);
   });
 
+  it('does not warn when there are no rewrites', () => {
+    expect(
+      hasBackendRewriteBehaviorChange({
+        projectRewrites: undefined,
+        builders: [builder('fastapi')],
+      })
+    ).toBe(false);
+  });
+
+  it('does not warn when there are no builders', () => {
+    expect(
+      hasBackendRewriteBehaviorChange({
+        projectRewrites: [{ source: '/old', destination: '/new' }],
+        builders: null,
+      })
+    ).toBe(false);
+  });
+
   it('describes the behavior change and its impact', () => {
     expect(BACKEND_REWRITE_BEHAVIOR_WARNING).toContain(
       'now route requests using the rewritten destination path'
     );
-    expect(BACKEND_REWRITE_BEHAVIOR_WARNING).toContain(
-      'previously unsupported'
-    );
+    expect(BACKEND_REWRITE_BEHAVIOR_WARNING).toContain('previously unsupported');
     expect(BACKEND_REWRITE_BEHAVIOR_WARNING).toContain('behavior');
   });
 });

--- a/packages/cli/test/unit/util/build/backend-rewrite-warning.test.ts
+++ b/packages/cli/test/unit/util/build/backend-rewrite-warning.test.ts
@@ -14,29 +14,37 @@ function builder(framework: string, use = '@vercel/static-build'): Builder {
 }
 
 describe('backend rewrite behavior warning', () => {
-  it.each(['fastapi', 'flask', 'django', 'python', 'fasthtml'])(
-    'warns for an internal rewrite in a %s (Python) project',
-    framework => {
-      expect(
-        hasBackendRewriteBehaviorChange({
-          projectRewrites: [{ source: '/old', destination: '/new' }],
-          builders: [builder(framework)],
-        })
-      ).toBe(true);
-    }
-  );
+  it.each([
+    'fastapi',
+    'flask',
+    'django',
+    'python',
+    'fasthtml',
+  ])('warns for an internal rewrite in a %s (Python) project', framework => {
+    expect(
+      hasBackendRewriteBehaviorChange({
+        projectRewrites: [{ source: '/old', destination: '/new' }],
+        builders: [builder(framework)],
+      })
+    ).toBe(true);
+  });
 
-  it.each(['express', 'hono', 'h3', 'koa', 'nestjs', 'fastify', 'elysia'])(
-    'warns for an internal rewrite in a %s (Node backend) project',
-    framework => {
-      expect(
-        hasBackendRewriteBehaviorChange({
-          projectRewrites: [{ source: '/old', destination: '/new' }],
-          builders: [builder(framework)],
-        })
-      ).toBe(true);
-    }
-  );
+  it.each([
+    'express',
+    'hono',
+    'h3',
+    'koa',
+    'nestjs',
+    'fastify',
+    'elysia',
+  ])('warns for an internal rewrite in a %s (Node backend) project', framework => {
+    expect(
+      hasBackendRewriteBehaviorChange({
+        projectRewrites: [{ source: '/old', destination: '/new' }],
+        builders: [builder(framework)],
+      })
+    ).toBe(true);
+  });
 
   it('does not infer the framework from the builder package', () => {
     expect(
@@ -106,7 +114,9 @@ describe('backend rewrite behavior warning', () => {
     expect(BACKEND_REWRITE_BEHAVIOR_WARNING).toContain(
       'now route requests using the rewritten destination path'
     );
-    expect(BACKEND_REWRITE_BEHAVIOR_WARNING).toContain('previously unsupported');
+    expect(BACKEND_REWRITE_BEHAVIOR_WARNING).toContain(
+      'previously unsupported'
+    );
     expect(BACKEND_REWRITE_BEHAVIOR_WARNING).toContain('behavior');
   });
 });

--- a/packages/express/src/build.ts
+++ b/packages/express/src/build.ts
@@ -67,6 +67,27 @@ export const build: BuildV3 = async args => {
     slug: frameworkName,
     version,
   };
+  // Mirror the framework `defaultRoutes` catch-all, but copy the resolved
+  // (post-rewrite) path into the runtime request via a `request.path`
+  // transform so application routing observes the rewritten destination.
+  // Only emit when the node build did not already produce routes (e.g.
+  // middleware) so we don't clobber that behavior.
+  if (!res.routes) {
+    res.routes = [
+      { handle: 'filesystem' },
+      {
+        src: '/(.*)',
+        dest: '/',
+        transforms: [
+          {
+            type: 'request.path' as const,
+            op: 'set' as const,
+            args: '/$1',
+          },
+        ],
+      },
+    ];
+  }
   return res;
 };
 

--- a/packages/hono/src/build.ts
+++ b/packages/hono/src/build.ts
@@ -67,6 +67,27 @@ export const build: BuildV3 = async args => {
     slug: frameworkName,
     version,
   };
+  // Mirror the framework `defaultRoutes` catch-all, but copy the resolved
+  // (post-rewrite) path into the runtime request via a `request.path`
+  // transform so application routing observes the rewritten destination.
+  // Only emit when the node build did not already produce routes (e.g.
+  // middleware) so we don't clobber that behavior.
+  if (!res.routes) {
+    res.routes = [
+      { handle: 'filesystem' },
+      {
+        src: '/(.*)',
+        dest: '/',
+        transforms: [
+          {
+            type: 'request.path' as const,
+            op: 'set' as const,
+            args: '/$1',
+          },
+        ],
+      },
+    ];
+  }
   return res;
 };
 


### PR DESCRIPTION
Mirrors the Python framework rewrite fix (#17212) for the Node backend framework builders and the unified `@vercel/backends` builder.

## Problem

Rewrites for these frameworks are currently no-ops for the request path seen by user code — they only modify the path Vercel matches at the proxy layer, not the request path the application actually observes. So this has no effect today (user code still sees `/old`):

```json
{
  "rewrites": [{ "source": "/old", "destination": "/new" }]
}
```

## Fix

Add a `request.path` set transform to the emitted catch-all route so the resolved (post-rewrite) destination is exposed to application routing:

```json
{
  "src": "/(.*)",
  "dest": "/",
  "transforms": [{ "type": "request.path", "op": "set", "args": "/$1" }]
}
```

## Changes

- **`@vercel/backends`**: add the transform to the service catch-all (`src/index.ts`) and to the introspection catch-all + default fallback routes (`src/introspection/index.ts`). Cron services are untouched (they emit no catch-all).
- **`@vercel/build-utils`** `generateNodeBuilderFunctions` (shared by `h3`, `koa`, `nestjs`, `fastify`, `elysia`) and **`@vercel/express`** / **`@vercel/hono`**: emit the framework catch-all (mirroring `frameworks.ts` `defaultRoutes`) with the transform, guarded by `if (!res.routes)` so middleware/edge routes are not clobbered. Returned routes override `defaultRoutes` since the CLI only applies defaults when the builder returns none.
- **`vercel` (CLI)**: extend the rewrite behavior warning to also fire for Node backend frameworks (not just Python) via `isNodeBackendFramework`.

## Notes

- The CLI warning util (`backend-rewrite-warning.ts`) does not exist on the base branch yet — it comes from #17212. This PR creates a broadened version; expect a trivial merge/rebase against that PR.

## Testing

- `@vercel/backends` route snapshots (`test/fixtures/*/routes.json`, 23 fixtures) updated with the new transform. These do real builds and are the primary regression net. Verified locally:
  - `builds 01-express-index-ts-esm` — pass
  - `builds 04-hono-index-ts-esm` — pass (introspected routes + catch-all)
- New unit test `packages/cli/test/unit/util/build/backend-rewrite-warning.test.ts` — 17 passing (Python + Node frameworks + negatives).
- `@vercel/express` unit build test unaffected (asserts only handler/moduleType).
- type-check and biome lint pass on all touched files.

## Not included

The Python PR added runtime `probes.json` e2e fixtures that deploy and assert user code sees the rewritten path. This PR relies on the backends route snapshots to prove the correct route+transform is emitted, but does not add equivalent express/hono runtime probe fixtures. Happy to add those if desired.