### PR TITLE
[@vercel/firewall] document rate limit key defaults/overrides

### DIFF
--- a/.changeset/firewall-rate-limit-docs.md
+++ b/.changeset/firewall-rate-limit-docs.md
@@ -1,0 +1,5 @@
+---
+'@vercel/firewall': patch
+---
+
+Clarify rate limit key documentation and remove `x-real-ip` implementation detail from error message.

--- a/packages/firewall/docs/functions/checkRateLimit.md
+++ b/packages/firewall/docs/functions/checkRateLimit.md
@@ -40,7 +40,7 @@ The headers for the current request. Optional.
 
 `string`
 
-The key to use for rate-limiting. If not defined, defaults to the user's IP address.
+The entity being rate limited. Defaults to the client IP.
 
 #### request?
 

--- a/packages/firewall/src/rate-limit.ts
+++ b/packages/firewall/src/rate-limit.ts
@@ -31,7 +31,7 @@ export async function checkRateLimit(
   options?: {
     /** The host name on which the rate limit rules are defined */
     firewallHostForDevelopment?: string;
-    /** The key to use for rate-limiting. If not defined, defaults to the user's IP address. */
+    /** The entity being rate limited. Defaults to the client IP. */
     rateLimitKey?: string;
     /** The headers for the current request. Optional.  */
     headers?:
@@ -85,7 +85,7 @@ export async function checkRateLimit(
     fullRateLimitKey = requestHeaders.get('x-real-ip') || undefined;
     if (!fullRateLimitKey) {
       throw new Error(
-        'Could not determine rate limit key. `rateLimitKey` option is not provided, and `x-real-ip` header is not present in the request.'
+        'Could not determine rate limit key. `rateLimitKey` option is not provided and the client IP is not available.'
       );
     }
   }


### PR DESCRIPTION
# Problem

The `@vercel/firewall` checkRateLimit function accepts an optional key that defaults to the client IP; setting a custom rate limit key removes the client IP from the key entirely. Users have mistaken that such a rate limit would be IP + <rateLimitKey> and the documentation is vague.

# Solution

Indicate that the rate limit key _defaults_ to the client IP, and does not include the client IP when manually set.
