### PR TITLE
fix(cli): load gateway models in Codex picker

### DIFF
--- a/.changeset/codex-gateway-model-picker.md
+++ b/.changeset/codex-gateway-model-picker.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Configure Codex with command-backed Gateway authentication so its model picker loads the remote Gateway catalog.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
@@ -1,8 +1,8 @@
 import { join } from 'node:path';
 import type { AgentWarning, CodingAgent } from '../types';
-import { mergeToml, pathExists } from '../config-files';
+import { mergeToml, pathExists, removeTomlKeys } from '../config-files';
 import { isMacAppInstalled } from '../desktop-apps';
-import { GATEWAY_OPENAI_BASE_URL, GATEWAY_API_KEY_ENV } from '../gateway';
+import { GATEWAY_CODEX_BASE_URL, GATEWAY_API_KEY_ENV } from '../gateway';
 
 /** The Codex desktop app shares `~/.codex/config.toml` with the CLI. */
 const CODEX_DESKTOP_APP = 'Codex.app';
@@ -14,8 +14,10 @@ const CODEX_DESKTOP_APP = 'Codex.app';
  * rejected by current Codex). We deliberately do NOT pin a `model` — the user
  * keeps choosing their own. `wire_api` MUST be `responses` — Codex removed Chat
  * Completions support, and the gateway serves the Responses API at
- * `/v1/responses`. The key itself never lands in the TOML; `env_key` names an env
- * var Codex reads at runtime, so we also export it via the shell rc.
+ * `/v1/responses`. Command-backed auth makes Codex fetch the provider's remote
+ * model catalog for `/model`; `env_key` auth only exposes Codex's bundled
+ * models. The command reads the key from the environment, so the key itself
+ * never lands in the TOML and we continue to export it via the shell rc.
  *
  * Docs: https://vercel.com/docs/ai-gateway/coding-agents/openai-codex
  */
@@ -23,6 +25,31 @@ const CODEX_DESKTOP_APP = 'Codex.app';
 function codexDir(home: string): string {
   const dir = process.env.CODEX_HOME;
   return dir && dir.trim() ? dir : join(home, '.codex');
+}
+
+export function codexAuthConfig(platform: NodeJS.Platform = process.platform): {
+  command: string;
+  args: string[];
+  refresh_interval_ms: number;
+} {
+  if (platform === 'win32') {
+    return {
+      command: 'powershell.exe',
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `[Console]::Out.Write($env:${GATEWAY_API_KEY_ENV})`,
+      ],
+      refresh_interval_ms: 0,
+    };
+  }
+  return {
+    command: '/bin/sh',
+    args: ['-c', `printf '%s' "$${GATEWAY_API_KEY_ENV}"`],
+    refresh_interval_ms: 0,
+  };
 }
 
 export const codex: CodingAgent = {
@@ -63,23 +90,27 @@ export const codex: CodingAgent = {
           path,
           label: 'Codex config',
           format: 'toml',
-          transform: current =>
-            mergeToml(current, {
+          transform: current => {
+            const withoutEnvKey = removeTomlKeys(current, [
+              ['model_providers', 'vercel', 'env_key'],
+            ]);
+            return mergeToml(withoutEnvKey, {
               model_provider: 'vercel',
               model_providers: {
                 vercel: {
                   name: 'Vercel AI Gateway',
-                  base_url: GATEWAY_OPENAI_BASE_URL,
-                  env_key: GATEWAY_API_KEY_ENV,
+                  base_url: GATEWAY_CODEX_BASE_URL,
+                  auth: codexAuthConfig(),
                   wire_api: 'responses',
                 },
               },
-            }),
+            });
+          },
         },
       ],
       envExports: [{ name: GATEWAY_API_KEY_ENV, value: ctx.apiKey }],
       notes: [
-        'Codex now defaults to the Vercel AI Gateway; pick a model with --model or in config.',
+        'Codex now defaults to the Vercel AI Gateway; pick a model with /model, --model, or in config.',
         `Open a new terminal so ${GATEWAY_API_KEY_ENV} is loaded, or run: export ${GATEWAY_API_KEY_ENV}=<key>`,
       ],
     };

