### PR TITLE
ci: build and publish native binaries before publishing vercel

### DIFF
--- a/.changeset/binary-release-natives-before-vercel.md
+++ b/.changeset/binary-release-natives-before-vercel.md
@@ -1,0 +1,8 @@
+---
+---
+
+Release binaries before publishing `vercel`: the native `@vercel/vc-native-*`
+packages are now built and published to npm as a gating job before the
+changesets publish, and `vercel`'s native `optionalDependencies` are injected at
+pack time (hard failing if any native package is missing from npm). Removes the
+unused GitHub Release asset upload and the cross-workflow dispatch trigger.

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,24 +1,23 @@
 name: Release Binary
 
 on:
-  push:
-    tags:
-      - 'vercel@*'
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      tag:
-        description: Existing tag to build (e.g. vercel@53.3.1)
-        required: true
+      ref:
+        description: Git ref (SHA) to checkout and build
+        required: false
+        type: string
+        default: ''
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 env:
   TURBO_REMOTE_ONLY: 'true'
 
 concurrency:
-  group: release-binary-${{ inputs.tag || github.ref }}
+  group: release-binary-${{ inputs.ref || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -82,7 +81,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup Turborepo Remote Cache
         uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
@@ -272,111 +271,6 @@ jobs:
           retention-days: 3
           if-no-files-found: error
 
-      - name: Wait for GitHub Release
-        if: ${{ github.ref_type == 'tag' || github.event_name == 'workflow_dispatch' }}
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.tag || github.ref_name }}
-        run: |
-          set -euo pipefail
-          release_url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$TAG"
-          for i in $(seq 1 30); do
-            response="$(mktemp)"
-            status="$(curl -sS -L -o "$response" -w "%{http_code}" \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "$release_url")"
-
-            if [[ "$status" == "200" ]]; then
-              echo "Release $TAG ready"
-              exit 0
-            fi
-            if [[ "$status" != "404" ]]; then
-              cat "$response"
-            fi
-            echo "Waiting for release $TAG to be created ($i/30)..."
-            sleep 10
-          done
-          echo "::error::Timed out waiting for release $TAG after 5 minutes"
-          exit 1
-
-      - name: Upload to GitHub Release
-        if: ${{ github.ref_type == 'tag' || github.event_name == 'workflow_dispatch' }}
-        shell: bash
-        working-directory: packages/cli
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.tag || github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          auth_headers=(
-            -H "Authorization: Bearer $GH_TOKEN"
-            -H "Accept: application/vnd.github+json"
-            -H "X-GitHub-Api-Version: 2022-11-28"
-          )
-          release_json="$(mktemp)"
-          status="$(curl -sS -L -o "$release_json" -w "%{http_code}" \
-            "${auth_headers[@]}" \
-            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$TAG")"
-
-          if [[ "$status" != "200" ]]; then
-            cat "$release_json"
-            echo "::error::Could not fetch GitHub Release $TAG"
-            exit 1
-          fi
-
-          release_id="$(node -e "const fs = require('fs'); console.log(JSON.parse(fs.readFileSync(process.argv[1], 'utf8')).id)" "$release_json")"
-          upload_url="$(node -e "const fs = require('fs'); console.log(JSON.parse(fs.readFileSync(process.argv[1], 'utf8')).upload_url.split('{')[0])" "$release_json")"
-
-          request() {
-            local output="$1"
-            shift
-            local status
-            status="$(curl -sS -L -o "$output" -w "%{http_code}" "$@")"
-            if [[ "$status" -lt 200 || "$status" -ge 300 ]]; then
-              cat "$output"
-              echo "::error::GitHub API request failed with HTTP $status"
-              exit 1
-            fi
-          }
-
-          upload_asset() {
-            local file="$1"
-            local name
-            name="$(basename "$file")"
-            local encoded_name
-            encoded_name="$(node -e "console.log(encodeURIComponent(process.argv[1]))" "$name")"
-
-            local assets_json
-            assets_json="$(mktemp)"
-            request "$assets_json" \
-              "${auth_headers[@]}" \
-              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100"
-
-            local existing_asset_id
-            existing_asset_id="$(node -e "const fs = require('fs'); const assets = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); const asset = assets.find(asset => asset.name === process.argv[2]); console.log(asset?.id ?? '')" "$assets_json" "$name")"
-
-            if [[ -n "$existing_asset_id" ]]; then
-              request /dev/null \
-                -X DELETE \
-                "${auth_headers[@]}" \
-                "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/assets/$existing_asset_id"
-            fi
-
-            request /dev/null \
-              -X POST \
-              "${auth_headers[@]}" \
-              -H "Content-Type: application/octet-stream" \
-              --data-binary "@$file" \
-              "$upload_url?name=$encoded_name"
-          }
-
-          upload_asset "dist-bin/${{ matrix.asset }}${{ matrix.ext }}"
-          upload_asset "dist-bin/${{ matrix.asset }}${{ matrix.ext }}.sha256"
-
   publish-npm:
     name: Publish native npm packages
     runs-on: ubuntu-latest
