### PR TITLE
[@vercel/connect] add Resend Chat SDK adapter helper

### DIFF
--- a/.changeset/connect-resend-adapter.md
+++ b/.changeset/connect-resend-adapter.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Add `connectResendAdapter` to supply app-scoped Resend credentials and Connect-forwarded webhook verification to the official Chat SDK adapter.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -5,7 +5,7 @@ SDK for obtaining scoped tokens for third-party services on behalf of apps or us
 Seven entrypoints, all ESM:
 
 - `@vercel/connect` — core token / authorization SDK
-- `@vercel/connect/chat` — adapter helpers for the [Chat SDK](https://chat-sdk.dev) (`chat`): `connectSlackAdapter`, `connectGitHubAdapter`, `connectLinearAdapter` (no Chat SDK dependency — returns structural config)
+- `@vercel/connect/chat` — adapter helpers for the [Chat SDK](https://chat-sdk.dev) (`chat`): `connectSlackAdapter`, `connectGitHubAdapter`, `connectLinearAdapter`, `connectResendAdapter` (no Chat SDK dependency — returns structural config)
 - `@vercel/connect/ai-sdk` — [Vercel AI SDK](https://ai-sdk.dev) glue: re-exports `connectAuthProvider` for MCP transports (optional peers: `ai`, `@ai-sdk/mcp`)
 - `@vercel/connect/mcp` — canonical MCP-spec `OAuthClientProvider` for any MCP client (optional peer: `@ai-sdk/mcp`)
 - `@vercel/connect/eve` — adapter helpers for [Eve](https://github.com/vercel/eve) connections (optional peer: `eve`)
@@ -43,6 +43,19 @@ import { connectSlackAdapter } from '@vercel/connect/chat';
 createSlackAdapter({
   ...connectSlackAdapter('slack/acme-slack'),
   userName: 'my-bot',
+});
+```
+
+Resend's official adapter can use the same app-scoped credential and forwarded
+webhook verification:
+
+```ts
+import { createResendAdapter } from '@resend/chat-sdk-adapter';
+import { connectResendAdapter } from '@vercel/connect/chat';
+
+createResendAdapter({
+  ...connectResendAdapter('resend/support'),
+  fromAddress: 'support@example.com',
 });
 ```
 

--- a/packages/connect/src/chat/index.ts
+++ b/packages/connect/src/chat/index.ts
@@ -45,3 +45,8 @@ export {
   connectLinearAdapter,
   type ConnectLinearAdapterParams,
 } from './linear-adapter.js';
+export {
+  connectResendAdapter,
+  type ConnectResendAdapterConfig,
+  type ConnectResendAdapterParams,
+} from './resend-adapter.js';

--- a/packages/connect/src/chat/resend-adapter.ts
+++ b/packages/connect/src/chat/resend-adapter.ts
@@ -1,0 +1,36 @@
+import {
+  getToken,
+  type ConnectOptions,
+  type ConnectTokenParams,
+} from '../index.js';
+import type { ConnectTokenResolver } from './types.js';
+import {
+  createConnectWebhookVerifier,
+  type ConnectWebhookVerifier,
+} from './webhook-verifier.js';
+
+/** Token parameters accepted by {@link connectResendAdapter}. */
+export type ConnectResendAdapterParams = Omit<ConnectTokenParams, 'subject'>;
+
+/** Resend Chat SDK adapter fields backed by Vercel Connect. */
+export interface ConnectResendAdapterConfig {
+  apiKey: ConnectTokenResolver;
+  webhookVerifier: ConnectWebhookVerifier;
+}
+
+/**
+ * Build a Resend adapter config fragment backed by an app-scoped Vercel
+ * Connect connector. Connect supplies the API key and authenticates forwarded
+ * webhooks, so the deployment needs neither Resend credential in its env.
+ */
+export function connectResendAdapter(
+  connector: string,
+  params: ConnectResendAdapterParams = {},
+  options?: ConnectOptions
+): ConnectResendAdapterConfig {
+  return {
+    apiKey: () =>
+      getToken(connector, { ...params, subject: { type: 'app' } }, options),
+    webhookVerifier: createConnectWebhookVerifier(),
+  };
+}

--- a/packages/connect/test/chat/adapter-config.test.ts
+++ b/packages/connect/test/chat/adapter-config.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   connectGitHubAdapter,
   connectLinearAdapter,
+  connectResendAdapter,
   connectSlackAdapter,
 } from '../../src/chat/index.js';
 
@@ -74,6 +75,20 @@ describe('Chat SDK adapter config helpers', () => {
       installationId: 'linear-installation',
       subject: { type: 'app' },
     });
+  });
+
+  it('builds Resend config backed by an app-scoped Connect token', async () => {
+    fetchMock.mockResolvedValue(jsonTokenResponse('resend_token'));
+
+    const config = connectResendAdapter(
+      'resend/support',
+      {},
+      { vercelToken: 'vercel_token' }
+    );
+
+    expect(config.webhookVerifier).toEqual(expect.any(Function));
+    await expect(resolveToken(config.apiKey)).resolves.toBe('resend_token');
+    expectTokenRequest('resend/support', { subject: { type: 'app' } });
   });
 
   it('pins the subject to app even when params are omitted', async () => {


### PR DESCRIPTION
## Summary

- add `connectResendAdapter()` to the Chat SDK entrypoint
- resolve the Resend API key as an app-scoped Connect token
- verify Connect-forwarded webhooks through Vercel OIDC

Cross-repository dependencies:
- Resend adapter hooks: https://github.com/resend/resend-chat-sdk/pull/44
- Connect connector: https://github.com/vercel/api/pull/82399

## Validation

- helper request shape is covered in the shared adapter config test
- local execution is blocked by missing built workspace dependencies in the fresh worktree (`@vercel/oidc`, `@vercel/cli-config`)