### PR TITLE
[cli] Make vc logs branch filtering opt-in

### DIFF
--- a/.changeset/logs-branch-opt-in.md
+++ b/.changeset/logs-branch-opt-in.md
@@ -1,0 +1,9 @@
+---
+'vercel': minor
+---
+
+`vc logs` no longer filters by the current git branch, and `vc logs --follow` no longer prefers the current branch's deployment — matching the Vercel dashboard, which shows all branches by default.
+
+- Use `--branch <name>` to filter, or `--branch $(git branch --show-current)` to restore the previous behavior.
+- With no deployment specified, `--follow` now streams the latest production deployment. Use `--environment preview`, `--branch <name>`, or a deployment URL to stream something else.
+- `--no-branch` is still accepted but no longer does anything.

--- a/.changeset/logs-branch-opt-in.md
+++ b/.changeset/logs-branch-opt-in.md
@@ -4,6 +4,6 @@
 
 `vc logs` no longer filters by the current git branch, and `vc logs --follow` no longer prefers the current branch's deployment — matching the Vercel dashboard, which shows all branches by default.
 
-- Use `--branch <name>` to filter, or `--branch $(git branch --show-current)` to restore the previous behavior.
-- With no deployment specified, `--follow` now streams the latest production deployment. Use `--environment preview`, `--branch <name>`, or a deployment URL to stream something else.
+- Use `--branch <name>` to filter strictly; `--follow` returns an error when no READY deployment matches. Use `--branch $(git branch --show-current)` to restore the previous default branch selection.
+- With no deployment, branch, or environment specified, `--follow` now prefers the latest production deployment and falls back to your latest READY deployment. Use `--environment production` to require production, or use `--environment preview`, `--branch <name>`, or a deployment URL to select another deployment.
 - `--no-branch` is still accepted but no longer does anything.

--- a/.changeset/logs-branch-opt-in.md
+++ b/.changeset/logs-branch-opt-in.md
@@ -2,8 +2,10 @@
 'vercel': minor
 ---
 
-`vc logs` no longer filters by the current git branch, and `vc logs --follow` no longer prefers the current branch's deployment — matching the Vercel dashboard, which shows all branches by default.
+`vc logs` no longer filters by the current git branch and shows all branches by default. Use `--branch <name>` to filter, or `--branch $(git branch --show-current)` for the previous default.
 
-- Use `--branch <name>` to filter strictly; `--follow` returns an error when no READY deployment matches. Use `--branch $(git branch --show-current)` to restore the previous default branch selection.
-- With no deployment, branch, or environment specified, `--follow` now prefers the latest production deployment and falls back to your latest READY deployment. Use `--environment production` to require production, or use `--environment preview`, `--branch <name>`, or a deployment URL to select another deployment.
-- `--no-branch` is still accepted but no longer does anything.
+`vc logs --follow` no longer considers the current git branch when choosing a deployment. With no deployment, branch, or environment specified it now streams the latest production deployment, falling back to your latest READY deployment. To stream a preview you just deployed, pass the deployment URL that `vc deploy` prints, or use `--environment preview`.
+
+`--branch` now composes with `--environment` under `--follow`, and errors if no READY deployment matches instead of silently falling back to a different deployment.
+
+`--no-branch` is still accepted but no longer does anything.

--- a/.changeset/logs-branch-opt-in.md
+++ b/.changeset/logs-branch-opt-in.md
@@ -2,10 +2,10 @@
 'vercel': minor
 ---
 
-`vc logs` no longer filters by the current git branch and shows all branches by default. Use `--branch <name>` to filter, or `--branch $(git branch --show-current)` for the previous default.
+`vc logs` now displays request logs from all branches by default. Use `--branch <name>` to filter by branch. To preserve the previous behavior, pass the current branch name explicitly.
 
-`vc logs --follow` no longer considers the current git branch when choosing a deployment. With no deployment, branch, or environment specified it now streams the latest production deployment, falling back to your latest READY deployment. To stream a preview you just deployed, pass the deployment URL that `vc deploy` prints, or use `--environment preview`.
+`vc logs --follow` now streams the latest READY production deployment by default. If none exists, it falls back to your latest READY deployment. Use `--environment preview`, `--branch <name>`, or a deployment URL or ID to select another deployment.
 
-`--branch` now composes with `--environment` under `--follow`, and errors if no READY deployment matches instead of silently falling back to a different deployment.
+With `--follow`, `--branch` and `--environment` filter the deployment together. If no READY deployment matches both filters, the command returns an error instead of falling back to another branch or environment.
 
