### PR TITLE
[CLI] fixing more guardrails around vc env pull commands

### DIFF
--- a/.changeset/repair-stale-stepup-session.md
+++ b/.changeset/repair-stale-stepup-session.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Recover interactive commands from stale stored login sessions by starting a fresh device login, and retry Environment Variable reads after legacy authentication challenges.

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -26,6 +26,19 @@ export interface DeviceCodeTokens {
   refresh_token?: string;
 }
 
+interface DeviceCodeFlowOptions {
+  teamId?: string;
+  refreshToken?: string;
+  acrValues?: string;
+  /**
+   * A CLI version before 56.4.1 could persist the rotated access token after
+   * step-up without persisting its matching refresh token. Recover those
+   * sessions, along with authorizations that predate the `offline_access`
+   * requirement, by starting a full device login.
+   */
+  fallbackToLoginOnStepUpFailure?: boolean;
+}
+
 /**
  * Core device code flow: initiates the device authorization request,
  * displays the verification URL, opens the browser, and polls for
@@ -38,7 +51,7 @@ export interface DeviceCodeTokens {
  */
 export async function performDeviceCodeFlow(
   client: Client,
-  options?: { teamId?: string; refreshToken?: string; acrValues?: string }
+  options?: DeviceCodeFlowOptions
 ): Promise<DeviceCodeTokens | null> {
   const deviceAuthorizationResponse = await deviceAuthorizationRequest({
     refresh_token: options?.refreshToken,
@@ -53,7 +66,28 @@ export async function performDeviceCodeFlow(
     await processDeviceAuthorizationResponse(deviceAuthorizationResponse);
 
   if (deviceAuthorizationError) {
-    printError(deviceAuthorizationError);
+    if (
+      options?.fallbackToLoginOnStepUpFailure &&
+      options.refreshToken &&
+      isOAuthError(deviceAuthorizationError) &&
+      (deviceAuthorizationError.code === 'invalid_grant' ||
+        deviceAuthorizationError.code === 'invalid_scope')
+    ) {
+      o.debug(
+        `Step-up device authorization failed: ${deviceAuthorizationError.cause.message}`
+      );
+      o.log("Couldn't refresh the saved login. Starting a new login.");
+      return performDeviceCodeFlow(
+        client,
+        options.teamId ? { teamId: options.teamId } : undefined
+      );
+    }
+
+    printError(
+      isOAuthError(deviceAuthorizationError)
+        ? deviceAuthorizationError.cause
+        : deviceAuthorizationError
+    );
     return null;
   }
 

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -52,11 +52,16 @@ import type * as tty from 'tty';
 import type { z } from 'zod';
 import output from '../output-manager';
 import { parseArguments } from './get-args';
-import { processTokenResponse, refreshTokenRequest } from './oauth';
+import {
+  isOAuthError,
+  processTokenResponse,
+  refreshTokenRequest,
+} from './oauth';
 import {
   PromptBackError,
   PromptCanceledError,
 } from './input/prompt-cancellation';
+import { performDeviceCodeFlow } from '../commands/login/future';
 
 const DOMAINS_API_PATH = /^\/v\d+\/(?:domains|registrar)(?:\/|$)/;
 
@@ -371,6 +376,34 @@ export default class Client extends EventEmitter implements Stdio {
     });
 
     const [tokensError, tokens] = await processTokenResponse(tokenResponse);
+
+    // CLI versions before 56.4.1 could persist a rotated access token without
+    // its matching refresh token after step-up authentication. Once that
+    // access token expires, recover the interactive stored session here so
+    // commands such as `vercel link` do not fail before their first API call.
+    if (
+      isOAuthError(tokensError) &&
+      tokensError.code === 'invalid_grant' &&
+      !authConfig.tokenSource &&
+      this.stdin.isTTY &&
+      !this.nonInteractive
+    ) {
+      output.debug(
+        `Stored session refresh failed: ${tokensError.cause.message}`
+      );
+      output.log("Couldn't refresh the saved login. Starting a new login.");
+      const recoveredTokens = await performDeviceCodeFlow(this);
+      if (recoveredTokens) {
+        this.updateAuthConfig({
+          token: recoveredTokens.access_token,
+          userId: undefined,
+          expiresAt: Math.floor(Date.now() / 1000) + recoveredTokens.expires_in,
+          refreshToken: recoveredTokens.refresh_token,
+        });
+        this.persistAuthConfig();
+        return;
+      }
+    }
 
     // If we had an error, during the refresh process, empty the auth config
     // to force the user to re-authenticate

--- a/packages/cli/src/util/env/challenge-recovery.ts
+++ b/packages/cli/src/util/env/challenge-recovery.ts
@@ -3,43 +3,64 @@ import output from '../../output-manager';
 import { isAPIError } from '../errors-ts';
 import { performDeviceCodeFlow } from '../../commands/login/future';
 
+const RECOVERABLE_CHALLENGE_CODES = new Set([
+  'challenge_required',
+  'challenge_required_email_otp',
+  'user_auth_required',
+]);
+
 /**
  * Runs a request for Environment Variable records, recovering from
- * `challenge_required` API errors by performing a step-up device-code
- * authentication flow and retrying once. The fresh token pair is
- * persisted so subsequent commands reuse the elevated session until it
- * expires. Recovery requires a stored refresh token, a token that did
- * not come from `--token`/`VERCEL_TOKEN`, and an interactive terminal;
- * otherwise the original error is rethrown.
+ * authentication challenges by performing a step-up device-code flow when
+ * possible, or a full device login for legacy or invalid sessions, and then
+ * retrying once. The fresh token pair is persisted so subsequent commands
+ * reuse the elevated session until it expires. Recovery does not run for
+ * explicit tokens or in non-interactive terminals.
  */
 export async function withEnvChallengeRecovery<T>(
   client: Client,
   fn: () => Promise<T>
 ): Promise<T> {
+  const hadStoredSession = Boolean(
+    client.authConfig.token || client.authConfig.refreshToken
+  );
+
   try {
     return await fn();
   } catch (error) {
-    if (!isAPIError(error) || error.code !== 'challenge_required') {
+    if (!isAPIError(error)) {
       throw error;
     }
 
-    const refreshToken = client.authConfig.refreshToken;
-    if (!refreshToken || client.authConfig.tokenSource || !client.stdin.isTTY) {
+    const isRecoverableChallenge = RECOVERABLE_CHALLENGE_CODES.has(error.code);
+    const isRejectedStoredSession =
+      hadStoredSession && error.invalidToken === true;
+
+    if (!isRecoverableChallenge && !isRejectedStoredSession) {
+      throw error;
+    }
+
+    if (
+      client.authConfig.tokenSource ||
+      !client.stdin.isTTY ||
+      client.nonInteractive
+    ) {
       throw error;
     }
 
     output.stopSpinner();
     output.log('Sensitive Environment Variables require fresh authentication.');
 
+    const refreshToken = client.authConfig.refreshToken;
     const acrValues = getAcrValuesFromWWWAuthenticate(error.wwwAuthenticate);
-    if (!acrValues) {
-      throw error;
-    }
-
-    const tokens = await performDeviceCodeFlow(client, {
-      refreshToken,
-      acrValues,
-    });
+    const tokens =
+      isRecoverableChallenge && refreshToken && acrValues
+        ? await performDeviceCodeFlow(client, {
+            refreshToken,
+            acrValues,
+            fallbackToLoginOnStepUpFailure: true,
+          })
+        : await performDeviceCodeFlow(client);
     if (!tokens) {
       throw error;
     }
@@ -48,10 +69,8 @@ export async function withEnvChallengeRecovery<T>(
       token: tokens.access_token,
       userId: undefined,
       expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,
+      refreshToken: tokens.refresh_token,
     });
-    if (tokens.refresh_token) {
-      client.updateAuthConfig({ refreshToken: tokens.refresh_token });
-    }
     client.persistAuthConfig();
 
     return await fn();

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -377,6 +377,7 @@ describe('env pull', () => {
     expect(performDeviceCodeFlow).toHaveBeenCalledWith(client, {
       refreshToken: 'vcr_old',
       acrValues: 'urn:vercel:loa:sudo',
+      fallbackToLoginOnStepUpFailure: true,
     });
     expect(pullRequests).toBe(2);
     expect(client.authConfig.token).toBe('vca_new');

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import login from '../../../../src/commands/login';
+import { performDeviceCodeFlow } from '../../../../src/commands/login/future';
 import { client } from '../../../mocks/client';
 import { vi } from 'vitest';
 import _fetch, { Headers, type Response } from '../../../../src/util/fetch';
 import * as oauth from '../../../../src/util/oauth';
 import { randomUUID } from 'node:crypto';
+import * as open from 'open';
 
 const fetch = vi.mocked(_fetch);
 vi.mock('../../../../src/util/fetch', async () => ({
@@ -175,6 +177,132 @@ describe('login', () => {
         refresh_token: 'vcr_existing',
         acr_values: 'urn:vercel:loa:custom',
       }).toString()
+    );
+  });
+
+  it.each([
+    ['invalid_grant', 'Refresh token is invalid.'],
+    [
+      'invalid_scope',
+      'The "offline_access" scope is required for step-up authorization.',
+    ],
+  ])('starts a full device login when step-up returns %s', async (error, errorDescription) => {
+    const authorizationResult = {
+      device_code: randomUUID(),
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://vercel.com/device',
+      verification_uri_complete:
+        'https://vercel.com/oauth/device?user_code=ABCD-EFGH',
+      expires_in: 30,
+      interval: 0.005,
+    };
+
+    const tokenResult = {
+      access_token: 'vca_recovered',
+      token_type: 'Bearer' as const,
+      expires_in: 3600,
+      refresh_token: 'vcr_recovered',
+      scope: 'openid offline_access',
+    };
+
+    fetch.mockImplementation(async (_url, init) => {
+      if (!init?.body) {
+        return mockResponse({
+          issuer: 'https://vercel.com',
+          device_authorization_endpoint: 'https://vercel.com',
+          token_endpoint: 'https://vercel.com',
+          revocation_endpoint: 'https://vercel.com',
+          jwks_uri: 'https://vercel.com',
+          introspection_endpoint: 'https://vercel.com',
+        });
+      }
+
+      const body = init?.body?.toString();
+      if (body?.includes('refresh_token=vcr_stale')) {
+        return mockResponse(
+          {
+            error,
+            error_description: errorDescription,
+          },
+          false
+        );
+      }
+      if (
+        body?.includes(
+          'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code'
+        )
+      ) {
+        return mockResponse(tokenResult);
+      }
+      return mockResponse(authorizationResult);
+    });
+
+    const result = await performDeviceCodeFlow(client, {
+      refreshToken: 'vcr_stale',
+      acrValues: 'urn:vercel:loa:sudo',
+      fallbackToLoginOnStepUpFailure: true,
+    });
+
+    expect(result).toEqual({
+      access_token: tokenResult.access_token,
+      expires_in: tokenResult.expires_in,
+      refresh_token: tokenResult.refresh_token,
+    });
+    const requestBodies = fetch.mock.calls.map(([, init]) =>
+      init?.body?.toString()
+    );
+    expect(requestBodies).toContain(
+      new URLSearchParams({
+        client_id: oauth.VERCEL_CLI_CLIENT_ID,
+        refresh_token: 'vcr_stale',
+        acr_values: 'urn:vercel:loa:sudo',
+      }).toString()
+    );
+    expect(requestBodies).toContain(
+      new URLSearchParams({
+        client_id: oauth.VERCEL_CLI_CLIENT_ID,
+        scope: 'openid offline_access',
+      }).toString()
+    );
+    expect(open.default).toHaveBeenCalledWith(
+      authorizationResult.verification_uri_complete
+    );
+    expect(client.getFullOutput()).toContain(
+      "Couldn't refresh the saved login. Starting a new login."
+    );
+    expect(client.getFullOutput()).not.toContain(
+      'Device authorization request failed'
+    );
+  });
+
+  it('prints the OAuth error description when device authorization cannot recover', async () => {
+    fetch.mockImplementation(async (_url, init) => {
+      if (!init?.body) {
+        return mockResponse({
+          issuer: 'https://vercel.com',
+          device_authorization_endpoint: 'https://vercel.com',
+          token_endpoint: 'https://vercel.com',
+          revocation_endpoint: 'https://vercel.com',
+          jwks_uri: 'https://vercel.com',
+          introspection_endpoint: 'https://vercel.com',
+        });
+      }
+
+      return mockResponse(
+        {
+          error: 'invalid_client',
+          error_description: 'Vercel App not found.',
+        },
+        false
+      );
+    });
+
+    await expect(performDeviceCodeFlow(client)).resolves.toBeNull();
+    expect(client.getFullOutput()).toContain(
+      'invalid_client: Vercel App not found.'
+    );
+    expect(client.getFullOutput()).not.toContain(
+      'Device authorization request failed'
     );
   });
 

--- a/packages/cli/test/unit/util/env/challenge-recovery.integration.test.ts
+++ b/packages/cli/test/unit/util/env/challenge-recovery.integration.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as open from 'open';
+import _fetch, {
+  Headers,
+  Response,
+  type Request,
+} from '../../../../src/util/fetch';
+import * as oauth from '../../../../src/util/oauth';
+import { withEnvChallengeRecovery } from '../../../../src/util/env/challenge-recovery';
+import { client } from '../../../mocks/client';
+
+const fetch = vi.mocked(_fetch);
+
+vi.mock('../../../../src/util/fetch', async () => ({
+  ...(await vi.importActual('../../../../src/util/fetch')),
+  default: vi.fn(),
+}));
+
+vi.mock('open', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+function mockResponse(data: unknown, ok = true): Response {
+  return {
+    ok,
+    clone: () => ({ text: async () => JSON.stringify(data) }),
+    json: async () => data,
+  } as unknown as Response;
+}
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function challengeError() {
+  return Object.assign(new Error('Challenge required'), {
+    status: 403,
+    code: 'challenge_required',
+    wwwAuthenticate:
+      'Bearer error="insufficient_user_authentication", acr_values="urn:vercel:loa:sudo"',
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  client.authConfig = {
+    token: 'vca_rotated',
+    refreshToken: 'vcr_stale',
+  };
+  client.stdin.isTTY = true;
+  client.nonInteractive = false;
+});
+
+describe('Environment Variable challenge recovery integration', () => {
+  it('opens a clean browser login and retries after a stale step-up refresh token', async () => {
+    const authorizationResult = {
+      device_code: 'device-code',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://vercel.com/device',
+      verification_uri_complete:
+        'https://vercel.com/oauth/device?user_code=ABCD-EFGH',
+      expires_in: 30,
+      interval: 0.005,
+    };
+    const tokenResult = {
+      access_token: 'vca_recovered',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'vcr_recovered',
+      scope: 'openid offline_access',
+    };
+
+    fetch.mockImplementation(async (_url, init) => {
+      if (!init?.body) {
+        return mockResponse({
+          issuer: 'https://vercel.com',
+          device_authorization_endpoint: 'https://vercel.com',
+          token_endpoint: 'https://vercel.com',
+          revocation_endpoint: 'https://vercel.com',
+          jwks_uri: 'https://vercel.com',
+          introspection_endpoint: 'https://vercel.com',
+        });
+      }
+
+      const body = init.body.toString();
+      if (body.includes('refresh_token=vcr_stale')) {
+        return mockResponse(
+          {
+            error: 'invalid_grant',
+            error_description: 'Refresh token is invalid.',
+          },
+          false
+        );
+      }
+      if (
+        body.includes(
+          'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code'
+        )
+      ) {
+        return mockResponse(tokenResult);
+      }
+      return mockResponse(authorizationResult);
+    });
+
+    const error = challengeError();
+    const readEnvironmentVariables = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce('environment-records');
+
+    await expect(
+      withEnvChallengeRecovery(client, readEnvironmentVariables)
+    ).resolves.toBe('environment-records');
+
+    const requestBodies = fetch.mock.calls.map(([, init]) =>
+      init?.body?.toString()
+    );
+    expect(requestBodies).toContain(
+      new URLSearchParams({
+        client_id: oauth.VERCEL_CLI_CLIENT_ID,
+        refresh_token: 'vcr_stale',
+        acr_values: 'urn:vercel:loa:sudo',
+      }).toString()
+    );
+    expect(requestBodies).toContain(
+      new URLSearchParams({
+        client_id: oauth.VERCEL_CLI_CLIENT_ID,
+        scope: 'openid offline_access',
+      }).toString()
+    );
+    expect(open.default).toHaveBeenCalledWith(
+      authorizationResult.verification_uri_complete
+    );
+    expect(readEnvironmentVariables).toHaveBeenCalledTimes(2);
+    expect(client.authConfig).toMatchObject({
+      token: 'vca_recovered',
+      refreshToken: 'vcr_recovered',
+    });
+    expect(client.getFullOutput()).toContain(
+      "Couldn't refresh the saved login. Starting a new login."
+    );
+    expect(client.getFullOutput()).not.toContain(
+      'Device authorization request failed'
+    );
+  });
+
+  it('opens a clean browser login before the request when an expired session fails token refresh', async () => {
+    client.authConfig = {
+      token: 'vca_expired',
+      expiresAt: 0,
+      refreshToken: 'vcr_stale',
+    };
+
+    const authorizationResult = {
+      device_code: 'device-code',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://vercel.com/device',
+      verification_uri_complete:
+        'https://vercel.com/oauth/device?user_code=ABCD-EFGH',
+      expires_in: 30,
+      interval: 0.005,
+    };
+    const tokenResult = {
+      access_token: 'vca_recovered',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'vcr_recovered',
+      scope: 'openid offline_access',
+    };
+    let environmentRequests = 0;
+
+    fetch.mockImplementation(async (input, init) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : (input as Request).url;
+      const body = init?.body?.toString();
+
+      if (url.endsWith('.well-known/openid-configuration')) {
+        return jsonResponse({
+          issuer: 'https://vercel.com',
+          device_authorization_endpoint: 'https://vercel.com',
+          token_endpoint: 'https://vercel.com',
+          revocation_endpoint: 'https://vercel.com',
+          jwks_uri: 'https://vercel.com',
+          introspection_endpoint: 'https://vercel.com',
+        });
+      }
+      if (url.includes('/v3/env/pull/')) {
+        environmentRequests += 1;
+        const authorization = new Headers(init?.headers).get('authorization');
+        if (authorization === 'Bearer vca_recovered') {
+          return jsonResponse({ env: { EXAMPLE: 'value' }, buildEnv: {} });
+        }
+        return jsonResponse(
+          {
+            error: {
+              code: 'forbidden',
+              message: 'The request is missing an authentication token',
+              missingToken: true,
+            },
+          },
+          403
+        );
+      }
+      if (body?.includes('grant_type=refresh_token')) {
+        return jsonResponse(
+          {
+            error: 'invalid_grant',
+            error_description: 'Refresh token is invalid.',
+          },
+          400
+        );
+      }
+      if (
+        body?.includes(
+          'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code'
+        )
+      ) {
+        return jsonResponse(tokenResult);
+      }
+      return jsonResponse(authorizationResult);
+    });
+
+    await expect(
+      withEnvChallengeRecovery(client, () =>
+        client.fetch('/v3/env/pull/project-id')
+      )
+    ).resolves.toEqual({ env: { EXAMPLE: 'value' }, buildEnv: {} });
+
+    expect(environmentRequests).toBe(1);
+    expect(open.default).toHaveBeenCalledWith(
+      authorizationResult.verification_uri_complete
+    );
+    expect(client.authConfig).toMatchObject({
+      token: 'vca_recovered',
+      refreshToken: 'vcr_recovered',
+    });
+  });
+});

--- a/packages/cli/test/unit/util/env/challenge-recovery.test.ts
+++ b/packages/cli/test/unit/util/env/challenge-recovery.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { performDeviceCodeFlow } from '../../../../src/commands/login/future';
+import { withEnvChallengeRecovery } from '../../../../src/util/env/challenge-recovery';
+import { client } from '../../../mocks/client';
+
+vi.mock('../../../../src/commands/login/future', () => ({
+  performDeviceCodeFlow: vi.fn(),
+}));
+
+function challengeError(
+  code: string,
+  wwwAuthenticate?: string
+): Error & {
+  status: number;
+  code: string;
+  wwwAuthenticate?: string;
+} {
+  return Object.assign(new Error('Challenge required'), {
+    status: 403,
+    code,
+    wwwAuthenticate,
+  });
+}
+
+const stepUpHeader =
+  'Bearer error="insufficient_user_authentication", acr_values="urn:vercel:loa:sudo"';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  client.authConfig = {
+    token: 'vca_old',
+    refreshToken: 'vcr_old',
+  };
+  client.stdin.isTTY = true;
+  client.nonInteractive = false;
+});
+
+describe('withEnvChallengeRecovery', () => {
+  it('uses step-up authentication when the challenge includes an ACR value', async () => {
+    const error = challengeError('challenge_required', stepUpHeader);
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce('retried');
+    vi.mocked(performDeviceCodeFlow).mockResolvedValueOnce({
+      access_token: 'vca_new',
+      expires_in: 3600,
+      refresh_token: 'vcr_new',
+    });
+
+    await expect(withEnvChallengeRecovery(client, fn)).resolves.toBe('retried');
+
+    expect(performDeviceCodeFlow).toHaveBeenCalledWith(client, {
+      refreshToken: 'vcr_old',
+      acrValues: 'urn:vercel:loa:sudo',
+      fallbackToLoginOnStepUpFailure: true,
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(client.authConfig).toMatchObject({
+      token: 'vca_new',
+      refreshToken: 'vcr_new',
+    });
+  });
+
+  it.each([
+    ['a challenge without an ACR header', 'challenge_required', undefined],
+    ['an email OTP challenge', 'challenge_required_email_otp', undefined],
+    ['a user authentication challenge', 'user_auth_required', undefined],
+    [
+      'a challenge without a stored refresh token',
+      'challenge_required',
+      stepUpHeader,
+    ],
+  ])('starts a full device login for %s', async (_name, code, header) => {
+    if (_name === 'a challenge without a stored refresh token') {
+      delete client.authConfig.refreshToken;
+    }
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(challengeError(code, header))
+      .mockResolvedValueOnce('retried');
+    vi.mocked(performDeviceCodeFlow).mockResolvedValueOnce({
+      access_token: 'vca_new',
+      expires_in: 3600,
+      refresh_token: 'vcr_new',
+    });
+
+    await expect(withEnvChallengeRecovery(client, fn)).resolves.toBe('retried');
+
+    expect(performDeviceCodeFlow).toHaveBeenCalledWith(client);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(client.authConfig).toMatchObject({
+      token: 'vca_new',
+      refreshToken: 'vcr_new',
+    });
+  });
+
+  it('starts a full device login for a rejected stored token', async () => {
+    const error = Object.assign(new Error('Not authorized'), {
+      status: 403,
+      code: 'forbidden',
+      invalidToken: true,
+    });
+    const fn = vi.fn<() => Promise<string>>().mockRejectedValueOnce(error);
+    fn.mockResolvedValueOnce('retried');
+    vi.mocked(performDeviceCodeFlow).mockResolvedValueOnce({
+      access_token: 'vca_new',
+      expires_in: 3600,
+      refresh_token: 'vcr_new',
+    });
+
+    await expect(withEnvChallengeRecovery(client, fn)).resolves.toBe('retried');
+
+    expect(performDeviceCodeFlow).toHaveBeenCalledWith(client);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(client.authConfig).toMatchObject({
+      token: 'vca_new',
+      refreshToken: 'vcr_new',
+    });
+  });
+
+  it('does not start a second login after an earlier refresh attempt cleared the session', async () => {
+    const error = Object.assign(new Error('Not authorized'), {
+      status: 403,
+      code: 'forbidden',
+      missingToken: true,
+    });
+    const fn = vi.fn<() => Promise<string>>().mockImplementationOnce(() => {
+      client.authConfig = {};
+      return Promise.reject(error);
+    });
+
+    await expect(withEnvChallengeRecovery(client, fn)).rejects.toBe(error);
+
+    expect(performDeviceCodeFlow).not.toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start browser authentication when no stored session existed', async () => {
+    client.authConfig = {};
+    const error = Object.assign(new Error('Not authorized'), {
+      status: 403,
+      code: 'forbidden',
+      missingToken: true,
+    });
+    const fn = vi.fn<() => Promise<string>>().mockRejectedValueOnce(error);
+
+    await expect(withEnvChallengeRecovery(client, fn)).rejects.toBe(error);
+
+    expect(performDeviceCodeFlow).not.toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [
+      'a --token value',
+      () => {
+        client.authConfig.tokenSource = 'flag';
+      },
+    ],
+    [
+      'a VERCEL_TOKEN value',
+      () => {
+        client.authConfig.tokenSource = 'env';
+      },
+    ],
+    [
+      'non-TTY stdin',
+      () => {
+        client.stdin.isTTY = false;
+      },
+    ],
+    [
+      '--non-interactive',
+      () => {
+        client.nonInteractive = true;
+      },
+    ],
+  ])('does not start browser authentication for %s', async (_name, setup) => {
+    setup();
+    const error = challengeError('challenge_required', stepUpHeader);
+    const fn = vi.fn<() => Promise<string>>().mockRejectedValueOnce(error);
+
+    await expect(withEnvChallengeRecovery(client, fn)).rejects.toBe(error);
+
+    expect(performDeviceCodeFlow).not.toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not recover unrelated API errors', async () => {
+    const error = challengeError('token_type_not_allowed');
+    const fn = vi.fn<() => Promise<string>>().mockRejectedValueOnce(error);
+
+    await expect(withEnvChallengeRecovery(client, fn)).rejects.toBe(error);
+
+    expect(performDeviceCodeFlow).not.toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows the challenge when authentication is not completed', async () => {
+    const error = challengeError('challenge_required', stepUpHeader);
+    const fn = vi.fn<() => Promise<string>>().mockRejectedValueOnce(error);
+    vi.mocked(performDeviceCodeFlow).mockResolvedValueOnce(null);
+
+    await expect(withEnvChallengeRecovery(client, fn)).rejects.toBe(error);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/test/unit/util/login/token-refresh.test.ts
+++ b/packages/cli/test/unit/util/login/token-refresh.test.ts
@@ -1,16 +1,28 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import { randomUUID } from 'node:crypto';
 import _fetch, { Request, Response } from '../../../../src/util/fetch';
 
 import whoami from '../../../../src/commands/whoami';
 import { Chance } from 'chance';
+import { performDeviceCodeFlow } from '../../../../src/commands/login/future';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 
 const fetch = vi.mocked(_fetch);
 vi.mock('../../../../src/util/fetch', async () => ({
   ...(await vi.importActual('../../../../src/util/fetch')),
   default: vi.fn(),
 }));
+vi.mock('../../../../src/commands/login/future', () => ({
+  performDeviceCodeFlow: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(performDeviceCodeFlow).mockReset();
+  client.cwd = setupTmpDir();
+  delete client.config.currentTeam;
+  client.nonInteractive = false;
+});
 
 describe('OAuth Token Refresh', () => {
   it('should refresh the token when it is expired', async () => {
@@ -97,6 +109,142 @@ describe('OAuth Token Refresh', () => {
     expect(client.stderr).toOutput(name);
     expect(client.authConfig.token).toBeUndefined();
     expect(client.authConfig.expiresAt).toBeUndefined();
+    expect(client.authConfig.refreshToken).toBeUndefined();
+  });
+
+  it('should start a clean device login when a stored refresh token is invalid', async () => {
+    client.authConfig = {
+      token: 'vca_expired',
+      expiresAt: 0,
+      refreshToken: 'vcr_stale',
+    };
+    vi.mocked(performDeviceCodeFlow).mockResolvedValueOnce({
+      access_token: 'vca_recovered',
+      expires_in: 3600,
+      refresh_token: 'vcr_recovered',
+    });
+
+    const discovery = {
+      issuer: 'https://vercel.com/',
+      device_authorization_endpoint: 'https://device/',
+      token_endpoint: 'https://token/',
+      revocation_endpoint: 'https://revoke/',
+      jwks_uri: 'https://jwks/',
+      introspection_endpoint: 'https://introspection/',
+    };
+    fetch.mockImplementation(init => {
+      const url = init instanceof Request ? init.url : init.toString();
+
+      if (url.endsWith('.well-known/openid-configuration')) {
+        return json(discovery);
+      }
+      if (url === discovery.token_endpoint) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: 'Refresh token is invalid.',
+            }),
+            {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        );
+      }
+      if (url.endsWith('/v2/user')) {
+        return json({
+          user: {
+            id: randomUUID(),
+            email: Chance().email(),
+            username: 'recovered-user',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    await expect(whoami(client)).resolves.toBe(0);
+
+    await expect(client.stderr).toOutput(
+      "Couldn't refresh the saved login. Starting a new login."
+    );
+    await expect(client.stderr).toOutput('recovered-user');
+    expect(performDeviceCodeFlow).toHaveBeenCalledWith(client);
+    expect(client.authConfig).toMatchObject({
+      token: 'vca_recovered',
+      refreshToken: 'vcr_recovered',
+    });
+  });
+
+  it.each([
+    [
+      'non-interactive mode',
+      () => {
+        client.nonInteractive = true;
+      },
+    ],
+    [
+      'a non-TTY session',
+      () => {
+        client.stdin.isTTY = false;
+      },
+    ],
+  ])('should not start a clean device login in %s', async (_name, setup) => {
+    client.authConfig = {
+      token: 'vca_expired',
+      expiresAt: 0,
+      refreshToken: 'vcr_stale',
+    };
+    setup();
+
+    const discovery = {
+      issuer: 'https://vercel.com/',
+      device_authorization_endpoint: 'https://device/',
+      token_endpoint: 'https://token/',
+      revocation_endpoint: 'https://revoke/',
+      jwks_uri: 'https://jwks/',
+      introspection_endpoint: 'https://introspection/',
+    };
+    fetch.mockImplementation(init => {
+      const url = init instanceof Request ? init.url : init.toString();
+
+      if (url.endsWith('.well-known/openid-configuration')) {
+        return json(discovery);
+      }
+      if (url === discovery.token_endpoint) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: 'Refresh token is invalid.',
+            }),
+            {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        );
+      }
+      if (url.endsWith('/v2/user')) {
+        return json({
+          user: {
+            id: randomUUID(),
+            email: Chance().email(),
+            username: 'unauthenticated-user',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    await expect(whoami(client)).resolves.toBe(0);
+
+    await expect(client.stderr).toOutput('unauthenticated-user');
+    expect(performDeviceCodeFlow).not.toHaveBeenCalled();
+    expect(client.authConfig.token).toBeUndefined();
     expect(client.authConfig.refreshToken).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fix interactive CLI commands failing with stale refresh tokens by falling back to a fresh browser-based device login and persisting the new token pair. This restores vc link, vc env pull, and other environment-variable flows without affecting CI, non-interactive sessions, or explicit tokens.