### PR TITLE
Fix teams members pagination

### DIFF
--- a/.changeset/fix-teams-members-pagination.md
+++ b/.changeset/fix-teams-members-pagination.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix pagination for the `vercel teams members` command.

--- a/packages/cli/src/commands/teams/members.ts
+++ b/packages/cli/src/commands/teams/members.ts
@@ -83,7 +83,7 @@ export default async function members(
 
   const query = new URLSearchParams({ limit: String(limit ?? 20) });
   if (next) {
-    query.set('next', String(next));
+    query.set('until', String(next));
   }
 
   const result = await client.fetch<TeamMembersResponse>(

--- a/packages/cli/test/unit/commands/teams/members.test.ts
+++ b/packages/cli/test/unit/commands/teams/members.test.ts
@@ -41,6 +41,26 @@ describe('teams members', () => {
     ]);
   });
 
+  it('uses the next timestamp as the API until cursor', async () => {
+    client.config.currentTeam = 'team_123';
+    client.scenario.get('/v2/teams/:teamId/members', (req, res) => {
+      expect(req.query.until).toBe('1584722256178');
+      expect(req.query.next).toBeUndefined();
+      res.json({
+        members: [],
+        pagination: {
+          count: 0,
+          next: null,
+          prev: 1584722256178,
+        },
+      });
+    });
+    client.setArgv('teams', 'members', '--next', '1584722256178');
+
+    const exitCode = await teams(client);
+    expect(exitCode).toBe(0);
+  });
+
   it('outputs valid JSON with --format json', async () => {
     client.config.currentTeam = 'team_123';
     client.scenario.get('/v2/teams/:teamId/members', (_req, res) => {


### PR DESCRIPTION
## Summary

- send the members pagination cursor using the API’s `until` parameter
- add regression coverage for `--next`

## Testing

- `vercel teams members --next 1783966948541` now returns different correct results from `vercel teams members` when run locally
- `pnpm test test/unit/commands/teams/members.test.ts`
- `pnpm type-check`
- `pnpm lint`