### PR TITLE
[@vercel/connect] Add Photon credential helper

### DIFF
--- a/.changeset/brave-photons-connect.md
+++ b/.changeset/brave-photons-connect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Add `connectPhotonCredentials` for resolving app-scoped Photon project credentials from a Vercel Connect connector.

--- a/packages/connect/src/eve/index.ts
+++ b/packages/connect/src/eve/index.ts
@@ -34,6 +34,7 @@ export {
 } from './linear-credentials.js';
 export {
   connectPhotonCredentials,
+  type ConnectPhotonCredentialProvider,
   type PhotonCredentials,
   type ConnectPhotonCredentialsParams,
 } from './photon-credentials.js';

--- a/packages/connect/src/eve/index.ts
+++ b/packages/connect/src/eve/index.ts
@@ -33,6 +33,11 @@ export {
   type ConnectLinearCredentialsParams,
 } from './linear-credentials.js';
 export {
+  connectPhotonCredentials,
+  type PhotonCredentials,
+  type ConnectPhotonCredentialsParams,
+} from './photon-credentials.js';
+export {
   connectSlackCredentials,
   type ConnectSlackCredentialsParams,
 } from './slack-credentials.js';

--- a/packages/connect/src/eve/photon-credentials.ts
+++ b/packages/connect/src/eve/photon-credentials.ts
@@ -1,0 +1,57 @@
+import {
+  getToken,
+  type ConnectOptions,
+  type ConnectTokenParams,
+} from '../index.js';
+
+/** Photon project credentials returned by {@link connectPhotonCredentials}. */
+export interface PhotonCredentials {
+  projectId: string;
+  projectSecret: string;
+}
+
+/**
+ * Token parameters accepted by {@link connectPhotonCredentials}.
+ *
+ * Mirrors {@link ConnectTokenParams} from `@vercel/connect`, minus
+ * `subject` — Photon project credentials are app-scoped, so `subject`
+ * is pinned to `{ type: "app" }` by this helper and cannot be overridden.
+ */
+export type ConnectPhotonCredentialsParams = Omit<
+  ConnectTokenParams,
+  'subject'
+>;
+
+/**
+ * Resolve Photon project credentials from a Vercel Connect connector.
+ *
+ * Photon connectors issue app-scoped credentials encoded as
+ * `projectId:projectSecret`. This helper requests that credential and returns
+ * the fields expected by Photon clients and adapters.
+ *
+ * ```ts
+ * import { connectPhotonCredentials } from '@vercel/connect/eve';
+ *
+ * const { projectId, projectSecret } =
+ *   await connectPhotonCredentials('photon/my-project');
+ * ```
+ */
+export async function connectPhotonCredentials(
+  connector: string,
+  params: ConnectPhotonCredentialsParams = {},
+  options?: ConnectOptions
+): Promise<PhotonCredentials> {
+  const credential = await getToken(
+    connector,
+    { ...params, subject: { type: 'app' } },
+    options
+  );
+  const separator = credential.indexOf(':');
+  if (separator < 1 || separator === credential.length - 1) {
+    throw new Error('Photon connector returned invalid credentials.');
+  }
+  return {
+    projectId: credential.slice(0, separator),
+    projectSecret: credential.slice(separator + 1),
+  };
+}

--- a/packages/connect/src/eve/photon-credentials.ts
+++ b/packages/connect/src/eve/photon-credentials.ts
@@ -1,5 +1,5 @@
 import {
-  getToken,
+  getTokenResponse,
   type ConnectOptions,
   type ConnectTokenParams,
 } from '../index.js';
@@ -25,9 +25,9 @@ export type ConnectPhotonCredentialsParams = Omit<
 /**
  * Resolve Photon project credentials from a Vercel Connect connector.
  *
- * Photon connectors issue app-scoped credentials encoded as
- * `projectId:projectSecret`. This helper requests that credential and returns
- * the fields expected by Photon clients and adapters.
+ * Photon connectors issue the project secret as an app-scoped token and the
+ * project ID as public token metadata. This helper returns both fields in the
+ * shape expected by Photon clients and adapters.
  *
  * ```ts
  * import { connectPhotonCredentials } from '@vercel/connect/eve';
@@ -41,17 +41,17 @@ export async function connectPhotonCredentials(
   params: ConnectPhotonCredentialsParams = {},
   options?: ConnectOptions
 ): Promise<PhotonCredentials> {
-  const credential = await getToken(
+  const response = await getTokenResponse(
     connector,
     { ...params, subject: { type: 'app' } },
     options
   );
-  const separator = credential.indexOf(':');
-  if (separator < 1 || separator === credential.length - 1) {
+  const projectId = response.metadata?.projectId;
+  if (typeof projectId !== 'string' || projectId.length === 0) {
     throw new Error('Photon connector returned invalid credentials.');
   }
   return {
-    projectId: credential.slice(0, separator),
-    projectSecret: credential.slice(separator + 1),
+    projectId,
+    projectSecret: response.token,
   };
 }

--- a/packages/connect/src/eve/photon-credentials.ts
+++ b/packages/connect/src/eve/photon-credentials.ts
@@ -4,11 +4,14 @@ import {
   type ConnectTokenParams,
 } from '../index.js';
 
-/** Photon project credentials returned by {@link connectPhotonCredentials}. */
+/** Photon project credentials resolved by {@link connectPhotonCredentials}. */
 export interface PhotonCredentials {
   projectId: string;
   projectSecret: string;
 }
