### PR TITLE
docs(firewall): clarify rate limit key IP default and override behavior

### DIFF
--- a/.changeset/firewall-rate-limit-key-docs.md
+++ b/.changeset/firewall-rate-limit-key-docs.md
@@ -1,0 +1,5 @@
+---
+'@vercel/firewall': patch
+---
+
+Document that `checkRateLimit`'s rate limit key defaults to the caller's IP address, and that providing a custom `rateLimitKey` replaces that IP default (so the bucket is no longer implicitly scoped by IP unless the caller includes it in the key).

--- a/packages/firewall/README.md
+++ b/packages/firewall/README.md
@@ -18,6 +18,36 @@ export async function POST() {
 }
 ```
 
+### Rate limit key
+
+Every rate limit is counted per key. By default, `checkRateLimit` uses the caller's IP address
+as the key (read from the `x-real-ip` request header), so requests are bucketed per IP.
+
+Passing `options.rateLimitKey` replaces the IP default entirely — the request is bucketed by
+the provided key alone and is no longer implicitly scoped to the caller's IP. The same applies
+to rate limit rules defined in the Vercel Firewall dashboard that use a `@vercel/firewall`
+condition: the rule is keyed by whatever key this SDK provides for the matching request,
+rather than by IP.
+
+To preserve per-IP bucketing while adding a custom dimension (for example a user ID), include
+the IP in the key you pass:
+
+```ts
+import { checkRateLimit } from '@vercel/firewall';
+
+export async function POST(request: Request) {
+  const ip = request.headers.get('x-real-ip') ?? '';
+  const userId = await getUserId(request);
+  const { rateLimited } = await checkRateLimit('my-rate-limit-id', {
+    rateLimitKey: `${userId}:${ip}`,
+  });
+  if (rateLimited) {
+    return new Response('', { status: 429 });
+  }
+  // Implement logic guarded by rate limit
+}
+```
+
 <p align="center">
   <a href="https://vercel.com">
     <img src="https://assets.vercel.com/image/upload/v1588805858/repositories/vercel/logo.png" height="96">

--- a/packages/firewall/docs/functions/checkRateLimit.md
+++ b/packages/firewall/docs/functions/checkRateLimit.md
@@ -6,13 +6,30 @@
 
 > **checkRateLimit**(`rateLimitId`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<\{ `error?`: `"not-found"` \| `"blocked"`; `rateLimited`: `boolean`; \}\>
 
-Defined in: [rate-limit.ts:29](https://github.com/vercel/vercel/blob/main/packages/firewall/src/rate-limit.ts#L29)
+Defined in: [rate-limit.ts:75](https://github.com/vercel/vercel/blob/main/packages/firewall/src/rate-limit.ts#L75)
 
 Experimental: Check rate-limits defined through the Vercel Firewall.
 
 This function provides programmatic access to rate limits defined in the Vercel Firewall
 from Vercel Functions. The given ID is matched against rate limit rules defined with the same
 ID. The return value indicates whether the request is rate limited or not.
+
+## Rate limit key
+
+Every rate limit is counted per key, and the key controls the bucket the current request
+counts against.
+
+- By default (when `options.rateLimitKey` is not provided), the request's IP address is used
+  as the key, so requests are bucketed per client IP. The IP is read from the `x-real-ip`
+  request header; if that header is missing, an error is thrown.
+- Passing `options.rateLimitKey` replaces the IP default entirely — the request is bucketed
+  by the provided key alone and is no longer implicitly scoped to the caller's IP. To
+  preserve per-IP bucketing while adding a custom dimension (for example a user ID), include
+  the IP in the key you pass, for example `` `${userId}:${ip}` ``.
+
+The same behavior applies to rate limit rules defined in the Vercel Firewall dashboard that
+use a `@vercel/firewall` condition: the rule is keyed by whatever key this SDK provides for
+the matching request, rather than by IP.
 
 ## Parameters
 
@@ -40,7 +57,14 @@ The headers for the current request. Optional.
 
 `string`
 
-The key to use for rate-limiting. If not defined, defaults to the user's IP address.
+The key to use for rate-limiting. Each unique key gets its own rate limit bucket.
+
+If not defined, defaults to the caller's IP address (read from the `x-real-ip`
+request header), so requests are bucketed per IP. Providing a value here replaces
+that IP default entirely — the request is bucketed by the provided key alone and
+is no longer implicitly scoped to the caller's IP. To preserve per-IP bucketing
+while adding a custom dimension (for example a user ID), include the IP in the
+key you pass, for example `` `${userId}:${ip}` ``.
 
 #### request?
 
@@ -55,7 +79,7 @@ The current request object. Optional.
 A promise that resolves to an object with a `rateLimited` property that is `true` if the request is rate-limited, and `false` otherwise. The
 `error` property is defined if the request was blocked by the firewall or the rate limit ID was not found.
 
-## Example
+## Examples
 
 ```js
 import { unstable_checkRateLimit as checkRateLimit } from '@vercel/firewall';