@@ -390,7 +284,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -414,23 +308,9 @@ jobs:
         shell: bash
         env:
           NPM_CONFIG_PROVENANCE: 'true'
-        run: |
-          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-            node packages/vc-native/scripts/publish-packages.mjs
-          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            version="$(node -p "require('./packages/cli/package.json').version")"
-            latest="$(npm view vercel version)"
-            if [[ "$version" == "$latest" ]]; then
-              node packages/vc-native/scripts/publish-packages.mjs
-            else
-              node packages/vc-native/scripts/publish-packages.mjs --tag "rebuild-$version"
-            fi
-          else
-            node packages/vc-native/scripts/publish-packages.mjs --dry-run
-          fi
+        run: node packages/vc-native/scripts/publish-packages.mjs
 
       - name: Verify @vercel/vc-native global install
-        if: ${{ github.ref_type == 'tag' || github.event_name == 'workflow_dispatch' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -8,6 +8,15 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      SENTRY_DSN:
+        required: false
+      APPLE_CERT_DATA:
+        required: false
+      APPLE_API_KEY:
+        required: false
+      APPLE_CERT_PASSWORD:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,54 @@ env:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  determine:
+    name: Determine vercel publish
+    runs-on: ubuntu-latest
+    outputs:
+      # 'true' when the committed vercel version is not yet on npm, which means
+      # this push will publish vercel and therefore needs native binaries on npm
+      # first. On "Version Packages" PR merges (version already published, or
+      # only a version bump PR) this is 'false' and the binary build is skipped.
+      should-release-binary: ${{ steps.check.outputs.should-release-binary }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Check if this is a vercel publish
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./packages/cli/package.json').version")"
+          if npm view "vercel@$version" version >/dev/null 2>&1; then
+            echo "vercel@$version already on npm; skipping binary release."
+            echo "should-release-binary=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "vercel@$version not on npm; this run will publish it."
+            echo "should-release-binary=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  binary:
+    name: Binary release
+    needs: determine
+    if: needs.determine.outputs.should-release-binary == 'true'
+    uses: ./.github/workflows/release-binary.yml
+    with:
+      ref: ${{ github.sha }}
+    secrets: inherit
+
   release:
     name: Release
+    needs:
+      - determine
+      - binary
+    # Run once the natives are published (binary success), or when there is no
+    # vercel publish this run (binary skipped). Never run if the binary build
+    # was attempted and failed, so vercel is not published without its natives.
+    if: |
+      always() &&
+      needs.determine.result == 'success' &&
+      (needs.binary.result == 'success' || needs.binary.result == 'skipped')
     runs-on: ubuntu-latest
     environment: release # Must be kept for trusted publishing on PyPI
     permissions:
@@ -84,27 +130,6 @@ jobs:
           NPM_CONFIG_PROVENANCE: 'true'
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-      - name: Trigger binary release
-        if: steps.changesets.outputs.published == 'true' && contains(fromJSON(steps.changesets.outputs.publishedPackages).*.name, 'vercel')
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const pkg = JSON.parse(
-              fs.readFileSync('packages/cli/package.json', 'utf8')
-            );
-            const tag = `vercel@${pkg.version}`;
-
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'release-binary.yml',
-              ref: 'main',
-              inputs: { tag },
-            });
-
       # TODO: re-enable with a new bot token or GitHub App
       # - name: Trigger Update (if a Publish Happened)
       #   if: steps.changesets.outputs.published == 'true'
@@ -128,8 +153,29 @@ jobs:
     name: Summary (release)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: always()
     needs:
+      - determine
+      - binary
       - release
     steps:
       - name: Check All
-        run: echo OK
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "determine: ${{ needs.determine.result }}"
+          echo "binary:    ${{ needs.binary.result }}"
+          echo "release:   ${{ needs.release.result }}"
+          if [[ "${{ needs.determine.result }}" != "success" ]]; then
+            echo "::error::determine job did not succeed"
+            exit 1
+          fi
+          if [[ "${{ needs.binary.result }}" != "success" && "${{ needs.binary.result }}" != "skipped" ]]; then
+            echo "::error::binary job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.release.result }}" != "success" ]]; then
+            echo "::error::release job did not succeed"
+            exit 1
+          fi
+          echo OK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,11 @@ jobs:
     uses: ./.github/workflows/release-binary.yml
     with:
       ref: ${{ github.sha }}