--- a/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
@@ -156,6 +156,10 @@ function patchSatisfied(existing: unknown, patch: JsonObject): boolean {
 }
 
 function tomlScalar(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    const items = value.map(tomlScalar);
+    return items.some(item => item === null) ? null : `[${items.join(', ')}]`;
+  }
   switch (typeof value) {
     case 'string':
       // A JSON string is a valid TOML basic string.
@@ -212,6 +216,93 @@ function flattenTomlPatch(
 }
 
 const TOML_HEADER = /^\s*\[\[?\s*([^\]]*?)\s*\]\]?\s*(?:#.*)?$/;
+
+/**
+ * Remove nested TOML keys while preserving the user's formatting whenever the
+ * keys are ordinary assignments inside ordinary tables. Exotic layouts (for
+ * example inline tables or assignment-lookalikes inside multi-line strings)
+ * fall back to a verified full rewrite.
+ */
+export function removeTomlKeys(
+  current: string | null,
+  paths: readonly (readonly string[])[]
+): string | null {
+  if (!current || !current.trim() || paths.length === 0) {
+    return current;
+  }
+
+  let parsed: JsonObject;
+  try {
+    parsed = tomlParse(current) as JsonObject;
+  } catch (err) {
+    throw new Error(
+      `existing file is not valid TOML (${(err as Error).message})`
+    );
+  }
+
+  let changed = false;
+  for (const path of paths) {
+    if (path.length === 0) {
+      continue;
+    }
+    let parent: JsonObject = parsed;
+    for (const segment of path.slice(0, -1)) {
+      const child = parent[segment];
+      if (!isPlainObject(child)) {
+        parent = {};
+        break;
+      }
+      parent = child;
+    }
+    const key = path[path.length - 1];
+    if (Object.prototype.hasOwnProperty.call(parent, key)) {
+      delete parent[key];
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return current;
+  }
+
+  let section = '';
+  const pathKeys = new Map<string, Set<string>>();
+  for (const path of paths) {
+    if (path.length === 0) {
+      continue;
+    }
+    const table = path.slice(0, -1).join('.');
+    const keys = pathKeys.get(table) ?? new Set<string>();
+    keys.add(path[path.length - 1]);
+    pathKeys.set(table, keys);
+  }
+
+  const lines = current.split('\n').filter(line => {
+    const header = line.match(TOML_HEADER);
+    if (header) {
+      section = header[1]
+        .split('.')
+        .map(segment => segment.trim())
+        .join('.');
+      return true;
+    }
+    const keys = pathKeys.get(section);
+    if (!keys) {
+      return true;
+    }
+    return ![...keys].some(key => new RegExp(`^\\s*${key}\\s*=`).test(line));
+  });
+  const result = lines.join('\n');
+
+  try {
+    if (isDeepStrictEqual(tomlParse(result), parsed)) {
+      return result;
+    }
+  } catch {
+    // fall through to a verified full rewrite
+  }
+  return `${tomlStringify(parsed)}\n`;
+}
 
 /**
  * The user's file is edited line by line, never re-serialized: assignments the

--- a/packages/cli/src/util/ai-gateway/coding-agents/gateway.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/gateway.ts
@@ -1,4 +1,5 @@
 export const GATEWAY_OPENAI_BASE_URL = 'https://ai-gateway.vercel.sh/v1';
+export const GATEWAY_CODEX_BASE_URL = 'https://ai-gateway.vercel.sh/codex/v1';
 export const GATEWAY_ANTHROPIC_BASE_URL = 'https://ai-gateway.vercel.sh';
 
 export const GATEWAY_API_KEY_ENV = 'AI_GATEWAY_API_KEY';

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -32,11 +32,15 @@ import { renderDiff } from '../../../../src/util/ai-gateway/coding-agents/diff';
 import {
   mergeJson,
   mergeToml,
+  removeTomlKeys,
   upsertManagedBlock,
 } from '../../../../src/util/ai-gateway/coding-agents/config-files';
 import { useTeam } from '../../../mocks/team';
 import { claudeCode } from '../../../../src/util/ai-gateway/coding-agents/agents/claude-code';
-import { codex } from '../../../../src/util/ai-gateway/coding-agents/agents/codex';
+import {
+  codex,
+  codexAuthConfig,
+} from '../../../../src/util/ai-gateway/coding-agents/agents/codex';
 import { opencode } from '../../../../src/util/ai-gateway/coding-agents/agents/opencode';
 import {
   isKeychainAvailable,
@@ -240,10 +244,13 @@ describe('ai-gateway coding-agents setup', () => {
         // We never pin a default model — only the provider/URL/auth are set up.
         expect(toml.model).toBeUndefined();
         expect(toml.model_providers.vercel.base_url).toBe(
-          'https://ai-gateway.vercel.sh/v1'
+          'https://ai-gateway.vercel.sh/codex/v1'
         );
         expect(toml.model_providers.vercel.wire_api).toBe('responses');
-        expect(toml.model_providers.vercel.env_key).toBe('AI_GATEWAY_API_KEY');
+        expect(toml.model_providers.vercel.env_key).toBeUndefined();
+        expect(toml.model_providers.vercel.auth).toEqual(
+          codexAuthConfig(process.platform)
+        );
 
         const bashrc = readFileSync(bashrcPath(), 'utf8');
         expect(bashrc).toContain('# >>> vercel ai-gateway >>>');
@@ -1914,6 +1921,23 @@ describe('ai-gateway coding-agents setup', () => {
       expect(() => mergeToml('model = [unclosed', { a: 1 })).toThrow(
         /existing file is not valid TOML/
       );
+    });
+
+    it('removes a nested key without changing unrelated TOML', () => {
+      const current = [
+        'model = "gpt-5.5"  # my pick',
+        '',
+        '[model_providers.vercel]',
+        'env_key = "AI_GATEWAY_API_KEY"',
+        'query_params = "keep"',
+        '',
+      ].join('\n');
+      const next = removeTomlKeys(current, [
+        ['model_providers', 'vercel', 'env_key'],
+      ]);
+      expect(next).toContain('model = "gpt-5.5"  # my pick');
+      expect(next).toContain('query_params = "keep"');
+      expect(next).not.toContain('env_key');
     });
 
     it('never corrupts a multi-line string that looks like an assignment', () => {

--- a/packages/cli/test/unit/util/ai-gateway/codex-agent.test.ts
+++ b/packages/cli/test/unit/util/ai-gateway/codex-agent.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { parse as tomlParse } from 'smol-toml';
+import {
+  codex,
+  codexAuthConfig,
+} from '../../../../src/util/ai-gateway/coding-agents/agents/codex';
+
+describe('Codex AI Gateway setup', () => {
+  it('uses command-backed auth so Codex fetches the remote model catalog', () => {
+    const plan = codex.buildPlan({
+      apiKey: 'vck_TestKey',
+      home: '/home/test',
+    });
+    const config = tomlParse(plan.fileChanges[0].transform(null)) as Record<
+      string,
+      any
+    >;
+
+    expect(config.model_provider).toBe('vercel');
+    expect(config.model_providers.vercel.base_url).toBe(
+      'https://ai-gateway.vercel.sh/codex/v1'
+    );
+    expect(config.model_providers.vercel.env_key).toBeUndefined();
+    expect(config.model_providers.vercel.auth).toEqual(
+      codexAuthConfig(process.platform)
+    );
+    expect(plan.envExports).toEqual([
+      { name: 'AI_GATEWAY_API_KEY', value: 'vck_TestKey' },
+    ]);
+  });
+
+  it('migrates env_key auth without clobbering user settings', () => {
+    const current = [
+      'model = "openai/gpt-5.4"  # keep my model',
+      '',
+      '[model_providers.vercel]',
+      'name = "Old name"',
+      'env_key = "AI_GATEWAY_API_KEY"',
+      'query_params = "keep"',
+      '',
+    ].join('\n');
+    const plan = codex.buildPlan({
+      apiKey: 'vck_TestKey',
+      home: '/home/test',
+    });
+    const next = plan.fileChanges[0].transform(current);
+    const config = tomlParse(next) as Record<string, any>;
+
+    expect(next).toContain('model = "openai/gpt-5.4"  # keep my model');
+    expect(config.model_providers.vercel.query_params).toBe('keep');
+    expect(config.model_providers.vercel.env_key).toBeUndefined();
+    expect(config.model_providers.vercel.auth).toEqual(
+      codexAuthConfig(process.platform)
+    );
+  });
+
+  it('uses platform-native commands without writing the key to TOML', () => {
+    expect(codexAuthConfig('linux')).toEqual({
+      command: '/bin/sh',
+      args: ['-c', `printf '%s' "$AI_GATEWAY_API_KEY"`],
+      refresh_interval_ms: 0,
+    });
+    expect(codexAuthConfig('win32')).toEqual({
+      command: 'powershell.exe',
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        '[Console]::Out.Write($env:AI_GATEWAY_API_KEY)',
+      ],
+      refresh_interval_ms: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- point Codex setup at the Gateway's Codex-compatible `/codex/v1` surface
- use command-backed auth so Codex refreshes the remote model catalog
- migrate existing `env_key` setups without writing the Gateway key to TOML
- preserve user TOML formatting while adding auth command arguments

## Root cause

Codex does not fetch a custom provider's `/models` catalog when the provider only uses `env_key`. Command-backed auth enables the remote catalog refresh. The provider must also use `/codex/v1`, because the standard `/v1/models` response has the OpenAI catalog shape instead of Codex's `ModelInfo` shape.

This is the CLI companion to [vercel/ai-gateway#2825](https://github.com/vercel/ai-gateway/pull/2825), which adds backward-compatible catalog fields required by Codex 0.137.

## Validation

- [x] focused Codex setup tests
- [x] Biome lint on changed files
- [x] targeted TypeScript check
- [x] exact generated auth command verified with Codex 0.145
- [x] Codex fetched and cached all 197 preview models
- [x] interactive picker selected OpenAI, Anthropic, and Google models through Computer Use