@@ -68,5 +92,34 @@ export async function POST() {
     });
   }
   // Implement logic guarded by rate limit
+}
+```
+
+Bucket by a custom key (for example a user ID) instead of IP:
+
+```js
+import { unstable_checkRateLimit as checkRateLimit } from '@vercel/firewall';
+
+export async function POST(request) {
+  const userId = await getUserId(request);
+  const { rateLimited } = await checkRateLimit('my-rate-limit-id', {
+    rateLimitKey: userId,
+  });
+  // ...
+}
+```
+
+Bucket by both IP and a custom dimension by composing them into the key:
+
+```js
+import { unstable_checkRateLimit as checkRateLimit } from '@vercel/firewall';
+
+export async function POST(request) {
+  const ip = request.headers.get('x-real-ip') ?? '';
+  const userId = await getUserId(request);
+  const { rateLimited } = await checkRateLimit('my-rate-limit-id', {
+    rateLimitKey: `${userId}:${ip}`,
+  });
+  // ...
 }
 ```

--- a/packages/firewall/src/rate-limit.ts
+++ b/packages/firewall/src/rate-limit.ts
@@ -5,6 +5,23 @@
  * from Vercel Functions. The given ID is matched against rate limit rules defined with the same
  * ID. The return value indicates whether the request is rate limited or not.
  *
+ * ## Rate limit key
+ *
+ * Every rate limit is counted per key, and the key controls the bucket the current request
+ * counts against.
+ *
+ * - By default (when `options.rateLimitKey` is not provided), the request's IP address is used
+ *   as the key, so requests are bucketed per client IP. The IP is read from the `x-real-ip`
+ *   request header; if that header is missing, an error is thrown.
+ * - Passing `options.rateLimitKey` replaces the IP default entirely — the request is bucketed
+ *   by the provided key alone and is no longer implicitly scoped to the caller's IP. To
+ *   preserve per-IP bucketing while adding a custom dimension (for example a user ID), include
+ *   the IP in the key you pass, for example `` `${userId}:${ip}` ``.
+ *
+ * The same behavior applies to rate limit rules defined in the Vercel Firewall dashboard that
+ * use a `@vercel/firewall` condition: the rule is keyed by whatever key this SDK provides for
+ * the matching request, rather than by IP.
+ *
  * @param rateLimitId The ID of the rate limit to check. The same ID must be defined in the Vercel Firewall as a @vercel/firewall rule condition.
  * @param options
  * @returns A promise that resolves to an object with a `rateLimited` property that is `true` if the request is rate-limited, and `false` otherwise. The
@@ -25,13 +42,51 @@
  * }
  * ```
  *