-    secrets: inherit
+    secrets:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
 
   release:
     name: Release

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prepare": "husky install",
     "pack": "cd utils && node -r ts-eager/register ./pack.ts",
     "ci:version": "changeset version && node utils/sync-python-version.js && uv lock && pnpm install --no-frozen-lockfile",
-    "ci:publish": "node utils/publish-runtimes.mjs && bash utils/npm-publish.sh && changeset tag",
+    "ci:publish": "node utils/inject-native-optional-deps.mjs && node utils/publish-runtimes.mjs && bash utils/npm-publish.sh && changeset tag",
     "ci:version:canary": "node utils/changeset-version-canary.js && pnpm install --no-frozen-lockfile",
     "ci:publish:canary": "bash utils/npm-publish.sh canary",
     "type-check": "turbo type-check --concurrency=12 --output-logs=errors-only --summarize --continue"

--- a/packages/vc-native/scripts/platforms.mjs
+++ b/packages/vc-native/scripts/platforms.mjs
@@ -1,0 +1,38 @@
+// Single source of truth for the native per-platform packages.
+// Consumed by stage-packages.mjs (staging/publishing the native npm packages)
+// and utils/inject-native-optional-deps.mjs (wiring them onto `vercel` as
+// optionalDependencies at pack time). Keep this list in sync with the build
+// matrix in .github/workflows/release-binary.yml.
+export const platforms = [
+  {
+    name: '@vercel/vc-native-darwin-arm64',
+    asset: 'vercel-darwin-arm64',
+    os: ['darwin'],
+    cpu: ['arm64'],
+  },
+  {
+    name: '@vercel/vc-native-darwin-x64',
+    asset: 'vercel-darwin-x64',
+    os: ['darwin'],
+    cpu: ['x64'],
+  },
+  {
+    name: '@vercel/vc-native-linux-arm64',
+    asset: 'vercel-linux-arm64',
+    os: ['linux'],
+    cpu: ['arm64'],
+  },
+  {
+    name: '@vercel/vc-native-linux-x64',
+    asset: 'vercel-linux-x64',
+    os: ['linux'],
+    cpu: ['x64'],
+  },
+  {
+    name: '@vercel/vc-native-win32-x64',
+    asset: 'vercel-windows-x64.exe',
+    os: ['win32'],
+    cpu: ['x64'],
+    binary: 'vercel.exe',
+  },
+];

--- a/packages/vc-native/scripts/stage-packages.mjs
+++ b/packages/vc-native/scripts/stage-packages.mjs
@@ -9,6 +9,7 @@ import {
 } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { platforms } from './platforms.mjs';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(packageRoot, '..', '..');
@@ -21,40 +22,6 @@ const outputRoot = join(packageRoot, 'dist-native');
 const binaryRoot = join(cliRoot, 'dist-bin');
 const checkSourcesOnly = process.argv.includes('--check-sources');
 const allowMissing = process.argv.includes('--allow-missing');
