### PR TITLE
[cli] add shell completion for bash, zsh, and fish

### DIFF
--- a/.changeset/cli-shell-completion.md
+++ b/.changeset/cli-shell-completion.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel completion` to generate shell completion scripts for bash, zsh, and fish. Completion includes commands, subcommands, and flags, plus live team-name completion for `vercel teams switch` and the global `--scope`/`--team` flags. Run `vercel completion install` to set it up for your shell; a successful `vercel upgrade` keeps an installed completion current.

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -18,6 +18,7 @@ export { default as cache } from './commands/cache';
 export { default as connex } from './commands/connex';
 export { default as contract } from './commands/contract';
 export { default as certs } from './commands/certs';
+export { default as completion } from './commands/completion';
 export { default as crons } from './commands/crons';
 export { default as curl } from './commands/curl';
 export { default as deployHooks } from './commands/deploy-hooks';

--- a/packages/cli/src/commands/completion/command.ts
+++ b/packages/cli/src/commands/completion/command.ts
@@ -1,0 +1,66 @@
+import { packageName } from '../../util/pkg-name';
+import { SUPPORTED_SHELLS } from '../../util/completion/scripts';
+
+// Internal driver invoked by the generated shell scripts. Hidden from help and
+// from completion of `completion`'s own subcommands.
+export const completeSubcommand = {
+  name: '__complete',
+  aliases: [],
+  hidden: true,
+  description: 'Emit completion candidates for the given words (internal)',
+  arguments: [{ name: 'words', required: false, multiple: true }],
+  options: [],
+  examples: [],
+} as const;
+
+export const installSubcommand = {
+  name: 'install',
+  aliases: [],
+  description:
+    'Install the completion script into your shell (auto-detects the shell)',
+  arguments: [{ name: 'shell', required: false, values: SUPPORTED_SHELLS }],
+  options: [],
+  examples: [
+    {
+      name: 'Install completion for your current shell',
+      value: `${packageName} completion install`,
+    },
+    {
+      name: 'Install completion for a specific shell',
+      value: `${packageName} completion install zsh`,
+    },
+  ],
+} as const;
+
+export const completionCommand = {
+  name: 'completion',
+  aliases: [],
+  description: 'Generate a shell completion script (bash, zsh, or fish)',
+  arguments: [
+    {
+      name: 'shell',
+      required: true,
+      values: SUPPORTED_SHELLS,
+    },
+  ],
+  subcommands: [installSubcommand, completeSubcommand],
+  options: [],
+  examples: [
+    {
+      name: 'Install completion into your shell (recommended)',
+      value: `${packageName} completion install`,
+    },
+    {
+      name: 'Load completions in the current bash session',
+      value: `source <(${packageName} completion bash)`,
+    },
+    {
+      name: 'Load completions in the current zsh session',
+      value: `source <(${packageName} completion zsh)`,
+    },
+    {
+      name: 'Load completions in the current fish session',
+      value: `${packageName} completion fish | source`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/completion/index.ts
+++ b/packages/cli/src/commands/completion/index.ts
@@ -1,0 +1,163 @@
+import type Client from '../../util/client';
+import { help } from '../help';
+import { commandsStructs } from '..';
+import { globalCommandOptions } from '../../util/arg-common';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName, packageName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { CompletionTelemetryClient } from '../../util/telemetry/commands/completion';
+import { complete } from '../../util/completion/complete';
+import { resolveCompletionSource } from '../../util/completion/sources';
+import {
+  SUPPORTED_SHELLS,
+  type SupportedShell,
+  completionScript,
+  isSupportedShell,
+} from '../../util/completion/scripts';
+import {
+  detectShell,
+  fpathHintFor,
+  writeCompletionFiles,
+} from '../../util/completion/install';
+import { completionCommand } from './command';
+
+async function runInstall(
+  client: Client,
+  telemetry: CompletionTelemetryClient,
+  shellArg: string | undefined
+): Promise<number> {
+  telemetry.trackCliSubcommandInstall();
+
+  if (shellArg && !isSupportedShell(shellArg)) {
+    output.error(
+      `Unsupported shell "${shellArg}". Supported shells: ${SUPPORTED_SHELLS.join(
+        ', '
+      )}.`
+    );
+    return 1;
+  }
+
+  const shell = detectShell(shellArg);
+  telemetry.trackCliArgumentShell(shell);
+
+  if (!shell) {
+    output.error(
+      `Could not detect your shell from $SHELL. Run ${getCommandName(
+        'completion install <shell>'
+      )} with one of: ${SUPPORTED_SHELLS.join(', ')}.`
+    );
+    return 1;
+  }
+
+  let paths: string[];
+  try {
+    paths = await writeCompletionFiles(shell);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  output.success(`Installed ${shell} completion for the Vercel CLI:`);
+  for (const path of paths) {
+    output.log(`  ${path}`);
+  }
+
+  const hint = fpathHintFor(shell);
+  if (hint) {
+    output.log(
+      "If completions don't load, add this to your ~/.zshrc before `compinit`:"
+    );
+    output.log(`  ${hint}`);
+  }
+
+  output.log('Restart your shell or open a new terminal to start using it.');
+  return 0;
+}
+
+export default async function completion(client: Client): Promise<number> {
+  const telemetry = new CompletionTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  const argv = client.argv.slice(2);
+
+  // Hidden driver path: `completion __complete -- <words>`. This runs on every
+  // TAB, so it must stay silent: only candidates go to stdout, nothing else.
+  //
+  // The words after `--` are read raw, NOT through parseArguments: they are the
+  // line being completed, so flag-like tokens (`--sc`) and a trailing empty word
+  // must reach the engine verbatim. The generated shell scripts always call
+  // `<binary> completion __complete -- <tokens>` with no flags of their own, so
+  // any global flag a user typed (e.g. `vercel --debug ...`) sits before
+  // `__complete` and is correctly excluded from the completion words.
+  const completeIdx = argv.indexOf('__complete');
+  if (completeIdx !== -1) {
+    let words = argv.slice(completeIdx + 1);
+    if (words[0] === '--') {
+      words = words.slice(1);
+    }
+    const candidates = await complete(words, {
+      commands: commandsStructs,
+      globalOptions: globalCommandOptions,
+      resolveSource: source => resolveCompletionSource(source, client),
+    });
+    if (candidates.length > 0) {
+      client.stdout.write(`${candidates.join('\n')}\n`);
+    }
+    return 0;
+  }
+
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(completionCommand.options)
+    );
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    telemetry.trackCliFlagHelp('completion');
+    output.print(help(completionCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  // args[0] is the command name ("completion").
+  const sub = parsedArgs.args[1];
+
+  if (sub === 'install') {
+    return runInstall(client, telemetry, parsedArgs.args[2]);
+  }
+
+  // Script generation path: `completion <shell>`.
+  const shell = sub;
+  telemetry.trackCliArgumentShell(shell);
+
+  if (!shell) {
+    output.error(
+      `Missing shell argument. Run ${getCommandName(
+        'completion <shell>'
+      )} where <shell> is one of: ${SUPPORTED_SHELLS.join(
+        ', '
+      )}, or ${getCommandName('completion install')} to set it up automatically.`
+    );
+    return 1;
+  }
+
+  if (!isSupportedShell(shell)) {
+    output.error(
+      `Unsupported shell "${shell}". Supported shells: ${SUPPORTED_SHELLS.join(
+        ', '
+      )}.`
+    );
+    return 1;
+  }
+
+  const supportedShell: SupportedShell = shell;
+  client.stdout.write(completionScript(supportedShell, packageName));
+  return 0;
+}

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -12,6 +12,13 @@ export type PrimitiveConstructor =
   | typeof Boolean
   | typeof Number;
 
+/**
+ * Tags an argument or option value as a dynamic resource so shell completion
+ * can fetch candidates at runtime. Extend the union as more sources are wired
+ * (e.g. 'project').
+ */
+export type CompletionSource = 'team';
+
 export interface CommandOption {
   readonly name: string;
   readonly shorthand: string | null;
@@ -19,11 +26,15 @@ export interface CommandOption {
   readonly argument?: string;
   readonly deprecated: boolean;
   readonly description?: string;
+  readonly completion?: CompletionSource;
 }
 export interface CommandArgument {
   readonly name: string;
   readonly required: boolean;
   readonly multiple?: true;
+  readonly completion?: CompletionSource;
+  /** Static candidates for shell completion (e.g. a fixed set of shells). */
+  readonly values?: ReadonlyArray<string>;
 }
 export interface CommandExample {
   readonly name: string;

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -9,6 +9,7 @@ import { buildCommand } from './build/command';
 import { buyCommand } from './buy/command';
 import { cacheCommand } from './cache/command';
 import { certsCommand } from './certs/command';
+import { completionCommand } from './completion/command';
 import { connexCommand } from './connex/command';
 import { contractCommand } from './contract/command';
 import { cronsCommand } from './crons/command';
@@ -64,7 +65,7 @@ import { webhooksCommand } from './webhooks/command';
 import type { Command } from './help';
 import output from '../output-manager';
 
-const commandsStructs = [
+export const commandsStructs = [
   agentCommand,
   aiGatewayCommand,
   alertsCommand,
@@ -77,6 +78,7 @@ const commandsStructs = [
   buyCommand,
   cacheCommand,
   certsCommand,
+  completionCommand,
   contractCommand,
   cronsCommand,
   curlCommand,

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -88,6 +88,7 @@ export const switchSubcommand = {
     {
       name: 'name',
       required: false,
+      completion: 'team',
     },
   ],
   options: [],

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -631,6 +631,17 @@ const main = async () => {
     client.argv.push('-h');
   }
 
+  // Shell completion is routed before the login prompt, telemetry command
+  // tracking, and post-run update check. The hidden `__complete` driver runs on
+  // every TAB, so it must emit only candidates with no other side effects;
+  // script generation (`completion <shell>`) needs no auth either.
+  if (subcommand === 'completion') {
+    const completion = (await import('./commands/completion')).default;
+    const code = await completion(client);
+    // Keep the per-keystroke driver free of telemetry flushes.
+    return client.argv.includes('__complete') ? code : finishWithExitCode(code);
+  }
+
   const subcommandsWithoutToken = [
     'agent',
     'login',
@@ -642,6 +653,9 @@ const main = async () => {
     'telemetry',
     'upgrade',
     'skills',
+    // Script generation needs no auth; the `__complete` driver authenticates
+    // best-effort on its own and returns nothing when logged out.
+    'completion',
   ];
 
   if (process.env.FF_GUIDANCE_MODE) {

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -70,6 +70,7 @@ export const globalCommandOptions = [
     type: String,
     description: 'Set a custom scope',
     deprecated: false,
+    completion: 'team',
   },
   {
     name: 'token',
@@ -79,7 +80,13 @@ export const globalCommandOptions = [
     description: 'Login token',
     deprecated: false,
   },
-  { name: 'team', shorthand: 'T', type: String, deprecated: false },
+  {
+    name: 'team',
+    shorthand: 'T',
+    type: String,
+    deprecated: false,
+    completion: 'team',
+  },
   { name: 'api', shorthand: null, type: String, deprecated: false },
 ] as const;
 

--- a/packages/cli/src/util/completion/complete.ts
+++ b/packages/cli/src/util/completion/complete.ts
@@ -1,0 +1,235 @@
+import type {
+  CommandArgument,
+  CommandOption,
+  CompletionSource,
+} from '../../commands/help';
+
+/**
+ * Structural view of a command struct that the engine needs. Kept loose so the
+ * real registry array (which mixes full commands with the bare `help` entry)
+ * and test fixtures both satisfy it.
+ */
+export interface CompletionCommand {
+  readonly name: string;
+  readonly aliases?: ReadonlyArray<string>;
+  readonly hidden?: true;
+  readonly arguments?: ReadonlyArray<CommandArgument>;
+  readonly options?: ReadonlyArray<CommandOption>;
+  readonly subcommands?: ReadonlyArray<CompletionCommand>;
+  readonly disabledGlobalOptions?: ReadonlyArray<string>;
+}
+
+export interface CompleteOptions {
+  /** Top-level command structs (e.g. the registry's commandsStructs). */
+  readonly commands: ReadonlyArray<CompletionCommand>;
+  /** Options valid on every command (globalCommandOptions). */
+  readonly globalOptions: ReadonlyArray<CommandOption>;
+  /**
+   * Resolves dynamic candidates for a source tag (e.g. team slugs). Omitted in
+   * static tests so dynamic slots simply yield nothing.
+   */
+  readonly resolveSource?: (source: CompletionSource) => Promise<string[]>;
+}
+
+function matchesCommand(command: CompletionCommand, token: string): boolean {
+  return command.name === token || (command.aliases?.includes(token) ?? false);
+}
+
+function optionTakesValue(option: CommandOption): boolean {
+  const ctor = Array.isArray(option.type) ? option.type[0] : option.type;
+  return ctor === String || ctor === Number;
+}
+
+function optionsFor(
+  current: CompletionCommand | undefined,
+  globalOptions: ReadonlyArray<CommandOption>
+): CommandOption[] {
+  const disabled = new Set(current?.disabledGlobalOptions ?? []);
+  const globals = globalOptions.filter(option => !disabled.has(option.name));
+  return [...(current?.options ?? []), ...globals];
+}
+
+function findOption(
+  token: string,
+  options: ReadonlyArray<CommandOption>
+): CommandOption | undefined {
+  if (token.startsWith('--')) {
+    const name = token.slice(2).split('=')[0];
+    return options.find(option => option.name === name);
+  }
+  if (token.startsWith('-') && token.length >= 2) {
+    const shorthand = token[1];
+    return options.find(option => option.shorthand === shorthand);
+  }
+  return undefined;
+}
+
+function positionalAt(
+  current: CompletionCommand,
+  index: number
+): CommandArgument | undefined {
+  const args = current.arguments ?? [];
+  if (index < args.length) {
+    return args[index];
+  }
+  // A trailing `multiple: true` argument keeps accepting further positionals.
+  const last = args[args.length - 1];
+  return last?.multiple ? last : undefined;
+}
+
+function filterPrefix(
+  candidates: ReadonlyArray<string>,
+  prefix: string
+): string[] {
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (candidate.startsWith(prefix)) {
+      seen.add(candidate);
+    }
+  }
+  return Array.from(seen).sort();
+}
+
+/**
+ * Given the words a shell passes for completion (everything after the binary
+ * name, with the final element being the partial word under the cursor),
+ * returns the candidate completions. Command names, subcommands, and flags are
+ * derived from the declarative command tree; dynamic slots (tagged with a
+ * `completion` source) are resolved via `resolveSource`.
+ */
+export async function complete(
+  words: ReadonlyArray<string>,
+  opts: CompleteOptions
+): Promise<string[]> {
+  const { commands, globalOptions, resolveSource } = opts;
+  const toComplete = words.length > 0 ? words[words.length - 1] : '';
+  const committed = words.slice(0, -1);
+
+  // Walk committed tokens to establish the current command and how many
+  // positionals have been consumed, skipping options (and their values).
+  let current: CompletionCommand | undefined;
+  let positional = 0;
+  // Set once a committed top-level token doesn't name a known command, so we
+  // don't fall back to listing every command for an unknown/extension command.
+  let unknownCommand = false;
+  for (let i = 0; i < committed.length; i++) {
+    const token = committed[i];
+    if (token.startsWith('-')) {
+      const option = findOption(token, optionsFor(current, globalOptions));
+      if (option && optionTakesValue(option) && !token.includes('=')) {
+        i++; // consume the option's value token
+      }
+      continue;
+    }
+    if (!current) {
+      const command = commands.find(c => matchesCommand(c, token));
+      if (command) {
+        current = command;
+      } else {
+        unknownCommand = true;
+      }
+      continue;
+    }
+    if (
+      current.subcommands &&
+      current.subcommands.length > 0 &&
+      positional === 0
+    ) {
+      const sub = current.subcommands.find(c => matchesCommand(c, token));
+      if (sub) {
+        current = sub;
+        positional = 0;
+        continue;
+      }
+    }
+    positional++;
+  }
+
+  // An unknown command was committed: we can't know its flags or arguments, so
+  // offer nothing rather than re-listing every top-level command.
+  if (unknownCommand) {
+    return [];
+  }
+
+  // (a) Value for a space-separated value-expecting option: `--scope <TAB>`.
+  // Only the immediately-preceding token matters: a value-taking option consumes
+  // exactly the next token, so `--scope <TAB>` has `--scope` last, while
+  // `--scope acme --prod <TAB>` has the Boolean `--prod` last and falls through.
+  const lastCommitted = committed[committed.length - 1];
+  if (
+    lastCommitted &&
+    lastCommitted.startsWith('-') &&
+    !lastCommitted.includes('=') &&
+    !toComplete.startsWith('-')
+  ) {
+    const option = findOption(
+      lastCommitted,
+      optionsFor(current, globalOptions)
+    );
+    if (option && optionTakesValue(option)) {
+      if (option.completion && resolveSource) {
+        return filterPrefix(await resolveSource(option.completion), toComplete);
+      }
+      return [];
+    }
+  }
+
+  // (b) `=`-joined option value: `--scope=ac<TAB>`.
+  if (toComplete.startsWith('--') && toComplete.includes('=')) {
+    const eq = toComplete.indexOf('=');
+    const flag = toComplete.slice(0, eq);
+    const partial = toComplete.slice(eq + 1);
+    const option = findOption(flag, optionsFor(current, globalOptions));
+    if (option?.completion && resolveSource) {
+      const values = await resolveSource(option.completion);
+      return values
+        .filter(value => value.startsWith(partial))
+        .sort()
+        .map(value => `${flag}=${value}`);
+    }
+    return [];
+  }
+
+  // (c) Flag completion.
+  if (toComplete.startsWith('-')) {
+    const options = optionsFor(current, globalOptions).filter(
+      option => !option.deprecated
+    );
+    const longs = options.map(option => `--${option.name}`);
+    const shorts = options
+      .filter(option => option.shorthand)
+      .map(option => `-${option.shorthand}`);
+    const candidates = toComplete.startsWith('--')
+      ? longs
+      : toComplete === '-'
+        ? [...shorts, ...longs]
+        : shorts;
+    return filterPrefix(candidates, toComplete);
+  }
+
+  // (d) Command name, subcommand name, and/or positional value.
+  if (!current) {
+    const names = commands.filter(c => !c.hidden).map(c => c.name);
+    return filterPrefix(names, toComplete);
+  }
+  const candidates: string[] = [];
+  // At the first slot, visible subcommand names are candidates. A command can
+  // also define a positional there (e.g. `completion` has both an `install`
+  // subcommand and a `shell` argument), so both sets are offered together.
+  if (
+    current.subcommands &&
+    current.subcommands.length > 0 &&
+    positional === 0
+  ) {
+    candidates.push(
+      ...current.subcommands.filter(c => !c.hidden).map(c => c.name)
+    );
+  }
+  const arg = positionalAt(current, positional);
+  if (arg?.values) {
+    candidates.push(...arg.values);
+  } else if (arg?.completion && resolveSource) {
+    candidates.push(...(await resolveSource(arg.completion)));
+  }
+  return filterPrefix(candidates, toComplete);
+}

--- a/packages/cli/src/util/completion/install.ts
+++ b/packages/cli/src/util/completion/install.ts
@@ -1,0 +1,105 @@
+import { existsSync } from 'fs';
+import { mkdir, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+import { packageName } from '../pkg-name';
+import {
+  SUPPORTED_SHELLS,
+  type SupportedShell,
+  completionScript,
+  isSupportedShell,
+} from './scripts';
+
+function xdgConfigHome(): string {
+  return process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+}
+
+function xdgDataHome(): string {
+  return process.env.XDG_DATA_HOME || join(homedir(), '.local', 'share');
+}
+
+/**
+ * Standard per-shell autoload locations. Dropping a file here is picked up with
+ * no rc-file edits: fish and bash-completion autoload by filename; zsh autoloads
+ * `_vercel` when its directory is on `$fpath` (see `fpathHintFor`). bash needs a
+ * file per command name, since bash-completion lazy-loads by the completed word.
+ */
+export function completionTargetPaths(shell: SupportedShell): string[] {
+  switch (shell) {
+    case 'fish':
+      return [join(xdgConfigHome(), 'fish', 'completions', 'vercel.fish')];
+    case 'bash':
+      return [
+        join(xdgDataHome(), 'bash-completion', 'completions', 'vercel'),
+        join(xdgDataHome(), 'bash-completion', 'completions', 'vc'),
+      ];
+    case 'zsh':
+      return [join(xdgDataHome(), 'zsh', 'site-functions', '_vercel')];
+  }
+}
+
+/**
+ * zsh only loads an autoloaded completion when its directory is on `$fpath`,
+ * which we can't guarantee from a non-interactive process. Returns the line the
+ * user can add to `~/.zshrc` (before `compinit`) if completions don't load.
+ */
+export function fpathHintFor(shell: SupportedShell): string | undefined {
+  if (shell !== 'zsh') {
+    return undefined;
+  }
+  const dir = dirname(completionTargetPaths('zsh')[0]);
+  return `fpath=(${dir} $fpath)`;
+}
+
+/** Resolves the target shell from an explicit arg or the `$SHELL` basename. */
+export function detectShell(explicit?: string): SupportedShell | undefined {
+  if (explicit) {
+    return isSupportedShell(explicit) ? explicit : undefined;
+  }
+  const shellPath = process.env.SHELL;
+  if (!shellPath) {
+    return undefined;
+  }
+  const base = shellPath.split('/').pop() ?? '';
+  return isSupportedShell(base) ? base : undefined;
+}
+
+/** Writes the completion script(s) for a shell, returning the paths written. */
+export async function writeCompletionFiles(
+  shell: SupportedShell
+): Promise<string[]> {
+  const script = completionScript(shell, packageName);
+  const paths = completionTargetPaths(shell);
+  for (const path of paths) {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, script, 'utf8');
+  }
+  return paths;
+}
+
+/** Shells that already have a vercel completion file installed. */
+export function installedShells(): SupportedShell[] {
+  return SUPPORTED_SHELLS.filter(shell =>
+    completionTargetPaths(shell).some(path => existsSync(path))
+  );
+}
+
+/**
+ * Rewrites completion files for shells that already have them installed. Used
+ * after a successful upgrade to keep installs current; never creates a
+ * first-time install. Best-effort: individual write failures are swallowed so
+ * they can't break the upgrade.
+ */
+export async function refreshInstalledCompletions(): Promise<SupportedShell[]> {
+  const shells = installedShells();
+  const refreshed: SupportedShell[] = [];
+  for (const shell of shells) {
+    try {
+      await writeCompletionFiles(shell);
+      refreshed.push(shell);
+    } catch {
+      // Ignore: a read-only or missing dir must never fail the upgrade.
+    }
+  }
+  return refreshed;
+}

--- a/packages/cli/src/util/completion/scripts.ts
+++ b/packages/cli/src/util/completion/scripts.ts
@@ -61,8 +61,10 @@ function fishScript(binary: string): string {
 function __${binary}_completion
   set -l tokens (commandline -opc)
   set -l current (commandline -ct)
-  # Drop the program name; always append the current partial (may be empty).
-  set -l args $tokens[2..-1] $current
+  # $tokens[2..-1] drops the program name. Quote $current so an empty word
+  # (cursor after a space) still contributes one empty argument; unquoted, an
+  # empty fish variable expands to zero arguments and the word would be lost.
+  set -l args $tokens[2..-1] "$current"
   ${binary} completion __complete -- $args 2>/dev/null
 end
 complete -c ${binary} -a '(__${binary}_completion)'

--- a/packages/cli/src/util/completion/scripts.ts
+++ b/packages/cli/src/util/completion/scripts.ts
@@ -1,0 +1,85 @@
+export const SUPPORTED_SHELLS = ['bash', 'zsh', 'fish'] as const;
+export type SupportedShell = (typeof SUPPORTED_SHELLS)[number];
+
+export function isSupportedShell(value: string): value is SupportedShell {
+  return (SUPPORTED_SHELLS as ReadonlyArray<string>).includes(value);
+}
+
+/**
+ * Each script is a thin wrapper: it collects the command-line tokens (including
+ * the empty partial word under the cursor) and delegates to
+ * `<binary> completion __complete -- <tokens>`, which prints newline-separated
+ * candidates. All completion logic lives in the binary so the command tree
+ * never drifts. `binary` is the canonical bin name; both `vercel` and `vc`
+ * (always installed together) are registered.
+ */
+
+function bashScript(binary: string): string {
+  return `# ${binary} bash completion
+_${binary}_completion() {
+  local cur tokens completions
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  # Tokens after the program name, up to and including the current word.
+  tokens=("\${COMP_WORDS[@]:1:COMP_CWORD}")
+  completions="$(${binary} completion __complete -- "\${tokens[@]}" 2>/dev/null)"
+  local IFS=$'\\n'
+  COMPREPLY=($(compgen -W "\${completions}" -- "\${cur}"))
+}
+complete -o default -F _${binary}_completion ${binary}
+complete -o default -F _${binary}_completion vc
+`;
+}
+
+/**
+ * Dual-mode zsh script. As an autoloaded `#compdef` file on $fpath it is invoked
+ * directly as the `_vercel` completion widget; when sourced (e.g.
+ * `eval "$(vercel completion zsh)"`) it registers itself with `compdef`. The
+ * `funcstack` check distinguishes the two, following the widely-used rustup/
+ * docker pattern.
+ */
+function zshScript(binary: string): string {
+  return `#compdef ${binary} vc
+_${binary}() {
+  local -a tokens completions
+  # words[1] is the program; slice preserves the (possibly empty) current word.
+  tokens=("\${(@)words[2,CURRENT]}")
+  local out
+  out="$(${binary} completion __complete -- "\${tokens[@]}" 2>/dev/null)"
+  completions=("\${(@f)out}")
+  compadd -- "\${completions[@]}"
+}
+if [ "$funcstack[1]" = "_${binary}" ]; then
+  _${binary} "$@"
+else
+  compdef _${binary} ${binary} vc
+fi
+`;
+}
+
+function fishScript(binary: string): string {
+  return `# ${binary} fish completion
+function __${binary}_completion
+  set -l tokens (commandline -opc)
+  set -l current (commandline -ct)
+  # Drop the program name; always append the current partial (may be empty).
+  set -l args $tokens[2..-1] $current
+  ${binary} completion __complete -- $args 2>/dev/null
+end
+complete -c ${binary} -a '(__${binary}_completion)'
+complete -c vc -a '(__${binary}_completion)'
+`;
+}
+
+export function completionScript(
+  shell: SupportedShell,
+  binary: string
+): string {
+  switch (shell) {
+    case 'bash':
+      return bashScript(binary);
+    case 'zsh':
+      return zshScript(binary);
+    case 'fish':
+      return fishScript(binary);
+  }
+}

