### PR TITLE
[cli] Shim: Defer WebSocket invocation finalization

### DIFF
--- a/.changeset/quiet-websockets-wait.md
+++ b/.changeset/quiet-websockets-wait.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow Next.js `after()` callbacks registered from WebSocket close handlers to run during `vc dev`.

--- a/packages/cli/src/util/dev/next-dev-websocket-shim-preload.cjs
+++ b/packages/cli/src/util/dev/next-dev-websocket-shim-preload.cjs
@@ -121,8 +121,12 @@ function emitWebSocketRequest({
         requestContext.run(context, () => {
           req.emit('aborted');
           abortController.abort();
-          closeResponse();
         });
+
+        // Next dev treats ServerResponse "close" as the end of its request
+        // lifecycle. Let ws emit its user-facing "close" event first so those
+        // callbacks can register after() work before Next drains that work.
+        setImmediate(() => requestContext.run(context, closeResponse));
       });
       socket.once('error', noop);
 

--- a/packages/cli/test/unit/util/dev/next-dev-websocket-shim-preload.test.ts
+++ b/packages/cli/test/unit/util/dev/next-dev-websocket-shim-preload.test.ts
@@ -105,6 +105,16 @@ describe('next dev websocket shim preload', () => {
     });
   });
 
+  it('lets socket close listeners register response-close work', async () => {
+    await expect(
+      runShimScenario('late-work-from-socket-close')
+    ).resolves.toMatchObject({
+      socketCloseRan: true,
+      responseCloseRan: true,
+      lateWorkDone: true,
+    });
+  });
+
   it('does not crash when the upgraded socket emits an error', async () => {
     await expect(
       runShimScenario('socket-error-after-upgrade')
@@ -292,6 +302,34 @@ const server = http.createServer((req, res) => {
       return;
     }
 
+    if (scenario === 'late-work-from-socket-close') {
+      const result = {
+        socketCloseRan: false,
+        responseCloseRan: false,
+        lateWorkDone: false,
+      };
+      const { socket } = consumeUpgrade();
+      socket.resume();
+
+      socket.once('close', () => {
+        result.socketCloseRan = true;
+        ctx.waitUntil(
+          new Promise(resolve => {
+            res.once('close', () => {
+              result.responseCloseRan = true;
+              setTimeout(() => {
+                result.lateWorkDone = true;
+                resolve();
+              }, 10);
+            });
+          })
+        );
+        setTimeout(() => finish(result), 30);
+      });
+      setTimeout(() => socket.destroy(), 10);
+      return;
+    }
+
     if (scenario === 'socket-error-after-upgrade') {
       const { socket } = consumeUpgrade();
       setImmediate(() => {
@@ -353,6 +391,14 @@ server.listen(0, '127.0.0.1', async () => {
 
     if (scenario === 'response-close-after-upgrade') {
       await websocketRequest(port, '/ws');
+      return;
+    }
+
+    if (scenario === 'late-work-from-socket-close') {
+      const client = net.createConnection({ host: '127.0.0.1', port });
+      client.on('error', () => {});
+      await once(client, 'connect');
+      client.write(upgradeRequest('/ws'));
       return;
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/vercel/functions/pull/3445. Makes the same change in the local vc dev shim for Next.js apps.