+ * @example
+ * Bucket by a custom key (for example a user ID) instead of IP:
+ * ```js
+ * import { unstable_checkRateLimit as checkRateLimit } from '@vercel/firewall';
+ *
+ * export async function POST(request) {
+ *   const userId = await getUserId(request);
+ *   const { rateLimited } = await checkRateLimit('my-rate-limit-id', {
+ *     rateLimitKey: userId,
+ *   });
+ *   // ...
+ * }
+ * ```
+ *
+ * @example
+ * Bucket by both IP and a custom dimension by composing them into the key:
+ * ```js
+ * import { unstable_checkRateLimit as checkRateLimit } from '@vercel/firewall';
+ *
+ * export async function POST(request) {
+ *   const ip = request.headers.get('x-real-ip') ?? '';
+ *   const userId = await getUserId(request);
+ *   const { rateLimited } = await checkRateLimit('my-rate-limit-id', {
+ *     rateLimitKey: `${userId}:${ip}`,
+ *   });
+ *   // ...
+ * }
+ * ```
+ *
  */
 export async function checkRateLimit(
   rateLimitId: string,
   options?: {
     /** The host name on which the rate limit rules are defined */
     firewallHostForDevelopment?: string;
-    /** The key to use for rate-limiting. If not defined, defaults to the user's IP address. */
+    /**
+     * The key to use for rate-limiting. Each unique key gets its own rate limit bucket.
+     *
+     * If not defined, defaults to the caller's IP address (read from the `x-real-ip`
+     * request header), so requests are bucketed per IP. Providing a value here replaces
+     * that IP default entirely — the request is bucketed by the provided key alone and
+     * is no longer implicitly scoped to the caller's IP. To preserve per-IP bucketing
+     * while adding a custom dimension (for example a user ID), include the IP in the
+     * key you pass, for example `` `${userId}:${ip}` ``.
+     */
     rateLimitKey?: string;
     /** The headers for the current request. Optional.  */
     headers?:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the rate limit key behavior in `@vercel/firewall`'s `checkRateLimit` (a recurring source of confusion, most recently around a path-based rate limit that unexpectedly stopped being IP-scoped once a `@vercel/firewall` condition was added).

Specifically, the JSDoc, README, and generated docs now call out that:

- When `options.rateLimitKey` is **not** provided, the request's IP address (read from the `x-real-ip` header) is used as the key, so requests are bucketed per client IP.
- Providing `options.rateLimitKey` **replaces the IP default entirely** — the bucket is keyed by the provided value alone and is no longer implicitly scoped to the caller's IP.
- The same behavior applies to Vercel Firewall dashboard rate limit rules that use a `@vercel/firewall` condition: the rule is keyed by whatever key the SDK provides for the matching request, rather than by IP.
- To preserve per-IP bucketing while adding a custom dimension (e.g. a user ID), callers should include the IP in the key they pass, for example `` `${userId}:${ip}` ``. Two new usage examples show this.

## Changes

- `packages/firewall/src/rate-limit.ts`: expanded the JSDoc on `checkRateLimit` and its `rateLimitKey` option; added two new `@example` blocks (custom key, and composed key preserving IP scoping).
- `packages/firewall/README.md`: added a "Rate limit key" section mirroring the JSDoc guidance.
- `packages/firewall/docs/functions/checkRateLimit.md`: regenerated via `pnpm build:docs`.
- `.changeset/firewall-rate-limit-key-docs.md`: patch changeset for `@vercel/firewall`.

Docs-only change; no runtime behavior is modified.

## Verification

- `pnpm build` in `packages/firewall` succeeds (code + typedoc).
- `pnpm prettier --write` on touched files reports them unchanged (already formatted).

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C07MHC4CB89/p1784842850637259?thread_ts=1784842850.637259&cid=C07MHC4CB89)

<div><a href="https://cursor.com/agents/bc-df051b72-0d62-5f59-92b1-a8097f52522b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df051b72-0d62-5f59-92b1-a8097f52522b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