--- a/packages/cli/src/util/completion/sources.ts
+++ b/packages/cli/src/util/completion/sources.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'crypto';
+import { join } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+import type { CompletionSource } from '../../commands/help';
+import type Client from '../client';
+import { isValidAccessToken } from '../client';
+import getGlobalPathConfig from '../config/global-path';
+import getTeams from '../teams/get-teams';
+import getUser from '../get-user';
+
+/** Keep TAB responsive: never let a network fetch block longer than this. */
+const RESOLVE_TIMEOUT_MS = 1500;
+/** Cache dynamic candidates briefly so repeated TABs don't re-hit the API. */
+const CACHE_TTL_MS = 60_000;
+/**
+ * Empty results (a timeout, a transient network/auth error, or a genuinely
+ * empty set) are cached too, so a failing fetch doesn't hang every TAB. The TTL
+ * is short so completion recovers quickly once the underlying issue clears.
+ */
+const EMPTY_CACHE_TTL_MS = 10_000;
+const CACHE_FILE = 'completion-cache.json';
+
+interface CacheEntry {
+  at: number;
+  values: string[];
+}
+
+type Cache = Record<string, CacheEntry>;
+
+function cachePath(): string {
+  return join(getGlobalPathConfig(), CACHE_FILE);
+}
+
+function cacheKey(source: CompletionSource, client: Client): string {
+  const scope = `${client.authConfig.token ?? ''}:${
+    client.config.currentTeam ?? ''
+  }`;
+  return `${source}:${createHash('sha256').update(scope).digest('hex').slice(0, 16)}`;
+}
+
+function readCache(): Cache {
+  try {
+    return JSON.parse(readFileSync(cachePath(), 'utf8')) as Cache;
+  } catch {
+    return {};
+  }
+}
+
+function writeCache(cache: Cache): void {
+  try {
+    writeFileSync(cachePath(), JSON.stringify(cache), 'utf8');
+  } catch {
+    // Best effort: a missing dir or read-only FS must never break completion.
+  }
+}
+
+async function withTimeout(promise: Promise<string[]>): Promise<string[]> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<string[]>(resolve => {
+    timer = setTimeout(() => resolve([]), RESOLVE_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function fetchTeamSlugs(client: Client): Promise<string[]> {
+  const [user, teams] = await Promise.all([getUser(client), getTeams(client)]);
+  const slugs = teams.map(team => team.slug);
+  if (user?.username) {
+    slugs.push(user.username);
+  }
+  return slugs;
+}
+
+const fetchers: Record<
+  CompletionSource,
+  (client: Client) => Promise<string[]>
+> = {
+  team: fetchTeamSlugs,
+};
+
+/**
+ * Resolves candidates for a dynamic completion source, backed by a short-lived
+ * on-disk cache and a hard timeout. Returns `[]` for any failure (no auth,
+ * network error, or timeout), so the shell never hangs or sees an error.
+ */
+export async function resolveCompletionSource(
+  source: CompletionSource,
+  client: Client
+): Promise<string[]> {
+  if (!isValidAccessToken(client.authConfig)) {
+    return [];
+  }
+
+  const key = cacheKey(source, client);
+  const cache = readCache();
+  const cached = cache[key];
+  if (cached) {
+    const ttl = cached.values.length > 0 ? CACHE_TTL_MS : EMPTY_CACHE_TTL_MS;
+    if (Date.now() - cached.at < ttl) {
+      return cached.values;
+    }
+  }
+
+  let values: string[] = [];
+  try {
+    values = await withTimeout(fetchers[source](client));
+  } catch {
+    values = [];
+  }
+
+  // Always cache, including empty results, so a failed/empty fetch is not
+  // repeated on every keystroke; the shorter empty TTL lets it self-heal.
+  cache[key] = { at: Date.now(), values };
+  writeCache(cache);
+
+  return values;
+}

--- a/packages/cli/src/util/telemetry/commands/completion/index.ts
+++ b/packages/cli/src/util/telemetry/commands/completion/index.ts
@@ -1,0 +1,15 @@
+import { TelemetryClient } from '../..';
+
+export class CompletionTelemetryClient extends TelemetryClient {
+  trackCliArgumentShell(shell: string | undefined) {
+    // `shell` is a fixed enum (bash/zsh/fish), so the literal value is safe to
+    // record without redaction.
+    if (shell) {
+      this.trackCliArgument({ arg: 'shell', value: shell });
+    }
+  }
+
+  trackCliSubcommandInstall() {
+    this.trackCliSubcommand({ subcommand: 'install', value: 'install' });
+  }
+}

--- a/packages/cli/src/util/upgrade.ts
+++ b/packages/cli/src/util/upgrade.ts
@@ -4,6 +4,23 @@ import { tmpdir } from 'os';
 import { getUpdateCommandInfo } from './get-update-command';
 import pkg from './pkg';
 import output from '../output-manager';
+import { refreshInstalledCompletions } from './completion/install';
+
+/**
+ * Keeps already-installed shell completion scripts current after an upgrade.
+ * Never creates a first-time install, and never throws, so completion upkeep
+ * cannot affect the upgrade's outcome.
+ */
+async function refreshCompletionsAfterUpgrade(): Promise<void> {
+  try {
+    const refreshed = await refreshInstalledCompletions();
+    if (refreshed.length > 0) {
+      output.debug(`Refreshed shell completion for: ${refreshed.join(', ')}`);
+    }
+  } catch {
+    // Intentionally ignored.
+  }
+}
 
 const execFileAsync = promisify(execFile);
 
@@ -69,7 +86,7 @@ export async function executeUpgrade(targetVersion?: string): Promise<number> {
       resolve(1);
     });
 
-    upgradeProcess.on('close', (code: number | null) => {
+    upgradeProcess.on('close', async (code: number | null) => {
       if (code !== 0) {
         // Show output only on error
         const stdoutStr = Buffer.concat(stdout).toString();
@@ -87,6 +104,10 @@ export async function executeUpgrade(targetVersion?: string): Promise<number> {
         resolve(code ?? 1);
         return;
       }
+
+      // Keep any already-installed shell completions current with the new
+      // version. Best-effort and non-fatal.
+      await refreshCompletionsAfterUpgrade();
 
       if (targetVersion) {
         output.success(

--- a/packages/cli/test/unit/commands/completion/completion.test.ts
+++ b/packages/cli/test/unit/commands/completion/completion.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { client } from '../../../mocks/client';
+import completion from '../../../../src/commands/completion';
+
+// The dynamic source hits the network + an on-disk cache; stub it so the
+// driver's wiring is tested deterministically.
+vi.mock('../../../../src/util/completion/sources', () => ({
+  resolveCompletionSource: vi.fn(async () => ['acme', 'jsvana']),
+}));
+
+function stdoutLines(): string[] {
+  return client.stdout.getFullOutput().trim().split('\n').filter(Boolean);
+}
+
+describe('completion', () => {
+  describe('script generation', () => {
+    it('prints a bash script and registers both binaries', async () => {
+      client.setArgv('completion', 'bash');
+      const code = await completion(client);
+      expect(code).toEqual(0);
+      const out = client.stdout.getFullOutput();
+      expect(out).toContain('_vercel_completion()');
+      expect(out).toContain('complete -o default -F _vercel_completion vercel');
+      expect(out).toContain('complete -o default -F _vercel_completion vc');
+    });
+
+    it('prints a zsh script', async () => {
+      client.setArgv('completion', 'zsh');
+      expect(await completion(client)).toEqual(0);
+      expect(client.stdout.getFullOutput()).toContain('#compdef vercel vc');
+    });
+
+    it('prints a fish script', async () => {
+      client.setArgv('completion', 'fish');
+      expect(await completion(client)).toEqual(0);
+      expect(client.stdout.getFullOutput()).toContain('complete -c vercel');
+    });
+
+    it('tracks the shell argument', async () => {
+      client.setArgv('completion', 'zsh');
+      await completion(client);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'argument:shell', value: 'zsh' },
+      ]);
+    });
+
+    it('errors on an unsupported shell', async () => {
+      client.setArgv('completion', 'powershell');
+      expect(await completion(client)).toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain('Unsupported shell');
+    });
+
+    it('errors when the shell argument is missing', async () => {
+      client.setArgv('completion');
+      expect(await completion(client)).toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain('Missing shell');
+    });
+  });
+
+  describe('__complete driver', () => {
+    it('lists top-level commands', async () => {
+      client.setArgv('completion', '__complete', '--', '');
+      expect(await completion(client)).toEqual(0);
+      const lines = stdoutLines();
+      expect(lines).toContain('deploy');
+      expect(lines).toContain('teams');
+      expect(lines).toContain('completion');
+    });
+
+    it('lists teams subcommands', async () => {
+      client.setArgv('completion', '__complete', '--', 'teams', '');
+      await completion(client);
+      expect(stdoutLines()).toContain('switch');
+    });
+
+    it('completes flags', async () => {
+      client.setArgv('completion', '__complete', '--', 'deploy', '--sc');
+      await completion(client);
+      expect(stdoutLines()).toContain('--scope');
+    });
+
+    it('completes the shell argument values and the install subcommand', async () => {
+      client.setArgv('completion', '__complete', '--', 'completion', '');
+      await completion(client);
+      expect(stdoutLines()).toEqual(['bash', 'fish', 'install', 'zsh']);
+    });
+
+    it('completes shells after `completion install`', async () => {
+      client.setArgv(
+        'completion',
+        '__complete',
+        '--',
+        'completion',
+        'install',
+        ''
+      );
+      await completion(client);
+      expect(stdoutLines()).toEqual(['bash', 'fish', 'zsh']);
+    });
+
+    it('completes team slugs for `teams switch` via the source', async () => {
+      client.setArgv('completion', '__complete', '--', 'teams', 'switch', '');
+      await completion(client);
+      expect(stdoutLines()).toEqual(['acme', 'jsvana']);
+    });
+
+    it('emits nothing (and does not throw) for an unknown command', async () => {
+      client.setArgv('completion', '__complete', '--', 'notacommand', '');
+      expect(await completion(client)).toEqual(0);
+      expect(client.stdout.getFullOutput()).toEqual('');
+    });
+  });
+
+  describe('install', () => {
+    let tmp: string;
+    let savedEnv: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      tmp = mkdtempSync(join(tmpdir(), 'vc-completion-'));
+      savedEnv = {
+        XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+        XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+        SHELL: process.env.SHELL,
+      };
+      // Sandbox all install destinations under the temp dir.
+      process.env.XDG_CONFIG_HOME = join(tmp, 'config');
+      process.env.XDG_DATA_HOME = join(tmp, 'data');
+    });
+
+    afterEach(() => {
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    });
+
+    it('writes the fish completion file for an explicit shell', async () => {
+      client.setArgv('completion', 'install', 'fish');
+      expect(await completion(client)).toEqual(0);
+      const file = join(tmp, 'config', 'fish', 'completions', 'vercel.fish');
+      expect(existsSync(file)).toBe(true);
+      expect(readFileSync(file, 'utf8')).toContain('complete -c vercel');
+    });
+
+    it('detects the shell from $SHELL when no argument is given', async () => {
+      process.env.SHELL = '/opt/homebrew/bin/fish';
+      client.setArgv('completion', 'install');
+      expect(await completion(client)).toEqual(0);
+      expect(
+        existsSync(join(tmp, 'config', 'fish', 'completions', 'vercel.fish'))
+      ).toBe(true);
+    });
+
+    it('writes both bash files and prints an fpath hint for zsh', async () => {
+      client.setArgv('completion', 'install', 'bash');
+      expect(await completion(client)).toEqual(0);
+      const base = join(tmp, 'data', 'bash-completion', 'completions');
+      expect(existsSync(join(base, 'vercel'))).toBe(true);
+      expect(existsSync(join(base, 'vc'))).toBe(true);
+
+      client.setArgv('completion', 'install', 'zsh');
+      expect(await completion(client)).toEqual(0);
+      expect(
+        existsSync(join(tmp, 'data', 'zsh', 'site-functions', '_vercel'))
+      ).toBe(true);
+      expect(client.stderr.getFullOutput()).toContain('fpath=');
+    });
+
+    it('errors on an unsupported shell', async () => {
+      client.setArgv('completion', 'install', 'powershell');
+      expect(await completion(client)).toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain('Unsupported shell');
+    });
+
+    it('errors when the shell cannot be detected', async () => {
+      delete process.env.SHELL;
+      client.setArgv('completion', 'install');
+      expect(await completion(client)).toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain('Could not detect');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -18,6 +18,7 @@ describe('index', () => {
         ['cache', 'cache'],
         ['cert', 'certs'],
         ['certs', 'certs'],
+        ['completion', 'completion'],
         ['connect', 'connect'],
         ['contract', 'contract'],
         ['cron', 'crons'],

--- a/packages/cli/test/unit/util/completion/complete.test.ts
+++ b/packages/cli/test/unit/util/completion/complete.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import { complete } from '../../../../src/util/completion/complete';
+import type { CompletionCommand } from '../../../../src/util/completion/complete';
+import type {
+  CommandOption,
+  CompletionSource,
+} from '../../../../src/commands/help';
+
+const globalOptions: CommandOption[] = [
+  { name: 'help', shorthand: 'h', type: Boolean, deprecated: false },
+  {
+    name: 'scope',
+    shorthand: 'S',
+    type: String,
+    deprecated: false,
+    completion: 'team',
+  },
+  { name: 'legacy', shorthand: null, type: Boolean, deprecated: true },
+];
+
+const commands: CompletionCommand[] = [
+  {
+    name: 'teams',
+    aliases: ['team'],
+    options: [],
+    arguments: [],
+    subcommands: [
+      {
+        name: 'switch',
+        aliases: ['change'],
+        options: [],
+        arguments: [{ name: 'name', required: false, completion: 'team' }],
+      },
+      { name: 'list', aliases: ['ls'], options: [], arguments: [] },
+    ],
+  },
+  {
+    name: 'completion',
+    aliases: [],
+    options: [],
+    arguments: [
+      { name: 'shell', required: true, values: ['bash', 'zsh', 'fish'] },
+    ],
+    subcommands: [
+      {
+        name: 'install',
+        aliases: [],
+        options: [],
+        arguments: [
+          { name: 'shell', required: false, values: ['bash', 'zsh', 'fish'] },
+        ],
+      },
+      {
+        name: '__complete',
+        hidden: true,
+        aliases: [],
+        options: [],
+        arguments: [],
+      },
+    ],
+  },
+  {
+    name: 'deploy',
+    aliases: [],
+    options: [
+      { name: 'prod', shorthand: null, type: Boolean, deprecated: false },
+    ],
+    arguments: [{ name: 'path', required: false }],
+  },
+];
+
+function run(
+  words: string[],
+  resolveSource?: (s: CompletionSource) => Promise<string[]>
+) {
+  return complete(words, { commands, globalOptions, resolveSource });
+}
+
+const teamSource = vi.fn(
+  async (): Promise<string[]> => ['acme', 'jsvana', 'vercel']
+);
+
+describe('completion engine', () => {
+  it('completes top-level command names by prefix', async () => {
+    expect(await run(['te'])).toEqual(['teams']);
+    expect(await run(['c'])).toEqual(['completion']);
+    expect(await run([''])).toEqual(['completion', 'deploy', 'teams']);
+  });
+
+  it('completes subcommand names', async () => {
+    expect(await run(['teams', ''])).toEqual(['list', 'switch']);
+    expect(await run(['teams', 's'])).toEqual(['switch']);
+  });
+
+  it('resolves aliases when walking the tree', async () => {
+    // `team` is an alias of `teams`; still descends to subcommands.
+    expect(await run(['team', ''])).toEqual(['list', 'switch']);
+  });
+
+  it('completes long flags and excludes deprecated ones', async () => {
+    const out = await run(['deploy', '--']);
+    expect(out).toContain('--prod');
+    expect(out).toContain('--scope');
+    expect(out).not.toContain('--legacy');
+  });
+
+  it('offers short and long flags for a lone dash', async () => {
+    const out = await run(['deploy', '-']);
+    expect(out).toContain('-S');
+    expect(out).toContain('--scope');
+  });
+
+  it('completes static argument values', async () => {
+    expect(await run(['completion', 'z'])).toEqual(['zsh']);
+    // Nested subcommand positional values: `completion install <TAB>`.
+    expect(await run(['completion', 'install', ''])).toEqual([
+      'bash',
+      'fish',
+      'zsh',
+    ]);
+  });
+
+  it('resolves a dynamic positional via the source', async () => {
+    expect(await run(['teams', 'switch', ''], teamSource)).toEqual([
+      'acme',
+      'jsvana',
+      'vercel',
+    ]);
+    expect(await run(['teams', 'switch', 'v'], teamSource)).toEqual(['vercel']);
+  });
+
+  it('resolves a dynamic option value (space-separated)', async () => {
+    expect(await run(['deploy', '--scope', ''], teamSource)).toEqual([
+      'acme',
+      'jsvana',
+      'vercel',
+    ]);
+    expect(await run(['deploy', '--scope', 'a'], teamSource)).toEqual(['acme']);
+  });
+
+  it('resolves a dynamic option value (=-joined)', async () => {
+    expect(await run(['deploy', '--scope=j'], teamSource)).toEqual([
+      '--scope=jsvana',
+    ]);
+  });
+
+  it('merges visible subcommands with positional values and hides hidden ones', async () => {
+    // `completion` has a visible `install` subcommand, a hidden `__complete`
+    // subcommand, and a `shell` positional; the first slot offers install + shells.
+    const out = await run(['completion', '']);
+    expect(out).not.toContain('__complete');
+    expect(out).toEqual(['bash', 'fish', 'install', 'zsh']);
+  });
+
+  it('yields nothing for a dynamic slot when no resolver is provided', async () => {
+    expect(await run(['teams', 'switch', ''])).toEqual([]);
+  });
+
+  it('skips option values when counting positionals', async () => {
+    // `--scope acme` is an option+value, so `switch` remains the positional.
+    expect(await run(['teams', '--scope', 'acme', ''])).toEqual([
+      'list',
+      'switch',
+    ]);
+  });
+});

--- a/packages/cli/test/unit/util/completion/install.test.ts
+++ b/packages/cli/test/unit/util/completion/install.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  detectShell,
+  installedShells,
+  refreshInstalledCompletions,
+  writeCompletionFiles,
+} from '../../../../src/util/completion/install';
+
+describe('completion install helpers', () => {
+  let tmp: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'vc-install-'));
+    savedEnv = {
+      XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+      XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+      SHELL: process.env.SHELL,
+    };
+    process.env.XDG_CONFIG_HOME = join(tmp, 'config');
+    process.env.XDG_DATA_HOME = join(tmp, 'data');
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  describe('detectShell', () => {
+    it('prefers an explicit valid shell', () => {
+      expect(detectShell('zsh')).toBe('zsh');
+    });
+    it('rejects an unsupported explicit shell', () => {
+      expect(detectShell('powershell')).toBeUndefined();
+    });
+    it('falls back to the $SHELL basename', () => {
+      process.env.SHELL = '/usr/bin/bash';
+      expect(detectShell()).toBe('bash');
+    });
+    it('returns undefined for an unknown $SHELL', () => {
+      process.env.SHELL = '/usr/bin/tcsh';
+      expect(detectShell()).toBeUndefined();
+    });
+  });
+
+  describe('installedShells / refresh', () => {
+    it('reports nothing installed on a clean sandbox', () => {
+      expect(installedShells()).toEqual([]);
+    });
+
+    it('detects a shell once its file is written', async () => {
+      await writeCompletionFiles('fish');
+      expect(installedShells()).toEqual(['fish']);
+    });
+
+    it('refreshes only already-installed shells, never a first-time install', async () => {
+      await writeCompletionFiles('fish');
+      const fishFile = join(
+        tmp,
+        'config',
+        'fish',
+        'completions',
+        'vercel.fish'
+      );
+      // Clobber the content so we can prove refresh rewrote it (the file must
+      // still exist, else the shell no longer counts as installed).
+      writeFileSync(fishFile, 'STALE', 'utf8');
+
+      const refreshed = await refreshInstalledCompletions();
+
+      expect(refreshed).toEqual(['fish']);
+      expect(readFileSync(fishFile, 'utf8')).toContain('complete -c vercel');
+      // bash was never installed, so refresh must not create it.
+      expect(
+        existsSync(
+          join(tmp, 'data', 'bash-completion', 'completions', 'vercel')
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/cli/test/unit/util/completion/sources.test.ts
+++ b/packages/cli/test/unit/util/completion/sources.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const mocks = vi.hoisted(() => ({ getTeams: vi.fn(), getUser: vi.fn() }));
+
+// Point the on-disk cache at a per-test temp dir instead of the real config dir.
+vi.mock('../../../../src/util/config/global-path', () => ({
+  default: () => process.env.VC_TEST_GLOBAL_DIR ?? tmpdir(),
+}));
+vi.mock('../../../../src/util/teams/get-teams', () => ({
+  default: mocks.getTeams,
+}));
+vi.mock('../../../../src/util/get-user', () => ({ default: mocks.getUser }));
+
+import { resolveCompletionSource } from '../../../../src/util/completion/sources';
+
+function makeClient(token: string): any {
+  return { authConfig: { token }, config: {} };
+}
+
+describe('resolveCompletionSource', () => {
+  beforeEach(() => {
+    mocks.getTeams.mockReset();
+    mocks.getUser.mockReset();
+    process.env.VC_TEST_GLOBAL_DIR = mkdtempSync(join(tmpdir(), 'vc-src-'));
+  });
+
+  afterEach(() => {
+    delete process.env.VC_TEST_GLOBAL_DIR;
+  });
+
+  it('returns team slugs plus the personal username', async () => {
+    mocks.getUser.mockResolvedValue({ username: 'me' });
+    mocks.getTeams.mockResolvedValue([{ slug: 'acme' }, { slug: 'beta' }]);
+    expect(await resolveCompletionSource('team', makeClient('t1'))).toEqual([
+      'acme',
+      'beta',
+      'me',
+    ]);
+  });
+
+  it('caches non-empty results and does not re-fetch within the TTL', async () => {
+    mocks.getUser.mockResolvedValue({ username: 'me' });
+    mocks.getTeams.mockResolvedValue([{ slug: 'acme' }]);
+    const client = makeClient('t2');
+    const first = await resolveCompletionSource('team', client);
+    const second = await resolveCompletionSource('team', client);
+    expect(second).toEqual(first);
+    expect(mocks.getTeams).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches empty/failed results so a failing fetch is not repeated every TAB', async () => {
+    mocks.getUser.mockRejectedValue(new Error('bad token'));
+    mocks.getTeams.mockRejectedValue(new Error('bad token'));
+    const client = makeClient('t3');
+    expect(await resolveCompletionSource('team', client)).toEqual([]);
+    expect(await resolveCompletionSource('team', client)).toEqual([]);
+    expect(mocks.getTeams).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns nothing without a valid access token (no fetch)', async () => {
+    expect(await resolveCompletionSource('team', makeClient(''))).toEqual([]);
+    expect(mocks.getTeams).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

The CLI has no shell completion. Typing `vercel teams switch <TAB>` or `vercel --scope <TAB>` produces nothing, so users have to run `vercel teams ls` and copy a slug by hand.

## What

- New `vercel completion <bash|zsh|fish>` prints a thin wrapper that delegates to a hidden `completion __complete` driver. The driver walks the CLI's declarative command tree for command / subcommand / flag / value candidates, so the completion set never drifts from the real command definitions.
- Dynamic **team** completion for `vercel teams switch` and the global `--scope` / `--team` flags, resolved live through the existing client. Backed by a short on-disk cache and a 1.5s hard timeout so TAB never hangs; empty or failed fetches are cached briefly and self-heal.
- `vercel completion install [shell]` writes the script to the shell's autoload directory (auto-detecting from `$SHELL`) with no rc-file edits, printing the zsh `fpath` line when one is needed.
- A successful `vercel upgrade` refreshes any completion that is already installed (never a first-time install).

## Validation

- Exercised **bash, zsh, and fish** end-to-end against a dev build: static command/subcommand/flag completion, live team slugs for `teams switch` and `--scope`, `=`-joined option values, and `completion install` for each shell writing to the expected paths. fish was driven with `complete -C` (fish 4.8.1); bash and zsh via their generated wrappers.
- Confirmed the `__complete` driver keeps **stdout byte-clean** (the version banner is on stderr, which the wrappers discard), returns nothing when logged out, and never exceeds the timeout.
- Caught and fixed a fish-specific edge case from review: an unquoted empty current word expands to zero arguments in fish, which dropped the trailing empty token and stopped `teams <TAB>` from descending to subcommands. Verified fixed with `complete -C`.