-`--no-branch` is still accepted but no longer does anything.
+The deprecated `--no-branch` flag remains accepted as a no-op.

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -145,8 +145,8 @@ export const logsCommand = {
       name: 'no-branch',
       shorthand: null,
       type: Boolean,
-      deprecated: false,
-      description: 'Disable auto-detection of git branch',
+      deprecated: true,
+      description: 'No-op; branch filtering only applies when --branch is set',
     },
   ],
   examples: [

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -10,7 +10,7 @@ export const logsCommand = {
   aliases: ['log'],
   description:
     'Display request logs for a project.\n\n' +
-    'With --follow, stream live runtime logs from a deployment. When no deployment is specified, streams the latest production deployment. Use --environment preview, --branch, or a deployment URL/ID for anything else.\n\n' +
+    'With --follow, stream live runtime logs from a deployment. With no deployment, branch, or environment specified, prefer the latest production deployment and fall back to your latest READY deployment. Use --environment production to require production, or use --environment preview, --branch, or a deployment URL/ID to select another deployment.\n\n' +
     'Source types: λ = serverless, ε = edge/middleware, ◇ = static/external',
   arguments: [
     {
@@ -34,7 +34,7 @@ export const logsCommand = {
       type: String,
       deprecated: false,
       description:
-        'Filter by environment: production or preview. With --follow, selects which environment to stream (production always streams the latest production deployment)',
+        'Filter by environment: production or preview. With --follow, select which environment to stream',
     },
     {
       name: 'level',
@@ -92,7 +92,7 @@ export const logsCommand = {
       type: Boolean,
       deprecated: false,
       description:
-        'Stream live runtime logs. Without a deployment, follows the latest production deployment; use --environment preview, --branch, or a deployment URL/ID for anything else',
+        'Stream live runtime logs. With no deployment, branch, or environment specified, prefer the latest production deployment and fall back to your latest READY deployment',
     },
     {
       name: 'no-follow',
@@ -138,7 +138,8 @@ export const logsCommand = {
       shorthand: 'b',
       type: String,
       deprecated: false,
-      description: 'Filter by git branch',
+      description:
+        'Filter by git branch; with --follow, require a READY deployment on that branch',
     },
     {
       name: 'no-branch',

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -34,7 +34,7 @@ export const logsCommand = {
       type: String,
       deprecated: false,
       description:
-        'Filter by environment: production or preview. With --follow, select which environment to stream',
+        'Filter by environment: production or preview. With --follow, selects the deployment to stream: production uses the latest production deployment, preview uses your latest preview deployment',
     },
     {
       name: 'level',
@@ -151,47 +151,27 @@ export const logsCommand = {
   ],
   examples: [
     {
-      name: 'Stream live logs for the latest production deployment',
-      value: `${packageName} logs --follow`,
-    },
-    {
-      name: 'Stream live logs for your latest preview deployment',
-      value: `${packageName} logs --follow --environment preview`,
-    },
-    {
-      name: 'Stream live logs for the latest production deployment',
-      value: `${packageName} logs --follow --environment production`,
-    },
-    {
-      name: 'Stream live logs for a deployment URL',
-      value: `${packageName} logs https://my-app-xxxxx.vercel.app --follow`,
-    },
-    {
-      name: 'Stream live logs for a deployment ID',
-      value: `${packageName} logs dpl_xxxxx --follow`,
-    },
-    {
-      name: 'Stream logs for a specific project',
-      value: `${packageName} logs --project my-app --follow`,
-    },
-    {
-      name: 'Display recent logs for the linked project',
+      name: 'Display recent request logs for the linked project',
       value: `${packageName} logs`,
     },
     {
-      name: 'Display error logs from the last hour',
+      name: 'Display request logs for a specific project',
+      value: `${packageName} logs --project my-app`,
+    },
+    {
+      name: 'Display request error logs from the last hour',
       value: `${packageName} logs --level error --since 1h`,
     },
     {
-      name: 'Display logs for a specific deployment (historical)',
+      name: 'Display request logs for a specific deployment',
       value: `${packageName} logs dpl_xxxxx`,
     },
     {
-      name: 'Filter logs by status code and output as JSON',
+      name: 'Filter request logs by status code and output as JSON',
       value: `${packageName} logs --status-code 500 --json`,
     },
     {
-      name: 'Search logs and pipe to jq',
+      name: 'Search request logs and pipe to jq',
       value: `${packageName} logs --query "timeout" --json | jq '.message'`,
     },
     {
@@ -199,24 +179,28 @@ export const logsCommand = {
       value: `${packageName} logs --query 'status:500 error' --json | jq '.message'`,
     },
     {
-      name: 'Display production logs only',
+      name: 'Display production request logs only',
       value: `${packageName} logs --environment production`,
     },
     {
-      name: 'Display logs for a specific request',
+      name: 'Display request logs for a specific request',
       value: `${packageName} logs --request-id req_xxxxx`,
     },
     {
-      name: 'Display logs with full message details',
+      name: 'Display request logs with full message details',
       value: `${packageName} logs --expand`,
     },
     {
-      name: 'Display logs for a specific branch',
+      name: 'Display request logs for a specific branch',
       value: `${packageName} logs --branch feature-x`,
     },
     {
-      name: 'Display logs for the current git branch',
-      value: `${packageName} logs --branch $(git branch --show-current)`,
+      name: 'Stream runtime logs for the latest production deployment',
+      value: `${packageName} logs --follow`,
+    },
+    {
+      name: 'Stream runtime logs for your latest preview deployment',
+      value: `${packageName} logs --follow --environment preview`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -10,7 +10,7 @@ export const logsCommand = {
   aliases: ['log'],
   description:
     'Display request logs for a project.\n\n' +
-    'With --follow, stream live runtime logs from a deployment. When no deployment is specified, resolves in order: latest deployment on the current git branch, then your latest deployment, then the latest production deployment. Use --environment production to always stream the latest production deployment.\n\n' +
+    'With --follow, stream live runtime logs from a deployment. When no deployment is specified, streams the latest production deployment. Use --environment preview, --branch, or a deployment URL/ID for anything else.\n\n' +
     'Source types: λ = serverless, ε = edge/middleware, ◇ = static/external',
   arguments: [
     {
@@ -92,7 +92,7 @@ export const logsCommand = {
       type: Boolean,
       deprecated: false,
       description:
-        'Stream live runtime logs. Without a deployment, follows the latest deployment on the current git branch, then your latest deployment, then the latest production deployment',
+        'Stream live runtime logs. Without a deployment, follows the latest production deployment; use --environment preview, --branch, or a deployment URL/ID for anything else',
     },
     {
       name: 'no-follow',
@@ -138,8 +138,7 @@ export const logsCommand = {
       shorthand: 'b',
       type: String,
       deprecated: false,
-      description:
-        'Filter by git branch (defaults to current branch for a linked project)',
+      description: 'Filter by git branch',
     },
     {
       name: 'no-branch',
@@ -151,8 +150,12 @@ export const logsCommand = {
   ],
   examples: [
     {
-      name: 'Stream live logs for your most recent deployment',
+      name: 'Stream live logs for the latest production deployment',
       value: `${packageName} logs --follow`,
+    },
+    {
+      name: 'Stream live logs for your latest preview deployment',
+      value: `${packageName} logs --follow --environment preview`,
     },
     {
       name: 'Stream live logs for the latest production deployment',
@@ -211,8 +214,8 @@ export const logsCommand = {
       value: `${packageName} logs --branch feature-x`,
     },
     {
-      name: 'Display logs for all branches (disable auto-detection)',
-      value: `${packageName} logs --no-branch`,
+      name: 'Display logs for the current git branch',
+      value: `${packageName} logs --branch $(git branch --show-current)`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -10,7 +10,7 @@ export const logsCommand = {
   aliases: ['log'],
   description:
     'Display request logs for a project.\n\n' +
-    'With --follow, stream live runtime logs from a deployment. With no deployment, branch, or environment specified, prefer the latest production deployment and fall back to your latest READY deployment. Use --environment production to require production, or use --environment preview, --branch, or a deployment URL/ID to select another deployment.\n\n' +
+    'Use --follow to stream live runtime logs from a deployment. By default, --follow prefers the latest READY production deployment and falls back to your latest READY deployment.\n\n' +
     'Source types: λ = serverless, ε = edge/middleware, ◇ = static/external',
   arguments: [
     {
@@ -34,7 +34,7 @@ export const logsCommand = {
       type: String,
       deprecated: false,
       description:
-        'Filter by environment: production or preview. With --follow, selects the deployment to stream: production uses the latest production deployment, preview uses your latest preview deployment',
+        'Filter by environment: production or preview; with --follow, select the latest production deployment or your latest preview deployment',
     },
     {
       name: 'level',
@@ -91,8 +91,7 @@ export const logsCommand = {
       shorthand: 'f',
       type: Boolean,
       deprecated: false,
-      description:
-        'Stream live runtime logs. With no deployment, branch, or environment specified, prefer the latest production deployment and fall back to your latest READY deployment',
+      description: 'Stream live runtime logs from a deployment',
     },
     {
       name: 'no-follow',
@@ -139,14 +138,14 @@ export const logsCommand = {
       type: String,
       deprecated: false,
       description:
-        'Filter by git branch; with --follow, require a READY deployment on that branch',
+        'Filter by Git branch; with --follow, require a matching READY deployment',
     },
     {
       name: 'no-branch',
       shorthand: null,
       type: Boolean,
       deprecated: true,
-      description: 'No-op; branch filtering only applies when --branch is set',
+      description: 'Deprecated no-op; use --branch to filter by branch',
     },
   ],
   examples: [
@@ -171,15 +170,11 @@ export const logsCommand = {
       value: `${packageName} logs --status-code 500 --json`,
     },
     {
-      name: 'Search request logs and pipe to jq',
-      value: `${packageName} logs --query "timeout" --json | jq '.message'`,
-    },
-    {
-      name: 'Use advanced search query with filters',
+      name: 'Search request logs by status and message',
       value: `${packageName} logs --query 'status:500 error' --json | jq '.message'`,
     },
     {
-      name: 'Display production request logs only',
+      name: 'Display request logs from production',
       value: `${packageName} logs --environment production`,
     },
     {
@@ -201,6 +196,10 @@ export const logsCommand = {
     {
       name: 'Stream runtime logs for your latest preview deployment',
       value: `${packageName} logs --follow --environment preview`,
+    },
+    {
+      name: 'Stream runtime logs for a specific deployment',
+      value: `${packageName} logs dpl_xxxxx --follow`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -114,7 +114,36 @@ async function resolveFollowDeployment({
     return { deploymentId: deployment.id, label: 'deployment' };
   }
 
-  // 2. --environment production → latest READY production, else error
+  // 2. Explicit --branch → latest matching READY deployment, else error
+  if (branch) {
+    output.spinner(`Finding latest deployment for branch "${branch}"`, 1000);
+    const branchDeployment = await getLatestDeployment(client, projectId, {
+      branch,
+      target: environment,
+    });
+    output.stopSpinner();
+
+    if (branchDeployment) {
+      output.debug(
+        `Found deployment ${branchDeployment.id} for branch ${branch}`
+      );
+      return {
+        deploymentId: branchDeployment.id,
+        label: `latest deployment on branch "${branch}"`,
+      };
+    }
+
+    const environmentLabel = environment ? ` ${environment}` : '';
+    const deployHint = environment
+      ? `Deploy that branch to ${environment} first`
+      : 'Deploy that branch first';
+    output.error(
+      `No READY${environmentLabel} deployments found for branch "${branch}" in ${formatProject(orgSlug, projectSlug)}. ${deployHint} or specify a deployment with ${chalk.bold('--deployment')}.`
+    );
+    return { exitCode: 1 };
+  }
+
+  // 3. --environment production → latest READY production, else error
   if (environment === 'production') {
     output.spinner('Finding latest production deployment', 1000);
     const productionDeployment = await getLatestDeployment(client, projectId, {
@@ -136,30 +165,6 @@ async function resolveFollowDeployment({
       deploymentId: productionDeployment.id,
       label: 'latest production deployment',
     };
-  }
-
-  const target = environment;
-
-  // 3. Explicit --branch only → latest READY on that branch (target = --environment)
-  if (branch) {
-    output.spinner(`Finding latest deployment for branch "${branch}"`, 1000);
-    const branchDeployment = await getLatestDeployment(client, projectId, {
-      branch,
-      target,
-    });
-    output.stopSpinner();
-
-    if (branchDeployment) {
-      output.debug(
-        `Found deployment ${branchDeployment.id} for branch ${branch}`
-      );
-      return {
-        deploymentId: branchDeployment.id,
-        label: `latest deployment on branch "${branch}"`,
-      };
-    }
-
-    output.debug(`No deployments found for branch "${branch}"`);
   }
 
   // 4. --environment preview → your latest READY preview, else error

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -3,7 +3,6 @@ import type { Deployment } from '@vercel-internals/types';
 import chalk from 'chalk';
 import format from 'date-fns/format';
 import type Client from '../../util/client';
-import { createGitMeta } from '../../util/create-git-meta';
 import { printError } from '../../util/error';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -89,42 +88,6 @@ async function getLatestDeployment(
     id: deployments[0].uid,
     url: deployments[0].url,
   };
-}
-
-interface ResolveBranchFilterOptions {
-  client: Client;
-  explicitBranch?: string;
-  logsTarget: LogsTarget;
-  noBranch?: boolean;
-}
-
-async function resolveBranchFilter({
-  client,
-  explicitBranch,
-  logsTarget,
-  noBranch,
-}: ResolveBranchFilterOptions): Promise<string | undefined> {
-  if (explicitBranch) {
-    return explicitBranch;
-  }
-
-  if (
-    noBranch ||
-    logsTarget.deployment ||
-    logsTarget.targetSource !== 'linked-project'
-  ) {
-    return;
-  }
-
-  try {
-    const gitMeta = await createGitMeta(client.cwd);
-    if (gitMeta?.commitRef) {
-      output.debug(`Detected git branch: ${gitMeta.commitRef}`);
-      return gitMeta.commitRef;
-    }
-  } catch {
-    // Not in a git repo or git not available, continue without branch filter
-  }
 }
 
 interface ResolveFollowDeploymentOptions {
@@ -681,18 +644,8 @@ export default async function logs(client: Client) {
     return 1;
   }
 
-  // Determine branch filter:
-  // - If --branch is explicitly set (string), use it
-  // - If --no-branch is set, don't filter by branch
-  // - Otherwise, auto-detect the current git branch only for a linked project
-  const noBranchFlagValue = parsedArguments.flags['--no-branch'];
-  const branchOption = await resolveBranchFilter({
-    client,
-    explicitBranch:
-      typeof branchFlagValue === 'string' ? branchFlagValue : undefined,
-    logsTarget,
-    noBranch: noBranchFlagValue,
-  });
+  const branchOption =
+    typeof branchFlagValue === 'string' ? branchFlagValue : undefined;
 
   if (
     environmentOption &&

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -109,10 +109,12 @@ async function resolveFollowDeployment({
 }: ResolveFollowDeploymentOptions): Promise<ResolveFollowDeploymentResult> {
   const { deployment, orgSlug, projectId, projectSlug } = logsTarget;
 
+  // 1. Explicit --deployment / positional
   if (deployment?.id) {
     return { deploymentId: deployment.id, label: 'deployment' };
   }
 
+  // 2. --environment production → latest READY production, else error
   if (environment === 'production') {
     output.spinner('Finding latest production deployment', 1000);
     const productionDeployment = await getLatestDeployment(client, projectId, {
@@ -138,6 +140,7 @@ async function resolveFollowDeployment({
 
   const target = environment;
 
+  // 3. Explicit --branch only → latest READY on that branch (target = --environment)
   if (branch) {
     output.spinner(`Finding latest deployment for branch "${branch}"`, 1000);
     const branchDeployment = await getLatestDeployment(client, projectId, {
@@ -159,11 +162,54 @@ async function resolveFollowDeployment({
     output.debug(`No deployments found for branch "${branch}"`);
   }
 
+  // 4. --environment preview → your latest READY preview, else error
+  if (environment === 'preview') {
+    const user = await getUser(client);
+    output.spinner('Finding your latest deployment', 1000);
+    const userDeployment = await getLatestDeployment(client, projectId, {
+      userId: user.id,
+      target: 'preview',
+    });
+    output.stopSpinner();
+
+    if (userDeployment) {
+      output.debug(
+        `Found latest deployment ${userDeployment.id} (${userDeployment.url}) created by current user`
+      );
+      return {
+        deploymentId: userDeployment.id,
+        label: 'your latest deployment',
+      };
+    }
+
+    output.error(
+      `No READY preview deployments found for ${formatProject(orgSlug, projectSlug)}. Deploy a preview first or specify a deployment with ${chalk.bold('--deployment')}.`
+    );
+    return { exitCode: 1 };
+  }
+
+  // 5. No environment specified → latest READY production, if found
+  output.spinner('Finding latest production deployment', 1000);
+  const productionDeployment = await getLatestDeployment(client, projectId, {
+    target: 'production',
+  });
+  output.stopSpinner();
+
+  if (productionDeployment) {
+    output.debug(
+      `Found latest production deployment ${productionDeployment.id} (${productionDeployment.url})`
+    );
+    return {
+      deploymentId: productionDeployment.id,
+      label: 'latest production deployment',
+    };
+  }
+
+  // 6. No production exists → your latest READY deployment, if found
   const user = await getUser(client);
   output.spinner('Finding your latest deployment', 1000);
   const userDeployment = await getLatestDeployment(client, projectId, {
     userId: user.id,
-    target,
   });
   output.stopSpinner();
 
@@ -177,33 +223,11 @@ async function resolveFollowDeployment({
     };
   }
 
-  if (environment === 'preview') {
-    output.error(
-      `No READY preview deployments found for ${formatProject(orgSlug, projectSlug)}. Deploy a preview first or specify a deployment with ${chalk.bold('--deployment')}.`
-    );
-    return { exitCode: 1 };
-  }
-
-  output.spinner('Finding latest production deployment', 1000);
-  const productionDeployment = await getLatestDeployment(client, projectId, {
-    target: 'production',
-  });
-  output.stopSpinner();
-
-  if (!productionDeployment) {
-    output.error(
-      `No READY deployments found for ${formatProject(orgSlug, projectSlug)}. Deploy first or specify a deployment with ${chalk.bold('--deployment')}.`
-    );
-    return { exitCode: 1 };
-  }
-
-  output.debug(
-    `Found latest production deployment ${productionDeployment.id} (${productionDeployment.url})`
+  // 7. Otherwise → error
+  output.error(
+    `No READY deployments found for ${formatProject(orgSlug, projectSlug)}. Deploy first or specify a deployment with ${chalk.bold('--deployment')}.`
   );
-  return {
-    deploymentId: productionDeployment.id,
-    label: 'latest production deployment',
-  };
+  return { exitCode: 1 };
 }
 
 const TIME_ONLY_FORMAT = 'HH:mm:ss.SS';

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -572,6 +572,7 @@ export default async function logs(client: Client) {
   const requestIdOption = parsedArguments.flags['--request-id'];
   const expandOption = parsedArguments.flags['--expand'];
   const branchFlagValue = parsedArguments.flags['--branch'];
+  const noBranchFlagValue = parsedArguments.flags['--no-branch'];
 
   const noFollowFlagValue = parsedArguments.flags['--no-follow'];
   const followOption = parsedArguments.flags['--follow'];
@@ -594,6 +595,7 @@ export default async function logs(client: Client) {
   telemetry.trackCliOptionRequestId(requestIdOption);
   telemetry.trackCliFlagExpand(expandOption);
   telemetry.trackCliOptionBranch(branchFlagValue);
+  telemetry.trackCliFlagNoBranch(noBranchFlagValue);
 
   if (followOption) {
     const incompatibleFlags = [

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -132,6 +132,16 @@ describe('logs', () => {
         'production always streams the latest production deployment'
       );
     });
+
+    it('should hide the deprecated --no-branch flag', async () => {
+      client.setArgv('logs', '--help');
+      await logs(client);
+
+      const normalizedOutput = client.getFullOutput().replace(/\s+/g, ' ');
+      expect(normalizedOutput).toContain('--branch');
+      expect(normalizedOutput).not.toContain('--no-branch');
+      expect(normalizedOutput).not.toContain('Disable auto-detection');
+    });
   });
 
   describe('with linked project', () => {
@@ -302,6 +312,62 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(0);
       expect(receivedBranch).toEqual('feature-x');
+    });
+
+    it('should accept the deprecated --no-branch flag as a no-op', async () => {
+      let receivedBranch: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedBranch = req.query.branch as string | undefined;
+        res.json({
+          rows: [createMockLog()],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--no-branch');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedBranch).toBeUndefined();
+    });
+
+    it('should keep an explicit branch when --no-branch is also passed', async () => {
+      let receivedBranch: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedBranch = req.query.branch as string | undefined;
+        res.json({
+          rows: [createMockLog()],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--branch', 'feature-x', '--no-branch');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedBranch).toEqual('feature-x');
+    });
+
+    it('should track telemetry for the --no-branch flag', async () => {
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        res.json({
+          rows: [createMockLog()],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--no-branch');
+      await logs(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:no-branch',
+          value: 'TRUE',
+        },
+      ]);
     });
   });
 

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -5,12 +5,7 @@ import { useTeam, useTeams } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
 import { useDeployment, useRuntimeLogs } from '../../../mocks/deployment';
 import logs from '../../../../src/commands/logs';
-import { createGitMeta } from '../../../../src/util/create-git-meta';
 import { join } from 'path';
-
-vi.mock('../../../../src/util/create-git-meta', () => ({
-  createGitMeta: vi.fn(),
-}));
 
 const logsFixturesDir = join(__dirname, '../../../fixtures/unit/commands/logs');
 
@@ -122,9 +117,20 @@ describe('logs', () => {
       await logs(client);
 
       const output = client.getFullOutput();
-      expect(output).toContain('Display request logs');
-      expect(output).toContain('--level');
-      expect(output).toContain('--environment');
+      const normalizedOutput = output.replace(/\s+/g, ' ');
+      expect(normalizedOutput).toContain('Display request logs');
+      expect(normalizedOutput).toContain('--level');
+      expect(normalizedOutput).toContain('--environment');
+      expect(normalizedOutput).toContain(
+        'fall back to your latest READY deployment'
+      );
+      expect(normalizedOutput).toContain(
+        'with --follow, require a READY deployment on that branch'
+      );
+      expect(normalizedOutput).not.toContain('defaults to current branch');
+      expect(normalizedOutput).not.toContain(
+        'production always streams the latest production deployment'
+      );
     });
   });
 
@@ -262,11 +268,7 @@ describe('logs', () => {
       await expect(client.stderr).toOutput('No logs found');
     });
 
-    it('should not filter by git branch for a linked project', async () => {
-      vi.mocked(createGitMeta).mockResolvedValue({
-        commitRef: 'feature-from-git',
-      });
-
+    it('should fetch logs from all branches for a linked project by default', async () => {
       let receivedBranch: string | undefined;
       client.scenario.get('/api/logs/request-logs', (req, res) => {
         receivedBranch = req.query.branch as string | undefined;
@@ -282,7 +284,6 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(0);
       expect(receivedBranch).toBeUndefined();
-      expect(createGitMeta).not.toHaveBeenCalled();
     });
 
     it('should filter by an explicitly selected branch on a linked project', async () => {
@@ -1486,24 +1487,40 @@ describe('logs', () => {
       });
     });
 
-    it('should fall back to the latest production deployment when no deployments match the branch', async () => {
-      const user = useUser();
+    it('should error when no deployments match an explicit branch', async () => {
+      const deploymentQueries: Array<Record<string, unknown>> = [];
+      client.scenario.get('/v6/deployments', (req, res) => {
+        deploymentQueries.push({ ...req.query });
+        res.json({ deployments: [] });
+      });
 
-      // Register before useLogsDeployment(), whose catch-all
-      // `/:version/deployments` route would otherwise handle this path
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--follow', '--branch', 'main');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(1);
+      expect(deploymentQueries).toEqual([
+        expect.objectContaining({
+          branch: 'main',
+          projectId: 'prj_logstest',
+          state: 'READY',
+        }),
+      ]);
+      await expect(client.stderr).toOutput(
+        'No READY deployments found for branch "main"'
+      );
+    });
+
+    it('should combine an explicit branch with the production environment', async () => {
       let productionDeployment: ReturnType<typeof useLogsDeployment>;
       const deploymentQueries: Array<Record<string, unknown>> = [];
       client.scenario.get('/v6/deployments', (req, res) => {
         deploymentQueries.push({ ...req.query });
-        if (req.query.target === 'production') {
-          res.json({
-            deployments: [
-              { uid: productionDeployment.id, url: productionDeployment.url },
-            ],
-          });
-          return;
-        }
-        res.json({ deployments: [] });
+        res.json({
+          deployments: [
+            { uid: productionDeployment.id, url: productionDeployment.url },
+          ],
+        });
       });
 
       productionDeployment = useLogsDeployment(user);
@@ -1517,17 +1534,27 @@ describe('logs', () => {
       );
 
       client.cwd = fixture('linked-project');
-      client.setArgv('logs', '--follow', '--branch', 'main');
+      client.setArgv(
+        'logs',
+        '--follow',
+        '--branch',
+        'main',
+        '--environment',
+        'production'
+      );
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
-      expect(deploymentQueries.some(q => q.branch === 'main')).toEqual(true);
-      expect(deploymentQueries.some(q => q.users !== undefined)).toEqual(false);
-      expect(deploymentQueries.some(q => q.target === 'production')).toEqual(
-        true
-      );
+      expect(deploymentQueries).toEqual([
+        expect.objectContaining({
+          branch: 'main',
+          projectId: 'prj_logstest',
+          state: 'READY',
+          target: 'production',
+        }),
+      ]);
       await expect(client.stderr).toOutput(
-        `Streaming logs for latest production deployment ${productionDeployment.id}`
+        `Streaming logs for latest deployment on branch "main" ${productionDeployment.id}`
       );
     });
 

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -122,10 +122,10 @@ describe('logs', () => {
       expect(normalizedOutput).toContain('--level');
       expect(normalizedOutput).toContain('--environment');
       expect(normalizedOutput).toContain(
-        'fall back to your latest READY deployment'
+        'falls back to your latest READY deployment'
       );
       expect(normalizedOutput).toContain(
-        'with --follow, require a READY deployment on that branch'
+        'with --follow, require a matching READY deployment'
       );
       expect(normalizedOutput).not.toContain('defaults to current branch');
       expect(normalizedOutput).not.toContain(

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -5,7 +5,12 @@ import { useTeam, useTeams } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
 import { useDeployment, useRuntimeLogs } from '../../../mocks/deployment';
 import logs from '../../../../src/commands/logs';
+import { createGitMeta } from '../../../../src/util/create-git-meta';
 import { join } from 'path';
+
+vi.mock('../../../../src/util/create-git-meta', () => ({
+  createGitMeta: vi.fn(),
+}));
 
 const logsFixturesDir = join(__dirname, '../../../fixtures/unit/commands/logs');
 
@@ -256,6 +261,47 @@ describe('logs', () => {
       expect(exitCode).toEqual(0);
       await expect(client.stderr).toOutput('No logs found');
     });
+
+    it('should not filter by git branch for a linked project', async () => {
+      vi.mocked(createGitMeta).mockResolvedValue({
+        commitRef: 'feature-from-git',
+      });
+
+      let receivedBranch: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedBranch = req.query.branch as string | undefined;
+        res.json({
+          rows: [createMockLog()],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedBranch).toBeUndefined();
+      expect(createGitMeta).not.toHaveBeenCalled();
+    });
+
+    it('should filter by an explicitly selected branch on a linked project', async () => {
+      let receivedBranch: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedBranch = req.query.branch as string | undefined;
+        res.json({
+          rows: [createMockLog()],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--branch', 'feature-x');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedBranch).toEqual('feature-x');
+    });
   });
 
   describe('--project option', () => {
@@ -311,38 +357,41 @@ describe('logs', () => {
       expect(receivedBranch).toEqual('feature-branch');
     });
 
-    it('should follow your latest deployment for an explicit project', async () => {
+    it('should follow the latest production deployment for an explicit project', async () => {
       let requestedProjectId: string | undefined;
       let requestedLimit: string | undefined;
       let requestedState: string | undefined;
       let requestedUsers: string | undefined;
-      let latestDeployment: ReturnType<typeof useDeployment>;
+      let requestedTarget: string | undefined;
+      let productionDeployment: ReturnType<typeof useDeployment>;
 
       client.scenario.get('/v6/deployments', (req, res) => {
         requestedProjectId = req.query.projectId as string | undefined;
         requestedLimit = req.query.limit as string | undefined;
         requestedState = req.query.state as string | undefined;
         requestedUsers = req.query.users as string | undefined;
+        requestedTarget = req.query.target as string | undefined;
         res.json({
           deployments: [
             {
-              uid: latestDeployment.id,
-              url: latestDeployment.url,
+              uid: productionDeployment.id,
+              url: productionDeployment.url,
             },
           ],
         });
       });
 
-      latestDeployment = useDeployment({
+      productionDeployment = useDeployment({
         creator: user,
         project: {
           ...defaultProject,
           id: 'prj_explicit',
           name: 'explicit-project',
         },
+        target: 'production',
       });
       useRuntimeLogs({
-        deployment: latestDeployment,
+        deployment: productionDeployment,
         logProducer: async function* () {},
       });
 
@@ -353,9 +402,58 @@ describe('logs', () => {
       expect(requestedProjectId).toEqual('prj_explicit');
       expect(requestedLimit).toEqual('1');
       expect(requestedState).toEqual('READY');
+      expect(requestedTarget).toEqual('production');
+      expect(requestedUsers).toBeUndefined();
+      await expect(client.stderr).toOutput(
+        `Streaming logs for latest production deployment ${productionDeployment.id}`
+      );
+    });
+
+    it('should follow your latest deployment when no production deployment exists', async () => {
+      let requestedUsers: string | undefined;
+      let userDeployment: ReturnType<typeof useDeployment>;
+      const deploymentQueries: Array<Record<string, unknown>> = [];
+
+      client.scenario.get('/v6/deployments', (req, res) => {
+        deploymentQueries.push({ ...req.query });
+        if (req.query.target === 'production') {
+          res.json({ deployments: [] });
+          return;
+        }
+        requestedUsers = req.query.users as string | undefined;
+        res.json({
+          deployments: [
+            {
+              uid: userDeployment.id,
+              url: userDeployment.url,
+            },
+          ],
+        });
+      });
+
+      userDeployment = useDeployment({
+        creator: user,
+        project: {
+          ...defaultProject,
+          id: 'prj_explicit',
+          name: 'explicit-project',
+        },
+      });
+      useRuntimeLogs({
+        deployment: userDeployment,
+        logProducer: async function* () {},
+      });
+
+      client.setArgv('logs', '--project', 'explicit-project', '--follow');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(deploymentQueries.some(q => q.target === 'production')).toEqual(
+        true
+      );
       expect(requestedUsers).toEqual(user.id);
       await expect(client.stderr).toOutput(
-        `Streaming logs for your latest deployment ${latestDeployment.id}`
+        `Streaming logs for your latest deployment ${userDeployment.id}`
       );
     });
 
@@ -1424,7 +1522,7 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(0);
       expect(deploymentQueries.some(q => q.branch === 'main')).toEqual(true);
-      expect(deploymentQueries.some(q => q.users !== undefined)).toEqual(true);
+      expect(deploymentQueries.some(q => q.users !== undefined)).toEqual(false);
       expect(deploymentQueries.some(q => q.target === 'production')).toEqual(
         true
       );
@@ -1433,26 +1531,28 @@ describe('logs', () => {
       );
     });
 
-    it('should stream your latest deployment with --no-branch', async () => {
+    it('should stream the latest production deployment with --follow', async () => {
       // Register before useLogsDeployment(), whose catch-all
       // `/:version/deployments` route would otherwise handle this path
-      let latestDeployment: ReturnType<typeof useLogsDeployment>;
+      let productionDeployment: ReturnType<typeof useLogsDeployment>;
       let requestedUsers: string | undefined;
       let requestedBranch: string | undefined;
+      let requestedTarget: string | undefined;
       client.scenario.get('/v6/deployments', (req, res) => {
         requestedUsers = req.query.users as string | undefined;
         requestedBranch = req.query.branch as string | undefined;
+        requestedTarget = req.query.target as string | undefined;
         res.json({
           deployments: [
-            { uid: latestDeployment.id, url: latestDeployment.url },
+            { uid: productionDeployment.id, url: productionDeployment.url },
           ],
         });
       });
 
-      latestDeployment = useLogsDeployment(user);
+      productionDeployment = useLogsDeployment(user);
 
       client.scenario.get(
-        `/v1/projects/prj_logstest/deployments/${latestDeployment.id}/runtime-logs`,
+        `/v1/projects/prj_logstest/deployments/${productionDeployment.id}/runtime-logs`,
         (_req, res) => {
           res.status(200);
           res.end();
@@ -1460,14 +1560,144 @@ describe('logs', () => {
       );
 
       client.cwd = fixture('linked-project');
-      client.setArgv('logs', '--follow', '--no-branch');
+      client.setArgv('logs', '--follow');
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
-      expect(requestedUsers).toEqual(user.id);
+      expect(requestedTarget).toEqual('production');
+      expect(requestedUsers).toBeUndefined();
       expect(requestedBranch).toBeUndefined();
       await expect(client.stderr).toOutput(
-        `Streaming logs for your latest deployment ${latestDeployment.id}`
+        `Streaming logs for latest production deployment ${productionDeployment.id}`
+      );
+    });
+
+    it('should fall back to your latest deployment when no production deployment exists', async () => {
+      let userDeployment: ReturnType<typeof useLogsDeployment>;
+      const deploymentQueries: Array<Record<string, unknown>> = [];
+      client.scenario.get('/v6/deployments', (req, res) => {
+        deploymentQueries.push({ ...req.query });
+        if (req.query.target === 'production') {
+          res.json({ deployments: [] });
+          return;
+        }
+        res.json({
+          deployments: [{ uid: userDeployment.id, url: userDeployment.url }],
+        });
+      });
+
+      userDeployment = useLogsDeployment(user);
+
+      client.scenario.get(
+        `/v1/projects/prj_logstest/deployments/${userDeployment.id}/runtime-logs`,
+        (_req, res) => {
+          res.status(200);
+          res.end();
+        }
+      );
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--follow');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(deploymentQueries.some(q => q.target === 'production')).toEqual(
+        true
+      );
+      expect(deploymentQueries.some(q => q.users === user.id)).toEqual(true);
+      await expect(client.stderr).toOutput(
+        `Streaming logs for your latest deployment ${userDeployment.id}`
+      );
+    });
+
+    it('should follow the latest deployment on an explicit branch', async () => {
+      let branchDeployment: ReturnType<typeof useLogsDeployment>;
+      const deploymentQueries: Array<Record<string, unknown>> = [];
+      client.scenario.get('/v6/deployments', (req, res) => {
+        deploymentQueries.push({ ...req.query });
+        if (req.query.branch === 'feature-x') {
+          res.json({
+            deployments: [
+              { uid: branchDeployment.id, url: branchDeployment.url },
+            ],
+          });
+          return;
+        }
+        res.json({ deployments: [] });
+      });
+
+      branchDeployment = useLogsDeployment(user);
+
+      client.scenario.get(
+        `/v1/projects/prj_logstest/deployments/${branchDeployment.id}/runtime-logs`,
+        (_req, res) => {
+          res.status(200);
+          res.end();
+        }
+      );
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--follow', '--branch', 'feature-x');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(deploymentQueries).toHaveLength(1);
+      expect(deploymentQueries[0].branch).toEqual('feature-x');
+      expect(deploymentQueries[0].target).toBeUndefined();
+      await expect(client.stderr).toOutput(
+        `Streaming logs for latest deployment on branch "feature-x" ${branchDeployment.id}`
+      );
+    });
+
+    it('should follow your latest preview deployment with --environment preview', async () => {
+      let previewDeployment: ReturnType<typeof useLogsDeployment>;
+      let productionDeployment: ReturnType<typeof useLogsDeployment>;
+      const deploymentQueries: Array<Record<string, unknown>> = [];
+      client.scenario.get('/v6/deployments', (req, res) => {
+        deploymentQueries.push({ ...req.query });
+        if (req.query.target === 'production') {
+          res.json({
+            deployments: [
+              {
+                uid: productionDeployment.id,
+                url: productionDeployment.url,
+              },
+            ],
+          });
+          return;
+        }
+        if (req.query.target === 'preview' && req.query.users) {
+          res.json({
+            deployments: [
+              { uid: previewDeployment.id, url: previewDeployment.url },
+            ],
+          });
+          return;
+        }
+        res.json({ deployments: [] });
+      });
+
+      previewDeployment = useLogsDeployment(user);
+      productionDeployment = useLogsDeployment(user);
+
+      client.scenario.get(
+        `/v1/projects/prj_logstest/deployments/${previewDeployment.id}/runtime-logs`,
+        (_req, res) => {
+          res.status(200);
+          res.end();
+        }
+      );
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--follow', '--environment', 'preview');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(deploymentQueries).toHaveLength(1);
+      expect(deploymentQueries[0].target).toEqual('preview');
+      expect(deploymentQueries[0].users).toEqual(user.id);
+      await expect(client.stderr).toOutput(
+        `Streaming logs for your latest deployment ${previewDeployment.id}`
       );
     });
 
@@ -1562,8 +1792,7 @@ describe('logs', () => {
       );
 
       client.cwd = fixture('linked-project');
-      // Use --no-branch to avoid branch detection and deployment lookup
-      client.setArgv('logs', '--follow', '--no-branch');
+      client.setArgv('logs', '--follow');
       await logs(client);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([


### PR DESCRIPTION
## Summary
- `vc logs` no longer auto-filters by the current git branch; use `--branch <name>` (or `--branch $(git branch --show-current)`) explicitly.
- `vc logs --follow` with nothing specified now prefers the latest production deployment, falling back to your latest READY deployment. Preview stays on your latest preview and does not fall through to production.
- Explicit `--branch` with `--follow` is strict: it requires a READY deployment on that branch (optionally scoped by `--environment`) and errors instead of falling back.
- `--no-branch` remains accepted as a hidden no-op for script compatibility, with telemetry wired so we can measure usage.

## Test plan
- [x] `cd packages/cli && pnpm vitest-run test/unit/commands/logs/index.test.ts` (or `npx vitest run …`)
- [x] `vc logs` in a linked feature-branch checkout matches dashboard (all branches; no silent branch filter)
- [x] `vc logs --branch main` filters; footer/empty-state mentions the branch
- [x] `vc logs --follow` announces latest production deployment
- [x] `vc logs --follow --environment preview` tails your latest preview
- [x] `vc logs --follow --branch <missing>` errors (no production fallthrough)
- [x] `vc logs --no-branch` behaves identically to bare `vc logs`


Made with [Cursor](https://cursor.com)