### PR TITLE
[ruby] buildpack followups

### DIFF
--- a/.changeset/ruby-buildpack-services.md
+++ b/.changeset/ruby-buildpack-services.md
@@ -27,7 +27,11 @@ Ruby services use `runtime: "ruby"` and require neither
 come from `Gemfile` or `BP_MRI_VERSION` (delivered via the CNB platform
 dir). On deploy the app is copied into the build container owned by the
 builder's build user (as `pack` does), so buildpacks can write to the
-workspace (bundler lockfile self-healing, asset compilation). A `command`
+workspace (bundler lockfile self-healing, asset compilation). Ruby builds
+bake overridable Heroku-style production defaults into the image
+(`RAILS_ENV`/`RACK_ENV=production`, `RAILS_LOG_TO_STDOUT`/
+`RAILS_SERVE_STATIC_FILES=enabled`) — project env vars always win, and each
+applied default is logged. A `command`
 override is baked into the image as its default `web` process via a Procfile
 copied on top of the app — the source tree is never mutated — so production
 (which launches the image's OCI config) and `vercel dev` (which execs via

--- a/.changeset/ruby-buildpack-services.md
+++ b/.changeset/ruby-buildpack-services.md
@@ -7,7 +7,7 @@
 ---
 
 Add generic Cloud Native Buildpack container builds, with Ruby as the first
-supported language, gated behind `VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1`.
+supported language, gated behind `VERCEL_RUBY_EXPERIMENTAL_BUILDPACK=1`.
 
 `@vercel/container` gains a language-agnostic CNB lifecycle driven by a
 per-language descriptor registry (`src/buildpacks/registry.ts`). Adding a

--- a/.changeset/ruby-buildpack-services.md
+++ b/.changeset/ruby-buildpack-services.md
@@ -7,18 +7,28 @@
 ---
 
 Add generic Cloud Native Buildpack container builds, with Ruby as the first
-supported language.
+supported language, gated behind `VERCEL_EXPERIMENTAL_BUILDPACKS=1`.
 
 `@vercel/container` gains a language-agnostic CNB lifecycle driven by a
-per-language descriptor registry (`src/buildpacks/registry.ts`); follow-up
-languages (PHP, Java, …) only add a registry entry plus an fs-detectors
-`BUILDPACK_RUNTIMES` entry. Builder and run images are pinned by digest.
+per-language descriptor registry (`src/buildpacks/registry.ts`). Adding a
+follow-up language (PHP, Java, …) means a registry entry (runtime slug,
+project markers, digest-pinned builder/run images, buildpack group), an
+fs-detectors `BUILDPACK_RUNTIMES` entry, and optionally a framework preset.
+Detection runs against a generated `order.toml` scoped to the descriptor's
+buildpack group, so mixed-language roots always build as the requested
+language.
 
-Ruby Services use `runtime: "ruby"` and require neither `entrypoint` nor
-`command`; versions come from `Gemfile` or `BP_MRI_VERSION` (delivered via
-the CNB platform dir). A `command` override is baked into the image as its
-default `web` process so production (which launches the image's OCI config)
-and `vercel dev` (which execs via the CNB launcher) behave identically.
-Projects with `framework: "ruby"` also switch from the `@vercel/ruby` Lambda
-builder to container builds. There is no Lambda path for buildpack services;
-only framework-null `api/**/*.rb` functions continue to use `@vercel/ruby`.
+With the flag set, Ruby services use `runtime: "ruby"` and require neither
+`entrypoint` nor `command` (`entrypoint` is ignored with a warning); versions
+come from `Gemfile` or `BP_MRI_VERSION` (delivered via the CNB platform
+dir). A `command` override is baked into the image as its default `web`
+process via a Procfile written to a staged app copy, so production (which
+launches the image's OCI config) and `vercel dev` (which execs via the CNB
+launcher) behave identically. Projects with `framework: "ruby"` also switch
+from the `@vercel/ruby` Lambda builder to container builds. A
+`Dockerfile.vercel`/`Containerfile.vercel` marker opts a service out of
+buildpacks; a conventional `Dockerfile` does not.
+
+Without the flag, Ruby keeps its legacy `@vercel/ruby` behavior everywhere.
+There is no Lambda path for buildpack services; framework-null `api/**/*.rb`
+functions continue to use `@vercel/ruby` regardless of the flag.

--- a/.changeset/ruby-buildpack-services.md
+++ b/.changeset/ruby-buildpack-services.md
@@ -7,7 +7,7 @@
 ---
 
 Add generic Cloud Native Buildpack container builds, with Ruby as the first
-supported language, gated behind `VERCEL_EXPERIMENTAL_BUILDPACKS=1`.
+supported language, gated behind `VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1`.
 
 `@vercel/container` gains a language-agnostic CNB lifecycle driven by a
 per-language descriptor registry (`src/buildpacks/registry.ts`). Adding a

--- a/.changeset/ruby-buildpack-services.md
+++ b/.changeset/ruby-buildpack-services.md
@@ -18,7 +18,11 @@ Detection runs against a generated `order.toml` scoped to the descriptor's
 buildpack group, so mixed-language roots always build as the requested
 language.
 
-With the flag set, Ruby services use `runtime: "ruby"` and require neither
+With the flag set, zero-config detection of the Ruby framework works without
+`VERCEL_USE_EXPERIMENTAL_FRAMEWORKS`, and its detectors mirror what the
+Paketo Ruby buildpack can build: a `Gemfile` plus a `config.ru` or a
+supported server gem (puma/thin/unicorn/passenger/rack) in `Gemfile.lock`.
+Ruby services use `runtime: "ruby"` and require neither
 `entrypoint` nor `command` (`entrypoint` is ignored with a warning); versions
 come from `Gemfile` or `BP_MRI_VERSION` (delivered via the CNB platform
 dir). A `command` override is baked into the image as its default `web`

--- a/.changeset/ruby-buildpack-services.md
+++ b/.changeset/ruby-buildpack-services.md
@@ -25,10 +25,13 @@ supported server gem (puma/thin/unicorn/passenger/rack) in `Gemfile.lock`.
 Ruby services use `runtime: "ruby"` and require neither
 `entrypoint` nor `command` (`entrypoint` is ignored with a warning); versions
 come from `Gemfile` or `BP_MRI_VERSION` (delivered via the CNB platform
-dir). A `command` override is baked into the image as its default `web`
-process via a Procfile written to a staged app copy, so production (which
-launches the image's OCI config) and `vercel dev` (which execs via the CNB
-launcher) behave identically. Projects with `framework: "ruby"` also switch
+dir). On deploy the app is copied into the build container owned by the
+builder's build user (as `pack` does), so buildpacks can write to the
+workspace (bundler lockfile self-healing, asset compilation). A `command`
+override is baked into the image as its default `web` process via a Procfile
+copied on top of the app — the source tree is never mutated — so production
+(which launches the image's OCI config) and `vercel dev` (which execs via
+the CNB launcher) behave identically. Projects with `framework: "ruby"` also switch
 from the `@vercel/ruby` Lambda builder to container builds. A
 `Dockerfile.vercel`/`Containerfile.vercel` marker opts a service out of
 buildpacks; a conventional `Dockerfile` does not.

--- a/packages/build-utils/src/framework-helpers.ts
+++ b/packages/build-utils/src/framework-helpers.ts
@@ -91,7 +91,7 @@ export function isExperimentalBackendsEnabled(): boolean {
  * Cloud Native Buildpack container builds via `@vercel/container`.
  */
 export function isRubyBuildpacksEnabled(): boolean {
-  return process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS === '1';
+  return process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK === '1';
 }
 
 export function isBackendBuilder(builder: Builder | null | undefined): boolean {

--- a/packages/build-utils/src/framework-helpers.ts
+++ b/packages/build-utils/src/framework-helpers.ts
@@ -87,12 +87,11 @@ export function isExperimentalBackendsEnabled(): boolean {
 }
 
 /**
- * Gates the migration of buildpack-backed runtimes (Ruby first) from their
- * per-language Lambda builders to Cloud Native Buildpack container builds
- * via `@vercel/container`.
+ * Gates the migration of Ruby from the `@vercel/ruby` Lambda builder to
+ * Cloud Native Buildpack container builds via `@vercel/container`.
  */
-export function isBuildpacksEnabled(): boolean {
-  return process.env.VERCEL_EXPERIMENTAL_BUILDPACKS === '1';
+export function isRubyBuildpacksEnabled(): boolean {
+  return process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS === '1';
 }
 
 export function isBackendBuilder(builder: Builder | null | undefined): boolean {

--- a/packages/build-utils/src/framework-helpers.ts
+++ b/packages/build-utils/src/framework-helpers.ts
@@ -86,6 +86,15 @@ export function isExperimentalBackendsEnabled(): boolean {
   );
 }
 
+/**
+ * Gates the migration of buildpack-backed runtimes (Ruby first) from their
+ * per-language Lambda builders to Cloud Native Buildpack container builds
+ * via `@vercel/container`.
+ */
+export function isBuildpacksEnabled(): boolean {
+  return process.env.VERCEL_EXPERIMENTAL_BUILDPACKS === '1';
+}
+
 export function isBackendBuilder(builder: Builder | null | undefined): boolean {
   if (!builder) return false;
   if (builder.use === UNIFIED_BACKEND_BUILDER) return true;

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -181,6 +181,7 @@ export {
   isBackendFramework,
   isNodeBackendFramework,
   isBackendBuilder,
+  isBuildpacksEnabled,
   isExperimentalBackendsEnabled,
   isExperimentalBackendsWithoutIntrospectionEnabled,
   shouldUseExperimentalBackends,

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -181,7 +181,7 @@ export {
   isBackendFramework,
   isNodeBackendFramework,
   isBackendBuilder,
-  isBuildpacksEnabled,
+  isRubyBuildpacksEnabled,
   isExperimentalBackendsEnabled,
   isExperimentalBackendsWithoutIntrospectionEnabled,
   shouldUseExperimentalBackends,

--- a/packages/container/BUILDPACKS.md
+++ b/packages/container/BUILDPACKS.md
@@ -5,6 +5,11 @@ built as OCI images with Cloud Native Buildpacks (Paketo). The CNB lifecycle
 is language-agnostic; everything language-specific lives in one descriptor in
 [`src/buildpacks/registry.ts`](src/buildpacks/registry.ts).
 
+Buildpack builds are gated behind `VERCEL_EXPERIMENTAL_BUILDPACKS=1` while
+the migration off per-language Lambda builders is in progress. With the flag
+unset, Ruby services and the Ruby framework preset keep their legacy
+`@vercel/ruby` behavior.
+
 Ruby is the first registry entry. There is no Lambda path for buildpack
 services; only framework-null `api/**/*.rb` functions continue to use
 `@vercel/ruby`, and that path resolves through builds-and-routes detection,
@@ -14,16 +19,19 @@ not services.
 
 1. Add a `BuildpackDescriptor` to `BUILDPACKS` in
    `src/buildpacks/registry.ts`: runtime slug, framework slugs, project
-   markers, and digest-pinned builder + run images. (Paketo builders are per
-   stack, not per language — `jammy-base` covers Ruby/Node/Go/Python;
-   `jammy-full` adds PHP.)
+   markers, digest-pinned builder + run images, and the buildpack group for
+   the generated `order.toml`. (Paketo builders are per stack, not per
+   language — `jammy-base` covers Ruby/Node/Go/Python; `jammy-full` adds
+   PHP.)
 2. Extend the `ServiceRuntime` union in `@vercel/build-utils` and, in
    `@vercel/fs-detectors`' `src/services/types.ts`, add the runtime to
-   `BUILDPACK_RUNTIMES`, `RUNTIME_BUILDERS` (buildpack runtimes map to
-   `@vercel/container` — no new builder package is created), and
-   `RUNTIME_MANIFESTS` (auto-detection markers, e.g. `pom.xml` for Java).
-3. Optionally add a framework preset in `@vercel/frameworks` pointing at
-   `@vercel/container` with the `<detect>` sentinel.
+   `BUILDPACK_RUNTIMES`, `RUNTIME_BUILDERS` (the legacy builder while the
+   flag is off — buildpack runtimes are rerouted to `@vercel/container` when
+   it is on; no new builder package is created), and `RUNTIME_MANIFESTS`
+   (auto-detection markers, e.g. `pom.xml` for Java).
+3. Optionally add a framework preset in `@vercel/frameworks`; builds-and-
+   routes detection reroutes buildpack-backed presets to `@vercel/container`
+   when the flag is on.
 4. Add fixtures and tests.
 
 No lifecycle, image-source, or resolver code should need to change.
@@ -40,13 +48,19 @@ No lifecycle, image-source, or resolver code should need to change.
 - Project markers (e.g. `Gemfile`, `config.ru` for Ruby) are language
   evidence used only to fail fast with an actionable error; Paketo's own
   detect phase is authoritative during the build.
+- Detection runs against a generated `order.toml` containing only the
+  descriptor's buildpack group, not the builder's full default order. A
+  mixed-language root (say a `go.mod` next to a `Gemfile`) therefore always
+  builds as the requested language.
 - Neither `entrypoint` nor `command` is required. Paketo selects the default
-  web process (e.g. from Rack/server gems for Ruby).
+  web process (e.g. from Rack/server gems for Ruby). `entrypoint` has no
+  effect on buildpack services and is ignored with a warning.
 - `command` in vercel.json is the Vercel-native process override. On deploy
-  it is baked into the image as the default `web` process (via a generated
-  Procfile, so it runs through the CNB launcher with buildpack-provided
-  env and lands in the image's OCI config — which is what production
-  launches). In `vercel dev` it is applied at `docker run` time via
+  it is baked into the image as the default `web` process (via a Procfile
+  generated into a staged copy of the app — the source tree is never
+  mutated — so it runs through the CNB launcher with buildpack-provided env
+  and lands in the image's OCI config, which is what production launches).
+  In `vercel dev` it is applied at `docker run` time via
   `--entrypoint launcher`.
 - A user-authored `Procfile` is **not** part of Vercel's configuration
   surface and is not a detection marker. Paketo's procfile buildpack does
@@ -55,6 +69,9 @@ No lifecycle, image-source, or resolver code should need to change.
 - Language versions come from the language's own manifests (e.g. `Gemfile`)
   or `BP_*` build env vars, delivered through the CNB platform dir
   (`/platform/env`).
+- CNB `project.toml` semantics (env, include/exclude, custom groups) are
+  currently ignored; custom builders and lifecycle extensions are
+  unsupported.
 
 ## Builder images
 
@@ -64,12 +81,14 @@ builds unreproducible and track unvetted upstream pushes. Bump digests
 deliberately.
 
 `VERCEL_BUILDPACK_<RUNTIME>_BUILDER` / `VERCEL_BUILDPACK_<RUNTIME>_RUN_IMAGE`
-(tag or digest) override the pinned defaults — the escape hatch for canarying
-a digest bump, unbreaking builds on a bad upstream image, or pointing dev at
-a custom builder. Overrides are per language on purpose: a generic variable
-would force one stack's builder onto every buildpack service in a
-mixed-language project. When only the builder is overridden, the run image
-follows the builder's metadata instead of the pinned default.
+(tag or digest) override the pinned defaults — an internal escape hatch for
+canarying a digest bump, unbreaking builds on a bad upstream image, or
+pointing dev at a custom builder. Overrides are per language on purpose: a
+generic variable would force one stack's builder onto every buildpack service
+in a mixed-language project. When only the builder is overridden, the run
+image comes from the builder's metadata; if it cannot be resolved, the build
+fails rather than pairing the custom builder with the pinned default run
+image.
 
 ## Local development
 
@@ -84,4 +103,5 @@ The Vercel build image creates a temporary Buildah working container from
 the trusted builder. The lifecycle exports directly to VCR using scoped
 `CNB_REGISTRY_AUTH` and the pinned run image, and `report.toml` supplies the
 final digest returned in the build output. Temporary Buildah containers,
-report dirs, and platform env dirs are removed on success and failure.
+report dirs, order dirs, platform env dirs, and staged app copies are
+removed on success and failure.

--- a/packages/container/BUILDPACKS.md
+++ b/packages/container/BUILDPACKS.md
@@ -5,7 +5,7 @@ built as OCI images with Cloud Native Buildpacks (Paketo). The CNB lifecycle
 is language-agnostic; everything language-specific lives in one descriptor in
 [`src/buildpacks/registry.ts`](src/buildpacks/registry.ts).
 
-Buildpack builds are gated behind `VERCEL_EXPERIMENTAL_BUILDPACKS=1` while
+Buildpack builds are gated behind `VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1` while
 the migration off per-language Lambda builders is in progress. With the flag
 unset, Ruby services and the Ruby framework preset keep their legacy
 `@vercel/ruby` behavior.

--- a/packages/container/BUILDPACKS.md
+++ b/packages/container/BUILDPACKS.md
@@ -33,8 +33,10 @@ No lifecycle, image-source, or resolver code should need to change.
 - Services select a buildpack via `runtime` (e.g. `"ruby"`); the framework
   preset path selects it via the framework slug. Both channels resolve
   through `requestedBuildpack()`.
-- A `Dockerfile` or `Containerfile` in the service root always takes
-  precedence — it is the escape hatch from buildpacks.
+- A `Dockerfile.vercel` or `Containerfile.vercel` in the service root always
+  takes precedence — it is the escape hatch from buildpacks. A conventional
+  `Dockerfile` is ignored, so a repo can keep one for CI or local tooling
+  without changing how Vercel builds it.
 - Project markers (e.g. `Gemfile`, `config.ru` for Ruby) are language
   evidence used only to fail fast with an actionable error; Paketo's own
   detect phase is authoritative during the build.

--- a/packages/container/BUILDPACKS.md
+++ b/packages/container/BUILDPACKS.md
@@ -5,7 +5,7 @@ built as OCI images with Cloud Native Buildpacks (Paketo). The CNB lifecycle
 is language-agnostic; everything language-specific lives in one descriptor in
 [`src/buildpacks/registry.ts`](src/buildpacks/registry.ts).
 
-Buildpack builds are gated behind `VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1` while
+Buildpack builds are gated behind `VERCEL_RUBY_EXPERIMENTAL_BUILDPACK=1` while
 the migration off per-language Lambda builders is in progress. With the flag
 unset, Ruby services and the Ruby framework preset keep their legacy
 `@vercel/ruby` behavior.

--- a/packages/container/BUILDPACKS.md
+++ b/packages/container/BUILDPACKS.md
@@ -45,9 +45,13 @@ No lifecycle, image-source, or resolver code should need to change.
   takes precedence — it is the escape hatch from buildpacks. A conventional
   `Dockerfile` is ignored, so a repo can keep one for CI or local tooling
   without changing how Vercel builds it.
-- Project markers (e.g. `Gemfile`, `config.ru` for Ruby) are language
-  evidence used only to fail fast with an actionable error; Paketo's own
-  detect phase is authoritative during the build.
+- Project markers (any-of, e.g. `Gemfile` for Ruby) are language evidence
+  used only to fail fast with an actionable error; Paketo's own detect phase
+  is authoritative during the build. List only files that phase requires —
+  for Ruby, `bundle-install` fails without a `Gemfile`, so a `config.ru` or
+  `Gemfile.lock` alone is not buildable. The framework preset's detectors
+  mirror the same rules (`Gemfile` plus a `config.ru` or a supported server
+  gem in `Gemfile.lock`).
 - Detection runs against a generated `order.toml` containing only the
   descriptor's buildpack group, not the builder's full default order. A
   mixed-language root (say a `go.mod` next to a `Gemfile`) therefore always

--- a/packages/container/BUILDPACKS.md
+++ b/packages/container/BUILDPACKS.md
@@ -73,6 +73,16 @@ No lifecycle, image-source, or resolver code should need to change.
 - Language versions come from the language's own manifests (e.g. `Gemfile`)
   or `BP_*` build env vars, delivered through the CNB platform dir
   (`/platform/env`).
+- Descriptors may declare `defaultBuildEnv` — Heroku-style production
+  defaults (Ruby: `RAILS_ENV=production`, `RACK_ENV=production`,
+  `RAILS_LOG_TO_STDOUT=enabled`, `RAILS_SERVE_STATIC_FILES=enabled`) baked
+  as launch-env defaults via Paketo's environment-variables buildpack
+  (`BPE_DEFAULT_<KEY>`). Env vars configured on the project always win (the
+  CNB launcher only applies defaults to unset variables), user build env
+  suppresses them at build time, and every applied default is logged.
+  `SECRET_KEY_BASE` is deliberately not defaulted yet — see the TODO in the
+  registry (per-deployment fallback plus a CLI prompt persisting a project
+  env var, rather than hiding the secret in the build cache like Heroku).
 - CNB `project.toml` semantics (env, include/exclude, custom groups) are
   currently ignored; custom builders and lifecycle extensions are
   unsupported.

--- a/packages/container/BUILDPACKS.md
+++ b/packages/container/BUILDPACKS.md
@@ -61,11 +61,11 @@ No lifecycle, image-source, or resolver code should need to change.
   effect on buildpack services and is ignored with a warning.
 - `command` in vercel.json is the Vercel-native process override. On deploy
   it is baked into the image as the default `web` process (via a Procfile
-  generated into a staged copy of the app — the source tree is never
-  mutated — so it runs through the CNB launcher with buildpack-provided env
-  and lands in the image's OCI config, which is what production launches).
-  In `vercel dev` it is applied at `docker run` time via
-  `--entrypoint launcher`.
+  copied into the build container on top of the app — the source tree is
+  never mutated — so it runs through the CNB launcher with
+  buildpack-provided env and lands in the image's OCI config, which is what
+  production launches). In `vercel dev` it is applied at `docker run` time
+  via `--entrypoint launcher`.
 - A user-authored `Procfile` is **not** part of Vercel's configuration
   surface and is not a detection marker. Paketo's procfile buildpack does
   honor one if present (useful for Heroku migrations), but the documented
@@ -104,8 +104,19 @@ Desktop context sockets are mounted into the builder when
 ## Deployments
 
 The Vercel build image creates a temporary Buildah working container from
-the trusted builder. The lifecycle exports directly to VCR using scoped
-`CNB_REGISTRY_AUTH` and the pinned run image, and `report.toml` supplies the
-final digest returned in the build output. Temporary Buildah containers,
-report dirs, order dirs, platform env dirs, and staged app copies are
-removed on success and failure.
+the trusted builder. The app is `buildah copy`ed into the container at
+`/workspace` owned by the builder's build user (`CNB_USER_ID:CNB_GROUP_ID`) —
+the environment pack provides and buildpacks are written against, so
+workspace writes (bundler lockfile updates, rails-assets, npm lockfiles, …)
+work for every language. Bind mounts are used only for read-only inputs
+(order, platform env) and the report output. The lifecycle exports directly
+to VCR using scoped `CNB_REGISTRY_AUTH` and the pinned run image, and
+`report.toml` supplies the final digest returned in the build output.
+Temporary Buildah containers, report dirs, order dirs, platform env dirs,
+and Procfile dirs are removed on success and failure.
+
+In `vercel dev` the workspace is still bind-mounted; on Linux dev hosts it
+is not writable by the build user (macOS Docker Desktop mounts are
+permissive). The planned fix mirrors pack's daemon flow: a named volume
+populated by a root helper container (see the TODO on
+`prepareAppDirectory`).

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -19,6 +19,9 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "smol-toml": "1.5.2"
+  },
   "devDependencies": {
     "@types/node": "20.11.0",
     "@vercel/build-utils": "workspace:*",

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -13,8 +13,11 @@
     "build": "node ../../utils/build-builder.mjs",
     "type-check": "tsc --noEmit",
     "test-unit": "vitest run --config ../../vitest.config.mts test/unit.test.ts",
+    "test-e2e": "vitest run --config ../../vitest.config.mts test/e2e.test.ts",
     "test-integration-buildpack": "RUN_BUILDPACK_INTEGRATION=1 vitest run --config ../../vitest.config.mts test/integration-buildpack.test.ts",
-    "vitest-unit": "glob --absolute 'test/unit.test.ts'"
+    "vitest-run": "vitest -c ../../vitest.config.mts",
+    "vitest-unit": "glob --absolute 'test/unit.test.ts'",
+    "vitest-e2e": "glob --absolute 'test/e2e.test.ts'"
   },
   "files": [
     "dist"

--- a/packages/container/src/buildpacks/index.ts
+++ b/packages/container/src/buildpacks/index.ts
@@ -5,6 +5,7 @@ export {
   requestedBuildpack,
   runImageRef,
   type BuildpackDescriptor,
+  type BuildpackGroupEntry,
 } from './registry';
 export {
   buildAndPushWithLifecycle,

--- a/packages/container/src/buildpacks/lifecycle.ts
+++ b/packages/container/src/buildpacks/lifecycle.ts
@@ -12,6 +12,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { stringify as stringifyToml } from 'smol-toml';
 import { DIGEST_RE, TARGET_PLATFORM } from '../engines/types';
 import { buildahStorageArgs } from '../storage-driver';
 import type { DevOutput } from '../util';
@@ -192,17 +193,21 @@ const ORDER_FILE = `${ORDER_MOUNT_DIR}/order.toml`;
  * env dir.
  */
 function writeOrderDir(bp: BuildpackDescriptor): string {
-  const lines = ['[[order]]'];
-  for (const entry of bp.buildpackGroup) {
-    lines.push('', '  [[order.group]]', `    id = "${entry.id}"`);
-    if (entry.optional) {
-      lines.push('    optional = true');
-    }
-  }
+  const order = {
+    order: [
+      {
+        group: bp.buildpackGroup.map(entry => ({
+          id: entry.id,
+          version: entry.version,
+          ...(entry.optional ? { optional: true } : {}),
+        })),
+      },
+    ],
+  };
   const dir = mkdtempSync(join(tmpdir(), 'vercel-cnb-order-'));
   chmodSync(dir, 0o755);
   const file = join(dir, 'order.toml');
-  writeFileSync(file, `${lines.join('\n')}\n`);
+  writeFileSync(file, stringifyToml(order));
   chmodSync(file, 0o644);
   return dir;
 }
@@ -581,7 +586,7 @@ export async function buildAndPushWithLifecycle(
         );
       } finally {
         try {
-          await runBuildah(['rm', '--force', containerName]);
+          await runBuildah(['rm', containerName]);
         } catch (err) {
           debug(
             `could not remove Buildah CNB container ${containerName}: ${

--- a/packages/container/src/buildpacks/lifecycle.ts
+++ b/packages/container/src/buildpacks/lifecycle.ts
@@ -153,6 +153,10 @@ function prepareAppDirectory(
  * contract and also leaks the whole map to every phase; the platform dir is
  * both spec-correct and scoped. World-readable so the lifecycle's unprivileged
  * builder user can read it across the container UID mapping.
+ *
+ * TODO: in dev this briefly exposes build env values (which may contain
+ * secrets) to other local users via the world-readable tmpdir. Tightening
+ * requires group-mapping the files to the builder user instead of 0644.
  */
 function writePlatformEnvDir(
   buildEnv: Record<string, string> | undefined
@@ -385,6 +389,9 @@ export async function buildWithLifecycle(
         '/cnb/lifecycle/creator',
         '-app=/workspace',
         `-order=${ORDER_FILE}`,
+        // TODO: replace -skip-restore with a persistent -cache-dir volume
+        // (namespaced by service and builder digest, under meta.devCacheDir)
+        // so dev rebuilds don't re-run full dependency installs.
         '-skip-restore',
         `-run-image=${runImage}`,
         '-daemon',
@@ -538,6 +545,9 @@ export async function buildAndPushWithLifecycle(
             '/cnb/lifecycle/creator',
             '-app=/workspace',
             `-order=${ORDER_FILE}`,
+            // TODO: replace -skip-restore with a persistent -cache-dir
+            // (namespaced by service and builder digest) wired into
+            // prepareCache so deploy rebuilds restore dependency layers.
             '-skip-restore',
             ...(runImage ? [`-run-image=${runImage}`] : []),
             '-report=/platform-output/report.toml',

--- a/packages/container/src/buildpacks/lifecycle.ts
+++ b/packages/container/src/buildpacks/lifecycle.ts
@@ -15,7 +15,14 @@ import { dirname, join } from 'node:path';
 import { DIGEST_RE, TARGET_PLATFORM } from '../engines/types';
 import { buildahStorageArgs } from '../storage-driver';
 import type { DevOutput } from '../util';
-import { debug, done, run, step, withSpan } from '../util';
+import {
+  assertValidCommandShell,
+  debug,
+  done,
+  run,
+  step,
+  withSpan,
+} from '../util';
 import type { BuildpackDescriptor } from './registry';
 import { builderImageRef, runImageRef } from './registry';
 
@@ -180,6 +187,7 @@ function writeCommandProcfile(
   command: string[],
   commandShell: boolean
 ): void {
+  assertValidCommandShell(command, commandShell);
   // Mirror the CNB launcher's own convention: a command string is a shell
   // command line (left raw so $VARs and operators work), while an array is an
   // argv vector (each element escaped so the Procfile shell preserves it).

--- a/packages/container/src/buildpacks/lifecycle.ts
+++ b/packages/container/src/buildpacks/lifecycle.ts
@@ -106,14 +106,20 @@ function needsRuntimeReadableCopy(path: string): boolean {
  * launches as an unprivileged user. Repositories created under a restrictive
  * umask can contain 0700 directories or 0600 files, so stage those trees and
  * make the staged copy runtime-readable without mutating the user's checkout.
+ * `forceStage` requests a copy even for readable trees, for callers that
+ * need to add generated files (e.g. a `command` Procfile) without touching
+ * the source tree.
  */
-function prepareAppDirectory(workPath: string): PreparedAppDirectory {
+function prepareAppDirectory(
+  workPath: string,
+  forceStage = false
+): PreparedAppDirectory {
   // Some unit-level builder callers use the filesystem root as a synthetic
   // workPath. It is never a valid app tree and cannot be staged beneath /tmp.
   if (dirname(workPath) === workPath) {
     return { workPath };
   }
-  if (!needsRuntimeReadableCopy(workPath)) {
+  if (!forceStage && !needsRuntimeReadableCopy(workPath)) {
     return { workPath };
   }
 
@@ -169,6 +175,34 @@ function shellEscape(arg: string): string {
     : `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
+/** In-container mount point for the generated `order.toml`. */
+const ORDER_MOUNT_DIR = '/platform/order';
+const ORDER_FILE = `${ORDER_MOUNT_DIR}/order.toml`;
+
+/**
+ * Write the descriptor's buildpack group as an explicit `order.toml` for the
+ * creator, replacing the builder's full default order. Without it, detection
+ * free-runs across every language family in the builder and a mixed-language
+ * root (say a `go.mod` next to a `Gemfile`) could build as the wrong
+ * language. World-readable for the same UID-mapping reason as the platform
+ * env dir.
+ */
+function writeOrderDir(bp: BuildpackDescriptor): string {
+  const lines = ['[[order]]'];
+  for (const entry of bp.buildpackGroup) {
+    lines.push('', '  [[order.group]]', `    id = "${entry.id}"`);
+    if (entry.optional) {
+      lines.push('    optional = true');
+    }
+  }
+  const dir = mkdtempSync(join(tmpdir(), 'vercel-cnb-order-'));
+  chmodSync(dir, 0o755);
+  const file = join(dir, 'order.toml');
+  writeFileSync(file, `${lines.join('\n')}\n`);
+  chmodSync(file, 0o644);
+  return dir;
+}
+
 /**
  * Bake a `command` override into the image as its default `web` process by
  * writing a Procfile for Paketo's procfile buildpack to pick up. This is the
@@ -178,9 +212,9 @@ function shellEscape(arg: string): string {
  * user Procfile is intentionally overwritten — explicit vercel.json config
  * wins over convention files.
  *
- * Only the deploy path does this: `workPath` there is the build sandbox. In
- * dev, `workPath` is the developer's source tree, so the command is applied
- * at `docker run` time via the launcher instead (see dev.ts).
+ * Only the deploy path does this, and only into the staged app copy so the
+ * source tree is never mutated. In dev the command is applied at
+ * `docker run` time via the launcher instead (see dev.ts).
  */
 function writeCommandProcfile(
   workPath: string,
@@ -220,9 +254,9 @@ async function resolveDockerSocket(): Promise<string | undefined> {
 }
 
 /**
- * The run image to pre-pull for dev daemon builds: an explicit override, the
- * run image declared by the (possibly overridden) builder's metadata, or the
- * descriptor's pinned default.
+ * The run image to pre-pull for dev daemon builds: an explicit override or
+ * pinned default, otherwise the run image declared by the overridden
+ * builder's metadata.
  */
 async function resolveDevRunImage(
   bp: BuildpackDescriptor,
@@ -256,7 +290,14 @@ async function resolveDevRunImage(
       }`
     );
   }
-  return bp.runImage;
+  // An overridden builder may target a different stack; pairing it with the
+  // pinned default run image would produce a broken image. Require an
+  // explicit run image instead of guessing.
+  throw new Error(
+    `Could not determine the run image for builder ${builder}. Set ` +
+      `VERCEL_BUILDPACK_${bp.runtime.toUpperCase()}_RUN_IMAGE to the run ` +
+      'image matching that builder.'
+  );
 }
 
 async function dockerImagePlatform(image: string): Promise<string | undefined> {
@@ -318,6 +359,7 @@ export async function buildWithLifecycle(
       const platformEnvMount = platformEnvDir
         ? ['-v', `${platformEnvDir}:/platform/env:ro`]
         : [];
+      const orderDir = writeOrderDir(bp);
 
       const dockerSocket = await resolveDockerSocket();
       const socketMount = dockerSocket
@@ -335,11 +377,14 @@ export async function buildWithLifecycle(
         'CNB_PLATFORM_API=0.13',
         '-v',
         `${appDirectory.workPath}:/workspace`,
+        '-v',
+        `${orderDir}:${ORDER_MOUNT_DIR}:ro`,
         ...platformEnvMount,
         ...socketMount,
         builder,
         '/cnb/lifecycle/creator',
         '-app=/workspace',
+        `-order=${ORDER_FILE}`,
         '-skip-restore',
         `-run-image=${runImage}`,
         '-daemon',
@@ -379,6 +424,7 @@ export async function buildWithLifecycle(
         if (platformEnvDir) {
           rmSync(platformEnvDir, { recursive: true, force: true });
         }
+        rmSync(orderDir, { recursive: true, force: true });
         appDirectory.cleanup?.();
       }
 
@@ -428,15 +474,17 @@ export async function buildAndPushWithLifecycle(
       const reportPath = join(reportDir, 'report.toml');
       chmodSync(reportDir, 0o777);
       const platformEnvDir = writePlatformEnvDir(params.buildEnv);
+      const orderDir = writeOrderDir(bp);
 
+      const hasCommand = Boolean(params.command?.length);
+      const appDirectory = prepareAppDirectory(params.workPath, hasCommand);
       if (params.command?.length) {
         writeCommandProcfile(
-          params.workPath,
+          appDirectory.workPath,
           params.command,
           params.commandShell ?? false
         );
       }
-      const appDirectory = prepareAppDirectory(params.workPath);
 
       try {
         step(
@@ -481,12 +529,15 @@ export async function buildAndPushWithLifecycle(
             `${appDirectory.workPath}:/workspace`,
             '--volume',
             `${reportDir}:/platform-output`,
+            '--volume',
+            `${orderDir}:${ORDER_MOUNT_DIR}`,
             ...platformEnvMount,
             ...envFlags,
             containerName,
             '--',
             '/cnb/lifecycle/creator',
             '-app=/workspace',
+            `-order=${ORDER_FILE}`,
             '-skip-restore',
             ...(runImage ? [`-run-image=${runImage}`] : []),
             '-report=/platform-output/report.toml',
@@ -532,6 +583,7 @@ export async function buildAndPushWithLifecycle(
         if (platformEnvDir) {
           rmSync(platformEnvDir, { recursive: true, force: true });
         }
+        rmSync(orderDir, { recursive: true, force: true });
         appDirectory.cleanup?.();
       }
     }

--- a/packages/container/src/buildpacks/lifecycle.ts
+++ b/packages/container/src/buildpacks/lifecycle.ts
@@ -23,6 +23,7 @@ import {
   run,
   step,
   withSpan,
+  write,
 } from '../util';
 import type { BuildpackDescriptor } from './registry';
 import { builderImageRef, runImageRef } from './registry';
@@ -178,6 +179,36 @@ function writePlatformEnvDir(
     chmodSync(file, 0o644);
   }
   return dir;
+}
+
+/**
+ * Merge the descriptor's {@link BuildpackDescriptor.defaultBuildEnv} beneath
+ * the user's build env. A default is skipped when the user already set the
+ * same key, or — for `BPE_DEFAULT_<KEY>` launch defaults — the unprefixed
+ * `<KEY>` itself. Returns the merged env plus a log line per applied
+ * default so builds are never silently reconfigured.
+ */
+export function mergeDefaultBuildEnv(
+  bp: BuildpackDescriptor,
+  buildEnv: Record<string, string> | undefined
+): { buildEnv: Record<string, string> | undefined; applied: string[] } {
+  const defaults = Object.entries(bp.defaultBuildEnv ?? {});
+  if (defaults.length === 0) {
+    return { buildEnv, applied: [] };
+  }
+  const merged = { ...(buildEnv ?? {}) };
+  const applied: string[] = [];
+  for (const [key, value] of defaults) {
+    const launchKey = key.startsWith('BPE_DEFAULT_')
+      ? key.slice('BPE_DEFAULT_'.length)
+      : key;
+    if (key in merged || launchKey in merged) continue;
+    merged[key] = value;
+    applied.push(
+      `Defaulting ${launchKey}=${value} (set the ${launchKey} environment variable to override)`
+    );
+  }
+  return { buildEnv: merged, applied };
 }
 
 function shellEscape(arg: string): string {
@@ -394,7 +425,11 @@ export async function buildWithLifecycle(
       emit(out, `  ✓ run image ready: ${runImage}`);
 
       const appDirectory = prepareAppDirectory(params.workPath);
-      const platformEnvDir = writePlatformEnvDir(params.buildEnv);
+      const defaultedEnv = mergeDefaultBuildEnv(bp, params.buildEnv);
+      for (const line of defaultedEnv.applied) {
+        emit(out, `  ${line}`);
+      }
+      const platformEnvDir = writePlatformEnvDir(defaultedEnv.buildEnv);
       const platformEnvMount = platformEnvDir
         ? ['-v', `${platformEnvDir}:/platform/env:ro`]
         : [];
@@ -557,7 +592,11 @@ export async function buildAndPushWithLifecycle(
       const reportDir = mkdtempSync(join(tmpdir(), 'vercel-cnb-report-'));
       const reportPath = join(reportDir, 'report.toml');
       chmodSync(reportDir, 0o777);
-      const platformEnvDir = writePlatformEnvDir(params.buildEnv);
+      const defaultedEnv = mergeDefaultBuildEnv(bp, params.buildEnv);
+      for (const line of defaultedEnv.applied) {
+        write(`  ${line}`);
+      }
+      const platformEnvDir = writePlatformEnvDir(defaultedEnv.buildEnv);
       const orderDir = writeOrderDir(bp);
 
       let procfileDir: string | undefined;

--- a/packages/container/src/buildpacks/lifecycle.ts
+++ b/packages/container/src/buildpacks/lifecycle.ts
@@ -15,7 +15,7 @@ import { dirname, join } from 'node:path';
 import { stringify as stringifyToml } from 'smol-toml';
 import { DIGEST_RE, TARGET_PLATFORM } from '../engines/types';
 import { buildahStorageArgs } from '../storage-driver';
-import type { DevOutput, RunError } from '../util';
+import type { DevOutput, RunError, RunResult } from '../util';
 import {
   assertValidCommandShell,
   debug,
@@ -107,20 +107,26 @@ function needsRuntimeReadableCopy(path: string): boolean {
  * launches as an unprivileged user. Repositories created under a restrictive
  * umask can contain 0700 directories or 0600 files, so stage those trees and
  * make the staged copy runtime-readable without mutating the user's checkout.
- * `forceStage` requests a copy even for readable trees, for callers that
- * need to add generated files (e.g. a `command` Procfile) without touching
- * the source tree.
+ *
+ * Dev-only: the deploy path copies the app into the working container with
+ * build-user ownership instead (see `buildAndPushWithLifecycle`).
+ *
+ * TODO: on Linux dev hosts the bind-mounted workspace is not writable by the
+ * builder's build user, so buildpacks that write to the app dir (bundler
+ * lockfile updates, rails-assets, ...) fail. Fix it the pack way — a named
+ * volume populated by a root helper container (`docker volume create` →
+ * helper `docker run` copy+chown → mount volume → `docker volume rm`) — not
+ * a chown through the bind mount, which leaves files the unprivileged dev
+ * process cannot delete. macOS Docker Desktop mounts are permissive, so dev
+ * is unaffected there today.
  */
-function prepareAppDirectory(
-  workPath: string,
-  forceStage = false
-): PreparedAppDirectory {
+function prepareAppDirectory(workPath: string): PreparedAppDirectory {
   // Some unit-level builder callers use the filesystem root as a synthetic
   // workPath. It is never a valid app tree and cannot be staged beneath /tmp.
   if (dirname(workPath) === workPath) {
     return { workPath };
   }
-  if (!forceStage && !needsRuntimeReadableCopy(workPath)) {
+  if (!needsRuntimeReadableCopy(workPath)) {
     return { workPath };
   }
 
@@ -244,9 +250,10 @@ function writeOrderDir(bp: BuildpackDescriptor): string {
  * user Procfile is intentionally overwritten — explicit vercel.json config
  * wins over convention files.
  *
- * Only the deploy path does this, and only into the staged app copy so the
- * source tree is never mutated. In dev the command is applied at
- * `docker run` time via the launcher instead (see dev.ts).
+ * Only the deploy path does this: the Procfile is written to a temp dir and
+ * copied into the working container on top of the app, so the source tree is
+ * never mutated. In dev the command is applied at `docker run` time via the
+ * launcher instead (see dev.ts).
  */
 function writeCommandProcfile(
   workPath: string,
@@ -489,10 +496,43 @@ function registryAuth(
 
 async function runBuildah(
   args: string[],
-  env?: NodeJS.ProcessEnv
-): Promise<void> {
+  env?: NodeJS.ProcessEnv,
+  opts: { quiet?: boolean } = {}
+): Promise<RunResult> {
   const storageArgs = await buildahStorageArgs();
-  await run('buildah', [...storageArgs, ...args], { quiet: false, env });
+  return run('buildah', [...storageArgs, ...args], {
+    quiet: opts.quiet ?? false,
+    env,
+  });
+}
+
+/**
+ * The builder's build uid:gid, read from the builder image's own
+ * `CNB_USER_ID`/`CNB_GROUP_ID` env via the working container. `pack` chowns
+ * the app directory to this user, and buildpacks assume the workspace is
+ * writable by it (bundler rewrites Gemfile.lock, rails-assets writes
+ * public/assets, npm rewrites lockfiles, ...).
+ */
+async function resolveBuildUser(containerName: string): Promise<string> {
+  const { stdout } = await runBuildah(
+    [
+      'run',
+      // Host networking like the creator run below: the build sandbox
+      // cannot set up bridge networking (netavark/iptables).
+      '--network',
+      'host',
+      containerName,
+      '--',
+      'sh',
+      '-c',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: shell parameter expansion inside the container
+      'echo "${CNB_USER_ID:-1000}:${CNB_GROUP_ID:-1000}"',
+    ],
+    undefined,
+    { quiet: true }
+  );
+  const user = stdout.trim().split('\n').at(-1) ?? '';
+  return /^\d+:\d+$/.test(user) ? user : '1000:1000';
 }
 
 /**
@@ -520,11 +560,14 @@ export async function buildAndPushWithLifecycle(
       const platformEnvDir = writePlatformEnvDir(params.buildEnv);
       const orderDir = writeOrderDir(bp);
 
-      const hasCommand = Boolean(params.command?.length);
-      const appDirectory = prepareAppDirectory(params.workPath, hasCommand);
+      let procfileDir: string | undefined;
       if (params.command?.length) {
+        // Validate before allocating the temp dir so a rejected command
+        // doesn't leak it (the cleanup below only runs after the try).
+        assertValidCommandShell(params.command, params.commandShell ?? false);
+        procfileDir = mkdtempSync(join(tmpdir(), 'vercel-cnb-procfile-'));
         writeCommandProcfile(
-          appDirectory.workPath,
+          procfileDir,
           params.command,
           params.commandShell ?? false
         );
@@ -542,6 +585,32 @@ export async function buildAndPushWithLifecycle(
           containerName,
           builder,
         ]);
+
+        // Copy the app into the working container instead of bind-mounting
+        // it, owned by the build user — the environment pack provides and
+        // buildpacks are written against. This makes /workspace writable
+        // during the build and exports the app layer with build-user
+        // ownership instead of the host uid's.
+        const buildUser = await resolveBuildUser(containerName);
+        await runBuildah([
+          'copy',
+          '--chown',
+          buildUser,
+          containerName,
+          params.workPath,
+          '/workspace',
+        ]);
+        if (procfileDir) {
+          // Explicit vercel.json `command` wins over a user-authored Procfile.
+          await runBuildah([
+            'copy',
+            '--chown',
+            buildUser,
+            containerName,
+            join(procfileDir, 'Procfile'),
+            '/workspace/Procfile',
+          ]);
+        }
 
         const lifecycleEnv: NodeJS.ProcessEnv = {
           ...process.env,
@@ -569,8 +638,6 @@ export async function buildAndPushWithLifecycle(
             'run',
             '--network',
             'host',
-            '--volume',
-            `${appDirectory.workPath}:/workspace`,
             '--volume',
             `${reportDir}:/platform-output`,
             '--volume',
@@ -637,7 +704,9 @@ export async function buildAndPushWithLifecycle(
           rmSync(platformEnvDir, { recursive: true, force: true });
         }
         rmSync(orderDir, { recursive: true, force: true });
-        appDirectory.cleanup?.();
+        if (procfileDir) {
+          rmSync(procfileDir, { recursive: true, force: true });
+        }
       }
     }
   );

--- a/packages/container/src/buildpacks/lifecycle.ts
+++ b/packages/container/src/buildpacks/lifecycle.ts
@@ -15,7 +15,7 @@ import { dirname, join } from 'node:path';
 import { stringify as stringifyToml } from 'smol-toml';
 import { DIGEST_RE, TARGET_PLATFORM } from '../engines/types';
 import { buildahStorageArgs } from '../storage-driver';
-import type { DevOutput } from '../util';
+import type { DevOutput, RunError } from '../util';
 import {
   assertValidCommandShell,
   debug,
@@ -178,6 +178,29 @@ function shellEscape(arg: string): string {
   return /^[A-Za-z0-9_/.=:@%^+-]+$/.test(arg)
     ? arg
     : `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Explain a CNB lifecycle/creator exit code in terms of the phase that
+ * failed, so failures point at the right part of the build output instead of
+ * a bare number. Codes per `buildpacks/lifecycle` `platform/exit.go`.
+ */
+export function describeCreatorExitCode(
+  code: number | undefined
+): string | undefined {
+  if (code === undefined) return undefined;
+  if (code === 20) return 'no buildpack detected the app';
+  if (code === 21)
+    return 'no buildpack detected the app and at least one errored during detection';
+  if (code >= 22 && code <= 29) return 'the detect phase failed';
+  if (code >= 30 && code <= 39) return 'the analyze phase failed';
+  if (code >= 40 && code <= 49) return 'the restore phase failed';
+  if (code === 51)
+    return 'a buildpack failed while building the app (e.g. installing dependencies) — its error is in the build output above';
+  if (code >= 50 && code <= 59) return 'the build phase failed';
+  if (code >= 60 && code <= 69)
+    return 'the export phase failed to write the image';
+  return undefined;
 }
 
 /** In-container mount point for the generated `order.toml`. */
@@ -428,8 +451,17 @@ export async function buildWithLifecycle(
             );
           });
           child.on('close', code => {
-            if (code === 0) resolve();
-            else reject(new Error(`\`docker run\` exited with code ${code}`));
+            if (code === 0) {
+              resolve();
+              return;
+            }
+            const hint = describeCreatorExitCode(code ?? undefined);
+            reject(
+              new Error(
+                `\`docker run\` exited with code ${code}` +
+                  (hint ? ` (${hint})` : '')
+              )
+            );
           });
         });
       } finally {
@@ -575,9 +607,15 @@ export async function buildAndPushWithLifecycle(
         });
         return { imageRef: params.imageRef, digest, builder };
       } catch (err) {
+        const hint = describeCreatorExitCode((err as RunError).exitCode);
         throw new Error(
           [
             `${bp.runtime} buildpack build failed via lifecycle/creator (${builder}).`,
+            ...(hint
+              ? [
+                  `The lifecycle exited with code ${(err as RunError).exitCode}: ${hint}.`,
+                ]
+              : []),
             '',
             `Underlying error: ${(err as Error).message}`,
             '',

--- a/packages/container/src/buildpacks/registry.ts
+++ b/packages/container/src/buildpacks/registry.ts
@@ -29,10 +29,12 @@ export interface BuildpackDescriptor {
    */
   frameworkSlugs?: readonly string[];
   /**
-   * Files that mark a service root as buildable by this buildpack. Purely
-   * language evidence (a `Gemfile` is Ruby; a `Procfile` is not) — used to
-   * fail fast with an actionable error before pulling a multi-GB builder,
-   * not to influence what Paketo's own detect phase does.
+   * Files that mark a service root as buildable by this buildpack. Any one
+   * marker suffices, so list only files the buildpack's detect phase
+   * requires (a `Gemfile` is mandatory for Ruby; a `config.ru` or `Procfile`
+   * alone is not buildable). Used to fail fast with an actionable error
+   * before pulling a multi-GB builder — Paketo's own detect phase stays
+   * authoritative.
    */
   projectMarkers: readonly string[];
   /**
@@ -78,7 +80,7 @@ export interface BuildpackGroupEntry {
 export const BUILDPACKS: readonly BuildpackDescriptor[] = [
   {
     runtime: 'ruby',
-    projectMarkers: ['Gemfile', 'config.ru', 'Gemfile.lock'],
+    projectMarkers: ['Gemfile'],
     builder:
       'paketobuildpacks/builder-jammy-base@sha256:622ba9d364d69f578b49fa8dee2e0d450adbd44b31e7c0a18b714a4eefdf371b',
     runImage:

--- a/packages/container/src/buildpacks/registry.ts
+++ b/packages/container/src/buildpacks/registry.ts
@@ -48,6 +48,23 @@ export interface BuildpackDescriptor {
    * depend on the mutable run-image tag recorded in the builder metadata.
    */
   runImage: string;
+  /**
+   * Buildpacks the lifecycle may detect with, written to an explicit
+   * `order.toml` instead of running the builder's full default order. This
+   * keeps detection deterministic in mixed-language roots: a `go.mod` next
+   * to a `Gemfile` must not let another language family out-detect the
+   * requested Ruby build. Versions are resolved by the pinned builder.
+   *
+   * Paketo language-family composites already include the optional procfile
+   * buildpack (which `command` overrides rely on); list it explicitly only
+   * for descriptors whose buildpacks don't.
+   */
+  buildpackGroup: readonly BuildpackGroupEntry[];
+}
+
+export interface BuildpackGroupEntry {
+  id: string;
+  optional?: boolean;
 }
 
 /**
@@ -64,6 +81,9 @@ export const BUILDPACKS: readonly BuildpackDescriptor[] = [
       'paketobuildpacks/builder-jammy-base@sha256:622ba9d364d69f578b49fa8dee2e0d450adbd44b31e7c0a18b714a4eefdf371b',
     runImage:
       'index.docker.io/paketobuildpacks/run-jammy-base@sha256:6de43ef8f4a30fa7b01be23600b2a0433c3ed3851b4fddc3b375212ed69490c2',
+    // The composite includes rackup/puma/etc process detection and the
+    // optional procfile buildpack in every group.
+    buildpackGroup: [{ id: 'paketo-buildpacks/ruby' }],
   },
 ];
 

--- a/packages/container/src/buildpacks/registry.ts
+++ b/packages/container/src/buildpacks/registry.ts
@@ -59,7 +59,7 @@ export interface BuildpackDescriptor {
 export const BUILDPACKS: readonly BuildpackDescriptor[] = [
   {
     runtime: 'ruby',
-    projectMarkers: ['Gemfile', 'config.ru'],
+    projectMarkers: ['Gemfile', 'config.ru', 'Gemfile.lock'],
     builder:
       'paketobuildpacks/builder-jammy-base@sha256:622ba9d364d69f578b49fa8dee2e0d450adbd44b31e7c0a18b714a4eefdf371b',
     runImage:

--- a/packages/container/src/buildpacks/registry.ts
+++ b/packages/container/src/buildpacks/registry.ts
@@ -53,7 +53,8 @@ export interface BuildpackDescriptor {
    * `order.toml` instead of running the builder's full default order. This
    * keeps detection deterministic in mixed-language roots: a `go.mod` next
    * to a `Gemfile` must not let another language family out-detect the
-   * requested Ruby build. Versions are resolved by the pinned builder.
+   * requested Ruby build. IDs and versions must match buildpacks installed
+   * in the pinned builder.
    *
    * Paketo language-family composites already include the optional procfile
    * buildpack (which `command` overrides rely on); list it explicitly only
@@ -64,6 +65,7 @@ export interface BuildpackDescriptor {
 
 export interface BuildpackGroupEntry {
   id: string;
+  version: string;
   optional?: boolean;
 }
 
@@ -83,7 +85,7 @@ export const BUILDPACKS: readonly BuildpackDescriptor[] = [
       'index.docker.io/paketobuildpacks/run-jammy-base@sha256:6de43ef8f4a30fa7b01be23600b2a0433c3ed3851b4fddc3b375212ed69490c2',
     // The composite includes rackup/puma/etc process detection and the
     // optional procfile buildpack in every group.
-    buildpackGroup: [{ id: 'paketo-buildpacks/ruby' }],
+    buildpackGroup: [{ id: 'paketo-buildpacks/ruby', version: '2.0.1' }],
   },
 ];
 

--- a/packages/container/src/buildpacks/registry.ts
+++ b/packages/container/src/buildpacks/registry.ts
@@ -63,6 +63,15 @@ export interface BuildpackDescriptor {
    * for descriptors whose buildpacks don't.
    */
   buildpackGroup: readonly BuildpackGroupEntry[];
+  /**
+   * Build env applied beneath the user's build env (user keys win). Use
+   * Paketo's environment-variables buildpack `BPE_DEFAULT_<KEY>` form to
+   * bake overridable launch-env defaults into the image: the CNB launcher
+   * only applies them when the variable is unset at run time, so env vars
+   * configured on the project always take precedence. Each applied default
+   * is logged during the build.
+   */
+  defaultBuildEnv?: Readonly<Record<string, string>>;
 }
 
 export interface BuildpackGroupEntry {
@@ -88,6 +97,23 @@ export const BUILDPACKS: readonly BuildpackDescriptor[] = [
     // The composite includes rackup/puma/etc process detection and the
     // optional procfile buildpack in every group.
     buildpackGroup: [{ id: 'paketo-buildpacks/ruby', version: '2.0.1' }],
+    // Heroku-style production defaults: overridable at run time by project
+    // env vars, harmless for non-Rails apps. (Paketo's MRI buildpack already
+    // defaults MALLOC_ARENA_MAX=2.)
+    //
+    // TODO: when Rails is detected and neither SECRET_KEY_BASE nor
+    // RAILS_MASTER_KEY is configured, generate a per-deployment
+    // BPE_DEFAULT_SECRET_KEY_BASE so production requests don't 500 with
+    // "Missing secret_key_base" (with a log line noting sessions reset each
+    // deploy), and add a CLI prompt that persists a generated value as a
+    // project env var — the durable store — instead of hiding the secret in
+    // the build cache the way Heroku does.
+    defaultBuildEnv: {
+      BPE_DEFAULT_RAILS_ENV: 'production',
+      BPE_DEFAULT_RACK_ENV: 'production',
+      BPE_DEFAULT_RAILS_LOG_TO_STDOUT: 'enabled',
+      BPE_DEFAULT_RAILS_SERVE_STATIC_FILES: 'enabled',
+    },
   },
 ];
 

--- a/packages/container/src/dev.ts
+++ b/packages/container/src/dev.ts
@@ -10,7 +10,13 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { resolveImageSource } from './image-source';
 import type { DevOutput } from './util';
-import { debug, devImageTag, normalizeCommand, withSpan } from './util';
+import {
+  assertValidCommandShell,
+  debug,
+  devImageTag,
+  normalizeCommand,
+  withSpan,
+} from './util';
 
 export type { DevOutput } from './util';
 
@@ -514,6 +520,9 @@ async function startContainer(
       const commandShell =
         typeof rawCommand === 'string' ||
         (config as { commandShell?: unknown }).commandShell === true;
+      if (isBuildpack) {
+        assertValidCommandShell(command, commandShell);
+      }
 
       // Honor the host port the orchestrator pre-allocated for this service
       // (passed via `meta.port`). Service bindings are built against this port

--- a/packages/container/src/image-source.ts
+++ b/packages/container/src/image-source.ts
@@ -34,17 +34,19 @@ export function resolveImageSource(
   // An entrypoint that names a Dockerfile (including the `Dockerfile.vercel` /
   // `Containerfile.vercel` opt-in markers) is built directly. Otherwise — e.g.
   // when a framework preset resolves its entrypoint via `<detect>` — discover
-  // one in the work directory. When a buildpack is selected, a conventional
-  // `Dockerfile` / `Containerfile` also counts and takes precedence over the
-  // buildpack, so users can always opt out of buildpacks by adding one.
+  // an opt-in marker in the work directory. A `Dockerfile.vercel` /
+  // `Containerfile.vercel` marker takes precedence over a selected buildpack
+  // (the opt-out from buildpack builds); a conventional `Dockerfile` does
+  // not, so a repo can keep one for other purposes.
   const dockerfileConfigured =
     entrypointRef && isDockerfileRef(entrypointRef)
       ? entrypointRef
-      : findDockerfile(workPath, buildpack !== undefined);
+      : findDockerfile(workPath);
   const dockerfileRel = dockerfileConfigured ?? 'Dockerfile';
   const dockerfilePath = path.join(workPath, dockerfileRel);
   const hasDockerfile =
-    dockerfileConfigured !== undefined || existsSync(dockerfilePath);
+    dockerfileConfigured !== undefined ||
+    (!buildpack && existsSync(dockerfilePath));
   if (hasDockerfile) {
     return { kind: 'dockerfile', dockerfileRel, dockerfilePath };
   }
@@ -67,8 +69,8 @@ export function resolveImageSource(
     throw new Error(
       `The ${buildpack.runtime} buildpack was selected, but no supported ` +
         `project marker was found in "${workPath}". Add ` +
-        `${buildpack.projectMarkers.join(' or ')}, or add a Dockerfile to ` +
-        'control the image build.'
+        `${buildpack.projectMarkers.join(' or ')}, or add a Dockerfile.vercel ` +
+        'to control the image build.'
     );
   }
 

--- a/packages/container/src/index.ts
+++ b/packages/container/src/index.ts
@@ -10,7 +10,6 @@ import {
 import type { BuildPushParams, ContainerEngine } from './engines/types';
 import { buildAndPushWithLifecycle } from './buildpacks/lifecycle';
 import type { BuildpackDescriptor } from './buildpacks/registry';
-import { requestedBuildpack } from './buildpacks/registry';
 import { resolveImageSource } from './image-source';
 import { resolveOidcTokenForBuild } from './oidc';
 import { ensureRepository } from './registry';
@@ -42,12 +41,7 @@ export { prepareCache } from './prepare-cache';
 function resolveFunctionSourceFile(options: BuildOptions): string {
   const entrypoint = readString(options.entrypoint) ?? '';
   if (entrypoint === '<detect>') {
-    return (
-      findDockerfile(
-        options.workPath,
-        requestedBuildpack(options.config) !== undefined
-      ) ?? entrypoint
-    );
+    return findDockerfile(options.workPath) ?? entrypoint;
   }
   return entrypoint;
 }

--- a/packages/container/src/util.ts
+++ b/packages/container/src/util.ts
@@ -169,6 +169,11 @@ export interface RunResult {
   stderr: string;
 }
 
+/** Rejection from {@link run} carrying the command's exit code. */
+export interface RunError extends Error {
+  exitCode?: number;
+}
+
 /**
  * Run a command, streaming its output to stderr while capturing it for parsing.
  */
@@ -232,12 +237,12 @@ export function run(
         resolve({ stdout, stderr });
       } else {
         const detail = stderr.trim().split('\n').slice(-5).join('\n');
-        reject(
-          new Error(
-            `\`${cmd} ${args.join(' ')}\` exited with code ${code}` +
-              (detail ? `\n${detail}` : '')
-          )
+        const error: RunError = new Error(
+          `\`${cmd} ${args.join(' ')}\` exited with code ${code}` +
+            (detail ? `\n${detail}` : '')
         );
+        error.exitCode = code ?? undefined;
+        reject(error);
       }
     });
 

--- a/packages/container/src/util.ts
+++ b/packages/container/src/util.ts
@@ -34,6 +34,22 @@ export function normalizeCommand(command: unknown): string[] | undefined {
   return undefined;
 }
 
+/**
+ * A shell `command` (`commandShell`) is a single command line; combining it
+ * with an argv array would silently drop every element after the first.
+ */
+export function assertValidCommandShell(
+  command: string[] | undefined,
+  commandShell: boolean
+): void {
+  if (commandShell && command && command.length !== 1) {
+    throw new Error(
+      `A shell "command" must be a single command string, but received ${command.length} elements. ` +
+        'Pass the command as one string, or as an argv array without "commandShell".'
+    );
+  }
+}
+
 export function write(line: string): void {
   process.stderr.write(`${line}\n`);
 }

--- a/packages/container/src/util.ts
+++ b/packages/container/src/util.ts
@@ -126,22 +126,16 @@ export const DOCKERFILE_CANDIDATES = [
   'Dockerfile.vercel',
   'Containerfile.vercel',
 ];
-const CONVENTIONAL_DOCKERFILE_CANDIDATES = ['Dockerfile', 'Containerfile'];
 
 /**
  * Discover a Vercel container opt-in marker (`Dockerfile.vercel` /
  * `Containerfile.vercel`) in `workPath`. Used by both the build and dev paths
  * so they resolve the same Dockerfile when the entrypoint is the `<detect>`
- * sentinel.
+ * sentinel. A conventional `Dockerfile` is deliberately not a marker: only
+ * the `.vercel` suffix opts a project out of buildpack or framework builds.
  */
-export function findDockerfile(
-  workPath: string,
-  includeConventional = false
-): string | undefined {
-  const candidates = includeConventional
-    ? [...DOCKERFILE_CANDIDATES, ...CONVENTIONAL_DOCKERFILE_CANDIDATES]
-    : DOCKERFILE_CANDIDATES;
-  return candidates.find(name => existsSync(join(workPath, name)));
+export function findDockerfile(workPath: string): string | undefined {
+  return DOCKERFILE_CANDIDATES.find(name => existsSync(join(workPath, name)));
 }
 
 /**

--- a/packages/container/test/e2e.test.ts
+++ b/packages/container/test/e2e.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, it, vi } from 'vitest';
+
+const {
+  testDeployment,
+} = require('../../../test/lib/deployment/test-deployment.js');
+
+vi.setConfig({
+  testTimeout: 15 * 60 * 1000,
+  hookTimeout: 15 * 60 * 1000,
+});
+
+const fixturesPath = path.resolve(__dirname, 'fixtures', 'ruby');
+const fixtures = fs
+  .readdirSync(fixturesPath, { withFileTypes: true })
+  .filter(entry => entry.isDirectory())
+  .map(entry => entry.name)
+  .sort();
+
+for (const fixture of fixtures) {
+  it.concurrent(`should build ${fixture}`, async () => {
+    await expect(
+      testDeployment(path.join(fixturesPath, fixture))
+    ).resolves.toBeDefined();
+  });
+}

--- a/packages/container/test/fixtures/ruby/00-cnb-rack-command/Gemfile
+++ b/packages/container/test/fixtures/ruby/00-cnb-rack-command/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+ruby "~> 3.3"
+
+gem "puma", "~> 6.0"
+gem "rack", "~> 3.1"
+gem "rackup", "~> 2.2"

--- a/packages/container/test/fixtures/ruby/00-cnb-rack-command/Gemfile.lock
+++ b/packages/container/test/fixtures/ruby/00-cnb-rack-command/Gemfile.lock
@@ -1,0 +1,25 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    nio4r (2.7.5)
+    puma (6.6.1)
+      nio4r (~> 2.0)
+    rack (3.2.6)
+    rackup (2.3.1)
+      rack (>= 3)
+
+PLATFORMS
+  arm64-darwin-25
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  puma (~> 6.0)
+  rack (~> 3.1)
+  rackup (~> 2.2)
+
+RUBY VERSION
+   ruby 3.3.10p183
+
+BUNDLED WITH
+   2.5.22

--- a/packages/container/test/fixtures/ruby/00-cnb-rack-command/Procfile
+++ b/packages/container/test/fixtures/ruby/00-cnb-rack-command/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rackup --host 0.0.0.0 --port "$PORT" wrong.ru

--- a/packages/container/test/fixtures/ruby/00-cnb-rack-command/config.ru
+++ b/packages/container/test/fixtures/ruby/00-cnb-rack-command/config.ru
@@ -1,0 +1,10 @@
+run lambda { |_env|
+  [
+    200,
+    {
+      "content-type" => "text/plain",
+      "x-command-source" => "vercel",
+    },
+    ["hello from the Vercel Rack command\n"],
+  ]
+}

--- a/packages/container/test/fixtures/ruby/00-cnb-rack-command/probes.json
+++ b/packages/container/test/fixtures/ruby/00-cnb-rack-command/probes.json
@@ -1,0 +1,16 @@
+{
+  "probes": [
+    {
+      "logMustContain": "via ruby buildpacks"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "bodyMustBe": "hello from the Vercel Rack command\n",
+      "responseHeaders": {
+        "content-type": "text/plain",
+        "x-command-source": "vercel"
+      }
+    }
+  ]
+}

--- a/packages/container/test/fixtures/ruby/00-cnb-rack-command/vercel.json
+++ b/packages/container/test/fixtures/ruby/00-cnb-rack-command/vercel.json
@@ -1,0 +1,23 @@
+{
+  "build": {
+    "env": {
+      "VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS": "1"
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": {
+        "type": "service",
+        "service": "rack"
+      }
+    }
+  ],
+  "services": {
+    "rack": {
+      "root": ".",
+      "framework": "ruby",
+      "command": "bundle exec rackup --host 0.0.0.0 --port \"$PORT\" config.ru"
+    }
+  }
+}

--- a/packages/container/test/fixtures/ruby/00-cnb-rack-command/vercel.json
+++ b/packages/container/test/fixtures/ruby/00-cnb-rack-command/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS": "1"
+      "VERCEL_RUBY_EXPERIMENTAL_BUILDPACK": "1"
     }
   },
   "rewrites": [

--- a/packages/container/test/fixtures/ruby/00-cnb-rack-command/wrong.ru
+++ b/packages/container/test/fixtures/ruby/00-cnb-rack-command/wrong.ru
@@ -1,0 +1,3 @@
+run lambda { |_env|
+  [200, { "content-type" => "text/plain" }, ["wrong Procfile command\n"]]
+}

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/Gemfile
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+ruby "~> 3.3"
+
+gem "puma", "~> 6.0"
+gem "rails", "~> 7.2"

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/Gemfile.lock
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/Gemfile.lock
@@ -1,0 +1,228 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.2.3.1)
+      actionpack (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.2.3.1)
+      actionpack (= 7.2.3.1)
+      activejob (= 7.2.3.1)
+      activerecord (= 7.2.3.1)
+      activestorage (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      mail (>= 2.8.0)
+    actionmailer (7.2.3.1)
+      actionpack (= 7.2.3.1)
+      actionview (= 7.2.3.1)
+      activejob (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      mail (>= 2.8.0)
+      rails-dom-testing (~> 2.2)
+    actionpack (7.2.3.1)
+      actionview (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      cgi
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4, < 3.3)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+      useragent (~> 0.16)
+    actiontext (7.2.3.1)
+      actionpack (= 7.2.3.1)
+      activerecord (= 7.2.3.1)
+      activestorage (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.2.3.1)
+      activesupport (= 7.2.3.1)
+      builder (~> 3.1)
+      cgi
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (7.2.3.1)
+      activesupport (= 7.2.3.1)
+      globalid (>= 0.3.6)
+    activemodel (7.2.3.1)
+      activesupport (= 7.2.3.1)
+    activerecord (7.2.3.1)
+      activemodel (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      timeout (>= 0.4.0)
+    activestorage (7.2.3.1)
+      actionpack (= 7.2.3.1)
+      activejob (= 7.2.3.1)
+      activerecord (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      marcel (~> 1.0)
+    activesupport (7.2.3.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    cgi (0.5.2)
+    concurrent-ruby (1.3.8)
+    connection_pool (3.0.2)
+    crass (1.0.7)
+    date (3.5.1)
+    drb (2.2.3)
+    erb (6.0.6)
+    erubi (1.13.1)
+    globalid (1.4.0)
+      activesupport (>= 6.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.2.1)
+    mini_mime (1.1.5)
+    minitest (5.27.0)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nio4r (2.7.5)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-musl)
+      racc (~> 1.4)
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    puma (6.6.1)
+      nio4r (~> 2.0)
+    racc (1.8.1)
+    rack (3.2.6)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (2.3.1)
+      rack (>= 3)
+    rails (7.2.3.1)
+      actioncable (= 7.2.3.1)
+      actionmailbox (= 7.2.3.1)
+      actionmailer (= 7.2.3.1)
+      actionpack (= 7.2.3.1)
+      actiontext (= 7.2.3.1)
+      actionview (= 7.2.3.1)
+      activejob (= 7.2.3.1)
+      activemodel (= 7.2.3.1)
+      activerecord (= 7.2.3.1)
+      activestorage (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      bundler (>= 1.15.0)
+      railties (= 7.2.3.1)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (7.2.3.1)
+      actionpack (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
+      cgi
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
+    rake (13.4.2)
+    rbs (4.1.0)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    reline (0.6.3)
+      io-console (~> 0.5)
+    securerandom (0.4.1)
+    thor (1.5.0)
+    timeout (0.6.1)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    useragent (0.16.11)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.2)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  puma (~> 6.0)
+  rails (~> 7.2)
+
+RUBY VERSION
+   ruby 3.3.10p183
+
+BUNDLED WITH
+   2.5.22

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/Rakefile
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/Rakefile
@@ -1,0 +1,14 @@
+require "fileutils"
+require_relative "config/application"
+
+Rails.application.load_tasks
+
+namespace :assets do
+  task precompile: :environment do
+    output = Rails.root.join("public", "buildpack-generated.txt")
+    FileUtils.mkdir_p(output.dirname)
+    output.write("generated while building the Rails application\n")
+  end
+
+  task clean: :environment
+end

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/app/assets/buildpack.txt
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/app/assets/buildpack.txt
@@ -1,0 +1,1 @@
+This file makes Paketo's Rails assets buildpack participate in the build.

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/app/controllers/status_controller.rb
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/app/controllers/status_controller.rb
@@ -1,0 +1,11 @@
+class StatusController < ActionController::API
+  def show
+    render json: {
+      message: "hello from Rails buildpacks",
+      rails_env: Rails.env,
+      rack_env: ENV.fetch("RACK_ENV", "missing"),
+      log_to_stdout: ENV.fetch("RAILS_LOG_TO_STDOUT", "missing"),
+      serve_static_files: ENV.fetch("RAILS_SERVE_STATIC_FILES", "missing"),
+    }
+  end
+end

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/bin/rails
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/bin/rails
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/config.ru
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/config.ru
@@ -1,0 +1,4 @@
+require_relative "config/environment"
+
+run Rails.application
+Rails.application.load_server

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/config/application.rb
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/config/application.rb
@@ -1,0 +1,12 @@
+require_relative "boot"
+require "rails"
+require "action_controller/railtie"
+
+Bundler.require(*Rails.groups)
+
+module BuildpackRails
+  class Application < Rails::Application
+    config.load_defaults 7.2
+    config.api_only = true
+  end
+end

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/config/boot.rb
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/config/boot.rb
@@ -1,0 +1,3 @@
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+
+require "bundler/setup"

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/config/environment.rb
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/config/environment.rb
@@ -1,0 +1,3 @@
+require_relative "application"
+
+Rails.application.initialize!

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/config/environments/production.rb
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/config/environments/production.rb
@@ -1,0 +1,12 @@
+Rails.application.configure do
+  config.consider_all_requests_local = false
+  config.eager_load = true
+  config.public_file_server.enabled =
+    ENV["RAILS_SERVE_STATIC_FILES"].present?
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(
+      ActiveSupport::Logger.new($stdout)
+    )
+  end
+end

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/config/puma.rb
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/config/puma.rb
@@ -1,0 +1,2 @@
+bind "tcp://0.0.0.0:#{ENV.fetch("PORT", 3000)}"
+environment ENV.fetch("RAILS_ENV", "development")

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/config/routes.rb
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/config/routes.rb
@@ -1,0 +1,3 @@
+Rails.application.routes.draw do
+  root "status#show"
+end

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/probes.json
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/probes.json
@@ -1,0 +1,23 @@
+{
+  "probes": [
+    {
+      "logMustContain": "via ruby buildpacks"
+    },
+    {
+      "logMustContain": "Defaulting RAILS_ENV=production"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "bodyMustBe": "{\"message\":\"hello from Rails buildpacks\",\"rails_env\":\"production\",\"rack_env\":\"fixture-override\",\"log_to_stdout\":\"enabled\",\"serve_static_files\":\"enabled\"}",
+      "responseHeaders": {
+        "content-type": "application/json; charset=utf-8"
+      }
+    },
+    {
+      "path": "/buildpack-generated.txt",
+      "status": 200,
+      "bodyMustBe": "generated while building the Rails application\n"
+    }
+  ]
+}

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/vercel.json
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/vercel.json
@@ -2,7 +2,7 @@
   "build": {
     "env": {
       "SECRET_KEY_BASE": "ruby-buildpack-e2e-build-secret",
-      "VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS": "1"
+      "VERCEL_RUBY_EXPERIMENTAL_BUILDPACK": "1"
     }
   },
   "env": {

--- a/packages/container/test/fixtures/ruby/01-cnb-rails/vercel.json
+++ b/packages/container/test/fixtures/ruby/01-cnb-rails/vercel.json
@@ -1,0 +1,12 @@
+{
+  "build": {
+    "env": {
+      "SECRET_KEY_BASE": "ruby-buildpack-e2e-build-secret",
+      "VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS": "1"
+    }
+  },
+  "env": {
+    "RACK_ENV": "fixture-override",
+    "SECRET_KEY_BASE": "ruby-buildpack-e2e-runtime-secret"
+  }
+}

--- a/packages/container/test/fixtures/ruby/02-cnb-sinatra/Gemfile
+++ b/packages/container/test/fixtures/ruby/02-cnb-sinatra/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+ruby "~> 3.3"
+
+gem "puma", "~> 6.0"
+gem "sinatra", "~> 4.1"

--- a/packages/container/test/fixtures/ruby/02-cnb-sinatra/Gemfile.lock
+++ b/packages/container/test/fixtures/ruby/02-cnb-sinatra/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.3.0)
+    logger (1.7.0)
+    mustermann (3.1.1)
+    nio4r (2.7.5)
+    puma (6.6.1)
+      nio4r (~> 2.0)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.8.0)
+
+PLATFORMS
+  arm64-darwin-25
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  puma (~> 6.0)
+  sinatra (~> 4.1)
+
+RUBY VERSION
+   ruby 3.3.10p183
+
+BUNDLED WITH
+   2.5.22

--- a/packages/container/test/fixtures/ruby/02-cnb-sinatra/app.rb
+++ b/packages/container/test/fixtures/ruby/02-cnb-sinatra/app.rb
@@ -1,0 +1,12 @@
+require "json"
+require "sinatra/base"
+
+class BuildpackSinatra < Sinatra::Base
+  get "/health" do
+    content_type :json
+    JSON.generate(
+      message: "hello from Sinatra buildpacks",
+      sinatra_version: Sinatra::VERSION
+    )
+  end
+end

--- a/packages/container/test/fixtures/ruby/02-cnb-sinatra/config.ru
+++ b/packages/container/test/fixtures/ruby/02-cnb-sinatra/config.ru
@@ -1,0 +1,3 @@
+require_relative "app"
+
+run BuildpackSinatra

--- a/packages/container/test/fixtures/ruby/02-cnb-sinatra/probes.json
+++ b/packages/container/test/fixtures/ruby/02-cnb-sinatra/probes.json
@@ -1,0 +1,15 @@
+{
+  "probes": [
+    {
+      "logMustContain": "via ruby buildpacks"
+    },
+    {
+      "path": "/health",
+      "status": 200,
+      "mustContain": "hello from Sinatra buildpacks",
+      "responseHeaders": {
+        "content-type": "application/json"
+      }
+    }
+  ]
+}

--- a/packages/container/test/fixtures/ruby/02-cnb-sinatra/vercel.json
+++ b/packages/container/test/fixtures/ruby/02-cnb-sinatra/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS": "1"
+      "VERCEL_RUBY_EXPERIMENTAL_BUILDPACK": "1"
     }
   },
   "rewrites": [

--- a/packages/container/test/fixtures/ruby/02-cnb-sinatra/vercel.json
+++ b/packages/container/test/fixtures/ruby/02-cnb-sinatra/vercel.json
@@ -1,0 +1,22 @@
+{
+  "build": {
+    "env": {
+      "VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS": "1"
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": {
+        "type": "service",
+        "service": "sinatra"
+      }
+    }
+  ],
+  "services": {
+    "sinatra": {
+      "root": ".",
+      "runtime": "ruby"
+    }
+  }
+}

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -101,7 +101,7 @@ function stubRegistryFetch(
 }
 
 /** Fake child process that exits with a failure code. */
-function fakeChildFailure(stderr = '') {
+function fakeChildFailure(stderr = '', code = 1) {
   const child: any = new EventEmitter();
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
@@ -110,7 +110,7 @@ function fakeChildFailure(stderr = '') {
     if (stderr) {
       child.stderr.emit('data', Buffer.from(stderr));
     }
-    child.emit('close', 1);
+    child.emit('close', code);
   });
   return child;
 }
@@ -1392,6 +1392,22 @@ describe('@vercel/container', () => {
       }
     });
 
+    it('describes CNB lifecycle creator exit codes by phase', async () => {
+      const { describeCreatorExitCode } = await import(
+        '../src/buildpacks/lifecycle'
+      );
+      expect(describeCreatorExitCode(20)).toBe('no buildpack detected the app');
+      expect(describeCreatorExitCode(21)).toMatch(/errored during detection/);
+      expect(describeCreatorExitCode(51)).toMatch(
+        /failed while building the app/
+      );
+      expect(describeCreatorExitCode(52)).toBe('the build phase failed');
+      expect(describeCreatorExitCode(62)).toMatch(/export phase/);
+      // Unknown / generic codes get no interpretation.
+      expect(describeCreatorExitCode(1)).toBeUndefined();
+      expect(describeCreatorExitCode(undefined)).toBeUndefined();
+    });
+
     it('resolves the buildpack from either config channel and honors marker precedence', () => {
       expect(requestedBuildpack({ buildpack: 'ruby' })).toBe(ruby);
       expect(requestedBuildpack({ framework: 'ruby' })).toBe(ruby);
@@ -1561,18 +1577,26 @@ describe('@vercel/container', () => {
           );
         }
         if (cmd === 'buildah' && args.includes('/cnb/lifecycle/creator')) {
-          return fakeChildFailure('ERROR: failed to detect a launch process');
+          // 51: lifecycle build-phase failure (a buildpack's /bin/build errored).
+          return fakeChildFailure('ERROR: failed to build: exit status 1', 51);
         }
         return fakeChild('');
       });
 
-      await expect(
-        build({
-          ...createBuildOptions({ buildpack: 'ruby' }),
-          entrypoint: '<detect>',
-          service: { name: 'api' },
-        })
-      ).rejects.toThrow(/failed to detect a launch process/);
+      const failure = await build({
+        ...createBuildOptions({ buildpack: 'ruby' }),
+        entrypoint: '<detect>',
+        service: { name: 'api' },
+      }).then(
+        () => undefined,
+        err => err as Error
+      );
+      expect(failure?.message).toContain('exited with code 51');
+      // The wrapper explains the lifecycle exit code instead of leaving a
+      // bare number.
+      expect(failure?.message).toContain(
+        'The lifecycle exited with code 51: a buildpack failed while building the app'
+      );
       const cleanupArgs = spawnMock.mock.calls.find(
         ([cmd, args]) => cmd === 'buildah' && (args as string[]).includes('rm')
       )?.[1] as string[] | undefined;
@@ -1660,6 +1684,34 @@ describe('@vercel/container', () => {
         )
       ).toBe(true);
       await result!.shutdown!();
+    });
+
+    it('explains creator exit codes when a dev buildpack build fails', async () => {
+      existsSyncMock.mockImplementation((p: string) => p === '/Gemfile');
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'docker' && args[0] === 'image' && args[1] === 'inspect') {
+          return fakeChild('linux/amd64\n');
+        }
+        if (
+          cmd === 'docker' &&
+          args[0] === 'run' &&
+          args.includes('/cnb/lifecycle/creator')
+        ) {
+          return fakeChildFailure('ERROR: No buildpack groups passed', 20);
+        }
+        return fakeChild('');
+      });
+
+      await expect(
+        startDevServer({
+          ...createBuildOptions({ buildpack: 'ruby' }),
+          entrypoint: '<detect>',
+          service: { name: 'ruby-api' },
+          meta: { isDev: true },
+        } as any)
+      ).rejects.toThrow(
+        /exited with code 20 \(no buildpack detected the app\)/
+      );
     });
 
     it('runs a dev command override through the CNB launcher', async () => {

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -1303,23 +1303,93 @@ describe('@vercel/container', () => {
   });
 
   describe('buildpacks (Ruby)', () => {
+    let BUILDPACKS: typeof import('../src/buildpacks/registry').BUILDPACKS;
     let ruby: import('../src/buildpacks/registry').BuildpackDescriptor;
     let requestedBuildpack: typeof import('../src/buildpacks/registry').requestedBuildpack;
     let resolveImageSource: typeof import('../src/image-source').resolveImageSource;
 
     beforeAll(async () => {
       const registry = await import('../src/buildpacks/registry');
+      BUILDPACKS = registry.BUILDPACKS;
       requestedBuildpack = registry.requestedBuildpack;
       ruby = registry.BUILDPACKS.find(bp => bp.runtime === 'ruby')!;
       resolveImageSource = (await import('../src/image-source'))
         .resolveImageSource;
     });
 
-    it('pins the builder and run images by digest', () => {
+    it('pins the builder and run images by digest and declares a buildpack group', () => {
       // Deploys run the builder on Vercel infrastructure — a mutable tag
       // would silently track upstream pushes.
-      expect(ruby.builder).toMatch(/@sha256:[0-9a-f]{64}$/);
-      expect(ruby.runImage).toMatch(/@sha256:[0-9a-f]{64}$/);
+      for (const bp of BUILDPACKS) {
+        expect(bp.builder).toMatch(/@sha256:[0-9a-f]{64}$/);
+        expect(bp.runImage).toMatch(/@sha256:[0-9a-f]{64}$/);
+        expect(bp.buildpackGroup.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('resolves images per descriptor without language-specific branches', async () => {
+      const { builderImageRef, runImageRef, hasProjectMarkers } = await import(
+        '../src/buildpacks/registry'
+      );
+      const synthetic = {
+        runtime: 'elixir',
+        projectMarkers: ['mix.exs'],
+        builder: 'example/builder-elixir@sha256:deadbeef',
+        runImage: 'example/run-elixir@sha256:deadbeef',
+        buildpackGroup: [{ id: 'example/elixir' }],
+      };
+
+      expect(builderImageRef(synthetic)).toBe(synthetic.builder);
+      expect(runImageRef(synthetic)).toBe(synthetic.runImage);
+
+      process.env.VERCEL_BUILDPACK_ELIXIR_BUILDER = 'example/custom:tag';
+      try {
+        expect(builderImageRef(synthetic)).toBe('example/custom:tag');
+        // A custom builder may target a different stack; never pair it with
+        // the pinned default run image.
+        expect(runImageRef(synthetic)).toBeUndefined();
+        process.env.VERCEL_BUILDPACK_ELIXIR_RUN_IMAGE = 'example/run:tag';
+        expect(runImageRef(synthetic)).toBe('example/run:tag');
+      } finally {
+        delete process.env.VERCEL_BUILDPACK_ELIXIR_BUILDER;
+        delete process.env.VERCEL_BUILDPACK_ELIXIR_RUN_IMAGE;
+      }
+
+      existsSyncMock.mockImplementation((p: string) => p === '/mix.exs');
+      expect(hasProjectMarkers(synthetic, '/')).toBe(true);
+      existsSyncMock.mockImplementation((p: string) => p === '/Gemfile');
+      expect(hasProjectMarkers(synthetic, '/')).toBe(false);
+    });
+
+    it('fails dev builds when an overridden builder has no resolvable run image', async () => {
+      process.env.VERCEL_BUILDPACK_RUBY_BUILDER = 'example/custom-builder:tag';
+      existsSyncMock.mockImplementation((p: string) => p === '/Gemfile');
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        if (
+          cmd === 'docker' &&
+          args[0] === 'image' &&
+          args.includes('io.buildpacks.builder.metadata')
+        ) {
+          return fakeChild('');
+        }
+        if (cmd === 'docker' && args[0] === 'image' && args[1] === 'inspect') {
+          return fakeChild('linux/amd64\n');
+        }
+        return fakeChild('');
+      });
+
+      try {
+        await expect(
+          startDevServer({
+            ...createBuildOptions({ buildpack: 'ruby' }),
+            entrypoint: '<detect>',
+            service: { name: 'ruby-api' },
+            meta: { isDev: true },
+          } as any)
+        ).rejects.toThrow(/VERCEL_BUILDPACK_RUBY_RUN_IMAGE/);
+      } finally {
+        delete process.env.VERCEL_BUILDPACK_RUBY_BUILDER;
+      }
     });
 
     it('resolves the buildpack from either config channel and honors marker precedence', () => {
@@ -1535,6 +1605,17 @@ describe('@vercel/container', () => {
               'utf8'
             )
           ).toBe('3.3');
+          // Dev detects with the same explicit buildpack order as deploys.
+          expect(args).toContain('-order=/platform/order/order.toml');
+          const orderMount = args
+            .filter((_arg, index) => args[index - 1] === '-v')
+            .find(arg => arg.endsWith(':/platform/order:ro'));
+          expect(
+            readFileSync(
+              `${orderMount!.slice(0, -':/platform/order:ro'.length)}/order.toml`,
+              'utf8'
+            )
+          ).toContain('id = "paketo-buildpacks/ruby"');
           return fakeChild('');
         }
         if (cmd === 'docker' && args[0] === 'run') {
@@ -1646,6 +1727,11 @@ describe('@vercel/container', () => {
       // platform env dir hit the real filesystem — use a real workPath.
       const workPath = mkdtempSync(join(tmpdir(), 'vercel-cnb-test-'));
       existsSyncMock.mockImplementation((p: string) => p.endsWith('/Gemfile'));
+      // The Procfile is written to a staged copy of the app (mounted at
+      // /workspace), never the source tree; capture it while the staged
+      // copy still exists.
+      let stagedProcfile: string | undefined;
+      let stagedOrder: string | undefined;
       spawnMock.mockImplementation((cmd: string, args: string[]) => {
         if (cmd === 'buildah' && args.includes('info')) {
           return fakeChild(
@@ -1660,12 +1746,29 @@ describe('@vercel/container', () => {
           );
         }
         if (cmd === 'buildah' && args.includes('/cnb/lifecycle/creator')) {
-          const reportMount = args
-            .filter((_arg, index) => args[index - 1] === '--volume')
-            .find(arg => arg.endsWith(':/platform-output'));
+          const mounts = args.filter(
+            (_arg, index) => args[index - 1] === '--volume'
+          );
+          const reportMount = mounts.find(arg =>
+            arg.endsWith(':/platform-output')
+          );
           writeFileSync(
             `${reportMount!.slice(0, -':/platform-output'.length)}/report.toml`,
             `[image]\ndigest = "${digest}"\n`
+          );
+          const workspaceMount = mounts.find(arg =>
+            arg.endsWith(':/workspace')
+          );
+          stagedProcfile = readFileSync(
+            `${workspaceMount!.slice(0, -':/workspace'.length)}/Procfile`,
+            'utf8'
+          );
+          const orderMount = mounts.find(arg =>
+            arg.endsWith(':/platform/order')
+          );
+          stagedOrder = readFileSync(
+            `${orderMount!.slice(0, -':/platform/order'.length)}/order.toml`,
+            'utf8'
           );
         }
         return fakeChild('');
@@ -1683,9 +1786,11 @@ describe('@vercel/container', () => {
           meta: { buildEnv: { BP_MRI_VERSION: '3.3' } },
         } as any);
 
-        expect(readFileSync(join(workPath, 'Procfile'), 'utf8')).toBe(
-          `web: bundle exec puma -p '$PORT'\n`
-        );
+        expect(stagedProcfile).toBe(`web: bundle exec puma -p '$PORT'\n`);
+        // The source tree must stay untouched.
+        expect(() => readFileSync(join(workPath, 'Procfile'))).toThrow();
+        // Detection is scoped to the descriptor's buildpack group.
+        expect(stagedOrder).toContain('id = "paketo-buildpacks/ruby"');
 
         // The build env travels via the CNB platform dir, not process env.
         const creatorArgs = spawnMock.mock.calls.find(
@@ -1697,6 +1802,7 @@ describe('@vercel/container', () => {
           .filter((_arg, index) => creatorArgs[index - 1] === '--volume')
           .find(arg => arg.endsWith(':/platform/env'));
         expect(platformEnvMount).toBeDefined();
+        expect(creatorArgs).toContain('-order=/platform/order/order.toml');
 
         await build({
           ...createBuildOptions({
@@ -1707,9 +1813,7 @@ describe('@vercel/container', () => {
           entrypoint: '<detect>',
           service: { name: 'api' },
         } as any);
-        expect(readFileSync(join(workPath, 'Procfile'), 'utf8')).toBe(
-          `web: bundle exec puma -p $PORT\n`
-        );
+        expect(stagedProcfile).toBe(`web: bundle exec puma -p $PORT\n`);
 
         // commandShell + multi-element argv would silently drop every
         // element after the first.

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -1777,11 +1777,12 @@ describe('@vercel/container', () => {
       // platform env dir hit the real filesystem — use a real workPath.
       const workPath = mkdtempSync(join(tmpdir(), 'vercel-cnb-test-'));
       existsSyncMock.mockImplementation((p: string) => p.endsWith('/Gemfile'));
-      // The Procfile is written to a staged copy of the app (mounted at
-      // /workspace), never the source tree; capture it while the staged
-      // copy still exists.
+      // The Procfile is written to a temp dir and `buildah copy`ed into the
+      // working container, never the source tree; capture its content while
+      // the temp file still exists.
       let stagedProcfile: string | undefined;
       let stagedOrder: string | undefined;
+      const copyCalls: string[][] = [];
       spawnMock.mockImplementation((cmd: string, args: string[]) => {
         if (cmd === 'buildah' && args.includes('info')) {
           return fakeChild(
@@ -1795,6 +1796,23 @@ describe('@vercel/container', () => {
             })
           );
         }
+        if (
+          cmd === 'buildah' &&
+          args.some(arg => arg.includes('CNB_USER_ID'))
+        ) {
+          // The build-user probe reads CNB_USER_ID/CNB_GROUP_ID from the
+          // builder image's env. It must use host networking: the build
+          // sandbox cannot set up bridge networking (netavark/iptables).
+          expect(args.join(' ')).toContain('--network host');
+          return fakeChild('1001:1000\n');
+        }
+        if (cmd === 'buildah' && args.includes('copy')) {
+          copyCalls.push([...args]);
+          if (args.at(-1) === '/workspace/Procfile') {
+            stagedProcfile = readFileSync(args.at(-2)!, 'utf8');
+          }
+          return fakeChild('');
+        }
         if (cmd === 'buildah' && args.includes('/cnb/lifecycle/creator')) {
           const mounts = args.filter(
             (_arg, index) => args[index - 1] === '--volume'
@@ -1806,13 +1824,8 @@ describe('@vercel/container', () => {
             `${reportMount!.slice(0, -':/platform-output'.length)}/report.toml`,
             `[image]\ndigest = "${digest}"\n`
           );
-          const workspaceMount = mounts.find(arg =>
-            arg.endsWith(':/workspace')
-          );
-          stagedProcfile = readFileSync(
-            `${workspaceMount!.slice(0, -':/workspace'.length)}/Procfile`,
-            'utf8'
-          );
+          // The app is copied into the container, not bind-mounted.
+          expect(mounts.some(arg => arg.endsWith(':/workspace'))).toBe(false);
           const orderMount = mounts.find(arg =>
             arg.endsWith(':/platform/order')
           );
@@ -1842,6 +1855,33 @@ describe('@vercel/container', () => {
         // Detection is scoped to the descriptor's buildpack group.
         expect(stagedOrder).toContain('id = "paketo-buildpacks/ruby"');
         expect(stagedOrder).toContain('version = "2.0.1"');
+
+        // The app is copied into the working container owned by the
+        // builder's build user (as pack does), then the command Procfile is
+        // copied on top of it.
+        const appCopy = copyCalls.find(args => args.at(-1) === '/workspace');
+        expect(appCopy).toBeDefined();
+        expect(appCopy).toEqual(
+          expect.arrayContaining(['copy', '--chown', '1001:1000'])
+        );
+        expect(appCopy?.at(-2)).toBe(workPath);
+        const procfileCopy = copyCalls.find(
+          args => args.at(-1) === '/workspace/Procfile'
+        );
+        expect(procfileCopy).toEqual(
+          expect.arrayContaining(['copy', '--chown', '1001:1000'])
+        );
+        const callKinds = spawnMock.mock.calls
+          .filter(([cmd]) => cmd === 'buildah')
+          .map(([, args]) => {
+            const a = args as string[];
+            if (a.includes('copy')) return 'copy';
+            if (a.includes('/cnb/lifecycle/creator')) return 'creator';
+            return 'other';
+          });
+        expect(callKinds.indexOf('copy')).toBeLessThan(
+          callKinds.indexOf('creator')
+        );
 
         // The build env travels via the CNB platform dir, not process env.
         const creatorArgs = spawnMock.mock.calls.find(

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -1710,6 +1710,21 @@ describe('@vercel/container', () => {
         expect(readFileSync(join(workPath, 'Procfile'), 'utf8')).toBe(
           `web: bundle exec puma -p $PORT\n`
         );
+
+        // commandShell + multi-element argv would silently drop every
+        // element after the first.
+        await expect(
+          build({
+            ...createBuildOptions({
+              buildpack: 'ruby',
+              command: ['bundle', 'exec', 'puma'],
+              commandShell: true,
+            }),
+            workPath,
+            entrypoint: '<detect>',
+            service: { name: 'api' },
+          } as any)
+        ).rejects.toThrow(/single command string/);
       } finally {
         rmSync(workPath, { recursive: true, force: true });
       }

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -1322,7 +1322,7 @@ describe('@vercel/container', () => {
       expect(ruby.runImage).toMatch(/@sha256:[0-9a-f]{64}$/);
     });
 
-    it('resolves the buildpack from either config channel and honors marker/Dockerfile precedence', () => {
+    it('resolves the buildpack from either config channel and honors marker precedence', () => {
       expect(requestedBuildpack({ buildpack: 'ruby' })).toBe(ruby);
       expect(requestedBuildpack({ framework: 'ruby' })).toBe(ruby);
       expect(requestedBuildpack({ runtime: 'container' })).toBeUndefined();
@@ -1338,13 +1338,23 @@ describe('@vercel/container', () => {
         resolveImageSource(options({ buildpack: 'ruby' }), 'build')
       ).toMatchObject({ kind: 'buildpack', buildpack: { runtime: 'ruby' } });
 
-      // A conventional Dockerfile opts out of buildpacks.
+      // Only a `.vercel` marker opts out of buildpacks; a conventional
+      // Dockerfile can coexist with a buildpack build.
       existsSyncMock.mockImplementation(
         (p: string) => p === '/Gemfile' || p === '/Dockerfile'
       );
       expect(
         resolveImageSource(options({ buildpack: 'ruby' }), 'build')
-      ).toMatchObject({ kind: 'dockerfile', dockerfileRel: 'Dockerfile' });
+      ).toMatchObject({ kind: 'buildpack', buildpack: { runtime: 'ruby' } });
+      existsSyncMock.mockImplementation(
+        (p: string) => p === '/Gemfile' || p === '/Dockerfile.vercel'
+      );
+      expect(
+        resolveImageSource(options({ buildpack: 'ruby' }), 'build')
+      ).toMatchObject({
+        kind: 'dockerfile',
+        dockerfileRel: 'Dockerfile.vercel',
+      });
 
       // A Procfile is not language evidence — it must not mark a project as
       // a Ruby buildpack project on its own.

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -1392,6 +1392,46 @@ describe('@vercel/container', () => {
       }
     });
 
+    it('applies overridable production env defaults beneath the user build env', async () => {
+      const { mergeDefaultBuildEnv } = await import(
+        '../src/buildpacks/lifecycle'
+      );
+
+      const defaulted = mergeDefaultBuildEnv(ruby, { BP_MRI_VERSION: '3.3' });
+      expect(defaulted.buildEnv).toMatchObject({
+        BP_MRI_VERSION: '3.3',
+        BPE_DEFAULT_RAILS_ENV: 'production',
+        BPE_DEFAULT_RACK_ENV: 'production',
+        BPE_DEFAULT_RAILS_LOG_TO_STDOUT: 'enabled',
+        BPE_DEFAULT_RAILS_SERVE_STATIC_FILES: 'enabled',
+      });
+      expect(defaulted.applied.join('\n')).toContain(
+        'Defaulting RAILS_ENV=production'
+      );
+
+      // A user-provided value suppresses the default, whether set as the
+      // launch variable itself or the BPE_DEFAULT_* form.
+      const overridden = mergeDefaultBuildEnv(ruby, {
+        RAILS_ENV: 'staging',
+        BPE_DEFAULT_RACK_ENV: 'staging',
+      });
+      expect(overridden.buildEnv).not.toHaveProperty('BPE_DEFAULT_RAILS_ENV');
+      expect(overridden.buildEnv).toMatchObject({
+        RAILS_ENV: 'staging',
+        BPE_DEFAULT_RACK_ENV: 'staging',
+        BPE_DEFAULT_RAILS_LOG_TO_STDOUT: 'enabled',
+      });
+      expect(overridden.applied.join('\n')).not.toContain('RAILS_ENV');
+      expect(overridden.applied.join('\n')).not.toContain('RACK_ENV=');
+
+      // Descriptors without defaults pass the env through untouched.
+      const none = mergeDefaultBuildEnv(
+        { ...ruby, defaultBuildEnv: undefined },
+        undefined
+      );
+      expect(none).toEqual({ buildEnv: undefined, applied: [] });
+    });
+
     it('describes CNB lifecycle creator exit codes by phase', async () => {
       const { describeCreatorExitCode } = await import(
         '../src/buildpacks/lifecycle'
@@ -1621,12 +1661,17 @@ describe('@vercel/container', () => {
             .filter((_arg, index) => args[index - 1] === '-v')
             .find(arg => arg.endsWith(':/platform/env:ro'));
           expect(platformEnvMount).toBeDefined();
+          const platformEnvDir = platformEnvMount!.slice(
+            0,
+            -':/platform/env:ro'.length
+          );
+          expect(readFileSync(`${platformEnvDir}/BP_MRI_VERSION`, 'utf8')).toBe(
+            '3.3'
+          );
+          // Dev applies the same overridable production defaults as deploys.
           expect(
-            readFileSync(
-              `${platformEnvMount!.slice(0, -':/platform/env:ro'.length)}/BP_MRI_VERSION`,
-              'utf8'
-            )
-          ).toBe('3.3');
+            readFileSync(`${platformEnvDir}/BPE_DEFAULT_RAILS_ENV`, 'utf8')
+          ).toBe('production');
           // Dev detects with the same explicit buildpack order as deploys.
           expect(args).toContain('-order=/platform/order/order.toml');
           const orderMount = args
@@ -1782,6 +1827,7 @@ describe('@vercel/container', () => {
       // the temp file still exists.
       let stagedProcfile: string | undefined;
       let stagedOrder: string | undefined;
+      let stagedDefaultRailsEnv: string | undefined;
       const copyCalls: string[][] = [];
       spawnMock.mockImplementation((cmd: string, args: string[]) => {
         if (cmd === 'buildah' && args.includes('info')) {
@@ -1831,6 +1877,11 @@ describe('@vercel/container', () => {
           );
           stagedOrder = readFileSync(
             `${orderMount!.slice(0, -':/platform/order'.length)}/order.toml`,
+            'utf8'
+          );
+          const envMount = mounts.find(arg => arg.endsWith(':/platform/env'));
+          stagedDefaultRailsEnv = readFileSync(
+            `${envMount!.slice(0, -':/platform/env'.length)}/BPE_DEFAULT_RAILS_ENV`,
             'utf8'
           );
         }
@@ -1894,6 +1945,8 @@ describe('@vercel/container', () => {
           .find(arg => arg.endsWith(':/platform/env'));
         expect(platformEnvMount).toBeDefined();
         expect(creatorArgs).toContain('-order=/platform/order/order.toml');
+        // Overridable production defaults ride along with the user's env.
+        expect(stagedDefaultRailsEnv).toBe('production');
 
         await build({
           ...createBuildOptions({

--- a/packages/container/test/unit.test.ts
+++ b/packages/container/test/unit.test.ts
@@ -1336,7 +1336,7 @@ describe('@vercel/container', () => {
         projectMarkers: ['mix.exs'],
         builder: 'example/builder-elixir@sha256:deadbeef',
         runImage: 'example/run-elixir@sha256:deadbeef',
-        buildpackGroup: [{ id: 'example/elixir' }],
+        buildpackGroup: [{ id: 'example/elixir', version: '1.2.3' }],
       };
 
       expect(builderImageRef(synthetic)).toBe(synthetic.builder);
@@ -1573,14 +1573,12 @@ describe('@vercel/container', () => {
           service: { name: 'api' },
         })
       ).rejects.toThrow(/failed to detect a launch process/);
-      expect(
-        spawnMock.mock.calls.some(
-          ([cmd, args]) =>
-            cmd === 'buildah' &&
-            (args as string[]).includes('rm') &&
-            (args as string[]).includes('--force')
-        )
-      ).toBe(true);
+      const cleanupArgs = spawnMock.mock.calls.find(
+        ([cmd, args]) => cmd === 'buildah' && (args as string[]).includes('rm')
+      )?.[1] as string[] | undefined;
+      expect(cleanupArgs).toBeDefined();
+      expect(cleanupArgs).not.toContain('--force');
+      expect(cleanupArgs?.at(-1)).toMatch(/^vercel-cnb-ruby-/);
     });
 
     it('builds and starts a Ruby buildpack image in local dev', async () => {
@@ -1615,7 +1613,7 @@ describe('@vercel/container', () => {
               `${orderMount!.slice(0, -':/platform/order:ro'.length)}/order.toml`,
               'utf8'
             )
-          ).toContain('id = "paketo-buildpacks/ruby"');
+          ).toContain('version = "2.0.1"');
           return fakeChild('');
         }
         if (cmd === 'docker' && args[0] === 'run') {
@@ -1791,6 +1789,7 @@ describe('@vercel/container', () => {
         expect(() => readFileSync(join(workPath, 'Procfile'))).toThrow();
         // Detection is scoped to the descriptor's buildpack group.
         expect(stagedOrder).toContain('id = "paketo-buildpacks/ruby"');
+        expect(stagedOrder).toContain('version = "2.0.1"');
 
         // The build env travels via the CNB platform dir, not process env.
         const creatorArgs = spawnMock.mock.calls.find(

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4368,7 +4368,7 @@ export const frameworks = [
     description:
       'A generic Ruby application deployed as a serverless function.',
     website: 'https://www.ruby-lang.org',
-    // With `VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1`, builds-and-routes detection
+    // With `VERCEL_RUBY_EXPERIMENTAL_BUILDPACK=1`, builds-and-routes detection
     // replaces this runtime with a `@vercel/container` buildpack build (see
     // fs-detectors `detectFrontBuilder`).
     useRuntime: { src: 'config.ru', use: '@vercel/ruby' },
@@ -4418,7 +4418,7 @@ export const frameworks = [
       {
         src: '/(.*)',
         dest:
-          process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS === '1'
+          process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK === '1'
             ? '/index'
             : '/config',
       },

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4373,13 +4373,22 @@ export const frameworks = [
     // fs-detectors `detectFrontBuilder`).
     useRuntime: { src: 'config.ru', use: '@vercel/ruby' },
     ignoreRuntimes: ['@vercel/ruby'],
+    // Mirrors the Paketo Ruby buildpack's detect phase: a Gemfile is
+    // mandatory, plus a `config.ru` or a supported server gem resolved in
+    // Gemfile.lock.
     detectors: {
       every: [
+        {
+          path: 'Gemfile',
+        },
+      ],
+      some: [
         {
           path: 'config.ru',
         },
         {
-          path: 'Gemfile',
+          path: 'Gemfile.lock',
+          matchContent: '^    (puma|thin|unicorn|passenger|rack) \\(',
         },
       ],
     },

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4366,9 +4366,12 @@ export const frameworks = [
     tagline:
       'A dynamic, open source programming language with a focus on simplicity and productivity.',
     description:
-      'A generic Ruby application built as a container with Cloud Native Buildpacks.',
+      'A generic Ruby application deployed as a serverless function.',
     website: 'https://www.ruby-lang.org',
-    useRuntime: { src: '<detect>', use: '@vercel/container' },
+    // With `VERCEL_EXPERIMENTAL_BUILDPACKS=1`, builds-and-routes detection
+    // replaces this runtime with a `@vercel/container` buildpack build (see
+    // fs-detectors `detectFrontBuilder`).
+    useRuntime: { src: 'config.ru', use: '@vercel/ruby' },
     ignoreRuntimes: ['@vercel/ruby'],
     detectors: {
       every: [
@@ -4397,13 +4400,18 @@ export const frameworks = [
       },
     },
     getOutputDirName: async () => 'public',
-    defaultRoutes: [
+    // The buildpack container build outputs `index`; the legacy Lambda build
+    // outputs a function named after its `config.ru` entrypoint.
+    defaultRoutes: async () => [
       {
         handle: 'filesystem',
       },
       {
         src: '/(.*)',
-        dest: '/index',
+        dest:
+          process.env.VERCEL_EXPERIMENTAL_BUILDPACKS === '1'
+            ? '/index'
+            : '/config',
       },
     ],
   },

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4368,7 +4368,7 @@ export const frameworks = [
     description:
       'A generic Ruby application deployed as a serverless function.',
     website: 'https://www.ruby-lang.org',
-    // With `VERCEL_EXPERIMENTAL_BUILDPACKS=1`, builds-and-routes detection
+    // With `VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1`, builds-and-routes detection
     // replaces this runtime with a `@vercel/container` buildpack build (see
     // fs-detectors `detectFrontBuilder`).
     useRuntime: { src: 'config.ru', use: '@vercel/ruby' },
@@ -4409,7 +4409,7 @@ export const frameworks = [
       {
         src: '/(.*)',
         dest:
-          process.env.VERCEL_EXPERIMENTAL_BUILDPACKS === '1'
+          process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS === '1'
             ? '/index'
             : '/config',
       },

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -27,6 +27,8 @@ import {
   getServicesBuilders,
   warnIgnoredDirectories,
 } from './services/get-services-builders';
+import { toBuildpackRuntime } from './services/types';
+import { inferRuntimeFromFramework } from './services/utils';
 
 /**
  * Pattern for finding all supported middleware files.
@@ -698,6 +700,15 @@ function detectFrontBuilder(
 
   const f = slugToFramework.get(framework || '');
   if (f && f.useRuntime) {
+    // Buildpack-backed runtime frameworks (Ruby, …) build the whole project
+    // into a container image instead of using their Lambda runtime.
+    if (toBuildpackRuntime(inferRuntimeFromFramework(framework))) {
+      return {
+        src: '<detect>',
+        use: `@vercel/container${withTag}`,
+        config,
+      };
+    }
     const { src, use } = f.useRuntime;
     // Replace framework-specific backend builders with the unified backend builder
     // when experimental backends is enabled

--- a/packages/fs-detectors/src/detect-framework.ts
+++ b/packages/fs-detectors/src/detect-framework.ts
@@ -68,7 +68,7 @@ function filterFrameworkList<T extends BaseFramework>(
     if (!experimental) {
       return true;
     }
-    // Buildpack-backed runtime frameworks (Ruby) are enabled by their own
+    // Buildpack-backed runtime frameworks are enabled by their own
     // flag and do not require experimental frameworks to be enabled.
     return toBuildpackRuntime(inferRuntimeFromFramework(f.slug)) !== undefined;
   });

--- a/packages/fs-detectors/src/detect-framework.ts
+++ b/packages/fs-detectors/src/detect-framework.ts
@@ -1,6 +1,8 @@
 import type { Framework, FrameworkDetectionItem } from '@vercel/frameworks';
 import { spawnSync } from 'child_process';
 import { DetectorFilesystem } from './detectors/filesystem';
+import { toBuildpackRuntime } from './services/types';
+import { inferRuntimeFromFramework } from './services/utils';
 
 interface BaseFramework {
   slug: Framework['slug'];
@@ -62,9 +64,13 @@ function filterFrameworkList<T extends BaseFramework>(
     return frameworkList;
   }
   return frameworkList.filter(f => {
-    // Check if framework has experimental property and filter it out if true
     const experimental = (f as { experimental?: boolean }).experimental;
-    return !experimental;
+    if (!experimental) {
+      return true;
+    }
+    // Buildpack-backed runtime frameworks (Ruby) are enabled by their own
+    // flag and do not require experimental frameworks to be enabled.
+    return toBuildpackRuntime(inferRuntimeFromFramework(f.slug)) !== undefined;
   });
 }
 

--- a/packages/fs-detectors/src/services/detect-services.ts
+++ b/packages/fs-detectors/src/services/detect-services.ts
@@ -211,7 +211,7 @@ export async function detectServices(
       routes: emptyRoutes(),
       rewrites: [],
       errors: result.errors,
-      warnings: [],
+      warnings: result.warnings,
     });
   }
 
@@ -238,7 +238,7 @@ export async function detectServices(
       routes,
       rewrites: [],
       errors: result.errors,
-      warnings: [],
+      warnings: result.warnings,
     });
   }
 
@@ -366,7 +366,7 @@ async function tryResolveInferred(
           : [],
         experimentalServicesV2: shouldInfer ? v2Services : undefined,
         errors: result.errors,
-        warnings: detectResult.warnings,
+        warnings: [...detectResult.warnings, ...result.warnings],
       },
       inferred
     );
@@ -414,7 +414,7 @@ async function tryResolveInferred(
       routes: emptyRoutes(),
       rewrites: [],
       errors: result.errors,
-      warnings: detectResult.warnings,
+      warnings: [...detectResult.warnings, ...result.warnings],
     },
     inferred
   );

--- a/packages/fs-detectors/src/services/resolve-v2.ts
+++ b/packages/fs-detectors/src/services/resolve-v2.ts
@@ -6,6 +6,7 @@ import type {
   ExperimentalServiceV2Config,
   ExperimentalServicesV2,
   ServiceDetectionError,
+  ServiceDetectionWarning,
   ServiceRuntime,
 } from './types';
 import { RUNTIME_BUILDERS, STATIC_BUILDERS, toBuildpackRuntime } from './types';
@@ -16,6 +17,7 @@ import {
   parsePyModuleAttrEntrypoint,
 } from './resolve';
 import {
+  buildpackEntrypointWarning,
   getBuilderForRuntime,
   inferRuntimeFromFramework,
   inferServiceRuntime,
@@ -504,9 +506,11 @@ export async function resolveAllConfiguredServicesV2(
 ): Promise<{
   services: ExperimentalServiceV2[];
   errors: ServiceDetectionError[];
+  warnings: ServiceDetectionWarning[];
 }> {
   const resolved: ExperimentalServiceV2[] = [];
   const errors: ServiceDetectionError[] = [];
+  const warnings: ServiceDetectionWarning[] = [];
 
   for (const name of Object.keys(services)) {
     const config = services[name];
@@ -527,6 +531,14 @@ export async function resolveAllConfiguredServicesV2(
       continue;
     }
     if (service) {
+      const entrypointWarning = buildpackEntrypointWarning(
+        name,
+        config.entrypoint,
+        service.builder
+      );
+      if (entrypointWarning) {
+        warnings.push(entrypointWarning);
+      }
       resolved.push(service);
     }
   }
@@ -553,5 +565,5 @@ export async function resolveAllConfiguredServicesV2(
     }
   }
 
-  return { services: resolved, errors };
+  return { services: resolved, errors, warnings };
 }

--- a/packages/fs-detectors/src/services/resolve-v2.ts
+++ b/packages/fs-detectors/src/services/resolve-v2.ts
@@ -8,7 +8,7 @@ import type {
   ServiceDetectionError,
   ServiceRuntime,
 } from './types';
-import { BUILDPACK_RUNTIMES, RUNTIME_BUILDERS, STATIC_BUILDERS } from './types';
+import { RUNTIME_BUILDERS, STATIC_BUILDERS, toBuildpackRuntime } from './types';
 import {
   getServiceFs,
   resolveEntrypointPath,
@@ -362,10 +362,9 @@ export async function resolveConfiguredServiceV2(
   // with Cloud Native Buildpacks: there is no entrypoint file to resolve or
   // require, and the builder is always `@vercel/container` with the
   // `<detect>` sentinel as its source.
-  const buildpackRuntime =
-    inferredRuntime && BUILDPACK_RUNTIMES.has(inferredRuntime as ServiceRuntime)
-      ? (inferredRuntime as ServiceRuntime)
-      : undefined;
+  const buildpackRuntime = toBuildpackRuntime(
+    inferredRuntime as ServiceRuntime | undefined
+  );
   if (
     detectedFramework &&
     frameworkRuntime &&

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -5,6 +5,7 @@ import type {
   ConfiguredServices,
   ExperimentalServiceConfig,
   ServiceDetectionError,
+  ServiceDetectionWarning,
   ServiceRuntime,
 } from './types';
 import {
@@ -22,6 +23,7 @@ import {
   toBuildpackRuntime,
 } from './types';
 import {
+  buildpackEntrypointWarning,
   DETECTION_FRAMEWORKS,
   filterFrameworksByRuntime,
   getBuilderForRuntime,
@@ -1065,9 +1067,11 @@ export async function resolveAllConfiguredServices(
 ): Promise<{
   services: ExperimentalService[];
   errors: ServiceDetectionError[];
+  warnings: ServiceDetectionWarning[];
 }> {
   const resolved: ExperimentalService[] = [];
   const errors: ServiceDetectionError[] = [];
+  const warnings: ServiceDetectionWarning[] = [];
   const webServicesByRoutePrefix = new Map<string, string>();
 
   for (const name of Object.keys(services)) {
@@ -1211,6 +1215,15 @@ export async function resolveAllConfiguredServices(
       routePrefixSource,
     });
 
+    const entrypointWarning = buildpackEntrypointWarning(
+      name,
+      serviceConfig.entrypoint,
+      service.builder
+    );
+    if (entrypointWarning) {
+      warnings.push(entrypointWarning);
+    }
+
     if (service.type === 'web' && typeof service.routePrefix === 'string') {
       const normalizedRoutePrefix = normalizeRoutePrefix(service.routePrefix);
       const existingServiceName = webServicesByRoutePrefix.get(
@@ -1236,7 +1249,7 @@ export async function resolveAllConfiguredServices(
     validateEnvRefs(service.env, service.name, servicesByName, errors);
   }
 
-  return { services: resolved, errors };
+  return { services: resolved, errors, warnings };
 }
 
 function validateEnvRefs(

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -38,7 +38,7 @@ import { detectFrameworks } from '../detect-framework';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 import { normalizeRoutePrefix } from '@vercel/routing-utils';
 import {
-  isBuildpacksEnabled,
+  isRubyBuildpacksEnabled,
   isNodeBackendFramework,
 } from '@vercel/build-utils';
 
@@ -331,7 +331,7 @@ export async function detectFrameworkFromWorkspace({
   // With buildpacks enabled, services intentionally include experimental
   // runtime-framework presets (Ruby, etc.) that are hidden from normal
   // project framework detection.
-  const buildpacksEnabled = isBuildpacksEnabled();
+  const buildpacksEnabled = isRubyBuildpacksEnabled();
   const frameworkCandidates = filterFrameworksByRuntime(
     buildpacksEnabled ? DETECTION_FRAMEWORKS : frameworkList,
     runtime

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -15,11 +15,11 @@ import {
   JobTrigger,
 } from '@vercel/build-utils';
 import {
-  BUILDPACK_RUNTIMES,
   ENTRYPOINT_EXTENSIONS,
   RUNTIME_BUILDERS,
   STATIC_BUILDERS,
   RUNTIME_MANIFESTS,
+  toBuildpackRuntime,
 } from './types';
 import {
   DETECTION_FRAMEWORKS,
@@ -35,7 +35,10 @@ import { frameworkList } from '@vercel/frameworks';
 import { detectFrameworks } from '../detect-framework';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 import { normalizeRoutePrefix } from '@vercel/routing-utils';
-import { isNodeBackendFramework } from '@vercel/build-utils';
+import {
+  isBuildpacksEnabled,
+  isNodeBackendFramework,
+} from '@vercel/build-utils';
 
 const frameworksBySlug = new Map(frameworkList.map(f => [f.slug, f]));
 
@@ -152,8 +155,7 @@ function getEntrypointRequiredRuntime(
 function getBuildpackRuntime(
   config: ConfiguredServiceConfig
 ): ServiceRuntime | undefined {
-  const runtime = getEntrypointRequiredRuntime(config);
-  return runtime && BUILDPACK_RUNTIMES.has(runtime) ? runtime : undefined;
+  return toBuildpackRuntime(getEntrypointRequiredRuntime(config));
 }
 
 function validateBackendFileEntrypoint(
@@ -324,16 +326,18 @@ export async function detectFrameworkFromWorkspace({
   runtime?: ServiceRuntime;
 }): Promise<{ framework?: string; error?: ServiceDetectionError }> {
   const serviceFs = workspace === '.' ? fs : fs.chdir(workspace);
-  // Services intentionally include runtime-framework presets (Ruby, Go, etc.)
-  // even when they are hidden from normal project framework detection.
+  // With buildpacks enabled, services intentionally include experimental
+  // runtime-framework presets (Ruby, etc.) that are hidden from normal
+  // project framework detection.
+  const buildpacksEnabled = isBuildpacksEnabled();
   const frameworkCandidates = filterFrameworksByRuntime(
-    DETECTION_FRAMEWORKS,
+    buildpacksEnabled ? DETECTION_FRAMEWORKS : frameworkList,
     runtime
   );
   const frameworks = await detectFrameworks({
     fs: serviceFs,
     frameworkList: frameworkCandidates,
-    useExperimentalFrameworks: true,
+    useExperimentalFrameworks: buildpacksEnabled || undefined,
   });
 
   if (frameworks.length > 1) {
@@ -848,10 +852,7 @@ export async function resolveConfiguredService(
     ...config,
     entrypoint: entrypointIsDirectory ? undefined : normalizedEntrypoint,
   });
-  const buildpackRuntime =
-    inferredRuntime && BUILDPACK_RUNTIMES.has(inferredRuntime)
-      ? inferredRuntime
-      : undefined;
+  const buildpackRuntime = toBuildpackRuntime(inferredRuntime);
   let workspace = '.';
   let resolvedEntrypointFile =
     entrypointIsDirectory || !normalizedEntrypoint

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -24,7 +24,6 @@ import {
 } from './types';
 import {
   buildpackEntrypointWarning,
-  DETECTION_FRAMEWORKS,
   filterFrameworksByRuntime,
   getBuilderForRuntime,
   hasFile,
@@ -37,10 +36,7 @@ import { frameworkList } from '@vercel/frameworks';
 import { detectFrameworks } from '../detect-framework';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 import { normalizeRoutePrefix } from '@vercel/routing-utils';
-import {
-  isRubyBuildpacksEnabled,
-  isNodeBackendFramework,
-} from '@vercel/build-utils';
+import { isNodeBackendFramework } from '@vercel/build-utils';
 
 const frameworksBySlug = new Map(frameworkList.map(f => [f.slug, f]));
 
@@ -328,18 +324,10 @@ export async function detectFrameworkFromWorkspace({
   runtime?: ServiceRuntime;
 }): Promise<{ framework?: string; error?: ServiceDetectionError }> {
   const serviceFs = workspace === '.' ? fs : fs.chdir(workspace);
-  // With buildpacks enabled, services intentionally include experimental
-  // runtime-framework presets (Ruby, etc.) that are hidden from normal
-  // project framework detection.
-  const buildpacksEnabled = isRubyBuildpacksEnabled();
-  const frameworkCandidates = filterFrameworksByRuntime(
-    buildpacksEnabled ? DETECTION_FRAMEWORKS : frameworkList,
-    runtime
-  );
+  const frameworkCandidates = filterFrameworksByRuntime(frameworkList, runtime);
   const frameworks = await detectFrameworks({
     fs: serviceFs,
     frameworkList: frameworkCandidates,
-    useExperimentalFrameworks: buildpacksEnabled || undefined,
   });
 
   if (frameworks.length > 1) {

--- a/packages/fs-detectors/src/services/types.ts
+++ b/packages/fs-detectors/src/services/types.ts
@@ -20,7 +20,7 @@ import type {
   Service,
   Builder,
 } from '@vercel/build-utils';
-import { isBuildpacksEnabled } from '@vercel/build-utils/dist/framework-helpers';
+import { isRubyBuildpacksEnabled } from '@vercel/build-utils/dist/framework-helpers';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 
 export type {
@@ -208,14 +208,14 @@ const BUILDPACK_RUNTIMES: ReadonlySet<ServiceRuntime> = new Set(['ruby']);
 /**
  * The buildpack runtime for `runtime`, or `undefined` when the runtime is
  * not buildpack-backed or buildpacks are not enabled
- * (`VERCEL_EXPERIMENTAL_BUILDPACKS=1`). While disabled, buildpack-backed
+ * (`VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1`). While disabled, buildpack-backed
  * runtimes keep their legacy {@link RUNTIME_BUILDERS} behavior.
  */
 export function toBuildpackRuntime(
   runtime: ServiceRuntime | undefined
 ): ServiceRuntime | undefined {
   return runtime !== undefined &&
-    isBuildpacksEnabled() &&
+    isRubyBuildpacksEnabled() &&
     BUILDPACK_RUNTIMES.has(runtime)
     ? runtime
     : undefined;

--- a/packages/fs-detectors/src/services/types.ts
+++ b/packages/fs-detectors/src/services/types.ts
@@ -20,6 +20,7 @@ import type {
   Service,
   Builder,
 } from '@vercel/build-utils';
+import { isBuildpacksEnabled } from '@vercel/build-utils/dist/framework-helpers';
 import type { DetectorFilesystem } from '../detectors/filesystem';
 
 export type {
@@ -178,18 +179,16 @@ export interface ServiceDetectionError {
  * their Lambda builders (e.g. `@vercel/ruby`) through builds-and-routes
  * detection instead and are unaffected by these entries.
  *
- * {@link BUILDPACK_RUNTIMES} map to `@vercel/container`: services for those
- * languages are always container images built with Cloud Native Buildpacks —
- * there is no Lambda services path. No per-language builder package exists
- * or should be created for them (a future `java` entry would also map to
- * `@vercel/container`).
+ * Runtimes in {@link toBuildpackRuntime}'s set are rerouted to
+ * `@vercel/container` when buildpacks are enabled, before these entries are
+ * consulted.
  */
 export const RUNTIME_BUILDERS: Record<ServiceRuntime, string> = {
   node: '@vercel/backends',
   python: '@vercel/python',
   go: '@vercel/go',
   rust: '@vercel/rust',
-  ruby: '@vercel/container',
+  ruby: '@vercel/ruby',
   container: '@vercel/container',
 };
 
@@ -197,13 +196,30 @@ export const RUNTIME_BUILDERS: Record<ServiceRuntime, string> = {
  * Runtimes whose services build the whole service root into a container
  * image with Cloud Native Buildpacks via `@vercel/container` (builder src is
  * the `<detect>` sentinel; no entrypoint file is required or resolved).
+ * There is no Lambda services path for them and no per-language builder
+ * package should be created (a future `java` entry would also build with
+ * `@vercel/container`).
  *
  * Adding a language here requires a matching descriptor in
  * `@vercel/container`'s buildpack registry (`src/buildpacks/registry.ts`).
  */
-export const BUILDPACK_RUNTIMES: ReadonlySet<ServiceRuntime> = new Set([
-  'ruby',
-]);
+const BUILDPACK_RUNTIMES: ReadonlySet<ServiceRuntime> = new Set(['ruby']);
+
+/**
+ * The buildpack runtime for `runtime`, or `undefined` when the runtime is
+ * not buildpack-backed or buildpacks are not enabled
+ * (`VERCEL_EXPERIMENTAL_BUILDPACKS=1`). While disabled, buildpack-backed
+ * runtimes keep their legacy {@link RUNTIME_BUILDERS} behavior.
+ */
+export function toBuildpackRuntime(
+  runtime: ServiceRuntime | undefined
+): ServiceRuntime | undefined {
+  return runtime !== undefined &&
+    isBuildpacksEnabled() &&
+    BUILDPACK_RUNTIMES.has(runtime)
+    ? runtime
+    : undefined;
+}
 
 export const RUNTIME_MANIFESTS: Partial<Record<ServiceRuntime, string[]>> = {
   node: ['package.json'],

--- a/packages/fs-detectors/src/services/types.ts
+++ b/packages/fs-detectors/src/services/types.ts
@@ -208,7 +208,7 @@ const BUILDPACK_RUNTIMES: ReadonlySet<ServiceRuntime> = new Set(['ruby']);
 /**
  * The buildpack runtime for `runtime`, or `undefined` when the runtime is
  * not buildpack-backed or buildpacks are not enabled
- * (`VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1`). While disabled, buildpack-backed
+ * (`VERCEL_RUBY_EXPERIMENTAL_BUILDPACK=1`). While disabled, buildpack-backed
  * runtimes keep their legacy {@link RUNTIME_BUILDERS} behavior.
  */
 export function toBuildpackRuntime(

--- a/packages/fs-detectors/src/services/utils.ts
+++ b/packages/fs-detectors/src/services/utils.ts
@@ -95,6 +95,29 @@ export function getInternalServiceWorkerPath(
   return `${getInternalServiceWorkerPathPrefix(serviceName)}/${normalizedEntrypoint}/${handler}`;
 }
 
+/**
+ * Buildpack-backed services build the whole service root; an `entrypoint`
+ * has no effect on them and is ignored with a warning rather than an error
+ * so configs remain portable between the flag-off and flag-on states.
+ */
+export function buildpackEntrypointWarning(
+  name: string,
+  entrypoint: string | undefined,
+  builder: { config?: { buildpack?: unknown } }
+): ServiceDetectionWarning | undefined {
+  if (!entrypoint || !builder.config?.buildpack) {
+    return undefined;
+  }
+  return {
+    code: 'BUILDPACK_ENTRYPOINT_IGNORED',
+    message:
+      `Service "${name}" specifies "entrypoint", which buildpack-backed ` +
+      'services ignore. Use "command" to override the start command, or ' +
+      'add a Dockerfile.vercel to control the image build.',
+    serviceName: name,
+  };
+}
+
 export function getBuilderForRuntime(runtime: ServiceRuntime): string {
   const builder = RUNTIME_BUILDERS[runtime];
   if (!builder) {

--- a/packages/fs-detectors/src/services/utils.ts
+++ b/packages/fs-detectors/src/services/utils.ts
@@ -217,19 +217,9 @@ export function inferServiceRuntime(config: {
     return frameworkRuntime;
   }
 
-  // Infer from builder. Buildpack runtimes (ruby, future java, …) also map
-  // to `@vercel/container` in RUNTIME_BUILDERS, so only the `container`
-  // runtime may claim that builder here — a service declaring
-  // `builder: "@vercel/container"` is a container service, not whichever
-  // buildpack runtime happens to come first in the map.
+  // Infer from builder
   if (config.builder) {
     for (const [runtime, builderName] of Object.entries(RUNTIME_BUILDERS)) {
-      if (
-        builderName === RUNTIME_BUILDERS.container &&
-        runtime !== 'container'
-      ) {
-        continue;
-      }
       if (config.builder === builderName) {
         return runtime as ServiceRuntime;
       }

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -773,7 +773,7 @@ describe('Test `detectBuilders`', () => {
   });
 
   it('routes the Ruby framework through the container buildpack builder when buildpacks are enabled', async () => {
-    process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS = '1';
+    process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK = '1';
     try {
       const { builders } = await invokeDetectBuildersAndThrow(
         ['Gemfile', 'config.ru'],
@@ -792,7 +792,7 @@ describe('Test `detectBuilders`', () => {
         },
       });
     } finally {
-      delete process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS;
+      delete process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK;
     }
   });
 

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -773,7 +773,7 @@ describe('Test `detectBuilders`', () => {
   });
 
   it('routes the Ruby framework through the container buildpack builder when buildpacks are enabled', async () => {
-    process.env.VERCEL_EXPERIMENTAL_BUILDPACKS = '1';
+    process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS = '1';
     try {
       const { builders } = await invokeDetectBuildersAndThrow(
         ['Gemfile', 'config.ru'],
@@ -792,7 +792,7 @@ describe('Test `detectBuilders`', () => {
         },
       });
     } finally {
-      delete process.env.VERCEL_EXPERIMENTAL_BUILDPACKS;
+      delete process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS;
     }
   });
 

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -772,7 +772,31 @@ describe('Test `detectBuilders`', () => {
     });
   });
 
-  it('routes the Ruby framework through the container buildpack builder', async () => {
+  it('routes the Ruby framework through the container buildpack builder when buildpacks are enabled', async () => {
+    process.env.VERCEL_EXPERIMENTAL_BUILDPACKS = '1';
+    try {
+      const { builders } = await invokeDetectBuildersAndThrow(
+        ['Gemfile', 'config.ru'],
+        null,
+        {
+          projectSettings: { framework: 'ruby' },
+        }
+      );
+
+      expect(builders).toContainEqual({
+        src: '<detect>',
+        use: '@vercel/container',
+        config: {
+          zeroConfig: true,
+          framework: 'ruby',
+        },
+      });
+    } finally {
+      delete process.env.VERCEL_EXPERIMENTAL_BUILDPACKS;
+    }
+  });
+
+  it('keeps the Ruby framework on the legacy Ruby builder when buildpacks are disabled', async () => {
     const { builders } = await invokeDetectBuildersAndThrow(
       ['Gemfile', 'config.ru'],
       null,
@@ -782,8 +806,8 @@ describe('Test `detectBuilders`', () => {
     );
 
     expect(builders).toContainEqual({
-      src: '<detect>',
-      use: '@vercel/container',
+      src: 'config.ru',
+      use: '@vercel/ruby',
       config: {
         zeroConfig: true,
         framework: 'ruby',

--- a/packages/fs-detectors/test/unit.detect-services-v2.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services-v2.test.ts
@@ -89,13 +89,13 @@ describe('detectServices (services)', () => {
     expect(worker.builder.src).toBe('svc/main.py');
   });
 
-  describe('buildpack runtimes (VERCEL_EXPERIMENTAL_BUILDPACKS=1)', () => {
+  describe('buildpack runtimes (VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1)', () => {
     beforeAll(() => {
-      process.env.VERCEL_EXPERIMENTAL_BUILDPACKS = '1';
+      process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS = '1';
     });
 
     afterAll(() => {
-      delete process.env.VERCEL_EXPERIMENTAL_BUILDPACKS;
+      delete process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS;
     });
 
     it('resolves a Ruby runtime without an entrypoint to the buildpack container builder', async () => {

--- a/packages/fs-detectors/test/unit.detect-services-v2.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services-v2.test.ts
@@ -193,6 +193,31 @@ describe('detectServices (services)', () => {
       });
     });
 
+    it('warns that a Ruby service entrypoint is ignored', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          services: {
+            api: { root: 'api', runtime: 'ruby', entrypoint: 'app.rb' },
+          },
+        }),
+        'api/Gemfile': 'source "https://rubygems.org"\n',
+        'api/app.rb': 'puts "hello"\n',
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      const [api] = servicesV2(result.services);
+      expect(api.builder).toMatchObject({
+        src: 'api/<detect>',
+        use: '@vercel/container',
+        config: { buildpack: 'ruby' },
+      });
+      expect(result.warnings).toMatchObject([
+        { code: 'BUILDPACK_ENTRYPOINT_IGNORED', serviceName: 'api' },
+      ]);
+    });
+
     it('auto-detects a Ruby service without requiring an entrypoint', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': vercelJson({

--- a/packages/fs-detectors/test/unit.detect-services-v2.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services-v2.test.ts
@@ -89,126 +89,153 @@ describe('detectServices (services)', () => {
     expect(worker.builder.src).toBe('svc/main.py');
   });
 
-  it('resolves a Ruby runtime without an entrypoint to the buildpack container builder', async () => {
-    const fs = new VirtualFilesystem({
-      'vercel.json': vercelJson({
-        services: {
-          api: {
-            root: 'api',
-            runtime: 'ruby',
-            command: ['bundle', 'exec', 'puma'],
+  describe('buildpack runtimes (VERCEL_EXPERIMENTAL_BUILDPACKS=1)', () => {
+    beforeAll(() => {
+      process.env.VERCEL_EXPERIMENTAL_BUILDPACKS = '1';
+    });
+
+    afterAll(() => {
+      delete process.env.VERCEL_EXPERIMENTAL_BUILDPACKS;
+    });
+
+    it('resolves a Ruby runtime without an entrypoint to the buildpack container builder', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          services: {
+            api: {
+              root: 'api',
+              runtime: 'ruby',
+              command: ['bundle', 'exec', 'puma'],
+            },
           },
-        },
-      }),
-      'api/Gemfile': 'source "https://rubygems.org"\ngem "puma"\n',
-    });
+        }),
+        'api/Gemfile': 'source "https://rubygems.org"\ngem "puma"\n',
+      });
 
-    const result = await detectServices({ fs });
+      const result = await detectServices({ fs });
 
-    expect(result.errors).toEqual([]);
-    const [api] = servicesV2(result.services);
-    expect(api).toMatchObject({
-      schema: 'experimentalServicesV2',
-      name: 'api',
-      root: 'api',
-      runtime: 'ruby',
-      command: ['bundle', 'exec', 'puma'],
-      entrypoint: undefined,
-    });
-    expect(api.builder).toEqual({
-      src: 'api/<detect>',
-      use: '@vercel/container',
-      config: {
-        zeroConfig: true,
-        buildpack: 'ruby',
+      expect(result.errors).toEqual([]);
+      const [api] = servicesV2(result.services);
+      expect(api).toMatchObject({
+        schema: 'experimentalServicesV2',
+        name: 'api',
+        root: 'api',
+        runtime: 'ruby',
         command: ['bundle', 'exec', 'puma'],
-        workspace: 'api',
-      },
-    });
-  });
-
-  it('preserves a Ruby shell command through normalized builder config', async () => {
-    const fs = new VirtualFilesystem({
-      'vercel.json': vercelJson({
-        services: {
-          api: {
-            root: 'api',
-            runtime: 'ruby',
-            command: 'bundle exec puma -p $PORT',
-          },
+        entrypoint: undefined,
+      });
+      expect(api.builder).toEqual({
+        src: 'api/<detect>',
+        use: '@vercel/container',
+        config: {
+          zeroConfig: true,
+          buildpack: 'ruby',
+          command: ['bundle', 'exec', 'puma'],
+          workspace: 'api',
         },
-      }),
-      'api/Gemfile': 'source "https://rubygems.org"\ngem "puma"\n',
+      });
     });
 
-    const result = await detectServices({ fs });
+    it('preserves a Ruby shell command through normalized builder config', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          services: {
+            api: {
+              root: 'api',
+              runtime: 'ruby',
+              command: 'bundle exec puma -p $PORT',
+            },
+          },
+        }),
+        'api/Gemfile': 'source "https://rubygems.org"\ngem "puma"\n',
+      });
 
-    expect(result.errors).toEqual([]);
-    const [api] = servicesV2(result.services);
-    expect(api.command).toEqual(['bundle exec puma -p $PORT']);
-    expect(api.builder.config).toMatchObject({
-      command: ['bundle exec puma -p $PORT'],
-      commandShell: true,
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      const [api] = servicesV2(result.services);
+      expect(api.command).toEqual(['bundle exec puma -p $PORT']);
+      expect(api.builder.config).toMatchObject({
+        command: ['bundle exec puma -p $PORT'],
+        commandShell: true,
+      });
+    });
+
+    it('resolves an explicit Ruby framework without an entrypoint to buildpacks', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          services: {
+            api: { root: 'api', framework: 'ruby' },
+          },
+        }),
+        'api/Gemfile': 'source "https://rubygems.org"\n',
+        'api/config.ru': 'run ->(_env) { [200, {}, ["ok"]] }\n',
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      const [api] = servicesV2(result.services);
+      expect(api).toMatchObject({
+        framework: 'ruby',
+        runtime: 'ruby',
+        entrypoint: undefined,
+      });
+      expect(api.builder).toEqual({
+        src: 'api/<detect>',
+        use: '@vercel/container',
+        config: {
+          zeroConfig: true,
+          framework: 'ruby',
+          buildpack: 'ruby',
+          workspace: 'api',
+        },
+      });
+    });
+
+    it('auto-detects a Ruby service without requiring an entrypoint', async () => {
+      const fs = new VirtualFilesystem({
+        'vercel.json': vercelJson({
+          services: {
+            api: { root: 'api' },
+          },
+        }),
+        'api/Gemfile': 'source "https://rubygems.org"\ngem "rack"\n',
+        'api/config.ru': 'run ->(_env) { [200, {}, ["ok"]] }\n',
+      });
+
+      const result = await detectServices({ fs });
+
+      expect(result.errors).toEqual([]);
+      const [api] = servicesV2(result.services);
+      expect(api).toMatchObject({
+        framework: 'ruby',
+        runtime: 'ruby',
+        entrypoint: undefined,
+      });
+      expect(api.builder).toMatchObject({
+        src: 'api/<detect>',
+        use: '@vercel/container',
+        config: { buildpack: 'ruby' },
+      });
     });
   });
 
-  it('resolves an explicit Ruby framework without an entrypoint to buildpacks', async () => {
+  it('requires an entrypoint for a Ruby runtime service when buildpacks are disabled', async () => {
     const fs = new VirtualFilesystem({
       'vercel.json': vercelJson({
         services: {
-          api: { root: 'api', framework: 'ruby' },
+          api: { root: 'api', runtime: 'ruby' },
         },
       }),
       'api/Gemfile': 'source "https://rubygems.org"\n',
-      'api/config.ru': 'run ->(_env) { [200, {}, ["ok"]] }\n',
     });
 
     const result = await detectServices({ fs });
 
-    expect(result.errors).toEqual([]);
-    const [api] = servicesV2(result.services);
-    expect(api).toMatchObject({
-      framework: 'ruby',
-      runtime: 'ruby',
-      entrypoint: undefined,
-    });
-    expect(api.builder).toEqual({
-      src: 'api/<detect>',
-      use: '@vercel/container',
-      config: {
-        zeroConfig: true,
-        framework: 'ruby',
-        buildpack: 'ruby',
-        workspace: 'api',
-      },
-    });
-  });
-
-  it('auto-detects a Ruby service without requiring an entrypoint', async () => {
-    const fs = new VirtualFilesystem({
-      'vercel.json': vercelJson({
-        services: {
-          api: { root: 'api' },
-        },
-      }),
-      'api/Gemfile': 'source "https://rubygems.org"\ngem "rack"\n',
-      'api/config.ru': 'run ->(_env) { [200, {}, ["ok"]] }\n',
-    });
-
-    const result = await detectServices({ fs });
-
-    expect(result.errors).toEqual([]);
-    const [api] = servicesV2(result.services);
-    expect(api).toMatchObject({
-      framework: 'ruby',
-      runtime: 'ruby',
-      entrypoint: undefined,
-    });
-    expect(api.builder).toMatchObject({
-      src: 'api/<detect>',
-      use: '@vercel/container',
-      config: { buildpack: 'ruby' },
-    });
+    expect(result.errors).toMatchObject([
+      { code: 'MISSING_SERVICE_CONFIG', serviceName: 'api' },
+    ]);
   });
 
   it('resolves a pyproject.toml entrypoint to the python builder', async () => {

--- a/packages/fs-detectors/test/unit.detect-services-v2.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services-v2.test.ts
@@ -89,13 +89,13 @@ describe('detectServices (services)', () => {
     expect(worker.builder.src).toBe('svc/main.py');
   });
 
-  describe('buildpack runtimes (VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1)', () => {
+  describe('buildpack runtimes (VERCEL_RUBY_EXPERIMENTAL_BUILDPACK=1)', () => {
     beforeAll(() => {
-      process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS = '1';
+      process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK = '1';
     });
 
     afterAll(() => {
-      delete process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS;
+      delete process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK;
     });
 
     it('resolves a Ruby runtime without an entrypoint to the buildpack container builder', async () => {

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -175,13 +175,13 @@ describe('detectServices', () => {
       });
     });
 
-    describe('buildpack runtimes (VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1)', () => {
+    describe('buildpack runtimes (VERCEL_RUBY_EXPERIMENTAL_BUILDPACK=1)', () => {
       beforeAll(() => {
-        process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS = '1';
+        process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK = '1';
       });
 
       afterAll(() => {
-        delete process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS;
+        delete process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK;
       });
 
       it('should route Ruby runtime services through buildpacks without an entrypoint', async () => {

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -216,7 +216,7 @@ describe('detectServices', () => {
         });
       });
 
-      it('should not treat a Ruby service entrypoint as a prebuilt image', async () => {
+      it('should ignore a Ruby service entrypoint with a warning', async () => {
         const fs = new VirtualFilesystem({
           'vercel.json': JSON.stringify({
             experimentalServices: {
@@ -238,6 +238,9 @@ describe('detectServices', () => {
           use: '@vercel/container',
           config: { buildpack: 'ruby' },
         });
+        expect(result.warnings).toMatchObject([
+          { code: 'BUILDPACK_ENTRYPOINT_IGNORED', serviceName: 'api' },
+        ]);
       });
 
       it('should infer Ruby workspace from nearest Gemfile when workspace is omitted', async () => {

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -175,59 +175,123 @@ describe('detectServices', () => {
       });
     });
 
-    it('should route Ruby runtime services through buildpacks without an entrypoint', async () => {
-      const fs = new VirtualFilesystem({
-        'vercel.json': JSON.stringify({
-          experimentalServices: {
-            api: {
-              runtime: 'ruby',
-              command: 'bundle exec puma',
-              mount: '/api',
+    describe('buildpack runtimes (VERCEL_EXPERIMENTAL_BUILDPACKS=1)', () => {
+      beforeAll(() => {
+        process.env.VERCEL_EXPERIMENTAL_BUILDPACKS = '1';
+      });
+
+      afterAll(() => {
+        delete process.env.VERCEL_EXPERIMENTAL_BUILDPACKS;
+      });
+
+      it('should route Ruby runtime services through buildpacks without an entrypoint', async () => {
+        const fs = new VirtualFilesystem({
+          'vercel.json': JSON.stringify({
+            experimentalServices: {
+              api: {
+                runtime: 'ruby',
+                command: 'bundle exec puma',
+                mount: '/api',
+              },
+            },
+          }),
+          Gemfile: 'source "https://rubygems.org"\ngem "puma"\n',
+        });
+        const result = await detectServices({ fs });
+
+        expect(result.errors).toEqual([]);
+        expect(result.services[0]).toMatchObject({
+          name: 'api',
+          runtime: 'ruby',
+          entrypoint: undefined,
+          builder: {
+            src: '<detect>',
+            use: '@vercel/container',
+            config: {
+              buildpack: 'ruby',
+              command: ['bundle exec puma'],
+              commandShell: true,
             },
           },
-        }),
-        Gemfile: 'source "https://rubygems.org"\ngem "puma"\n',
+        });
       });
-      const result = await detectServices({ fs });
 
-      expect(result.errors).toEqual([]);
-      expect(result.services[0]).toMatchObject({
-        name: 'api',
-        runtime: 'ruby',
-        entrypoint: undefined,
-        builder: {
+      it('should not treat a Ruby service entrypoint as a prebuilt image', async () => {
+        const fs = new VirtualFilesystem({
+          'vercel.json': JSON.stringify({
+            experimentalServices: {
+              api: {
+                runtime: 'ruby',
+                entrypoint: 'app.rb',
+                mount: '/api',
+              },
+            },
+          }),
+          Gemfile: 'source "https://rubygems.org"\n',
+          'app.rb': 'puts "hello"\n',
+        });
+        const result = await detectServices({ fs });
+
+        expect(result.errors).toEqual([]);
+        expect(result.services[0].builder).toMatchObject({
           src: '<detect>',
           use: '@vercel/container',
-          config: {
-            buildpack: 'ruby',
-            command: ['bundle exec puma'],
-            commandShell: true,
-          },
-        },
+          config: { buildpack: 'ruby' },
+        });
+      });
+
+      it('should infer Ruby workspace from nearest Gemfile when workspace is omitted', async () => {
+        const fs = new VirtualFilesystem({
+          'vercel.json': JSON.stringify({
+            experimentalServices: {
+              'ruby-api': {
+                entrypoint: 'services/ruby-api/config.ru',
+                routePrefix: '/ruby-api',
+              },
+            },
+          }),
+          'services/ruby-api/Gemfile': 'source "https://rubygems.org"',
+          'services/ruby-api/config.ru': 'run Sinatra::Application',
+        });
+        const result = await detectServices({ fs });
+
+        expect(result.errors).toEqual([]);
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0]).toMatchObject({
+          name: 'ruby-api',
+          workspace: 'services/ruby-api',
+          entrypoint: 'config.ru',
+        });
+        expect(result.services[0].builder.src).toBe(
+          'services/ruby-api/<detect>'
+        );
+        expect(result.services[0].builder.config).toMatchObject({
+          buildpack: 'ruby',
+          workspace: 'services/ruby-api',
+        });
       });
     });
 
-    it('should not treat a Ruby service entrypoint as a prebuilt image', async () => {
+    it('should keep Ruby runtime services on @vercel/ruby when buildpacks are disabled', async () => {
       const fs = new VirtualFilesystem({
         'vercel.json': JSON.stringify({
           experimentalServices: {
             api: {
               runtime: 'ruby',
-              entrypoint: 'app.rb',
+              entrypoint: 'config.ru',
               mount: '/api',
             },
           },
         }),
         Gemfile: 'source "https://rubygems.org"\n',
-        'app.rb': 'puts "hello"\n',
+        'config.ru': 'run Sinatra::Application',
       });
       const result = await detectServices({ fs });
 
       expect(result.errors).toEqual([]);
       expect(result.services[0].builder).toMatchObject({
-        src: '<detect>',
-        use: '@vercel/container',
-        config: { buildpack: 'ruby' },
+        src: 'config.ru',
+        use: '@vercel/ruby',
       });
     });
 
@@ -839,9 +903,10 @@ describe('detectServices', () => {
         workspace: 'services/ruby-api',
         entrypoint: 'config.ru',
       });
-      expect(result.services[0].builder.src).toBe('services/ruby-api/<detect>');
+      expect(result.services[0].builder.src).toBe(
+        'services/ruby-api/config.ru'
+      );
       expect(result.services[0].builder.config).toMatchObject({
-        buildpack: 'ruby',
         workspace: 'services/ruby-api',
       });
     });

--- a/packages/fs-detectors/test/unit.detect-services.test.ts
+++ b/packages/fs-detectors/test/unit.detect-services.test.ts
@@ -175,13 +175,13 @@ describe('detectServices', () => {
       });
     });
 
-    describe('buildpack runtimes (VERCEL_EXPERIMENTAL_BUILDPACKS=1)', () => {
+    describe('buildpack runtimes (VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS=1)', () => {
       beforeAll(() => {
-        process.env.VERCEL_EXPERIMENTAL_BUILDPACKS = '1';
+        process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS = '1';
       });
 
       afterAll(() => {
-        delete process.env.VERCEL_EXPERIMENTAL_BUILDPACKS;
+        delete process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS;
       });
 
       it('should route Ruby runtime services through buildpacks without an entrypoint', async () => {

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -401,7 +401,7 @@ describe('detectFramework()', () => {
     ).toBeNull();
   });
 
-  it('Detect Ruby with only VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS set', async () => {
+  it('Detect Ruby with only VERCEL_RUBY_EXPERIMENTAL_BUILDPACK set', async () => {
     const fs = new VirtualFilesystem({
       Gemfile: 'source "https://rubygems.org"\n',
       'config.ru': 'run ->(_env) { [200, {}, ["ok"]] }\n',
@@ -409,11 +409,11 @@ describe('detectFramework()', () => {
 
     expect(await detectFramework({ fs, frameworkList })).toBeNull();
 
-    process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS = '1';
+    process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK = '1';
     try {
       expect(await detectFramework({ fs, frameworkList })).toBe('ruby');
     } finally {
-      delete process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS;
+      delete process.env.VERCEL_RUBY_EXPERIMENTAL_BUILDPACK;
     }
   });
 

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -401,6 +401,37 @@ describe('detectFramework()', () => {
     ).toBeNull();
   });
 
+  it('Detect Ruby with only VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS set', async () => {
+    const fs = new VirtualFilesystem({
+      Gemfile: 'source "https://rubygems.org"\n',
+      'config.ru': 'run ->(_env) { [200, {}, ["ok"]] }\n',
+    });
+
+    expect(await detectFramework({ fs, frameworkList })).toBeNull();
+
+    process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS = '1';
+    try {
+      expect(await detectFramework({ fs, frameworkList })).toBe('ruby');
+    } finally {
+      delete process.env.VERCEL_EXPERIMENTAL_RUBY_BUILDPACKS;
+    }
+  });
+
+  it('Detect Ruby with only VERCEL_USE_EXPERIMENTAL_FRAMEWORKS set', async () => {
+    const fs = new VirtualFilesystem({
+      Gemfile: 'source "https://rubygems.org"\n',
+      'config.ru': 'run ->(_env) { [200, {}, ["ok"]] }\n',
+    });
+
+    expect(
+      await detectFramework({
+        fs,
+        frameworkList,
+        useExperimentalFrameworks: true,
+      })
+    ).toBe('ruby');
+  });
+
   it('Detect Nuxt.js', async () => {
     const fs = new VirtualFilesystem({
       'package.json': JSON.stringify({

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -432,6 +432,68 @@ describe('detectFramework()', () => {
     ).toBe('ruby');
   });
 
+  it('Detect Ruby via a server gem in Gemfile.lock', async () => {
+    const lockfile = [
+      'GEM',
+      '  remote: https://rubygems.org/',
+      '  specs:',
+      '    nio4r (2.7.3)',
+      '    puma (6.4.2)',
+      '      nio4r (~> 2.0)',
+      '',
+      'PLATFORMS',
+      '  ruby',
+      '',
+      'DEPENDENCIES',
+      '  puma',
+      '',
+      'BUNDLED WITH',
+      '   2.5.9',
+      '',
+    ].join('\n');
+    const fs = new VirtualFilesystem({
+      Gemfile: 'source "https://rubygems.org"\ngem "puma"\n',
+      'Gemfile.lock': lockfile,
+    });
+
+    expect(
+      await detectFramework({
+        fs,
+        frameworkList,
+        useExperimentalFrameworks: true,
+      })
+    ).toBe('ruby');
+  });
+
+  it.each([
+    ['a Gemfile alone', { Gemfile: 'source "https://rubygems.org"\n' }],
+    [
+      'a config.ru without a Gemfile',
+      { 'config.ru': 'run ->(_env) { [200, {}, ["ok"]] }\n' },
+    ],
+    [
+      'a Gemfile.lock without a Gemfile',
+      { 'Gemfile.lock': 'GEM\n  specs:\n    puma (6.4.2)\n' },
+    ],
+    [
+      'a Gemfile.lock without a server gem',
+      {
+        Gemfile: 'source "https://rubygems.org"\n',
+        'Gemfile.lock': 'GEM\n  specs:\n    rack-session (2.0.0)\n',
+      },
+    ],
+  ])('Ruby is not detected with %s', async (_, files) => {
+    const fs = new VirtualFilesystem(files);
+
+    expect(
+      await detectFramework({
+        fs,
+        frameworkList,
+        useExperimentalFrameworks: true,
+      })
+    ).toBeNull();
+  });
+
   it('Detect Nuxt.js', async () => {
     const fs = new VirtualFilesystem({
       'package.json': JSON.stringify({

--- a/packages/fs-detectors/test/virtual-file-system.ts
+++ b/packages/fs-detectors/test/virtual-file-system.ts
@@ -25,7 +25,9 @@ export default class VirtualFilesystem extends DetectorFilesystem {
   async _hasPath(name: string): Promise<boolean> {
     const basePath = this._normalizePath(posixPath.join(this.cwd, name));
     for (const file of this.files.keys()) {
-      if (file.startsWith(basePath)) {
+      // Match exact files or directory prefixes only ("Gemfile.lock" must
+      // not satisfy hasPath("Gemfile")).
+      if (file === basePath || file.startsWith(`${basePath}/`)) {
         return true;
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1160,6 +1160,10 @@ importers:
         version: 5.9.3
 
   packages/container:
+    dependencies:
+      smol-toml:
+        specifier: 1.5.2
+        version: 1.5.2
     devDependencies:
       '@types/node':
         specifier: 20.11.0


### PR DESCRIPTION
## What does this branch change?

- `Dockerfile/Containerfile` is not used to override a buildpack, only `Dockerfile.vercel/Containerfile.vercel`
- A flag `VERCEL_RUBY_EXPERIMENTAL_BUILDPACK` is added to gate this feature. `VERCEL_EXPERIMENTAL_FRAMEWORKS` is no longer needed to enable using this feature.
- We generate an `order.toml` to prevent vercel detecting one framework and the buildpack detecting another
- A bunch of smaller changes to improve dx. Better error handling, setting default env vars where we can etc.
- Three new e2e test fixtures for ruby buildpacks.