### PR TITLE
[@vercel/connect] adding getConnector() SDK helper to return connector metadata

### DIFF
--- a/.changeset/shy-bikes-enjoy.md
+++ b/.changeset/shy-bikes-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Adding `getConnector()` to `@vercel/connect` SDK

--- a/.changeset/shy-bikes-enjoy.md
+++ b/.changeset/shy-bikes-enjoy.md
@@ -2,4 +2,4 @@
 '@vercel/connect': minor
 ---
 
-Adding `getConnector()` to `@vercel/connect` SDK
+Adding `getConnectorMetadata()` to `@vercel/connect` SDK

--- a/packages/connect/src/connector.ts
+++ b/packages/connect/src/connector.ts
@@ -1,0 +1,63 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+import {
+  createConnectErrorFromResponse,
+  type ConnectOptions,
+} from './token.js';
+
+/**
+ * Connector metadata as returned by Vercel Connect. This is the stable, useful
+ * subset of the connector object the management APIs return; additional fields
+ * may be present on the wire but are not typed here.
+ */
+export interface ConnexConnector {
+  /** Opaque Vercel Connect connector id (e.g. `scl_…`). */
+  id: string;
+  /** Human-readable Vercel Connect connector UID. */
+  uid: string;
+  name: string;
+  /** Connector type identifier (e.g. `snowflake`, `oauth`). */
+  type: string;
+  /** Service the connector integrates with. */
+  service: string;
+  /** Fully-qualified URL for the connector's service when derivable. */
+  clientUrl?: string;
+  createdAt: number;
+  updatedAt: number;
+  /** Service-specific public configuration. */
+  data: Record<string, unknown>;
+}
+
+/**
+ * Fetch a connector's metadata from Vercel Connect.
+ *
+ * Authenticates with the deployment's Vercel OIDC token (same as
+ * {@link getToken}); the connector must be attached to the requesting
+ * deployment's project and enabled for its environment.
+ *
+ * @param connector - The connector id or UID.
+ */
+export async function getConnector(
+  connector: string,
+  options?: ConnectOptions
+): Promise<ConnexConnector> {
+  const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
+
+  const endpoint = `https://api.vercel.com/v1/connect/connectors/${encodeURIComponent(connector)}`;
+
+  const response = await fetch(endpoint, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${vercelToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw await createConnectErrorFromResponse(
+      response,
+      'Failed to get connector'
+    );
+  }
+
+  return (await response.json()) as ConnexConnector;
+}

--- a/packages/connect/src/connector.ts
+++ b/packages/connect/src/connector.ts
@@ -6,8 +6,7 @@ import {
 
 /**
  * Connector metadata as returned by Vercel Connect. This is the stable, useful
- * subset of the connector object the management APIs return; additional fields
- * may be present on the wire but are not typed here.
+ * subset of the connector object the management APIs return.
  */
 export interface ConnexConnector {
   /** Opaque Vercel Connect connector id (e.g. `scl_…`). */

--- a/packages/connect/src/connector.ts
+++ b/packages/connect/src/connector.ts
@@ -8,7 +8,7 @@ import {
  * Connector metadata as returned by Vercel Connect. This is the stable, useful
  * subset of the connector object the management APIs return.
  */
-export interface ConnexConnector {
+export interface ConnectorMetadata {
   /** Opaque Vercel Connect connector id (e.g. `scl_…`). */
   id: string;
   /** Human-readable Vercel Connect connector UID. */
@@ -22,8 +22,8 @@ export interface ConnexConnector {
   clientUrl?: string;
   createdAt: number;
   updatedAt: number;
-  /** Service-specific public configuration. */
-  data: Record<string, unknown>;
+  /** Vendor-specific public configuration. */
+  vendor: Record<string, unknown>;
 }
 
 /**
@@ -35,10 +35,10 @@ export interface ConnexConnector {
  *
  * @param connector - The connector id or UID.
  */
-export async function getConnector(
+export async function getConnectorMetadata(
   connector: string,
   options?: ConnectOptions
-): Promise<ConnexConnector> {
+): Promise<ConnectorMetadata> {
   const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
 
   const endpoint = `https://api.vercel.com/v1/connect/connectors/${encodeURIComponent(connector)}`;
@@ -58,5 +58,11 @@ export async function getConnector(
     );
   }
 
-  return (await response.json()) as ConnexConnector;
+  const { data, ...rest } = (await response.json()) as Record<
+    string,
+    unknown
+  > & {
+    data?: Record<string, unknown>;
+  };
+  return { ...rest, vendor: data ?? {} } as ConnectorMetadata;
 }

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -30,3 +30,5 @@ export {
 } from './installation.js';
 
 export type { ConnectAuthorizationDetail } from './authorization-details.js';
+
+export { getConnector, type ConnexConnector } from './connector.js';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -31,4 +31,7 @@ export {
 
 export type { ConnectAuthorizationDetail } from './authorization-details.js';
 
-export { getConnector, type ConnexConnector } from './connector.js';
+export {
+  getConnectorMetadata,
+  type ConnectorMetadata,
+} from './connector.js';

--- a/packages/connect/test/connector.test.ts
+++ b/packages/connect/test/connector.test.ts
@@ -1,6 +1,6 @@
 import { getVercelOidcToken } from '@vercel/oidc';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ConnectError, getConnector } from '../src/index.js';
+import { ConnectError, getConnectorMetadata } from '../src/index.js';
 
 vi.mock('@vercel/oidc', () => ({
   getVercelOidcToken: vi.fn(),
@@ -21,7 +21,7 @@ const CONNECTOR = {
   },
 };
 
-describe('getConnector', () => {
+describe('getConnectorMetadata', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe('getConnector', () => {
   it('fetches connector metadata with the explicit Vercel token', async () => {
     fetchMock.mockResolvedValue(jsonResponse(CONNECTOR));
 
-    const connector = await getConnector('snowflake/analytics', {
+    const connector = await getConnectorMetadata('snowflake/analytics', {
       vercelToken: 'vercel_token',
     });
 
@@ -63,7 +63,7 @@ describe('getConnector', () => {
   it('uses the Vercel OIDC token when no explicit token is provided', async () => {
     fetchMock.mockResolvedValue(jsonResponse(CONNECTOR));
 
-    await getConnector('snowflake/analytics');
+    await getConnectorMetadata('snowflake/analytics');
 
     expect(getVercelOidcToken).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -72,13 +72,15 @@ describe('getConnector', () => {
     );
   });
 
-  it('returns the connector service and service-specific data', async () => {
+  it('surfaces the wire `data` field as `vendor`', async () => {
     fetchMock.mockResolvedValue(jsonResponse(CONNECTOR));
 
-    const connector = await getConnector('snowflake/analytics');
+    const connector = await getConnectorMetadata('snowflake/analytics');
 
     expect(connector.service).toBe('snowflake');
-    expect(connector.data.accountIdentifier).toBe('ACME-XY123');
+    expect(connector.vendor.accountIdentifier).toBe('ACME-XY123');
+    expect(connector.vendor.defaultSessionRole).toBe('REPORTER');
+    expect('data' in connector).toBe(false);
   });
 
   it('throws a ConnectError on a non-ok response', async () => {
@@ -86,7 +88,7 @@ describe('getConnector', () => {
       jsonResponse({ error: { code: 'not_found' } }, { status: 404 })
     );
 
-    await expect(getConnector('scl_missing')).rejects.toBeInstanceOf(
+    await expect(getConnectorMetadata('scl_missing')).rejects.toBeInstanceOf(
       ConnectError
     );
   });

--- a/packages/connect/test/connector.test.ts
+++ b/packages/connect/test/connector.test.ts
@@ -1,0 +1,101 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectError, getConnector } from '../src/index.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn(),
+}));
+
+const CONNECTOR = {
+  id: 'scl_abc123',
+  uid: 'snowflake/analytics',
+  name: 'Analytics Warehouse',
+  type: 'snowflake',
+  service: 'snowflake',
+  clientUrl: 'https://ACME-XY123.snowflakecomputing.com',
+  createdAt: 1000,
+  updatedAt: 2000,
+  data: {
+    accountIdentifier: 'ACME-XY123',
+    defaultSessionRole: 'REPORTER',
+  },
+};
+
+describe('getConnector', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getVercelOidcToken).mockResolvedValue('oidc_token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches connector metadata with the explicit Vercel token', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(CONNECTOR));
+
+    const connector = await getConnector('snowflake/analytics', {
+      vercelToken: 'vercel_token',
+    });
+
+    expect(getVercelOidcToken).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://api.vercel.com/v1/connect/connectors/snowflake%2Fanalytics'
+    );
+    expect(init.method).toBe('GET');
+    expect(init.headers).toEqual({
+      Accept: 'application/json',
+      Authorization: 'Bearer vercel_token',
+    });
+    expect(connector.id).toBe('scl_abc123');
+    expect(connector.clientUrl).toBe(
+      'https://ACME-XY123.snowflakecomputing.com'
+    );
+  });
+
+  it('uses the Vercel OIDC token when no explicit token is provided', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(CONNECTOR));
+
+    await getConnector('snowflake/analytics');
+
+    expect(getVercelOidcToken).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer oidc_token'
+    );
+  });
+
+  it('returns the connector service and service-specific data', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(CONNECTOR));
+
+    const connector = await getConnector('snowflake/analytics');
+
+    expect(connector.service).toBe('snowflake');
+    expect(connector.data.accountIdentifier).toBe('ACME-XY123');
+  });
+
+  it('throws a ConnectError on a non-ok response', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ error: { code: 'not_found' } }, { status: 404 })
+    );
+
+    await expect(getConnector('scl_missing')).rejects.toBeInstanceOf(
+      ConnectError
+    );
+  });
+});
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}


### PR DESCRIPTION
Adding new SDK helper so that applications can surface connector metadata programatically.

Example:
```ts
import { getConnectorMetadata, getToken } from '@vercel/connect';
import snowflake from 'snowflake-sdk';

// Account identifier the user set once when creating the connector —
// no need to redefine it as an env var.
const connector = await getConnectorMetadata('my-snowflake');
const account = connector.vendor.accountIdentifier as string;

// Short-lived Snowflake OAuth token, brokered by Vercel Connect.
const token = await getToken('my-snowflake', {
  subject: { type: 'user', id: userId },
});

const connection = snowflake.createConnection({
  account,
  token,
  authenticator: 'OAUTH',
});
```

Use case: Snowflake queries using the Snowflake SDK (authorized by Vercel Connect) require the Snowflake account identifier/URL available. Users already have to specify this when setting up their Vercel Connect connector. Instead of having them redefine this twice (e.g. as an env variable), lift directly from the connect client.