### PR TITLE
[cli] Offer repo-wide linking in `vc link`

### DIFF
--- a/.changeset/link-all-projects-in-repo.md
+++ b/.changeset/link-all-projects-in-repo.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Offer to link every project connected to the repository in one pass from `vc link`
+Offer to link every project connected to the repository in one pass from `vc link`, and stop asking which Git remote to use while gathering those suggestions: the default remote (`origin` when present) is used and named in the option's footer

--- a/.changeset/link-all-projects-in-repo.md
+++ b/.changeset/link-all-projects-in-repo.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Offer to link every project connected to the repository in one pass from `vc link`

--- a/.changeset/link-all-projects-in-repo.md
+++ b/.changeset/link-all-projects-in-repo.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Offer to link every project connected to the repository in one pass from `vc link`, and stop asking which Git remote to use while gathering those suggestions: the default remote (`origin` when present) is used and named in the option's footer
+Offer to link every project connected to the repository in one pass from `vc link`, and stop asking which Git remote to use while gathering those suggestions: the default remote (`origin` when present) is used and named in the option's footer. When the repository has more than one remote, a "Choose a different remote" option re-runs the search against another remote

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -77,12 +77,20 @@ export default async function dev(
       );
       return 1;
     } else {
-      link = await setupAndLink(client, cwd, {
+      const setupResult = await setupAndLink(client, cwd, {
         autoConfirm: opts['--yes'],
         link,
         successEmoji: 'link',
         nonInteractive: client.nonInteractive,
       });
+
+      if (setupResult.status === 'repo_linked') {
+        // `dev` never opts into repo-wide linking, so this is unreachable.
+        output.error(`Unexpected repository-wide link result`);
+        return 1;
+      }
+
+      link = setupResult;
 
       if (link.status === 'not_linked') {
         // User aborted project linking questions

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -187,10 +187,18 @@ async function linkProject(client: Client) {
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
       pullEnv: false,
+      // Only `vc link` offers linking every project in the repo at once.
+      allowMultiProjectLink: !parsedArgs.flags['--project'],
     });
 
     if (typeof link === 'number') {
       return link;
+    }
+
+    // A repo-wide link has no single project directory to pull an OIDC token
+    // for; `vc env pull` runs per project directory instead.
+    if (link.status === 'repo_linked') {
+      return 0;
     }
 
     await refreshOidcTokenAfterLink(client, cwd);

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -16,6 +16,7 @@ const SEARCH_ALL_PROJECTS = 'search-all-projects' as const;
 const CREATE_NEW_PROJECT = 'create-new-project' as const;
 const BACK_TO_PROJECT_SELECTION = Symbol('back-to-project-selection');
 export const BACK_TO_TEAM_SELECTION = Symbol('back-to-team-selection');
+export const LINK_ALL_PROJECTS = Symbol('link-all-projects');
 const NO_EXISTING_PROJECTS = Symbol('no-existing-projects');
 
 async function inputProjectDecision(
@@ -214,6 +215,16 @@ async function searchExistingProjects(
   });
 }
 
+/**
+ * Offer to link every project in the repository in one pass. Only set when
+ * `vc link` runs from the repository root and more than one project on Vercel
+ * is already connected to this repository's Git remote.
+ */
+export interface MultiProjectOffer {
+  /** Projects already connected to this repo's Git remote in the team. */
+  connectedCount: number;
+}
+
 export default async function inputProject(
   client: Client,
   org: Org,
@@ -222,8 +233,15 @@ export default async function inputProject(
   skipAutoDetect = false,
   showProjectSuggestions = false,
   allowTeamSelectionBack = false,
-  repoMatches: CrossTeamMatch[] = []
-): Promise<Project | CrossTeamMatch | string | typeof BACK_TO_TEAM_SELECTION> {
+  repoMatches: CrossTeamMatch[] = [],
+  multiProjectOffer?: MultiProjectOffer
+): Promise<
+  | Project
+  | CrossTeamMatch
+  | string
+  | typeof BACK_TO_TEAM_SELECTION
+  | typeof LINK_ALL_PROJECTS
+> {
   const slugifiedName = slugify(detectedProjectName);
 
   // attempt to auto-detect a project to link
@@ -297,7 +315,8 @@ export default async function inputProject(
         | CrossTeamMatch
         | typeof SEARCH_ALL_PROJECTS
         | typeof CREATE_NEW_PROJECT
-        | typeof BACK_TO_TEAM_SELECTION;
+        | typeof BACK_TO_TEAM_SELECTION
+        | typeof LINK_ALL_PROJECTS;
       const choices: Array<
         | Separator
         | {
@@ -306,6 +325,20 @@ export default async function inputProject(
             description?: string;
           }
       > = [];
+
+      // Repository-wide linking is the strongest default when the command runs
+      // from the root of a repo whose workspace detection found several
+      // projects: one pass links them all instead of repeating `vc link`.
+      if (multiProjectOffer) {
+        const { connectedCount } = multiProjectOffer;
+        choices.push({
+          name: `Link all ${connectedCount} projects connected to this repo ${chalk.gray(
+            '(recommended)'
+          )}`,
+          value: LINK_ALL_PROJECTS,
+          description: `${connectedCount} projects in ${org.slug} are connected to this Git repository`,
+        });
+      }
 
       if (repoMatches.length > 0) {
         choices.push(
@@ -323,6 +356,10 @@ export default async function inputProject(
           },
           new Separator()
         );
+      } else if (multiProjectOffer) {
+        // Keep the repo-wide option visually separated from the fallback
+        // actions even when there is no per-directory suggestion.
+        choices.push(new Separator());
       }
       choices.push(
         {
@@ -351,6 +388,9 @@ export default async function inputProject(
 
       if (selected === BACK_TO_TEAM_SELECTION) {
         return BACK_TO_TEAM_SELECTION;
+      }
+      if (selected === LINK_ALL_PROJECTS) {
+        return LINK_ALL_PROJECTS;
       }
       if (selected === CREATE_NEW_PROJECT) {
         const projectName = await promptForProjectNameWithBack(

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -17,7 +17,20 @@ const CREATE_NEW_PROJECT = 'create-new-project' as const;
 const BACK_TO_PROJECT_SELECTION = Symbol('back-to-project-selection');
 export const BACK_TO_TEAM_SELECTION = Symbol('back-to-team-selection');
 export const LINK_ALL_PROJECTS = Symbol('link-all-projects');
+const CHOOSE_DIFFERENT_REMOTE = 'choose-different-remote' as const;
 const NO_EXISTING_PROJECTS = Symbol('no-existing-projects');
+
+/**
+ * The user chose a different Git remote; the caller re-runs the suggestion
+ * search against `remoteName`.
+ */
+export interface SelectRemote {
+  selectRemote: string;
+}
+
+export function isSelectRemote(value: unknown): value is SelectRemote {
+  return typeof value === 'object' && value !== null && 'selectRemote' in value;
+}
 
 async function inputProjectDecision(
   client: Client,
@@ -223,34 +236,45 @@ async function searchExistingProjects(
 export interface MultiProjectOffer {
   /** Projects already connected to this repo's Git remote in the team. */
   connectedCount: number;
-  /** Remote URL the connected projects were found through, for attribution. */
-  repoUrl?: string;
-  /** Name of that remote (`origin` unless the repo has no `origin`). */
-  remoteName?: string;
 }
 
 /**
- * Footer text for the repo-wide option. States the count, the team, and the
- * Git remote the connected projects were found through, so the chosen remote
- * is visible without a prompt that interrupts the suggestion search.
+ * The Git remote that project suggestions were derived from, plus whether the
+ * repo has others to switch to.
  */
-function describeConnectedSource({
-  connectedCount,
-  org,
-  repoUrl,
-  remoteName,
-}: {
-  connectedCount: number;
-  org: Org;
-  repoUrl?: string;
-  remoteName?: string;
-}): string {
-  const projects = `${connectedCount} projects in ${org.slug}`;
-  if (!repoUrl) {
-    return `${projects} are connected to this Git repository`;
-  }
-  const remoteSuffix = remoteName ? ` (${remoteName})` : '';
-  return `${projects} are connected to ${repoUrl}${remoteSuffix}`;
+export interface RemoteContext {
+  /** Name of the remote in use (`origin` unless the repo has no `origin`). */
+  remoteName: string;
+  /** Remote names available to switch to, excluding the one in use. */
+  otherRemoteNames: string[];
+}
+
+/**
+ * Picks which Git remote the project suggestions should come from. Includes a
+ * way back, since arriving here from the project picker should not be a
+ * one-way door.
+ */
+async function promptForRemote(
+  client: Client,
+  { remoteName, otherRemoteNames }: RemoteContext
+): Promise<string | typeof BACK_TO_PROJECT_SELECTION> {
+  const choices: Array<{
+    name: string;
+    value: string | typeof BACK_TO_PROJECT_SELECTION;
+  }> = [remoteName, ...otherRemoteNames].map(name => ({
+    name: name === remoteName ? `${name} ${chalk.bold('(current)')}` : name,
+    value: name,
+  }));
+  choices.push({
+    name: 'Back to project options',
+    value: BACK_TO_PROJECT_SELECTION,
+  });
+
+  return await client.input.select<string | typeof BACK_TO_PROJECT_SELECTION>({
+    message: 'Which Git remote?',
+    choices,
+    default: remoteName,
+  });
 }
 
 export default async function inputProject(
@@ -262,13 +286,15 @@ export default async function inputProject(
   showProjectSuggestions = false,
   allowTeamSelectionBack = false,
   repoMatches: CrossTeamMatch[] = [],
-  multiProjectOffer?: MultiProjectOffer
+  multiProjectOffer?: MultiProjectOffer,
+  remoteContext?: RemoteContext
 ): Promise<
   | Project
   | CrossTeamMatch
   | string
   | typeof BACK_TO_TEAM_SELECTION
   | typeof LINK_ALL_PROJECTS
+  | SelectRemote
 > {
   const slugifiedName = slugify(detectedProjectName);
 
@@ -344,7 +370,8 @@ export default async function inputProject(
         | typeof SEARCH_ALL_PROJECTS
         | typeof CREATE_NEW_PROJECT
         | typeof BACK_TO_TEAM_SELECTION
-        | typeof LINK_ALL_PROJECTS;
+        | typeof LINK_ALL_PROJECTS
+        | typeof CHOOSE_DIFFERENT_REMOTE;
       const choices: Array<
         | Separator
         | {
@@ -358,21 +385,17 @@ export default async function inputProject(
       // from the root of a repo whose workspace detection found several
       // projects: one pass links them all instead of repeating `vc link`.
       if (multiProjectOffer) {
-        const { connectedCount, repoUrl, remoteName } = multiProjectOffer;
+        const { connectedCount } = multiProjectOffer;
         choices.push({
           name: `Link all ${connectedCount} projects connected to this repo ${chalk.gray(
             '(recommended)'
           )}`,
           value: LINK_ALL_PROJECTS,
-          // Name the remote the count came from: the search picks the default
-          // remote without asking, so say which one it used rather than
-          // repeating the count already shown in the label.
-          description: describeConnectedSource({
-            connectedCount,
-            org,
-            repoUrl,
-            remoteName,
-          }),
+          // The label already states the count and that these are connected to
+          // this repo, so the footer only names the remote that produced them.
+          description: remoteContext
+            ? `Using remote ${remoteContext.remoteName}`
+            : undefined,
         });
       }
 
@@ -416,6 +439,17 @@ export default async function inputProject(
           description: 'Return to team selection',
         });
       }
+      // Only worth offering when the repo actually has another remote: with a
+      // single remote there is no choice to make.
+      if (remoteContext && remoteContext.otherRemoteNames.length > 0) {
+        choices.push({
+          name: 'Choose a different remote',
+          value: CHOOSE_DIFFERENT_REMOTE,
+          description: `Currently ${remoteContext.remoteName}; also ${remoteContext.otherRemoteNames.join(
+            ', '
+          )}`,
+        });
+      }
 
       const selected = await client.input.select<ProjectPickerValue>({
         message: 'Which project?',
@@ -427,6 +461,13 @@ export default async function inputProject(
       }
       if (selected === LINK_ALL_PROJECTS) {
         return LINK_ALL_PROJECTS;
+      }
+      if (selected === CHOOSE_DIFFERENT_REMOTE) {
+        const remoteName = await promptForRemote(client, remoteContext!);
+        if (remoteName === BACK_TO_PROJECT_SELECTION) {
+          continue;
+        }
+        return { selectRemote: remoteName };
       }
       if (selected === CREATE_NEW_PROJECT) {
         const projectName = await promptForProjectNameWithBack(

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -223,6 +223,34 @@ async function searchExistingProjects(
 export interface MultiProjectOffer {
   /** Projects already connected to this repo's Git remote in the team. */
   connectedCount: number;
+  /** Remote URL the connected projects were found through, for attribution. */
+  repoUrl?: string;
+  /** Name of that remote (`origin` unless the repo has no `origin`). */
+  remoteName?: string;
+}
+
+/**
+ * Footer text for the repo-wide option. States the count, the team, and the
+ * Git remote the connected projects were found through, so the chosen remote
+ * is visible without a prompt that interrupts the suggestion search.
+ */
+function describeConnectedSource({
+  connectedCount,
+  org,
+  repoUrl,
+  remoteName,
+}: {
+  connectedCount: number;
+  org: Org;
+  repoUrl?: string;
+  remoteName?: string;
+}): string {
+  const projects = `${connectedCount} projects in ${org.slug}`;
+  if (!repoUrl) {
+    return `${projects} are connected to this Git repository`;
+  }
+  const remoteSuffix = remoteName ? ` (${remoteName})` : '';
+  return `${projects} are connected to ${repoUrl}${remoteSuffix}`;
 }
 
 export default async function inputProject(
@@ -330,13 +358,21 @@ export default async function inputProject(
       // from the root of a repo whose workspace detection found several
       // projects: one pass links them all instead of repeating `vc link`.
       if (multiProjectOffer) {
-        const { connectedCount } = multiProjectOffer;
+        const { connectedCount, repoUrl, remoteName } = multiProjectOffer;
         choices.push({
           name: `Link all ${connectedCount} projects connected to this repo ${chalk.gray(
             '(recommended)'
           )}`,
           value: LINK_ALL_PROJECTS,
-          description: `${connectedCount} projects in ${org.slug} are connected to this Git repository`,
+          // Name the remote the count came from: the search picks the default
+          // remote without asking, so say which one it used rather than
+          // repeating the count already shown in the label.
+          description: describeConnectedSource({
+            connectedCount,
+            org,
+            repoUrl,
+            remoteName,
+          }),
         });
       }
 

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -443,9 +443,15 @@ export default async function inputProject(
       // single remote there is no choice to make.
       if (remoteContext && remoteContext.otherRemoteNames.length > 0) {
         choices.push({
-          name: 'Choose a different remote',
+          // Name the remote in the label, not just the description: unlike the
+          // team, which the "Which team?" line above still shows, nothing else
+          // on screen says which remote produced these suggestions, and
+          // descriptions only render for the highlighted row.
+          name: `Choose a different remote ${chalk.gray(
+            `(using ${remoteContext.remoteName})`
+          )}`,
           value: CHOOSE_DIFFERENT_REMOTE,
-          description: `Currently ${remoteContext.remoteName}; also ${remoteContext.otherRemoteNames.join(
+          description: `Also available: ${remoteContext.otherRemoteNames.join(
             ', '
           )}`,
         });

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -7,7 +7,10 @@ import {
   type ProjectLinkResultWithOrgId,
 } from '../projects/link';
 import { resolveProjectCwd } from '../projects/find-project-root';
-import type { SetupAndLinkOptions } from '../link/setup-and-link';
+import type {
+  RepoWideLinked,
+  SetupAndLinkOptions,
+} from '../link/setup-and-link';
 import type { ProjectLinked } from '@vercel-internals/types';
 import output from '../../output-manager';
 import { outputActionRequired, buildCommandWithYes } from '../agent-output';
@@ -44,8 +47,20 @@ export async function ensureLink(
   commandName: string,
   client: Client,
   cwd: string,
+  opts: EnsureLinkOptions & { allowMultiProjectLink: boolean }
+): Promise<ProjectLinked | RepoWideLinked | number>;
+export async function ensureLink(
+  commandName: string,
+  client: Client,
+  cwd: string,
+  opts?: EnsureLinkOptions
+): Promise<ProjectLinked | number>;
+export async function ensureLink(
+  commandName: string,
+  client: Client,
+  cwd: string,
   opts: EnsureLinkOptions = {}
-): Promise<ProjectLinked | number> {
+): Promise<ProjectLinked | RepoWideLinked | number> {
   cwd = await resolveProjectCwd(cwd);
 
   let link: ProjectLinkResultWithOrgId | undefined = opts.link;
@@ -101,7 +116,14 @@ export async function ensureLink(
       return 1;
     }
 
-    link = await setupAndLink(client, cwd, opts);
+    const setupResult = await setupAndLink(client, cwd, opts);
+
+    if (setupResult.status === 'repo_linked') {
+      // The whole repository was linked; there is no single project to return.
+      return setupResult;
+    }
+
+    link = setupResult;
 
     if (link.status === 'not_linked') {
       // User aborted project linking questions

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -67,6 +67,19 @@ export interface EnsureRepoLinkOptions {
   selectedOrg?: Org;
   /** Skip the `Link Git repository…?` confirmation when intent is known. */
   skipConfirm?: boolean;
+  /**
+   * Link every connected project without re-prompting. Set when the user
+   * already chose "Link all N projects connected to this repo".
+   */
+  linkAllConnected?: boolean;
+  /**
+   * Git remote and connected projects the caller already fetched, reused
+   * instead of re-crawling `/v9/projects?repoUrl=…`.
+   */
+  prefetchedConnected?: {
+    remote: ResolvedGitRemote;
+    projects: Project[];
+  };
 }
 
 interface NewProject {
@@ -246,6 +259,8 @@ async function discoverRepoProjects(
     existingRemoteName,
     selectedOrg,
     skipConfirm,
+    linkAllConnected,
+    prefetchedConnected,
   }: {
     yes: boolean;
     existingProjectIds?: Set<string>;
@@ -259,6 +274,28 @@ async function discoverRepoProjects(
      * already captured that intent, e.g. the `vc link` project picker.
      */
     skipConfirm?: boolean;
+    /**
+     * Link every project already connected to the repo's Git remote without
+     * re-asking which ones. Set when the user picked "Link all N projects
+     * connected to this repo": that choice already answered the question, so
+     * re-prompting with a pre-checked list adds a step and, at real scale,
+     * buries it under dozens of unrelated "new Projects" to create.
+     *
+     * Local framework detection is skipped entirely in this mode — creating
+     * new projects is a different intent from linking the existing ones.
+     */
+    linkAllConnected?: boolean;
+    /**
+     * Git remote and connected projects the caller already fetched, reused to
+     * avoid a second `/v9/projects?repoUrl=…` crawl (a partition-scoped filter
+     * whose cost grows with team size). Only honored when the remote resolves
+     * to the same `rootPath`; `projects` must be the full connected set for
+     * `selectedOrg`.
+     */
+    prefetchedConnected?: {
+      remote: ResolvedGitRemote;
+      projects: Project[];
+    };
   }
 ): Promise<
   | {
@@ -266,15 +303,20 @@ async function discoverRepoProjects(
       projects: RepoProjectConfig[];
       selectedProjects: Project[];
       orgSlug: string;
+      repoUrl: string;
     }
   | undefined
 > {
   // Detect the projects on the filesystem out of band, so that
-  // they will be ready by the time the projects are listed
-  const detectedProjectsPromise = detectProjects(rootPath).catch(err => {
-    output.debug(`Failed to detect local projects: ${err}`);
-    return new Map<string, Framework[]>();
-  });
+  // they will be ready by the time the projects are listed.
+  // Skipped when linking all connected projects: detection only feeds the
+  // "new Projects to be created" choices, which that flow never offers.
+  const detectedProjectsPromise = linkAllConnected
+    ? Promise.resolve(new Map<string, Framework[]>())
+    : detectProjects(rootPath).catch(err => {
+        output.debug(`Failed to detect local projects: ${err}`);
+        return new Map<string, Framework[]>();
+      });
 
   const promptAction = existingRemoteName ? 'add' : 'link';
   const confirmMessage =
@@ -297,10 +339,20 @@ async function discoverRepoProjects(
   const org = selectedOrg ?? (await selectOrg(client, 'Which team?', yes));
   client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
-  const remote = await resolveGitRemote(client, rootPath, {
-    yes,
-    existingRemoteName,
-  });
+  // Reuse the caller's remote only when it describes this same repo root and
+  // no specific remote was requested; otherwise resolve it here.
+  const reusableRemote =
+    prefetchedConnected &&
+    !existingRemoteName &&
+    prefetchedConnected.remote.rootPath === rootPath
+      ? prefetchedConnected.remote
+      : undefined;
+  const remote =
+    reusableRemote ??
+    (await resolveGitRemote(client, rootPath, {
+      yes,
+      existingRemoteName,
+    }));
   if (!remote) {
     throw new Error('Could not determine Git remote URLs');
   }
@@ -312,11 +364,20 @@ async function discoverRepoProjects(
   const repoUrlLink = output.link(repoUrl, repoInfoToUrl(parsedRepoUrl), {
     fallback: () => link(repoUrl),
   });
-  output.spinner(
-    `Fetching Projects for ${repoUrlLink} under ${chalk.bold(org.slug)}…`
-  );
+  // The caller's projects are only valid for the same remote URL.
+  const reusableProjects =
+    reusableRemote && prefetchedConnected?.remote.repoUrl === repoUrl
+      ? prefetchedConnected.projects
+      : undefined;
+  if (!reusableProjects) {
+    output.spinner(
+      `Fetching Projects for ${repoUrlLink} under ${chalk.bold(org.slug)}…`
+    );
+  }
   const detectedProjects = await detectedProjectsPromise;
-  let projects = await fetchProjectsForRepoUrl(client, repoUrl, org.id);
+  let projects =
+    reusableProjects ??
+    (await fetchProjectsForRepoUrl(client, repoUrl, org.id));
 
   // Filter out projects that are already linked in repo.json (by ID or directory)
   if (existingProjectIds || existingDirectories) {
@@ -332,7 +393,10 @@ async function discoverRepoProjects(
     output.print(
       `  No Projects are linked to ${repoUrlLink} under ${chalk.bold(org.slug)}.\n`
     );
-  } else {
+  } else if (!linkAllConnected) {
+    // Only useful as a preamble to the "which Projects?" list. When linking all
+    // connected projects there is no list, and the picker choice already named
+    // the count, so this would just restate it before the ✓ summary does.
     output.print(
       `  Found ${pluralize(
         'Project',
@@ -372,7 +436,8 @@ async function discoverRepoProjects(
   }
 
   let selected: (Project | NewProject)[];
-  if (yes) {
+  if (yes || linkAllConnected) {
+    // The caller already knows which projects to link: every connected one.
     selected = projects;
   } else {
     const addSeparators = projects.length > 0 && detectedProjectsCount > 0;
@@ -472,13 +537,21 @@ async function discoverRepoProjects(
     projects: repoProjects,
     selectedProjects: selected as Project[],
     orgSlug: org.slug,
+    repoUrl,
   };
 }
 
 export async function ensureRepoLink(
   client: Client,
   cwd: string,
-  { yes, overwrite, selectedOrg, skipConfirm }: EnsureRepoLinkOptions
+  {
+    yes,
+    overwrite,
+    selectedOrg,
+    skipConfirm,
+    linkAllConnected,
+    prefetchedConnected,
+  }: EnsureRepoLinkOptions
 ): Promise<RepoLink | undefined> {
   const repoLink = await getRepoLink(client, cwd);
   if (repoLink) {
@@ -494,6 +567,8 @@ export async function ensureRepoLink(
       yes,
       selectedOrg,
       skipConfirm,
+      linkAllConnected,
+      prefetchedConnected,
     });
     if (!result) {
       return;
@@ -510,11 +585,15 @@ export async function ensureRepoLink(
 
     await addToGitIgnore(rootPath);
 
+    output.print('\n');
     printAlignedLabel(
       'Linked',
       `${pluralize('Project', result.projects.length, true)} under ${result.orgSlug}`,
       { gutter: '✓' }
     );
+    // Name the repo on a continuation row so the summary is self-contained
+    // without repeating it in prose above.
+    printAlignedLabel('Repository', result.repoUrl);
   }
 
   return {

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -15,7 +15,7 @@ import selectOrg from '../input/select-org';
 import { addToGitIgnore } from './add-to-gitignore';
 import type Client from '../client';
 import type { Framework } from '@vercel/frameworks';
-import type { Project } from '@vercel-internals/types';
+import type { Org, Project } from '@vercel-internals/types';
 import createProject from '../projects/create-project';
 import { detectProjects } from '../projects/detect-projects';
 import { repoInfoToUrl } from '../git/repo-info-to-url';
@@ -47,6 +47,11 @@ export interface RepoLink {
   rootPath: string;
   repoConfigPath: string;
   repoConfig?: RepoProjectsConfig;
+  /**
+   * Projects selected during this run, in API form. Only set when the link
+   * flow actually discovered/created projects.
+   */
+  selectedProjects?: Project[];
 }
 
 export interface ResolvedGitRemote {
@@ -58,6 +63,10 @@ export interface ResolvedGitRemote {
 export interface EnsureRepoLinkOptions {
   yes: boolean;
   overwrite: boolean;
+  /** Team already resolved by the caller; skips the `Which team?` prompt. */
+  selectedOrg?: Org;
+  /** Skip the `Link Git repository…?` confirmation when intent is known. */
+  skipConfirm?: boolean;
 }
 
 interface NewProject {
@@ -235,15 +244,29 @@ async function discoverRepoProjects(
     existingProjectIds,
     existingDirectories,
     existingRemoteName,
+    selectedOrg,
+    skipConfirm,
   }: {
     yes: boolean;
     existingProjectIds?: Set<string>;
     existingDirectories?: Set<string>;
     /** When set, skip the remote selection prompt and use this remote. */
     existingRemoteName?: string;
+    /** Team already resolved by the caller; skips the `Which team?` prompt. */
+    selectedOrg?: Org;
+    /**
+     * Skip the `Link Git repository…?` confirmation. Use when the caller
+     * already captured that intent, e.g. the `vc link` project picker.
+     */
+    skipConfirm?: boolean;
   }
 ): Promise<
-  | { remoteName: string; projects: RepoProjectConfig[]; orgSlug: string }
+  | {
+      remoteName: string;
+      projects: RepoProjectConfig[];
+      selectedProjects: Project[];
+      orgSlug: string;
+    }
   | undefined
 > {
   // Detect the projects on the filesystem out of band, so that
@@ -263,14 +286,15 @@ async function discoverRepoProjects(
           `"${toHumanPath(rootPath)}"`
         )} to your Project(s)?`;
 
-  const shouldLink = yes || (await client.input.confirm(confirmMessage, true));
+  const shouldLink =
+    yes || skipConfirm || (await client.input.confirm(confirmMessage, true));
 
   if (!shouldLink) {
     output.print(`  Canceled. Repository not linked.\n`);
     return;
   }
 
-  const org = await selectOrg(client, 'Which team?', yes);
+  const org = selectedOrg ?? (await selectOrg(client, 'Which team?', yes));
   client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
   const remote = await resolveGitRemote(client, rootPath, {
@@ -443,13 +467,18 @@ async function discoverRepoProjects(
     };
   });
 
-  return { remoteName, projects: repoProjects, orgSlug: org.slug };
+  return {
+    remoteName,
+    projects: repoProjects,
+    selectedProjects: selected as Project[],
+    orgSlug: org.slug,
+  };
 }
 
 export async function ensureRepoLink(
   client: Client,
   cwd: string,
-  { yes, overwrite }: EnsureRepoLinkOptions
+  { yes, overwrite, selectedOrg, skipConfirm }: EnsureRepoLinkOptions
 ): Promise<RepoLink | undefined> {
   const repoLink = await getRepoLink(client, cwd);
   if (repoLink) {
@@ -458,12 +487,18 @@ export async function ensureRepoLink(
     throw new Error('Could not determine Git repository root directory');
   }
   let { rootPath, repoConfig, repoConfigPath } = repoLink;
+  let selectedProjects: Project[] | undefined;
 
   if (overwrite || !repoConfig) {
-    const result = await discoverRepoProjects(client, rootPath, { yes });
+    const result = await discoverRepoProjects(client, rootPath, {
+      yes,
+      selectedOrg,
+      skipConfirm,
+    });
     if (!result) {
       return;
     }
+    selectedProjects = result.selectedProjects;
 
     repoConfig = {
       remoteName: result.remoteName,
@@ -486,6 +521,7 @@ export async function ensureRepoLink(
     repoConfig,
     repoConfigPath,
     rootPath,
+    selectedProjects,
   };
 }
 

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -58,6 +58,11 @@ export interface ResolvedGitRemote {
   rootPath: string;
   remoteName: string;
   repoUrl: string;
+  /**
+   * Every remote configured in the repo, sorted. Lets callers offer a remote
+   * switcher only when there is actually another remote to switch to.
+   */
+  remoteNames?: string[];
 }
 
 export interface EnsureRepoLinkOptions {
@@ -119,10 +124,17 @@ export async function resolveGitRemote(
   {
     yes,
     existingRemoteName,
+    preferredRemoteName,
   }: {
     yes: boolean;
     /** When set, skip remote selection and use this remote. */
     existingRemoteName?: string;
+    /**
+     * Remote the user explicitly chose this run. Unlike `existingRemoteName`
+     * it is not authoritative: if it is gone, fall back to the default rather
+     * than failing, since nothing has been written against it yet.
+     */
+    preferredRemoteName?: string;
   }
 ): Promise<ResolvedGitRemote | undefined> {
   // Use getGitConfigPath to correctly resolve the config path for
@@ -144,6 +156,8 @@ export async function resolveGitRemote(
         `Git remote "${remoteName}" from repo.json no longer exists`
       );
     }
+  } else if (preferredRemoteName && remoteUrls[preferredRemoteName]) {
+    remoteName = preferredRemoteName;
   } else {
     const remoteNames = Object.keys(remoteUrls).sort();
     if (remoteNames.length === 1) {
@@ -166,7 +180,12 @@ export async function resolveGitRemote(
     }
   }
 
-  return { rootPath, remoteName, repoUrl: remoteUrls[remoteName] };
+  return {
+    rootPath,
+    remoteName,
+    repoUrl: remoteUrls[remoteName],
+    remoteNames: Object.keys(remoteUrls).sort(),
+  };
 }
 
 export async function fetchProjectsForRepoUrl(

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -15,7 +15,11 @@ import {
   VERCEL_DIR_README,
   VERCEL_DIR_PROJECT,
 } from '../projects/link';
-import { ensureRepoLink, linkRepoProject } from './repo';
+import {
+  ensureRepoLink,
+  linkRepoProject,
+  type ResolvedGitRemote,
+} from './repo';
 import createProject from '../projects/create-project';
 import type Client from '../client';
 import { printError } from '../error';
@@ -223,7 +227,11 @@ export function resolveMultiProjectOffer({
     return undefined;
   }
 
-  return { connectedCount: connectedProjects.length };
+  return {
+    connectedCount: connectedProjects.length,
+    repoUrl: repoSearch.remote?.repoUrl,
+    remoteName: repoSearch.remote?.remoteName,
+  };
 }
 
 /**
@@ -451,6 +459,11 @@ export default async function setupAndLink(
   // When the team was auto-selected as the only choice, there is no other
   // team to go back to, so the project picker hides that option.
   let teamAutoSelected = false;
+  // Projects connected to the repo remote for the team the user settled on,
+  // carried out of the loop so linking them does not refetch the same list.
+  let connectedForOrg:
+    | { remote: ResolvedGitRemote; projects: Project[] }
+    | undefined;
   for (;;) {
     if (!org) {
       const orgMeta: { choiceCount?: number } = {};
@@ -471,6 +484,7 @@ export default async function setupAndLink(
     // The repo-wide offer is derived from the same search, so it costs no
     // additional request.
     let multiProjectOffer: MultiProjectOffer | undefined;
+    connectedForOrg = undefined;
     if (showProjectSuggestions) {
       output.spinner('Searching for existing projects…', 1000);
       try {
@@ -479,10 +493,16 @@ export default async function setupAndLink(
           cwd: path,
           gitProjectName,
           orgs: [org],
-          autoConfirm,
-          nonInteractive,
         });
         repoMatches = repoSearch.matches;
+        // Reset per iteration: on a "back to team" loop the previous team's
+        // projects must not leak into the newly selected team.
+        connectedForOrg = repoSearch.remote
+          ? {
+              remote: repoSearch.remote,
+              projects: repoSearch.connectedByOrgId.get(org.id) ?? [],
+            }
+          : undefined;
         if (allowMultiProjectLink) {
           multiProjectOffer = resolveMultiProjectOffer({
             path,
@@ -537,6 +557,11 @@ export default async function setupAndLink(
       // Team and link intent were already resolved by the project picker.
       selectedOrg: org,
       skipConfirm: true,
+      // The picker choice was "link all connected", so don't re-ask which
+      // projects, and don't offer to create new ones.
+      linkAllConnected: true,
+      // The picker already fetched this exact list to build the offer.
+      prefetchedConnected: connectedForOrg,
     });
 
     if (!repoLink?.repoConfig) {

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -3,6 +3,7 @@ import { join, basename } from 'path';
 import { getPlatformEnv } from '@vercel/build-utils';
 import { LocalFileSystemDetector, getWorkspaces } from '@vercel/fs-detectors';
 import type {
+  Project,
   ProjectLinkResult,
   ProjectSettings,
   Org,
@@ -14,7 +15,7 @@ import {
   VERCEL_DIR_README,
   VERCEL_DIR_PROJECT,
 } from '../projects/link';
-import { linkRepoProject } from './repo';
+import { ensureRepoLink, linkRepoProject } from './repo';
 import createProject from '../projects/create-project';
 import type Client from '../client';
 import { printError } from '../error';
@@ -28,7 +29,11 @@ import {
 import toHumanPath from '../humanize-path';
 import { isDirectory } from '../fs';
 import selectOrg from '../input/select-org';
-import inputProject, { BACK_TO_TEAM_SELECTION } from '../input/input-project';
+import inputProject, {
+  BACK_TO_TEAM_SELECTION,
+  LINK_ALL_PROJECTS,
+  type MultiProjectOffer,
+} from '../input/input-project';
 import { validateRootDirectory } from '../validate-paths';
 import { inputRootDirectory } from '../input/input-root-directory';
 import {
@@ -55,8 +60,11 @@ import {
   toProjectRootDirectory,
   type InferredServicesChoice,
 } from './services-setup';
-import { searchProjectsByRepoRoot } from '../projects/search-project-across-teams';
-import type { CrossTeamMatch } from '../projects/search-project-across-teams';
+import { searchProjectsByRepoRootDetailed } from '../projects/search-project-across-teams';
+import type {
+  CrossTeamMatch,
+  RepoRootSearchResult,
+} from '../projects/search-project-across-teams';
 import { isPromptCanceledError } from '../input/prompt-cancellation';
 
 export interface SetupAndLinkOptions {
@@ -78,6 +86,32 @@ export interface SetupAndLinkOptions {
    * fail fast rather than creating a new project.
    */
   failIfNotFound?: boolean;
+  /**
+   * When true, run workspace detection and offer repository-wide linking in
+   * the project picker. Only `vc link` sets this: commands that need exactly
+   * one project (deploy, dev, pull, …) must not offer a multi-project link.
+   */
+  allowMultiProjectLink?: boolean;
+}
+
+/**
+ * Result of linking every project in a repository at once. It has no single
+ * project or per-directory `.vercel/project.json`, so it is kept separate from
+ * `ProjectLinked` instead of pretending one project was selected.
+ */
+export interface RepoWideLinked {
+  status: 'repo_linked';
+  org: Org;
+  repoRoot: string;
+  projects: Project[];
+}
+
+export type SetupAndLinkResult = ProjectLinkResult | RepoWideLinked;
+
+export function isRepoWideLinked(
+  result: SetupAndLinkResult
+): result is RepoWideLinked {
+  return result.status === 'repo_linked';
 }
 
 function isCrossTeamMatch(value: unknown): value is CrossTeamMatch {
@@ -150,6 +184,46 @@ async function hasWorkspaces(cwd: string): Promise<boolean> {
     }
     throw err;
   }
+}
+
+/**
+ * Decides whether the project picker should offer repository-wide linking, and
+ * describes the offer in terms of what the user actually gets.
+ *
+ * The count comes from projects on Vercel already connected to this
+ * repository's Git remote under the selected team — not from local framework
+ * detection, which counts every workspace package and overstates the work.
+ *
+ * `/v9/projects?repoUrl=…` is a partition-scoped filter whose cost grows with
+ * team size, so this reuses the projects the Git-match search already fetched
+ * rather than issuing a second crawl of the same data.
+ *
+ * The offer only applies from the repository root: inside a single package,
+ * linking one project is still the right job.
+ */
+export function resolveMultiProjectOffer({
+  path,
+  org,
+  repoSearch,
+}: {
+  path: string;
+  org: Org;
+  repoSearch: RepoRootSearchResult;
+}): MultiProjectOffer | undefined {
+  // Only offer from the repository root.
+  if (!repoSearch.rootPath || repoSearch.rootPath !== path) {
+    return undefined;
+  }
+
+  const connectedProjects = repoSearch.connectedByOrgId.get(org.id) ?? [];
+
+  // Nothing to batch: a single connected project is already covered by the
+  // `(linked by git)` suggestion.
+  if (connectedProjects.length < 2) {
+    return undefined;
+  }
+
+  return { connectedCount: connectedProjects.length };
 }
 
 /**
@@ -290,8 +364,9 @@ export default async function setupAndLink(
     nonInteractive = false,
     pullEnv = true,
     v0,
+    allowMultiProjectLink = false,
   }: SetupAndLinkOptions
-): Promise<ProjectLinkResult> {
+): Promise<SetupAndLinkResult> {
   const { config } = client;
   const gitProjectName = projectName;
   projectName = projectName ?? basename(path);
@@ -393,10 +468,13 @@ export default async function setupAndLink(
     }
 
     let repoMatches: CrossTeamMatch[] = [];
+    // The repo-wide offer is derived from the same search, so it costs no
+    // additional request.
+    let multiProjectOffer: MultiProjectOffer | undefined;
     if (showProjectSuggestions) {
       output.spinner('Searching for existing projects…', 1000);
       try {
-        repoMatches = await searchProjectsByRepoRoot({
+        const repoSearch = await searchProjectsByRepoRootDetailed({
           client,
           cwd: path,
           gitProjectName,
@@ -404,6 +482,14 @@ export default async function setupAndLink(
           autoConfirm,
           nonInteractive,
         });
+        repoMatches = repoSearch.matches;
+        if (allowMultiProjectLink) {
+          multiProjectOffer = resolveMultiProjectOffer({
+            path,
+            org,
+            repoSearch,
+          });
+        }
       } catch (err) {
         if (isPromptCanceledError(err)) {
           throw err;
@@ -423,7 +509,8 @@ export default async function setupAndLink(
         false,
         showProjectSuggestions,
         searchableTeamPicker && !selectedOrg && !teamAutoSelected,
-        repoMatches
+        repoMatches,
+        multiProjectOffer
       );
     } catch (err) {
       if (
@@ -440,6 +527,29 @@ export default async function setupAndLink(
       continue;
     }
     break;
+  }
+
+  if (projectOrNewProjectName === LINK_ALL_PROJECTS) {
+    config.currentTeam = org.type === 'team' ? org.id : undefined;
+    const repoLink = await ensureRepoLink(client, path, {
+      yes: autoConfirm,
+      overwrite: true,
+      // Team and link intent were already resolved by the project picker.
+      selectedOrg: org,
+      skipConfirm: true,
+    });
+
+    if (!repoLink?.repoConfig) {
+      // User selected no projects; nothing was written.
+      return { status: 'not_linked', org: null, project: null };
+    }
+
+    return {
+      status: 'repo_linked',
+      org,
+      repoRoot: repoLink.rootPath,
+      projects: repoLink.selectedProjects ?? [],
+    };
   }
 
   if (typeof projectOrNewProjectName === 'string') {

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -36,7 +36,9 @@ import selectOrg from '../input/select-org';
 import inputProject, {
   BACK_TO_TEAM_SELECTION,
   LINK_ALL_PROJECTS,
+  isSelectRemote,
   type MultiProjectOffer,
+  type RemoteContext,
 } from '../input/input-project';
 import { validateRootDirectory } from '../validate-paths';
 import { inputRootDirectory } from '../input/input-root-directory';
@@ -229,8 +231,6 @@ export function resolveMultiProjectOffer({
 
   return {
     connectedCount: connectedProjects.length,
-    repoUrl: repoSearch.remote?.repoUrl,
-    remoteName: repoSearch.remote?.remoteName,
   };
 }
 
@@ -464,6 +464,9 @@ export default async function setupAndLink(
   let connectedForOrg:
     | { remote: ResolvedGitRemote; projects: Project[] }
     | undefined;
+  // Set once the user overrides the default remote from the project picker, so
+  // the suggestion search re-runs against their choice.
+  let chosenRemoteName: string | undefined;
   for (;;) {
     if (!org) {
       const orgMeta: { choiceCount?: number } = {};
@@ -484,6 +487,7 @@ export default async function setupAndLink(
     // The repo-wide offer is derived from the same search, so it costs no
     // additional request.
     let multiProjectOffer: MultiProjectOffer | undefined;
+    let remoteContext: RemoteContext | undefined;
     connectedForOrg = undefined;
     if (showProjectSuggestions) {
       output.spinner('Searching for existing projects…', 1000);
@@ -493,8 +497,16 @@ export default async function setupAndLink(
           cwd: path,
           gitProjectName,
           orgs: [org],
+          remoteName: chosenRemoteName,
         });
         repoMatches = repoSearch.matches;
+        if (repoSearch.remote) {
+          const { remoteName, remoteNames = [] } = repoSearch.remote;
+          remoteContext = {
+            remoteName,
+            otherRemoteNames: remoteNames.filter(name => name !== remoteName),
+          };
+        }
         // Reset per iteration: on a "back to team" loop the previous team's
         // projects must not leak into the newly selected team.
         connectedForOrg = repoSearch.remote
@@ -530,7 +542,8 @@ export default async function setupAndLink(
         showProjectSuggestions,
         searchableTeamPicker && !selectedOrg && !teamAutoSelected,
         repoMatches,
-        multiProjectOffer
+        multiProjectOffer,
+        remoteContext
       );
     } catch (err) {
       if (
@@ -544,6 +557,11 @@ export default async function setupAndLink(
 
     if (projectOrNewProjectName === BACK_TO_TEAM_SELECTION) {
       org = undefined;
+      continue;
+    }
+    // Re-run the search against the chosen remote, keeping the same team.
+    if (isSelectRemote(projectOrNewProjectName)) {
+      chosenRemoteName = projectOrNewProjectName.selectRemote;
       continue;
     }
     break;

--- a/packages/cli/src/util/projects/search-project-across-teams.ts
+++ b/packages/cli/src/util/projects/search-project-across-teams.ts
@@ -153,11 +153,17 @@ export async function searchProjectsByRepoRootDetailed({
   cwd,
   gitProjectName,
   orgs,
+  remoteName,
 }: {
   client: Client;
   cwd: string;
   gitProjectName?: string;
   orgs: Org[];
+  /**
+   * Search this remote instead of the default. Set when the user explicitly
+   * picked a remote, so the suggestions follow their choice.
+   */
+  remoteName?: string;
 }): Promise<RepoRootSearchResult> {
   const empty: RepoRootSearchResult = {
     matches: [],
@@ -177,6 +183,7 @@ export async function searchProjectsByRepoRootDetailed({
     // would ask the user to choose before they know what it affects.
     remote = await resolveGitRemote(client, rootPath, {
       yes: true,
+      preferredRemoteName: remoteName,
     });
   } catch (error) {
     if (isPromptCanceledError(error)) {

--- a/packages/cli/src/util/projects/search-project-across-teams.ts
+++ b/packages/cli/src/util/projects/search-project-across-teams.ts
@@ -36,14 +36,10 @@ export default async function searchProjectAcrossTeams(
   projectName: string,
   cwd: string,
   {
-    autoConfirm = false,
-    nonInteractive = false,
     teams,
     skipLimited,
     gitProjectName,
   }: {
-    autoConfirm?: boolean;
-    nonInteractive?: boolean;
     teams?: Team[];
     skipLimited?: boolean;
     gitProjectName?: string;
@@ -85,8 +81,6 @@ export default async function searchProjectAcrossTeams(
     cwd,
     gitProjectName,
     orgs,
-    autoConfirm,
-    nonInteractive,
   });
 
   const slugifiedName = slugify(projectName);
@@ -150,8 +144,6 @@ export async function searchProjectsByRepoRoot(args: {
   cwd: string;
   gitProjectName?: string;
   orgs: Org[];
-  autoConfirm: boolean;
-  nonInteractive: boolean;
 }): Promise<CrossTeamMatch[]> {
   return (await searchProjectsByRepoRootDetailed(args)).matches;
 }
@@ -161,15 +153,11 @@ export async function searchProjectsByRepoRootDetailed({
   cwd,
   gitProjectName,
   orgs,
-  autoConfirm,
-  nonInteractive,
 }: {
   client: Client;
   cwd: string;
   gitProjectName?: string;
   orgs: Org[];
-  autoConfirm: boolean;
-  nonInteractive: boolean;
 }): Promise<RepoRootSearchResult> {
   const empty: RepoRootSearchResult = {
     matches: [],
@@ -183,8 +171,12 @@ export async function searchProjectsByRepoRootDetailed({
 
   let remote: ResolvedGitRemote | undefined;
   try {
+    // This search only builds suggestions, so it must never block on remote
+    // disambiguation: pick the default remote (`origin` when present) and let
+    // the caller show which remote the suggestions came from. Prompting here
+    // would ask the user to choose before they know what it affects.
     remote = await resolveGitRemote(client, rootPath, {
-      yes: autoConfirm || nonInteractive,
+      yes: true,
     });
   } catch (error) {
     if (isPromptCanceledError(error)) {

--- a/packages/cli/src/util/projects/search-project-across-teams.ts
+++ b/packages/cli/src/util/projects/search-project-across-teams.ts
@@ -131,7 +131,32 @@ export default async function searchProjectAcrossTeams(
   };
 }
 
-export async function searchProjectsByRepoRoot({
+export interface RepoRootSearchResult {
+  /** Projects whose Root Directory matches the current path. */
+  matches: CrossTeamMatch[];
+  /**
+   * Every project connected to the repo's Git remote, per searched org. Kept
+   * from the same request as `matches` so callers that need repo-wide counts
+   * do not issue a second `/v9/projects?repoUrl=…` crawl.
+   */
+  connectedByOrgId: Map<string, Project[]>;
+  /** Resolved Git remote, when the path is inside a Git repository. */
+  remote?: ResolvedGitRemote;
+  rootPath?: string;
+}
+
+export async function searchProjectsByRepoRoot(args: {
+  client: Client;
+  cwd: string;
+  gitProjectName?: string;
+  orgs: Org[];
+  autoConfirm: boolean;
+  nonInteractive: boolean;
+}): Promise<CrossTeamMatch[]> {
+  return (await searchProjectsByRepoRootDetailed(args)).matches;
+}
+
+export async function searchProjectsByRepoRootDetailed({
   client,
   cwd,
   gitProjectName,
@@ -145,10 +170,15 @@ export async function searchProjectsByRepoRoot({
   orgs: Org[];
   autoConfirm: boolean;
   nonInteractive: boolean;
-}): Promise<CrossTeamMatch[]> {
+}): Promise<RepoRootSearchResult> {
+  const empty: RepoRootSearchResult = {
+    matches: [],
+    connectedByOrgId: new Map(),
+  };
+
   const rootPath = await findRepoRoot(cwd);
   if (!rootPath) {
-    return [];
+    return empty;
   }
 
   let remote: ResolvedGitRemote | undefined;
@@ -161,14 +191,15 @@ export async function searchProjectsByRepoRoot({
       throw error;
     }
     output.debug(`Failed to resolve Git remote for project search: ${error}`);
-    return [];
+    return empty;
   }
 
   if (!remote) {
-    return [];
+    return empty;
   }
 
   const relativePath = relative(rootPath, cwd);
+  const connectedByOrgId = new Map<string, Project[]>();
   const results = await Promise.all(
     orgs.map(async org => {
       try {
@@ -177,6 +208,7 @@ export async function searchProjectsByRepoRoot({
           remote.repoUrl,
           org.id
         );
+        connectedByOrgId.set(org.id, projects);
         const repoProjectConfigs = projects
           .filter(
             project =>
@@ -223,5 +255,10 @@ export async function searchProjectsByRepoRoot({
     })
   );
 
-  return results.flat();
+  return {
+    matches: results.flat(),
+    connectedByOrgId,
+    remote,
+    rootPath,
+  };
 }

--- a/packages/cli/test/unit/util/link/resolve-multi-project-offer.test.ts
+++ b/packages/cli/test/unit/util/link/resolve-multi-project-offer.test.ts
@@ -38,14 +38,12 @@ describe('resolveMultiProjectOffer()', () => {
       }),
     });
 
-    expect(offer).toEqual({
-      connectedCount: 3,
-      repoUrl: 'git@github.com:vercel/front.git',
-      remoteName: 'origin',
-    });
+    expect(offer).toEqual({ connectedCount: 3 });
   });
 
-  it('carries no remote attribution when the remote is unresolved', () => {
+  it('offers repo-wide linking even when the remote is unresolved', () => {
+    // The offer describes the count only; naming the remote is the picker's
+    // job, so an unresolved remote must not suppress the offer.
     const offer = resolveMultiProjectOffer({
       path: '/repo',
       org,
@@ -55,11 +53,7 @@ describe('resolveMultiProjectOffer()', () => {
       }),
     });
 
-    expect(offer).toEqual({
-      connectedCount: 2,
-      repoUrl: undefined,
-      remoteName: undefined,
-    });
+    expect(offer).toEqual({ connectedCount: 2 });
   });
 
   it('does not offer repo-wide linking for a single connected project', () => {

--- a/packages/cli/test/unit/util/link/resolve-multi-project-offer.test.ts
+++ b/packages/cli/test/unit/util/link/resolve-multi-project-offer.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMultiProjectOffer } from '../../../../src/util/link/setup-and-link';
+import type { RepoRootSearchResult } from '../../../../src/util/projects/search-project-across-teams';
+import type { Org } from '@vercel-internals/types';
+import type { Project } from '@vercel-internals/types';
+
+const org: Org = { type: 'team', id: 'team_123', slug: 'vercel' };
+
+function project(id: string, rootDirectory?: string): Project {
+  return { id, name: id, rootDirectory } as Project;
+}
+
+function search(
+  overrides: Partial<RepoRootSearchResult> = {}
+): RepoRootSearchResult {
+  return {
+    matches: [],
+    connectedByOrgId: new Map(),
+    rootPath: '/repo',
+    remote: {
+      rootPath: '/repo',
+      remoteName: 'origin',
+      repoUrl: 'git@github.com:vercel/front.git',
+    },
+    ...overrides,
+  };
+}
+
+describe('resolveMultiProjectOffer()', () => {
+  it('offers repo-wide linking when several projects are connected', () => {
+    const offer = resolveMultiProjectOffer({
+      path: '/repo',
+      org,
+      repoSearch: search({
+        connectedByOrgId: new Map([
+          [org.id, [project('a'), project('b'), project('c')]],
+        ]),
+      }),
+    });
+
+    expect(offer).toEqual({
+      connectedCount: 3,
+      repoUrl: 'git@github.com:vercel/front.git',
+      remoteName: 'origin',
+    });
+  });
+
+  it('carries no remote attribution when the remote is unresolved', () => {
+    const offer = resolveMultiProjectOffer({
+      path: '/repo',
+      org,
+      repoSearch: search({
+        remote: undefined,
+        connectedByOrgId: new Map([[org.id, [project('a'), project('b')]]]),
+      }),
+    });
+
+    expect(offer).toEqual({
+      connectedCount: 2,
+      repoUrl: undefined,
+      remoteName: undefined,
+    });
+  });
+
+  it('does not offer repo-wide linking for a single connected project', () => {
+    // A lone project is already the preselected `(linked by git)` suggestion,
+    // so a "Link all 1 projects" row would only duplicate it.
+    const offer = resolveMultiProjectOffer({
+      path: '/repo',
+      org,
+      repoSearch: search({
+        connectedByOrgId: new Map([[org.id, [project('a')]]]),
+      }),
+    });
+
+    expect(offer).toBeUndefined();
+  });
+
+  it('does not offer repo-wide linking when nothing is connected', () => {
+    const offer = resolveMultiProjectOffer({
+      path: '/repo',
+      org,
+      repoSearch: search({ connectedByOrgId: new Map([[org.id, []]]) }),
+    });
+
+    expect(offer).toBeUndefined();
+  });
+
+  it('counts only projects connected under the selected team', () => {
+    const offer = resolveMultiProjectOffer({
+      path: '/repo',
+      org,
+      repoSearch: search({
+        connectedByOrgId: new Map([
+          [org.id, [project('a')]],
+          ['team_other', [project('b'), project('c'), project('d')]],
+        ]),
+      }),
+    });
+
+    expect(offer).toBeUndefined();
+  });
+
+  it('does not offer repo-wide linking from a subdirectory', () => {
+    // Inside a single package, linking that one project is the right job.
+    const offer = resolveMultiProjectOffer({
+      path: '/repo/apps/web',
+      org,
+      repoSearch: search({
+        connectedByOrgId: new Map([
+          [org.id, [project('a'), project('b'), project('c')]],
+        ]),
+      }),
+    });
+
+    expect(offer).toBeUndefined();
+  });
+
+  it('does not offer repo-wide linking outside a Git repository', () => {
+    const offer = resolveMultiProjectOffer({
+      path: '/repo',
+      org,
+      repoSearch: search({
+        rootPath: undefined,
+        remote: undefined,
+        connectedByOrgId: new Map([
+          [org.id, [project('a'), project('b'), project('c')]],
+        ]),
+      }),
+    });
+
+    expect(offer).toBeUndefined();
+  });
+});

--- a/packages/cli/test/unit/util/projects/search-projects-by-repo-root-remote.test.ts
+++ b/packages/cli/test/unit/util/projects/search-projects-by-repo-root-remote.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { searchProjectsByRepoRootDetailed } from '../../../../src/util/projects/search-project-across-teams';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import type { Org } from '@vercel-internals/types';
+
+const org: Org = { type: 'team', id: 'team_dummy', slug: 'vercel' };
+
+describe('searchProjectsByRepoRootDetailed() remote selection', () => {
+  let repoDir: string;
+
+  beforeAll(() => {
+    repoDir = mkdtempSync(join(tmpdir(), 'repo-root-remote-'));
+    execSync('git init', { cwd: repoDir, stdio: 'ignore' });
+    writeFileSync(join(repoDir, 'file.txt'), 'test');
+    // Deliberately add `origin` last: selection must prefer it by name, not by
+    // config order.
+    execSync('git remote add aaa https://github.com/test/aaa.git', {
+      cwd: repoDir,
+      stdio: 'ignore',
+    });
+    execSync('git remote add zzz https://github.com/test/zzz.git', {
+      cwd: repoDir,
+      stdio: 'ignore',
+    });
+    execSync('git remote add origin https://github.com/test/origin.git', {
+      cwd: repoDir,
+      stdio: 'ignore',
+    });
+  });
+
+  afterAll(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('uses origin without prompting when the repo has several remotes', async () => {
+    useUser();
+    client.scenario.get('/v9/projects', (_req, res) => {
+      res.json({ projects: [], pagination: { count: 0, next: null } });
+    });
+    // Any prompt here would block the suggestion search on a question the user
+    // cannot yet act on, so assert none is attempted.
+    const select = vi.spyOn(client.input, 'select');
+
+    const result = await searchProjectsByRepoRootDetailed({
+      client,
+      cwd: repoDir,
+      orgs: [org],
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(result.remote?.remoteName).toEqual('origin');
+    expect(result.remote?.repoUrl).toEqual(
+      'https://github.com/test/origin.git'
+    );
+  });
+});


### PR DESCRIPTION
## Problem

In a monorepo with several projects already on Vercel, `vc link` is a per-directory command. Linking each one means re-running it, re-picking the team, and re-answering the same prompts.

## What this does

When `vc link` runs **from the repository root** and the selected team already has **more than one project connected to this repo's Git remote**, the project picker gains a top option:

```
❯ Link all 4 projects connected to this repo (recommended)
  ──────────────
  Search all projects
  Create new project
```

There is normally no `(linked by git)` suggestion next to it: that list comes from `findProjectsFromPath`, which at the repo root (`relativePath === ''`) only matches a project whose Root Directory is `.`. In the usual monorepo layout, where every project lives under `apps/*`, nothing matches at the root, so the repo-wide option stands alone. A per-directory suggestion appears alongside it only in the uncommon case of a project rooted at the repository root itself.

Choosing it delegates to the existing `ensureRepoLink` flow, which writes the repo-level `.vercel/repo.json`.

## Where the count comes from

Not framework detection. An earlier revision used `detectProjects`, which counts every workspace package on disk — in this repo that read "82 project directories," which is not what linking would do.

The count now comes from projects already connected to the repo's Git remote in the selected team, taken from the response the Git-match search **already** fetched. `searchProjectsByRepoRoot` gained a `…Detailed` variant that returns the full per-org project lists alongside the existing matches, so the offer costs no extra request — relevant because `/v9/projects?repoUrl=…` is partition-scoped and its cost grows with team size.

Gated to be conservative:
- repository root only (inside a package, linking one project is still right)
- at least 2 connected projects (a single one is already covered by `(linked by git)`)

## Result type

Repo-wide linking has no single project and no per-directory `.vercel/project.json`, so it returns a new `RepoWideLinked` (`status: 'repo_linked'`) instead of being forced into `ProjectLinked`. `setupAndLink` now returns a union.

Opt-in via `allowMultiProjectLink`, set only by `vc link` (and not with `--project`). `ensureLink` uses an overload so callers that don't opt in keep the old narrower return type and need no changes. `dev` handles the case explicitly as unreachable rather than silently mishandling it.

## Testing

- `pnpm vitest run test/unit/util/link/ test/unit/util/input/input-project.test.ts` → **38 passed** (5 files)
- `pnpm type-check` in `packages/cli` → no errors in touched files; 2 pre-existing `TS2307` in `src/util/projects/detect-entrypoint.ts` (`@vercel/backends`, `@vercel/go`) from unbuilt workspace deps
- `pnpm prettier --write` clean; pre-commit biome format + lint passed

Draft: no new unit tests yet for `resolveMultiProjectOffer` (the root-only and `< 2` gates) or for the `repo_linked` branch in `vc link`. Those are the parts worth locking down before merge, and I'd like a read on the UX first.

## Not included

Cross-team linking. This links projects within the **selected team** only — the picker still resolves one team first. The API-side cross-team endpoint that would have allowed "link everything across all your teams" is parked.