-
-const platforms = [
-  {
-    name: '@vercel/vc-native-darwin-arm64',
-    asset: 'vercel-darwin-arm64',
-    os: ['darwin'],
-    cpu: ['arm64'],
-  },
-  {
-    name: '@vercel/vc-native-darwin-x64',
-    asset: 'vercel-darwin-x64',
-    os: ['darwin'],
-    cpu: ['x64'],
-  },
-  {
-    name: '@vercel/vc-native-linux-arm64',
-    asset: 'vercel-linux-arm64',
-    os: ['linux'],
-    cpu: ['arm64'],
-  },
-  {
-    name: '@vercel/vc-native-linux-x64',
-    asset: 'vercel-linux-x64',
-    os: ['linux'],
-    cpu: ['x64'],
-  },
-  {
-    name: '@vercel/vc-native-win32-x64',
-    asset: 'vercel-windows-x64.exe',
-    os: ['win32'],
-    cpu: ['x64'],
-    binary: 'vercel.exe',
-  },
-];
 
 if (checkSourcesOnly) {
   await stat(join(packageRoot, 'bin', 'vercel'));

--- a/utils/inject-native-optional-deps.mjs
+++ b/utils/inject-native-optional-deps.mjs
@@ -1,0 +1,94 @@
+// Wire the native per-platform packages onto `vercel` as optionalDependencies
+// immediately before it is packed and published.
+//
+// Why this exists:
+//   The @vercel/vc-native-<platform> packages are built on the fly during the
+//   release and are not workspace packages, so `packages/cli/package.json` has
+//   no optionalDependencies in source. Before `vercel` is packed, we pin those
+//   packages at the exact version being published so the published tarball
+//   resolves them at install time. `vc.js` walks node_modules for
+//   @vercel/vc-native-<platform>-<arch> and trampolines to it when present,
+//   falling back to the JS CLI otherwise.
+//
+// Safety:
+//   - No-op when this version of `vercel` is already on npm (i.e. this is not a
+//     publishing run), so it is safe to run on every release invocation.
+//   - Hard fails if the version is about to be published but any native package
+//     is missing from npm, so `vercel` is never published pointing at
+//     optionalDependencies that cannot resolve.
+
+import { execFile } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { platforms } from '../packages/vc-native/scripts/platforms.mjs';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const cliPackageJsonPath = join(repoRoot, 'packages', 'cli', 'package.json');
+
+const raw = await readFile(cliPackageJsonPath, 'utf8');
+const pkg = JSON.parse(raw);
+const version = pkg.version;
+
+if (await isPublished(`vercel@${version}`)) {
+  console.log(
+    `vercel@${version} is already on npm; skipping native optionalDependencies injection.`
+  );
+  process.exit(0);
+}
+
+const missing = [];
+for (const platform of platforms) {
+  const spec = `${platform.name}@${version}`;
+  if (!(await isPublished(spec))) {
+    missing.push(spec);
+  }
+}
+
+if (missing.length > 0) {
+  console.error(
+    `::error::Cannot publish vercel@${version}: missing native packages on npm:\n` +
+      missing.map(spec => `  - ${spec}`).join('\n') +
+      `\nThe binary release must publish these before vercel is packed.`
+  );
+  process.exit(1);
+}
+
+const optionalDependencies = {
+  ...(pkg.optionalDependencies ?? {}),
+};
+for (const platform of platforms) {
+  optionalDependencies[platform.name] = version;
+}
+pkg.optionalDependencies = sortKeys(optionalDependencies);
+
+// Preserve trailing newline behavior of the original file.
+const trailingNewline = raw.endsWith('\n') ? '\n' : '';
+await writeFile(
+  cliPackageJsonPath,
+  JSON.stringify(pkg, null, 2) + trailingNewline
+);
+
+console.log(
+  `Injected native optionalDependencies into packages/cli/package.json for vercel@${version}:`
+);
+for (const platform of platforms) {
+  console.log(`  - ${platform.name}@${version}`);
+}
+
+async function isPublished(spec) {
+  try {
+    await execFileAsync('npm', ['view', spec, 'version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sortKeys(object) {
+  return Object.fromEntries(
+    Object.entries(object).sort(([left], [right]) => left.localeCompare(right))
+  );
+}


### PR DESCRIPTION
## What

Restructure the release flow so the native `@vercel/vc-native-*` packages are built and published to npm **before** the changesets publish of `vercel`. This lets `vercel` carry the natives as `optionalDependencies` that resolve on the very first install.

Supersedes the WIP in #17087 (that branch is left untouched).

## Flow

```
push to main
  └─ determine   npm view vercel@<version>  →  not on npm ⇒ this run publishes vercel
  └─ binary      (if publishing) reusable release-binary.yml: matrix build → publish natives to npm
  └─ release     needs [determine, binary]: changesets publish
                   └─ ci:publish injects native optionalDependencies, then packs/publishes vercel
```

## Changes

- **release.yml**: new `determine` job detects whether this run publishes `vercel`; new `binary` gating job calls the reusable workflow; `release` now `needs: [determine, binary]` so `vercel` publishes only after its natives are on npm. Removed the old fire-and-forget `workflow_dispatch` trigger. `summary` surfaces each job result.
- **release-binary.yml**: converted to `workflow_call`; removed the unused GitHub Release asset upload + wait-for-release steps; simplified native npm publish.
- **utils/inject-native-optional-deps.mjs** (new): injects the native `optionalDependencies` into `packages/cli/package.json` at pack time, **hard failing** if any native package is missing from npm. Wired as the first step of `ci:publish`. No-op when `vercel@<version>` is already published.
- **packages/vc-native/scripts/platforms.mjs** (new): single source of truth for the native platform list, shared by `stage-packages.mjs` and the inject script.

## Verification

- `node --check` on all three mjs files: ok
- `stage-packages.mjs --allow-missing`: staged all 5 platforms + wrapper (refactor intact)
- inject script no-op path (`vercel@57.0.0`): exit 0, `packages/cli/package.json` byte-clean after
- inject script hard-fail path (fake unpublished version): exit 1 with missing-natives error
- `pnpm prettier --write` on touched files: all unchanged (already formatted)

Not machine-linted locally (no yaml parser / actionlint available) — relying on CI to validate the Actions YAML.