### PR TITLE
[services] Fix api dir builds receiving incorrect framework or runtime.

### DIFF
--- a/.changeset/strong-pots-exercise.md
+++ b/.changeset/strong-pots-exercise.md
@@ -1,0 +1,8 @@
+---
+'@vercel/fs-detectors': minor
+'@vercel/static-build': minor
+'@vercel/build-utils': minor
+'vercel': minor
+---
+
+Fix api dir builds receiving incorrect framework or runtime.

--- a/packages/build-utils/src/node-diagnostics.ts
+++ b/packages/build-utils/src/node-diagnostics.ts
@@ -435,6 +435,7 @@ export async function generateProjectManifest({
   lockfileVersion,
   framework,
   serviceType,
+  outputRuntime = 'node',
 }: {
   workPath: string;
   nodeVersion: NodeVersion;
@@ -443,6 +444,7 @@ export async function generateProjectManifest({
   lockfileVersion: number | undefined;
   framework?: string;
   serviceType?: string;
+  outputRuntime?: string;
 }): Promise<void> {
   try {
     const pkgJson = await readPackageJson(workPath);
@@ -525,7 +527,7 @@ export async function generateProjectManifest({
       ],
     };
 
-    await writeProjectManifest(manifest, workPath, 'node');
+    await writeProjectManifest(manifest, workPath, outputRuntime);
   } catch (err) {
     debug(
       `generateProjectManifest: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/build-utils/src/ruby-diagnostics.ts
+++ b/packages/build-utils/src/ruby-diagnostics.ts
@@ -147,11 +147,13 @@ export async function generateRubyProjectManifest({
   gemfileLockPath,
   framework,
   serviceType,
+  outputRuntime = 'ruby',
 }: {
   workPath: string;
   gemfileLockPath: string | undefined;
   framework?: string | null;
   serviceType?: string | null;
+  outputRuntime?: string;
 }): Promise<void> {
   try {
     if (!gemfileLockPath) return;
@@ -206,7 +208,7 @@ export async function generateRubyProjectManifest({
       ],
     };
 
-    await writeProjectManifest(manifest, workPath, 'ruby');
+    await writeProjectManifest(manifest, workPath, outputRuntime);
   } catch {
     // never throw — build must succeed
   }

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -54,6 +54,7 @@ import type { VercelConfig } from '@vercel/client';
 import { fileNameSymbol } from '@vercel/client';
 import { frameworkList, type Framework } from '@vercel/frameworks';
 import {
+  builderToFrameworks,
   detectBuilders,
   detectFrameworkRecord,
   detectFrameworkVersion,
@@ -1348,7 +1349,11 @@ async function doBuild(
               buildCommand: projectSettings.buildCommand ?? undefined,
               framework: isFrontendBuilder
                 ? projectSettings.framework
-                : (build.config?.framework ?? undefined),
+                : (build.config?.framework ??
+                  (await detectApiDirFramework(
+                    build.use ?? '',
+                    buildWorkPath
+                  ))),
               nodeVersion: projectSettings.nodeVersion,
               bunVersion: localConfig.bunVersion ?? undefined,
             };
@@ -2986,6 +2991,30 @@ async function writeFlagsJSON(
   if (hasFlags) {
     await fs.writeJSON(flagsFilePath, flags, { spaces: 2 });
   }
+}
+
+/**
+ * Detects the framework used by an api/dir builder.
+ *
+ * Runs a narrow scan scoped to the builder's own frameworks. Memoised so
+ * multiple api/dir files of the same type share one filesystem scan.
+ */
+const apiDirFrameworkCache = new Map<string, Promise<string[]>>();
+
+async function detectApiDirFramework(
+  builderUse: string,
+  workPath: string
+): Promise<string | undefined> {
+  const runtimeFrameworks = builderToFrameworks.get(builderUse) ?? [];
+  if (runtimeFrameworks.length === 0) return undefined;
+
+  const cacheKey = `${builderUse}:${workPath}`;
+  let cached = apiDirFrameworkCache.get(cacheKey);
+  if (!cached) {
+    cached = detectAllFrameworks(workPath, runtimeFrameworks);
+    apiDirFrameworkCache.set(cacheKey, cached);
+  }
+  return (await cached)[0];
 }
 
 async function writeBuildJson(buildsJson: BuildsManifest, outputDir: string) {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1346,7 +1346,9 @@ async function doBuild(
               installCommand: projectSettings.installCommand ?? undefined,
               devCommand: projectSettings.devCommand ?? undefined,
               buildCommand: projectSettings.buildCommand ?? undefined,
-              framework: projectSettings.framework,
+              framework: isFrontendBuilder
+                ? projectSettings.framework
+                : (build.config?.framework ?? undefined),
               nodeVersion: projectSettings.nodeVersion,
               bunVersion: localConfig.bunVersion ?? undefined,
             };

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1532,14 +1532,23 @@ async function doBuild(
                         service && serviceWorkspace && serviceWorkspace !== '.'
                           ? serviceWorkspace
                           : '.';
-                      packageManifests.push({
-                        workspace,
-                        key: fullKey,
-                        buildConfig: buildConfig,
-                        manifest: packageManifest,
-                        service,
-                        builderUse: builderPkg.name,
-                      });
+                      // Only keep one manifest per builder+workspace — multiple
+                      // api/dir files for the same builder share a manifest slot.
+                      const alreadyPushed = packageManifests.some(
+                        m =>
+                          m.builderUse === builderPkg.name &&
+                          m.workspace === workspace
+                      );
+                      if (!alreadyPushed) {
+                        packageManifests.push({
+                          workspace,
+                          key: fullKey,
+                          buildConfig: buildConfig,
+                          manifest: packageManifest,
+                          service,
+                          builderUse: builderPkg.name,
+                        });
+                      }
                     }
                   } catch (e) {
                     output.debug(
@@ -3011,10 +3020,14 @@ async function detectApiDirFramework(
   const cacheKey = `${builderUse}:${workPath}`;
   let cached = apiDirFrameworkCache.get(cacheKey);
   if (!cached) {
-    cached = detectAllFrameworks(workPath, runtimeFrameworks);
+    cached = detectAllFrameworks(workPath, runtimeFrameworks).catch(() => []);
     apiDirFrameworkCache.set(cacheKey, cached);
   }
-  return (await cached)[0];
+  const detectedSlugs = await cached;
+  // Return the framework only when exactly one is detected. Zero means none
+  // found; more than one means ambiguous (e.g. fastapi + flask), so return
+  // undefined rather than picking arbitrarily.
+  return detectedSlugs.length === 1 ? detectedSlugs[0] : undefined;
 }
 
 async function writeBuildJson(buildsJson: BuildsManifest, outputDir: string) {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1190,6 +1190,7 @@ async function doBuild(
     builderUse: string;
   }> = [];
 
+  const apiDirFrameworkDetector = createApiDirFrameworkDetector();
   const getHasDetectedServices = () =>
     detectedResolvedServices !== undefined &&
     detectedResolvedServices.length > 0;
@@ -1310,7 +1311,10 @@ async function doBuild(
         // Backend framework detected for api/ dir builds.
         const apiDirFramework: string | undefined =
           isZeroConfig && !service && !isFrontendBuilder
-            ? await detectApiDirFramework(build.use ?? '', buildWorkPath)
+            ? await apiDirFrameworkDetector.detect(
+                build.use ?? '',
+                buildWorkPath
+              )
             : undefined;
 
         let buildConfig: Config;
@@ -3005,6 +3009,30 @@ async function writeFlagsJSON(
   if (hasFlags) {
     await fs.writeJSON(flagsFilePath, flags, { spaces: 2 });
   }
+}
+
+interface ApiDirFrameworkDetector {
+  detect(builderUse: string, workPath: string): Promise<string | undefined>;
+}
+
+/**
+ * Creates a memoised api/dir framework detector, scoped to one build, so N
+ * api/dir files sharing a builder+workPath share one filesystem scan instead
+ * of running one per file.
+ */
+function createApiDirFrameworkDetector(): ApiDirFrameworkDetector {
+  const cache = new Map<string, Promise<string | undefined>>();
+  return {
+    detect(builderUse, workPath) {
+      const cacheKey = `${builderUse}:${workPath}`;
+      let cached = cache.get(cacheKey);
+      if (!cached) {
+        cached = detectApiDirFramework(builderUse, workPath);
+        cache.set(cacheKey, cached);
+      }
+      return cached;
+    },
+  };
 }
 
 /**

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1307,6 +1307,11 @@ async function doBuild(
         // the project-level framework is 'services'.
         const builderFramework =
           build.config?.framework ?? projectSettings.framework;
+        // Backend framework detected for api/ dir builds.
+        const apiDirFramework: string | undefined =
+          isZeroConfig && !service && !isFrontendBuilder
+            ? await detectApiDirFramework(build.use ?? '', buildWorkPath)
+            : undefined;
 
         let buildConfig: Config;
 
@@ -1349,11 +1354,7 @@ async function doBuild(
               buildCommand: projectSettings.buildCommand ?? undefined,
               framework: isFrontendBuilder
                 ? projectSettings.framework
-                : (build.config?.framework ??
-                  (await detectApiDirFramework(
-                    build.use ?? '',
-                    buildWorkPath
-                  ))),
+                : undefined,
               nodeVersion: projectSettings.nodeVersion,
               bunVersion: localConfig.bunVersion ?? undefined,
             };
@@ -1544,7 +1545,11 @@ async function doBuild(
                           workspace,
                           key: fullKey,
                           buildConfig: buildConfig,
-                          manifest: packageManifest,
+                          manifest: {
+                            ...packageManifest,
+                            framework:
+                              packageManifest.framework ?? apiDirFramework,
+                          },
                           service,
                           builderUse: builderPkg.name,
                         });
@@ -3005,11 +3010,10 @@ async function writeFlagsJSON(
 /**
  * Detects the framework used by an api/dir builder.
  *
- * Runs a narrow scan scoped to the builder's own frameworks. Memoised so
- * multiple api/dir files of the same type share one filesystem scan.
+ * Runs a narrow scan scoped to the builder's own frameworks; builders with
+ * no framework mappings (e.g. `@vercel/node`) return without touching the
+ * filesystem.
  */
-const apiDirFrameworkCache = new Map<string, Promise<string[]>>();
-
 async function detectApiDirFramework(
   builderUse: string,
   workPath: string
@@ -3017,13 +3021,10 @@ async function detectApiDirFramework(
   const runtimeFrameworks = builderToFrameworks.get(builderUse) ?? [];
   if (runtimeFrameworks.length === 0) return undefined;
 
-  const cacheKey = `${builderUse}:${workPath}`;
-  let cached = apiDirFrameworkCache.get(cacheKey);
-  if (!cached) {
-    cached = detectAllFrameworks(workPath, runtimeFrameworks).catch(() => []);
-    apiDirFrameworkCache.set(cacheKey, cached);
-  }
-  const detectedSlugs = await cached;
+  const detectedSlugs = await detectAllFrameworks(
+    workPath,
+    runtimeFrameworks
+  ).catch(() => []);
   // Return the framework only when exactly one is detected. Zero means none
   // found; more than one means ambiguous (e.g. fastapi + flask), so return
   // undefined rather than picking arbitrarily.

--- a/packages/cli/src/commands/build/manifest.ts
+++ b/packages/cli/src/commands/build/manifest.ts
@@ -39,11 +39,21 @@ export async function writeManifests(
     builderUse,
   } of packageManifests) {
     const key = `${builderUse}:${workspace}`;
+    // api/ dir builds don't receive a framework in their build config (it
+    // would change builder behavior), so fall back to whatever the caller
+    // resolved into the manifest (builder-reported, or CLI-detected for
+    // api/ dir builds — see `apiDirFramework` in `doBuild`). Applied to both
+    // manifests: the explicit key below would otherwise clobber the correct
+    // value coming through the `...manifest` spread.
+    const framework =
+      service?.framework ??
+      buildConfig.framework ??
+      (manifest as unknown as PackageManifest).framework;
     projectManifest[key] = {
       ...manifest,
       workspace,
       builder: builderUse,
-      framework: service?.framework ?? buildConfig.framework,
+      framework,
       serviceName: service?.name,
       serviceType:
         service && isExperimentalService(service) ? service.type : undefined,
@@ -56,6 +66,7 @@ export async function writeManifests(
       manifest as unknown as PackageManifest;
     deployManifestBuilds[key] = {
       ...manifestWithoutVersion,
+      framework,
       root: workspace,
       builder: builderUse,
     };

--- a/packages/cli/src/util/build/framework-detection.ts
+++ b/packages/cli/src/util/build/framework-detection.ts
@@ -3,7 +3,7 @@ import {
   detectFrameworkRecord,
   detectFrameworks,
 } from '@vercel/fs-detectors';
-import { frameworkList } from '@vercel/frameworks';
+import { frameworkList, type Framework } from '@vercel/frameworks';
 import { debug as builderDebug } from '@vercel/build-utils';
 import output from '../../output-manager';
 
@@ -107,11 +107,14 @@ export async function detectFirstDeploymentFramework(options: {
 }
 
 /** Detect all frameworks matching the source at `workPath`, returning slugs. */
-export async function detectAllFrameworks(workPath: string): Promise<string[]> {
+export async function detectAllFrameworks(
+  workPath: string,
+  customFrameworkList?: readonly Framework[]
+): Promise<string[]> {
   logDebug(`Framework cross-check: detecting frameworks at "${workPath}"`);
   const frameworks = await detectFrameworks({
     fs: new LocalFileSystemDetector(workPath),
-    frameworkList,
+    frameworkList: customFrameworkList ?? frameworkList,
   });
   const slugs = frameworks
     .map(f => f.slug)

--- a/packages/cli/test/unit/commands/build/manifest.test.ts
+++ b/packages/cli/test/unit/commands/build/manifest.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { FileBlob, type Files } from '@vercel/build-utils';
+import { writeManifests } from '../../../../src/commands/build/manifest';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readBlob(files: Files, key: string): unknown {
+  const blob = files[key] as FileBlob | undefined;
+  if (!blob) return undefined;
+  return JSON.parse(blob.data as string);
+}
+
+const outputDir = join(tmpdir(), 'vc-manifest-test');
+
+function pythonManifest(extra: Record<string, unknown> = {}) {
+  return { version: '20260304', runtime: 'python', dependencies: [], ...extra };
+}
+
+function nodeManifest(extra: Record<string, unknown> = {}) {
+  return { version: '20260304', runtime: 'node', dependencies: [], ...extra };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('writeManifests', () => {
+  let diagnostics: Files;
+  let ops: Promise<Error | void>[];
+
+  beforeEach(() => {
+    diagnostics = {};
+    ops = [];
+  });
+
+  it('emits nothing when packageManifests is empty', async () => {
+    await writeManifests([], diagnostics, ops, outputDir);
+    expect(diagnostics['deploy-manifest.json']).toBeUndefined();
+    expect(diagnostics['project-manifest.json']).toBeUndefined();
+  });
+
+  describe('deploy-manifest framework field', () => {
+    it('reflects the framework the builder wrote in its package manifest', async () => {
+      await writeManifests(
+        [
+          {
+            workspace: '.',
+            key: '@vercel/next:.',
+            buildConfig: { framework: 'nextjs' },
+            manifest: nodeManifest({ framework: 'nextjs' }),
+            builderUse: '@vercel/next',
+          },
+        ],
+        diagnostics,
+        ops,
+        outputDir
+      );
+
+      const deploy = readBlob(diagnostics, 'deploy-manifest.json') as any;
+      expect(deploy.builds['@vercel/next:.'].runtime).toBe('node');
+      expect(deploy.builds['@vercel/next:.'].framework).toBe('nextjs');
+    });
+
+    it('produces a separate entry per builder', async () => {
+      await writeManifests(
+        [
+          {
+            workspace: '.',
+            key: '@vercel/next:.',
+            buildConfig: { framework: 'nextjs' },
+            manifest: nodeManifest({ framework: 'nextjs' }),
+            builderUse: '@vercel/next',
+          },
+          {
+            workspace: '.',
+            key: '@vercel/python:.',
+            buildConfig: { framework: 'fastapi' },
+            manifest: pythonManifest({ framework: 'fastapi' }),
+            builderUse: '@vercel/python',
+          },
+        ],
+        diagnostics,
+        ops,
+        outputDir
+      );
+
+      const deploy = readBlob(diagnostics, 'deploy-manifest.json') as any;
+      expect(deploy.builds['@vercel/next:.'].framework).toBe('nextjs');
+      expect(deploy.builds['@vercel/python:.'].framework).toBe('fastapi');
+    });
+  });
+
+  describe('diagnostics blobs', () => {
+    it('populates both deploy-manifest and project-manifest entries', async () => {
+      await writeManifests(
+        [
+          {
+            workspace: '.',
+            key: '@vercel/next:.',
+            buildConfig: { framework: 'nextjs' },
+            manifest: nodeManifest({ framework: 'nextjs' }),
+            builderUse: '@vercel/next',
+          },
+        ],
+        diagnostics,
+        ops,
+        outputDir
+      );
+
+      expect(diagnostics['deploy-manifest.json']).toBeInstanceOf(FileBlob);
+      expect(diagnostics['project-manifest.json']).toBeInstanceOf(FileBlob);
+    });
+  });
+});

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -73,6 +73,25 @@ const slugToFramework = new Map<string | null, Framework>(
   frameworkList.map(f => [f.slug, f])
 );
 
+/**
+ * Maps each builder name to the frameworks it handles.
+ */
+export const builderToFrameworks: ReadonlyMap<string, readonly Framework[]> =
+  (() => {
+    const map = new Map<string, Framework[]>();
+    for (const f of frameworkList) {
+      if (!f.useRuntime?.use) continue;
+      const builder = f.useRuntime.use;
+      const entry = map.get(builder);
+      if (entry) {
+        entry.push(f);
+      } else {
+        map.set(builder, [f]);
+      }
+    }
+    return map;
+  })();
+
 export interface ErrorResponse {
   code: string;
   message: string;

--- a/packages/fs-detectors/src/index.ts
+++ b/packages/fs-detectors/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  builderToFrameworks,
   detectBuilders,
   detectOutputDirectory,
   detectApiDirectory,

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -10,14 +10,7 @@ import {
   type ChildProcess,
   type SpawnOptions,
 } from 'child_process';
-import {
-  existsSync,
-  readFileSync,
-  statSync,
-  readdirSync,
-  mkdirSync,
-  promises as fsPromises,
-} from 'fs';
+import { existsSync, readFileSync, statSync, readdirSync, mkdirSync } from 'fs';
 import { cpus } from 'os';
 import {
   BuildOptions,
@@ -44,10 +37,8 @@ import {
   generateProjectManifest,
   generateRubyProjectManifest,
   writeProjectManifest,
-  manifestPath,
   MANIFEST_VERSION,
-  FileBlob,
-  Diagnostics,
+  createDiagnostics,
   getReportedServiceType,
   getNodeVersion,
   debug,
@@ -977,7 +968,14 @@ export const prepareCache: PrepareCache = async ({
   return cacheFiles;
 };
 
-const STATIC_BUILD_MANIFEST_RUNTIMES = ['node', 'go', 'rust', 'ruby'] as const;
+// Manifest storage slot for this builder. Language builders (@vercel/go,
+// @vercel/rust, @vercel/ruby) write to 'go', 'rust', and 'ruby' slots
+// respectively, so using 'static-build' keeps our manifests in a separate
+// directory and prevents overwrites when both builders run in the same project
+// (e.g. Hugo + api/*.go). This value only appears as a directory name on disk
+// (.vercel/static-build/package-manifest.json) and never in the output
+// manifests, whose keys are derived from the builder name and workspace.
+const STATIC_BUILD_MANIFEST_RUNTIME = 'static-build' as const;
 
 async function generateStaticBuildManifest({
   framework,
@@ -1023,7 +1021,7 @@ async function generateStaticBuildManifest({
           ],
         },
         entrypointDir,
-        'go'
+        STATIC_BUILD_MANIFEST_RUNTIME
       );
     } catch (err) {
       debug(
@@ -1057,7 +1055,7 @@ async function generateStaticBuildManifest({
           ],
         },
         entrypointDir,
-        'rust'
+        STATIC_BUILD_MANIFEST_RUNTIME
       );
     } catch (err) {
       debug(
@@ -1070,6 +1068,7 @@ async function generateStaticBuildManifest({
       gemfileLockPath: path.join(entrypointDir, 'Gemfile.lock'),
       framework: framework.slug,
       serviceType: service ? getReportedServiceType(service) : undefined,
+      outputRuntime: STATIC_BUILD_MANIFEST_RUNTIME,
     });
   } else if (framework?.slug) {
     try {
@@ -1081,6 +1080,7 @@ async function generateStaticBuildManifest({
         lockfileVersion,
         framework: framework.slug,
         serviceType: service ? getReportedServiceType(service) : undefined,
+        outputRuntime: STATIC_BUILD_MANIFEST_RUNTIME,
       });
     } catch (err) {
       debug(
@@ -1090,19 +1090,4 @@ async function generateStaticBuildManifest({
   }
 }
 
-export const diagnostics: Diagnostics = async ({ workPath }) => {
-  const files: Files = {};
-  await Promise.all(
-    STATIC_BUILD_MANIFEST_RUNTIMES.map(async runtime => {
-      const relPath = manifestPath(runtime);
-      try {
-        const data = await fsPromises.readFile(
-          path.join(workPath, relPath),
-          'utf-8'
-        );
-        files[relPath] = new FileBlob({ data });
-      } catch {}
-    })
-  );
-  return files;
-};
+export const diagnostics = createDiagnostics(STATIC_BUILD_MANIFEST_RUNTIME);

--- a/packages/static-build/test/diagnostics.test.ts
+++ b/packages/static-build/test/diagnostics.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Tests for the `diagnostics` export of @vercel/static-build.
+ * Each runtime slot is associated with the framework(s) this builder writes there:
+ *   go → hugo  |  rust → zola  |  ruby → jekyll, middleman  |  node → pass-through
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { FileBlob, manifestPath, MANIFEST_VERSION } from '@vercel/build-utils';
+import { diagnostics } from '../src';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(tmpdir(), 'vc-sb-diag-test-'));
+}
+
+function writeManifest(
+  workPath: string,
+  runtime: string,
+  data: Record<string, unknown>
+): void {
+  const filePath = path.join(workPath, manifestPath(runtime));
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data));
+}
+
+function readResult(
+  files: Record<string, unknown>,
+  runtime: string
+): Record<string, unknown> | null {
+  const blob = files[manifestPath(runtime)] as FileBlob | undefined;
+  if (!blob) return null;
+  return JSON.parse(blob.data as string);
+}
+
+const BASE = { version: MANIFEST_VERSION, dependencies: [] };
+
+// ---------------------------------------------------------------------------
+// go runtime — Hugo
+// ---------------------------------------------------------------------------
+
+describe('diagnostics – go runtime', () => {
+  it('includes the manifest when framework is hugo', async () => {
+    const workPath = makeTempDir();
+    writeManifest(workPath, 'go', {
+      ...BASE,
+      runtime: 'go',
+      framework: 'hugo',
+    });
+
+    const files = await diagnostics({ workPath } as any);
+
+    expect(readResult(files, 'go')).toMatchObject({
+      runtime: 'go',
+      framework: 'hugo',
+    });
+  });
+
+  it('returns nothing when no manifest file exists', async () => {
+    const files = await diagnostics({ workPath: makeTempDir() } as any);
+    expect(readResult(files, 'go')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rust runtime — Zola
+// ---------------------------------------------------------------------------
+
+describe('diagnostics – rust runtime', () => {
+  it('includes the manifest when framework is zola', async () => {
+    const workPath = makeTempDir();
+    writeManifest(workPath, 'rust', {
+      ...BASE,
+      runtime: 'rust',
+      framework: 'zola',
+    });
+
+    const files = await diagnostics({ workPath } as any);
+
+    expect(readResult(files, 'rust')).toMatchObject({
+      runtime: 'rust',
+      framework: 'zola',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ruby runtime — Jekyll and Middleman
+// ---------------------------------------------------------------------------
+
+describe('diagnostics – ruby runtime', () => {
+  it('includes the manifest when framework is jekyll', async () => {
+    const workPath = makeTempDir();
+    writeManifest(workPath, 'ruby', {
+      ...BASE,
+      runtime: 'ruby',
+      framework: 'jekyll',
+    });
+
+    const files = await diagnostics({ workPath } as any);
+
+    expect(readResult(files, 'ruby')).toMatchObject({ framework: 'jekyll' });
+  });
+
+  it('includes the manifest when framework is middleman', async () => {
+    const workPath = makeTempDir();
+    writeManifest(workPath, 'ruby', {
+      ...BASE,
+      runtime: 'ruby',
+      framework: 'middleman',
+    });
+
+    const files = await diagnostics({ workPath } as any);
+
+    expect(readResult(files, 'ruby')).toMatchObject({ framework: 'middleman' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// node runtime — pass-through for all JS/TS static-build frameworks
+// ---------------------------------------------------------------------------
+
+describe('diagnostics – node runtime', () => {
+  it('includes the manifest regardless of framework slug', async () => {
+    const workPath = makeTempDir();
+    writeManifest(workPath, 'node', {
+      ...BASE,
+      runtime: 'node',
+      framework: 'gatsby',
+    });
+
+    const files = await diagnostics({ workPath } as any);
+
+    expect(readResult(files, 'node')).toMatchObject({ framework: 'gatsby' });
+  });
+
+  it('returns nothing when no manifest file exists', async () => {
+    const files = await diagnostics({ workPath: makeTempDir() } as any);
+    expect(readResult(files, 'node')).toBeNull();
+  });
+});

--- a/packages/static-build/test/diagnostics.test.ts
+++ b/packages/static-build/test/diagnostics.test.ts
@@ -1,38 +1,42 @@
 /*
  * Tests for the `diagnostics` export of @vercel/static-build.
- * Each runtime slot is associated with the framework(s) this builder writes there:
- *   go → hugo  |  rust → zola  |  ruby → jekyll, middleman  |  node → pass-through
+ * All manifests are written to and read from the 'static-build' slot,
+ * keeping them separate from the language-builder slots that @vercel/go,
+ * @vercel/rust, etc. use. The runtime field inside the manifest reflects
+ * the actual runtime of the framework (go for Hugo, rust for Zola, etc.).
  */
 import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { tmpdir } from 'os';
-import { FileBlob, manifestPath, MANIFEST_VERSION } from '@vercel/build-utils';
+import {
+  FileBlob,
+  MANIFEST_FILENAME,
+  MANIFEST_VERSION,
+  manifestPath,
+} from '@vercel/build-utils';
 import { diagnostics } from '../src';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+const SLOT = 'static-build';
+
 function makeTempDir(): string {
   return fs.mkdtempSync(path.join(tmpdir(), 'vc-sb-diag-test-'));
 }
 
-function writeManifest(
-  workPath: string,
-  runtime: string,
-  data: Record<string, unknown>
-): void {
-  const filePath = path.join(workPath, manifestPath(runtime));
+function writeManifest(workPath: string, data: Record<string, unknown>): void {
+  const filePath = path.join(workPath, manifestPath(SLOT));
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, JSON.stringify(data));
 }
 
 function readResult(
-  files: Record<string, unknown>,
-  runtime: string
+  files: Record<string, unknown>
 ): Record<string, unknown> | null {
-  const blob = files[manifestPath(runtime)] as FileBlob | undefined;
+  const blob = files[MANIFEST_FILENAME] as FileBlob | undefined;
   if (!blob) return null;
   return JSON.parse(blob.data as string);
 }
@@ -46,15 +50,9 @@ const BASE = { version: MANIFEST_VERSION, dependencies: [] };
 describe('diagnostics – go runtime', () => {
   it('includes the manifest when framework is hugo', async () => {
     const workPath = makeTempDir();
-    writeManifest(workPath, 'go', {
-      ...BASE,
-      runtime: 'go',
-      framework: 'hugo',
-    });
-
+    writeManifest(workPath, { ...BASE, runtime: 'go', framework: 'hugo' });
     const files = await diagnostics({ workPath } as any);
-
-    expect(readResult(files, 'go')).toMatchObject({
+    expect(readResult(files)).toMatchObject({
       runtime: 'go',
       framework: 'hugo',
     });
@@ -62,7 +60,7 @@ describe('diagnostics – go runtime', () => {
 
   it('returns nothing when no manifest file exists', async () => {
     const files = await diagnostics({ workPath: makeTempDir() } as any);
-    expect(readResult(files, 'go')).toBeNull();
+    expect(readResult(files)).toBeNull();
   });
 });
 
@@ -73,15 +71,9 @@ describe('diagnostics – go runtime', () => {
 describe('diagnostics – rust runtime', () => {
   it('includes the manifest when framework is zola', async () => {
     const workPath = makeTempDir();
-    writeManifest(workPath, 'rust', {
-      ...BASE,
-      runtime: 'rust',
-      framework: 'zola',
-    });
-
+    writeManifest(workPath, { ...BASE, runtime: 'rust', framework: 'zola' });
     const files = await diagnostics({ workPath } as any);
-
-    expect(readResult(files, 'rust')).toMatchObject({
+    expect(readResult(files)).toMatchObject({
       runtime: 'rust',
       framework: 'zola',
     });
@@ -95,51 +87,46 @@ describe('diagnostics – rust runtime', () => {
 describe('diagnostics – ruby runtime', () => {
   it('includes the manifest when framework is jekyll', async () => {
     const workPath = makeTempDir();
-    writeManifest(workPath, 'ruby', {
-      ...BASE,
+    writeManifest(workPath, { ...BASE, runtime: 'ruby', framework: 'jekyll' });
+    const files = await diagnostics({ workPath } as any);
+    expect(readResult(files)).toMatchObject({
       runtime: 'ruby',
       framework: 'jekyll',
     });
-
-    const files = await diagnostics({ workPath } as any);
-
-    expect(readResult(files, 'ruby')).toMatchObject({ framework: 'jekyll' });
   });
 
   it('includes the manifest when framework is middleman', async () => {
     const workPath = makeTempDir();
-    writeManifest(workPath, 'ruby', {
+    writeManifest(workPath, {
       ...BASE,
       runtime: 'ruby',
       framework: 'middleman',
     });
-
     const files = await diagnostics({ workPath } as any);
-
-    expect(readResult(files, 'ruby')).toMatchObject({ framework: 'middleman' });
+    expect(readResult(files)).toMatchObject({
+      runtime: 'ruby',
+      framework: 'middleman',
+    });
   });
 });
 
 // ---------------------------------------------------------------------------
-// node runtime — pass-through for all JS/TS static-build frameworks
+// node runtime — all JS/TS static-build frameworks
 // ---------------------------------------------------------------------------
 
 describe('diagnostics – node runtime', () => {
   it('includes the manifest regardless of framework slug', async () => {
     const workPath = makeTempDir();
-    writeManifest(workPath, 'node', {
-      ...BASE,
+    writeManifest(workPath, { ...BASE, runtime: 'node', framework: 'gatsby' });
+    const files = await diagnostics({ workPath } as any);
+    expect(readResult(files)).toMatchObject({
       runtime: 'node',
       framework: 'gatsby',
     });
-
-    const files = await diagnostics({ workPath } as any);
-
-    expect(readResult(files, 'node')).toMatchObject({ framework: 'gatsby' });
   });
 
   it('returns nothing when no manifest file exists', async () => {
     const files = await diagnostics({ workPath: makeTempDir() } as any);
-    expect(readResult(files, 'node')).toBeNull();
+    expect(readResult(files)).toBeNull();
   });
 });


### PR DESCRIPTION
1. Project framework leaked into api/dir builder manifests

The CLI unconditionally set `framework: projectSettings.framework` in `buildConfig` for all zero-config builders, including api/dir language builders. A nextjs project with `api/*.py` produced `{ runtime: 'python', framework: 'nextjs' }` in the deploy manifest.

Fixed by scoping the project framework only to the frontend builder. Api/dir builders no longer receive a framework, instead CLI detects the framework and folds it in.

2. `@vercel/static-build` claimed wrong runtimes in the deploy manifest

The static-build diagnostics function scanned shared runtime slots (go, rust, ruby, node) and re-emitted whatever it found, including manifests written by co-running language builders.

Fixed by routing all static-build manifests through a dedicated static-build slot.

**Deferred**: if there are multiple api/dir builds with the same root, they will still collide. This is probably not something we care that much about.