### PR TITLE
[MKT-3999] Add custom environment routing to connect attach

### DIFF
--- a/.changeset/connex-trigger-custom-environments.md
+++ b/.changeset/connex-trigger-custom-environments.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add custom-environment targeting for Connex trigger destinations.

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -89,6 +89,7 @@ export async function attach(
     '--project'?: string;
     '--triggers'?: boolean;
     '--trigger-branch'?: string;
+    '--trigger-environment'?: string;
     '--trigger-path'?: string;
     '--yes'?: boolean;
     '--format'?: string;
@@ -104,6 +105,7 @@ export async function attach(
   const skipConfirmation = !!flags['--yes'];
   const withTriggers = !!flags['--triggers'];
   const triggerBranch = flags['--trigger-branch'];
+  const triggerEnvironment = flags['--trigger-environment'];
   const triggerPath = flags['--trigger-path'];
 
   if (asJson && !skipConfirmation) {
@@ -111,9 +113,16 @@ export async function attach(
     return 1;
   }
 
-  if (!withTriggers && (triggerBranch || triggerPath)) {
+  if (!withTriggers && (triggerBranch || triggerEnvironment || triggerPath)) {
     output.error(
-      '--trigger-branch and --trigger-path require --triggers to also be set.'
+      '--trigger-branch, --trigger-environment, and --trigger-path require --triggers to also be set.'
+    );
+    return 1;
+  }
+
+  if (triggerBranch && triggerEnvironment) {
+    output.error(
+      '--trigger-branch and --trigger-environment are mutually exclusive.'
     );
     return 1;
   }
@@ -235,8 +244,32 @@ export async function attach(
     }
 
     triggersEnabledOnConnector = target.triggers?.enabled === true;
+
+    let customEnvironmentId: string | undefined;
+    if (triggerEnvironment) {
+      let customEnvironments;
+      try {
+        customEnvironments = await getCustomEnvironments(client, projectId);
+      } catch (err: unknown) {
+        printError(err);
+        return 1;
+      }
+      const customEnvironment = pickCustomEnvironment(
+        customEnvironments,
+        triggerEnvironment
+      );
+      if (!customEnvironment) {
+        output.error(
+          `Unknown trigger environment ${chalk.bold(triggerEnvironment)} for project ${chalk.bold(projectName)}. Use a custom environment slug or stable ID from that project.`
+        );
+        return 1;
+      }
+      customEnvironmentId = customEnvironment.id;
+    }
+
     desiredDestination = buildTriggerDestination({
       projectId,
+      customEnvironmentId,
       branch: triggerBranch,
       path: triggerPath,
     });

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -81,6 +81,28 @@ function envSetsEqual(a: readonly string[], b: readonly string[]): boolean {
   return b.every(env => aSet.has(env));
 }
 
+function getAttachmentEnvironments(
+  requestedEnvironments: readonly string[],
+  projectId: string,
+  destinations: readonly ConnexTriggerDestination[]
+): string[] {
+  const environments = new Set(requestedEnvironments);
+
+  // The API adds custom environments required by trigger destinations to the
+  // connector-project link. Preserve those implicit entries so a repeat attach
+  // remains a no-op and an attachment update does not remove trigger access.
+  for (const destination of destinations) {
+    if (
+      destination.projectId === projectId &&
+      destination.customEnvironmentId !== undefined
+    ) {
+      environments.add(destination.customEnvironmentId);
+    }
+  }
+
+  return [...environments];
+}
+
 export async function attach(
   client: Client,
   args: string[],
@@ -113,17 +135,27 @@ export async function attach(
     return 1;
   }
 
-  if (!withTriggers && (triggerBranch || triggerEnvironment || triggerPath)) {
+  if (
+    !withTriggers &&
+    (triggerBranch !== undefined ||
+      triggerEnvironment !== undefined ||
+      triggerPath !== undefined)
+  ) {
     output.error(
       '--trigger-branch, --trigger-environment, and --trigger-path require --triggers to also be set.'
     );
     return 1;
   }
 
-  if (triggerBranch && triggerEnvironment) {
+  if (triggerBranch !== undefined && triggerEnvironment !== undefined) {
     output.error(
       '--trigger-branch and --trigger-environment are mutually exclusive.'
     );
+    return 1;
+  }
+
+  if (triggerEnvironment !== undefined && triggerEnvironment.trim() === '') {
+    output.error('--trigger-environment must not be empty.');
     return 1;
   }
 
@@ -246,7 +278,7 @@ export async function attach(
     triggersEnabledOnConnector = target.triggers?.enabled === true;
 
     let customEnvironmentId: string | undefined;
-    if (triggerEnvironment) {
+    if (triggerEnvironment !== undefined) {
       let customEnvironments;
       try {
         customEnvironments = await getCustomEnvironments(client, projectId);
@@ -304,9 +336,14 @@ export async function attach(
     }
   }
 
+  const attachmentEnvironments = getAttachmentEnvironments(
+    environments,
+    projectId,
+    target.triggerDestinations ?? []
+  );
   const attachmentMatches =
     existingAttachment !== undefined &&
-    envSetsEqual(existingAttachment.environments ?? [], environments);
+    envSetsEqual(existingAttachment.environments ?? [], attachmentEnvironments);
   const shouldAttach = !attachmentMatches;
   const shouldRegisterTrigger = withTriggers && !triggerAlreadyRegistered;
 
@@ -319,7 +356,7 @@ export async function attach(
             clientId: target.id,
             uid: target.uid,
             projectId,
-            environments,
+            environments: attachmentEnvironments,
             triggerDestination: withTriggers ? desiredDestination : undefined,
             unchanged: true,
           },
@@ -335,7 +372,7 @@ export async function attach(
     output.log(
       `Connector ${chalk.bold(displayName)} is already attached to ${chalk.bold(
         projectName
-      )} for environments: ${environments.join(', ')}${triggerPart}. Nothing to do.`
+      )} for environments: ${attachmentEnvironments.join(', ')}${triggerPart}. Nothing to do.`
     );
     return 0;
   }
@@ -353,7 +390,7 @@ export async function attach(
       if (existingAttachment) {
         const current =
           (existingAttachment.environments ?? []).join(', ') || '—';
-        const next = environments.join(', ');
+        const next = attachmentEnvironments.join(', ');
         output.log(
           `Connector ${chalk.bold(displayName)} is already attached to ${chalk.bold(
             projectName
@@ -365,7 +402,7 @@ export async function attach(
         output.log(
           `Connector ${chalk.bold(displayName)} will be attached to ${chalk.bold(
             projectName
-          )} for environments: ${environments.join(', ')}.`
+          )} for environments: ${attachmentEnvironments.join(', ')}.`
         );
       }
     }
@@ -396,7 +433,7 @@ export async function attach(
         `/v1/connect/connectors/${encodeURIComponent(target.id)}/projects/${encodeURIComponent(projectId)}`,
         {
           method: 'POST',
-          body: { environments },
+          body: { environments: attachmentEnvironments },
         }
       );
     } catch (err: unknown) {
@@ -457,7 +494,7 @@ export async function attach(
           clientId: target.id,
           uid: target.uid,
           projectId,
-          environments,
+          environments: attachmentEnvironments,
           triggerDestination: withTriggers ? desiredDestination : undefined,
         },
         null,
@@ -469,7 +506,7 @@ export async function attach(
 
   if (shouldAttach) {
     output.success(
-      `Attached connector ${chalk.bold(displayName)} to ${chalk.bold(projectName)} for environments: ${environments.join(', ')}.`
+      `Attached connector ${chalk.bold(displayName)} to ${chalk.bold(projectName)} for environments: ${attachmentEnvironments.join(', ')}.`
     );
   }
   if (shouldRegisterTrigger && desiredDestination) {

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -513,6 +513,15 @@ export const attachSubcommand = {
         'Target a specific git branch for the trigger destination (default: production). Only valid with --triggers.',
     },
     {
+      name: 'trigger-environment',
+      shorthand: null,
+      type: String,
+      argument: 'ENV',
+      deprecated: false,
+      description:
+        'Target a custom environment by slug or stable ID. Mutually exclusive with --trigger-branch and only valid with --triggers.',
+    },
+    {
       name: 'trigger-path',
       shorthand: null,
       type: String,
@@ -555,6 +564,10 @@ export const attachSubcommand = {
     {
       name: 'Attach and register a preview-branch trigger destination',
       value: `${packageName} connect attach scl_abc123 --triggers --trigger-branch staging --trigger-path /slack`,
+    },
+    {
+      name: 'Attach and register a custom-environment trigger destination',
+      value: `${packageName} connect attach scl_abc123 --triggers --trigger-environment qa --trigger-path /slack`,
     },
     {
       name: 'Non-interactive output as JSON',

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -196,6 +196,9 @@ export default async function connex(client: Client): Promise<number> {
         telemetry.trackCliOptionTriggerBranch(
           attachParsedArgs.flags['--trigger-branch']
         );
+        telemetry.trackCliOptionTriggerEnvironment(
+          attachParsedArgs.flags['--trigger-environment']
+        );
         telemetry.trackCliOptionTriggerPath(
           attachParsedArgs.flags['--trigger-path']
         );

--- a/packages/cli/src/commands/connex/types.ts
+++ b/packages/cli/src/commands/connex/types.ts
@@ -32,6 +32,7 @@ export interface ConnexClientIdentity {
 
 export interface ConnexTriggerDestination {
   projectId: string;
+  customEnvironmentId?: string;
   branch?: string;
   path?: string;
 }

--- a/packages/cli/src/util/connex/trigger-destinations.ts
+++ b/packages/cli/src/util/connex/trigger-destinations.ts
@@ -30,7 +30,7 @@ export function buildTriggerDestination(input: {
   branch?: string;
   path?: string;
 }): ConnexTriggerDestination {
-  if (input.branch && input.customEnvironmentId) {
+  if (input.branch !== undefined && input.customEnvironmentId !== undefined) {
     throw new Error(
       'Trigger destinations cannot target both a branch and a custom environment.'
     );

--- a/packages/cli/src/util/connex/trigger-destinations.ts
+++ b/packages/cli/src/util/connex/trigger-destinations.ts
@@ -11,6 +11,7 @@ export function destinationsMatch(
 ): boolean {
   return (
     a.projectId === b.projectId &&
+    (a.customEnvironmentId ?? null) === (b.customEnvironmentId ?? null) &&
     (a.branch ?? null) === (b.branch ?? null) &&
     (a.path ?? null) === (b.path ?? null)
   );
@@ -25,10 +26,20 @@ export function findMatchingDestination(
 
 export function buildTriggerDestination(input: {
   projectId: string;
+  customEnvironmentId?: string;
   branch?: string;
   path?: string;
 }): ConnexTriggerDestination {
+  if (input.branch && input.customEnvironmentId) {
+    throw new Error(
+      'Trigger destinations cannot target both a branch and a custom environment.'
+    );
+  }
+
   const dest: ConnexTriggerDestination = { projectId: input.projectId };
+  if (input.customEnvironmentId !== undefined) {
+    dest.customEnvironmentId = input.customEnvironmentId;
+  }
   if (input.branch !== undefined) {
     dest.branch = input.branch;
   }
@@ -39,15 +50,22 @@ export function buildTriggerDestination(input: {
 }
 
 export function formatDestination(d: ConnexTriggerDestination): string {
+  const target = d.customEnvironmentId
+    ? `custom environment ${chalk.bold(d.customEnvironmentId)}`
+    : `branch ${chalk.bold(d.branch ?? 'production')}`;
+
   return [
     `project ${chalk.bold(d.projectId)}`,
-    `branch ${chalk.bold(d.branch ?? 'production')}`,
+    target,
     `path ${chalk.bold(d.path ?? '<default>')}`,
   ].join(', ');
 }
 
 function toJsonDestination(d: ConnexTriggerDestination): JSONObject {
   const entry: JSONObject = { projectId: d.projectId };
+  if (d.customEnvironmentId !== undefined) {
+    entry.customEnvironmentId = d.customEnvironmentId;
+  }
   if (d.branch !== undefined) {
     entry.branch = d.branch;
   }

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -164,6 +164,15 @@ export class ConnexTelemetryClient
     }
   }
 
+  trackCliOptionTriggerEnvironment(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'trigger-environment',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliOptionTriggerPath(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -759,17 +759,19 @@ exports[`help command > connex help output snapshots > connex attach subcommand 
 
   Options:
 
-  -e,  --environment <ENV>        Environments to enable by system name, custom slug, or custom ID. Repeatable and         
-                                  comma-separated. Defaults to production, preview, and development.                       
-  -F,  --format <FORMAT>          Specify the output format (json)                                                         
-  -p,  --project <NAME_OR_ID>     Project name or ID (default: current linked project)                                     
-       --trigger-branch <BRANCH>  Target a specific git branch for the trigger destination (default: production). Only     
-                                  valid with --triggers.                                                                   
-       --trigger-path <PATH>      Path on the destination project that receives the forwarded webhook (default:            
-                                  /{service}). Only valid with --triggers.                                                 
-       --triggers                 Also register this project as a trigger destination so the connector forwards verified   
-                                  webhooks to it (max 3 destinations per connector)                                        
-  -y,  --yes                      Skip the confirmation prompt                                                             
+  -e,  --environment <ENV>          Environments to enable by system name, custom slug, or custom ID. Repeatable and         
+                                    comma-separated. Defaults to production, preview, and development.                       
+  -F,  --format <FORMAT>            Specify the output format (json)                                                         
+  -p,  --project <NAME_OR_ID>       Project name or ID (default: current linked project)                                     
+       --trigger-branch <BRANCH>    Target a specific git branch for the trigger destination (default: production). Only     
+                                    valid with --triggers.                                                                   
+       --trigger-environment <ENV>  Target a custom environment by slug or stable ID. Mutually exclusive with                
+                                    --trigger-branch and only valid with --triggers.                                         
+       --trigger-path <PATH>        Path on the destination project that receives the forwarded webhook (default:            
+                                    /{service}). Only valid with --triggers.                                                 
+       --triggers                   Also register this project as a trigger destination so the connector forwards verified   
+                                    webhooks to it (max 3 destinations per connector)                                        
+  -y,  --yes                        Skip the confirmation prompt                                                             
 
 
   Global Options:
@@ -815,6 +817,10 @@ exports[`help command > connex help output snapshots > connex attach subcommand 
   - Attach and register a preview-branch trigger destination
 
     $ vercel connect attach scl_abc123 --triggers --trigger-branch staging --trigger-path /slack
+
+  - Attach and register a custom-environment trigger destination
+
+    $ vercel connect attach scl_abc123 --triggers --trigger-environment qa --trigger-path /slack
 
   - Non-interactive output as JSON
 

--- a/packages/cli/test/unit/commands/connex/attach.test.ts
+++ b/packages/cli/test/unit/commands/connex/attach.test.ts
@@ -698,6 +698,52 @@ describe('connex attach', () => {
       );
     });
 
+    it('rejects an empty custom-environment target before retrieving the connector', async () => {
+      await setupLinkedProject(team);
+      let connectorRequested = false;
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        connectorRequested = true;
+        res.json({});
+      });
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--trigger-environment=',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      expect(connectorRequested).toBe(false);
+      expect(client.stderr.getFullOutput()).toContain(
+        '--trigger-environment must not be empty'
+      );
+    });
+
+    it('treats an empty branch flag as mutually exclusive with a custom environment', async () => {
+      await setupLinkedProject(team);
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--trigger-branch=',
+        '--trigger-environment',
+        'qa',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '--trigger-branch and --trigger-environment are mutually exclusive'
+      );
+    });
+
     it('errors when the connector does not support triggers', async () => {
       await setupLinkedProject(team);
       client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
@@ -1172,6 +1218,191 @@ describe('connex attach', () => {
       const parsed = JSON.parse(client.stdout.getFullOutput().trim());
       expect(parsed.unchanged).toBe(true);
       expect(parsed.triggerDestination).toEqual({ projectId: PROJECT_ID });
+    });
+
+    it('no-ops a repeated custom-environment trigger destination', async () => {
+      await setupLinkedProject(team);
+      let patchCalled = false;
+      let postCalled = false;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [
+            {
+              projectId: PROJECT_ID,
+              customEnvironmentId: 'env_qa123',
+              path: '/slack-events',
+            },
+          ],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({
+            clientId: 'scl_abc123',
+            projectId: PROJECT_ID,
+            environments: ['production', 'preview', 'development', 'env_qa123'],
+          });
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          postCalled = true;
+          res.json({});
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (_req, res) => {
+          patchCalled = true;
+          res.json({});
+        }
+      );
+
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--trigger-environment',
+        'env_qa123',
+        '--trigger-path',
+        '/slack-events',
+        '--yes',
+        '--format=json'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(postCalled).toBe(false);
+      expect(patchCalled).toBe(false);
+      const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(parsed.unchanged).toBe(true);
+      expect(parsed.environments).toEqual([
+        'production',
+        'preview',
+        'development',
+        'env_qa123',
+      ]);
+      expect(parsed.triggerDestination).toEqual({
+        projectId: PROJECT_ID,
+        customEnvironmentId: 'env_qa123',
+        path: '/slack-events',
+      });
+    });
+
+    it('preserves custom environments required by existing trigger destinations when updating an attachment', async () => {
+      await setupLinkedProject(team);
+      let postBody: { environments?: string[] } | undefined;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          triggerDestinations: [
+            {
+              projectId: PROJECT_ID,
+              customEnvironmentId: 'env_qa123',
+            },
+            {
+              projectId: 'prj_other',
+              customEnvironmentId: 'env_other',
+            },
+          ],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({
+            clientId: 'scl_abc123',
+            projectId: PROJECT_ID,
+            environments: ['production', 'env_qa123'],
+          });
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (req, res) => {
+          postBody = req.body;
+          res.json({});
+        }
+      );
+
+      client.setArgv('connect', 'attach', 'scl_abc123', '-e', 'preview');
+
+      const exitCodePromise = connect(client);
+
+      await expect(client.stderr).toOutput('Will set: preview, env_qa123');
+      await expect(client.stderr).toOutput('Continue?');
+      client.stdin.write('y\n');
+
+      const exitCode = await exitCodePromise;
+
+      expect(exitCode).toBe(0);
+      expect(postBody?.environments).toEqual(['preview', 'env_qa123']);
+      expect(client.stderr.getFullOutput()).toContain(
+        'for environments: preview, env_qa123'
+      );
+    });
+
+    it('reports preserved trigger environments in JSON after updating an attachment', async () => {
+      await setupLinkedProject(team);
+      let postBody: { environments?: string[] } | undefined;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          triggerDestinations: [
+            {
+              projectId: PROJECT_ID,
+              customEnvironmentId: 'env_qa123',
+            },
+          ],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({
+            clientId: 'scl_abc123',
+            projectId: PROJECT_ID,
+            environments: ['production', 'env_qa123'],
+          });
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (req, res) => {
+          postBody = req.body;
+          res.json({});
+        }
+      );
+
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '-e',
+        'preview',
+        '--yes',
+        '--format=json'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(postBody?.environments).toEqual(['preview', 'env_qa123']);
+      const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(parsed.environments).toEqual(['preview', 'env_qa123']);
     });
 
     it('still PATCHes the trigger destination when attachment is unchanged but destination is new', async () => {

--- a/packages/cli/test/unit/commands/connex/attach.test.ts
+++ b/packages/cli/test/unit/commands/connex/attach.test.ts
@@ -654,7 +654,47 @@ describe('connex attach', () => {
 
       expect(exitCode).toBe(1);
       expect(client.stderr.getFullOutput()).toContain(
-        '--trigger-branch and --trigger-path require --triggers'
+        '--trigger-branch, --trigger-environment, and --trigger-path require --triggers'
+      );
+    });
+
+    it('rejects --trigger-environment without --triggers', async () => {
+      await setupLinkedProject(team);
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--trigger-environment',
+        'qa',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain('--trigger-environment');
+      expect(client.stderr.getFullOutput()).toContain('require --triggers');
+    });
+
+    it('rejects branch and custom-environment trigger targets together', async () => {
+      await setupLinkedProject(team);
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--trigger-branch',
+        'staging',
+        '--trigger-environment',
+        'qa',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '--trigger-branch and --trigger-environment are mutually exclusive'
       );
     });
 
@@ -786,6 +826,172 @@ describe('connex attach', () => {
       expect(patchBody?.destinations).toEqual([
         { projectId: PROJECT_ID, branch: 'staging', path: '/slack-events' },
       ]);
+    });
+
+    it('resolves a custom-environment slug to its stable ID for the PATCH', async () => {
+      await setupLinkedProject(team);
+      let patchBody:
+        | {
+            destinations: Array<{
+              projectId: string;
+              customEnvironmentId?: string;
+              path?: string;
+            }>;
+          }
+        | undefined;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.statusCode = 404;
+          res.json({});
+        }
+      );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({});
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (req, res) => {
+          patchBody = req.body;
+          res.json({});
+        }
+      );
+
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--trigger-environment',
+        'qa',
+        '--trigger-path',
+        '/slack-events',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody?.destinations).toEqual([
+        {
+          projectId: PROJECT_ID,
+          customEnvironmentId: 'env_qa123',
+          path: '/slack-events',
+        },
+      ]);
+    });
+
+    it('accepts a stable custom-environment ID belonging to the project', async () => {
+      await setupLinkedProject(team);
+      let patchBody:
+        | {
+            destinations: Array<{
+              projectId: string;
+              customEnvironmentId?: string;
+            }>;
+          }
+        | undefined;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({
+            clientId: 'scl_abc123',
+            projectId: PROJECT_ID,
+            environments: ['production', 'preview', 'development'],
+          });
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (req, res) => {
+          patchBody = req.body;
+          res.json({});
+        }
+      );
+
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--trigger-environment',
+        'env_qa123',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody?.destinations).toEqual([
+        {
+          projectId: PROJECT_ID,
+          customEnvironmentId: 'env_qa123',
+        },
+      ]);
+    });
+
+    it('rejects an unknown or wrong-project custom-environment ID', async () => {
+      await setupLinkedProject(team);
+      let patchCalled = false;
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [],
+        });
+      });
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (_req, res) => {
+          patchCalled = true;
+          res.json({});
+        }
+      );
+
+      client.setArgv(
+        'connect',
+        'attach',
+        'scl_abc123',
+        '--triggers',
+        '--trigger-environment',
+        'env_other_project',
+        '--yes'
+      );
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      expect(patchCalled).toBe(false);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('Unknown trigger environment');
+      expect(stderr).toContain('env_other_project');
+      expect(stderr).toContain(PROJECT_NAME);
     });
 
     it('merges with existing trigger destinations', async () => {


### PR DESCRIPTION
## Summary

- add `--trigger-environment` to `vercel connect attach`
- accept a project custom-environment slug or stable ID and send only the stable `customEnvironmentId`
- reject unknown or wrong-project environments and branch/custom-environment combinations
- preserve trigger-required custom-environment IDs when an attachment is repeated or updated
- add help, telemetry, tests, and a CLI changeset

The API trigger-routing foundation is merged in [vercel/api#81501](https://github.com/vercel/api/pull/81501).

Part of [MKT-3999](https://linear.app/vercel/issue/MKT-3999/support-custom-environments-in-vercel-connect).

## Evidence

[Datadog trace](https://app.datadoghq.com/apm/trace/6a63c0900000000045d79b78608d23fb?graphType=flamegraph)

- a locally built CLI resolved the custom-environment slug to its stable ID; repeating with that ID returned `unchanged: true` and reported the full preserved attachment
- signed event `EvMKT3999-CLI-1784922256` reached the explicit custom-environment domain with environment-scoped OIDC and HTTP 200; the trace records signature verification, domain resolution, forwarding, and the 200 response

## Validation

- `pnpm vitest run test/unit/commands/connex/attach.test.ts test/unit/commands/help.test.ts` — 181 tests passed
- `pnpm turbo build --filter=vercel` — 39 tasks passed
- affected-file Biome lint and formatting checks — passed
- live built-CLI slug registration and stable-ID repeat against the deployed API — passed
- signed post-repeat trigger event — receiver and Datadog trace returned 200
- disposable connector, project, custom environment, domain, and deployment cleanup — verified 404

## Scope

This PR adds the explicit CLI trigger option and preserves trigger-implied attachment environments. Deletion cleanup, SDK generation, Dashboard UI, and API delivery behavior remain outside this PR.