+
+/** Lazy Photon credential provider returned by {@link connectPhotonCredentials}. */
+export type ConnectPhotonCredentialProvider = () => Promise<PhotonCredentials>;
 
 /**
  * Token parameters accepted by {@link connectPhotonCredentials}.
@@ -23,35 +26,40 @@ export type ConnectPhotonCredentialsParams = Omit<
 >;
 
 /**
- * Resolve Photon project credentials from a Vercel Connect connector.
+ * Build a lazy Photon credential provider backed by a Vercel Connect
+ * connector.
  *
  * Photon connectors issue the project secret as an app-scoped token and the
- * project ID as public token metadata. This helper returns both fields in the
- * shape expected by Photon clients and adapters.
+ * project ID as public token metadata. The returned provider resolves both
+ * fields when the Photon client or adapter first needs them.
  *
  * ```ts
  * import { connectPhotonCredentials } from '@vercel/connect/eve';
+ * import { createiMessageAdapter } from '@photon-ai/chat-adapter-imessage';
  *
- * const { projectId, projectSecret } =
- *   await connectPhotonCredentials('photon/my-project');
+ * const imessage = createiMessageAdapter({
+ *   credentials: connectPhotonCredentials('photon/my-project'),
+ * });
  * ```
  */
-export async function connectPhotonCredentials(
+export function connectPhotonCredentials(
   connector: string,
   params: ConnectPhotonCredentialsParams = {},
   options?: ConnectOptions
-): Promise<PhotonCredentials> {
-  const response = await getTokenResponse(
-    connector,
-    { ...params, subject: { type: 'app' } },
-    options
-  );
-  const projectId = response.metadata?.projectId;
-  if (typeof projectId !== 'string' || projectId.length === 0) {
-    throw new Error('Photon connector returned invalid credentials.');
-  }
-  return {
-    projectId,
-    projectSecret: response.token,
+): ConnectPhotonCredentialProvider {
+  return async () => {
+    const response = await getTokenResponse(
+      connector,
+      { ...params, subject: { type: 'app' } },
+      options
+    );
+    const projectId = response.metadata?.projectId;
+    if (typeof projectId !== 'string' || projectId.length === 0) {
+      throw new Error('Photon connector returned invalid credentials.');
+    }
+    return {
+      projectId,
+      projectSecret: response.token,
+    };
   };
 }

--- a/packages/connect/test/eve/channel-credentials.test.ts
+++ b/packages/connect/test/eve/channel-credentials.test.ts
@@ -61,7 +61,9 @@ describe('Eve channel credential helpers', () => {
 
   it('resolves Photon credentials from an app-scoped Connect token', async () => {
     fetchMock.mockResolvedValue(
-      jsonTokenResponse('photon-project:photon:secret')
+      jsonTokenResponse('photon-secret', {
+        metadata: { projectId: 'photon-project' },
+      })
     );
 
     await expect(
@@ -72,7 +74,7 @@ describe('Eve channel credential helpers', () => {
       )
     ).resolves.toEqual({
       projectId: 'photon-project',
-      projectSecret: 'photon:secret',
+      projectSecret: 'photon-secret',
     });
     expectTokenRequest('photon/my-project', {
       subject: { type: 'app' },
@@ -80,18 +82,22 @@ describe('Eve channel credential helpers', () => {
   });
 
   it.each([
-    'missing-separator',
-    ':missing-project',
-    'missing-secret:',
-  ])('rejects malformed Photon credentials: %s', async token => {
-    fetchMock.mockResolvedValue(jsonTokenResponse(token));
+    undefined,
+    {},
+    { projectId: '' },
+    { projectId: 123 },
+  ])('rejects malformed Photon metadata: %j', async metadata => {
+    fetchMock.mockResolvedValue(
+      jsonTokenResponse('photon-secret', { metadata })
+    );
 
     await expect(
       connectPhotonCredentials(
-        `photon/${token}`,
+        'photon/my-project',
         {},
         {
           vercelToken: 'vercel_token',
+          forceRefresh: true,
         }
       )
     ).rejects.toThrow('Photon connector returned invalid credentials.');
@@ -143,12 +149,16 @@ async function resolveToken(
   return token();
 }
 
-function jsonTokenResponse(token: string): Response {
+function jsonTokenResponse(
+  token: string,
+  overrides: Record<string, unknown> = {}
+): Response {
   return new Response(
     JSON.stringify({
       token,
       expiresAt: Date.now() + 60 * 60 * 1000,
       connector: { id: 'scl_abc', uid: 'oauth/test', type: 'oauth' },
+      ...overrides,
     }),
     { status: 200, headers: { 'Content-Type': 'application/json' } }
   );

--- a/packages/connect/test/eve/channel-credentials.test.ts
+++ b/packages/connect/test/eve/channel-credentials.test.ts
@@ -66,13 +66,14 @@ describe('Eve channel credential helpers', () => {
       })
     );
 
-    await expect(
-      connectPhotonCredentials(
-        'photon/my-project',
-        {},
-        { vercelToken: 'vercel_token' }
-      )
-    ).resolves.toEqual({
+    const credentials = connectPhotonCredentials(
+      'photon/my-project',
+      {},
+      { vercelToken: 'vercel_token' }
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(credentials()).resolves.toEqual({
       projectId: 'photon-project',
       projectSecret: 'photon-secret',
     });
@@ -91,16 +92,18 @@ describe('Eve channel credential helpers', () => {
       jsonTokenResponse('photon-secret', { metadata })
     );
 
-    await expect(
-      connectPhotonCredentials(
-        'photon/my-project',
-        {},
-        {
-          vercelToken: 'vercel_token',
-          forceRefresh: true,
-        }
-      )
-    ).rejects.toThrow('Photon connector returned invalid credentials.');
+    const credentials = connectPhotonCredentials(
+      'photon/my-project',
+      {},
+      {
+        vercelToken: 'vercel_token',
+        forceRefresh: true,
+      }
+    );
+
+    await expect(credentials()).rejects.toThrow(
+      'Photon connector returned invalid credentials.'
+    );
   });
 
   it('keeps Slack credentials backed by an app-scoped Connect token', async () => {

--- a/packages/connect/test/eve/channel-credentials.test.ts
+++ b/packages/connect/test/eve/channel-credentials.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   connectGitHubCredentials,
   connectLinearCredentials,
+  connectPhotonCredentials,
   connectSlackCredentials,
 } from '../../src/eve/index.js';
 
@@ -56,6 +57,44 @@ describe('Eve channel credential helpers', () => {
       installationId: 'linear-installation',
       subject: { type: 'app' },
     });
+  });
+
+  it('resolves Photon credentials from an app-scoped Connect token', async () => {
+    fetchMock.mockResolvedValue(
+      jsonTokenResponse('photon-project:photon:secret')
+    );
+
+    await expect(
+      connectPhotonCredentials(
+        'photon/my-project',
+        {},
+        { vercelToken: 'vercel_token' }
+      )
+    ).resolves.toEqual({
+      projectId: 'photon-project',
+      projectSecret: 'photon:secret',
+    });
+    expectTokenRequest('photon/my-project', {
+      subject: { type: 'app' },
+    });
+  });
+
+  it.each([
+    'missing-separator',
+    ':missing-project',
+    'missing-secret:',
+  ])('rejects malformed Photon credentials: %s', async token => {
+    fetchMock.mockResolvedValue(jsonTokenResponse(token));
+
+    await expect(
+      connectPhotonCredentials(
+        `photon/${token}`,
+        {},
+        {
+          vercelToken: 'vercel_token',
+        }
+      )
+    ).rejects.toThrow('Photon connector returned invalid credentials.');
   });
 
   it('keeps Slack credentials backed by an app-scoped Connect token', async () => {


### PR DESCRIPTION
## Why / Summary

- Add `connectPhotonCredentials()` so Eve and Photon integrations can consume a Connect-managed Photon project without hand-written token handling.
- Return a lazy credential provider matching `@photon-ai/chat-adapter-imessage`, so token retrieval happens when the adapter initializes rather than during module evaluation.
- Read the project secret from the token and the non-secret project ID from public token metadata, avoiding a service-specific `projectId:projectSecret` encoding.

```ts
import { connectPhotonCredentials } from "@vercel/connect/eve";
import { photonChannel } from "eve/channels/photon";

export default photonChannel({
  credentials: connectPhotonCredentials(process.env.PHOTON_CONNECTOR_ID!),
});
```

Depends on vercel/api#82511. Consumed by vercel/eve#1283.

## Validation

- Covered lazy app-scoped token resolution, structured credential reconstruction, and malformed/missing Photon metadata.