### PR TITLE
[cli] Resolve build settings and env from the API

### DIFF
--- a/.changeset/lazy-pandas-listen.md
+++ b/.changeset/lazy-pandas-listen.md
@@ -2,4 +2,10 @@
 'vercel': minor
 ---
 
-`vercel build` now resolves Project Settings and Environment Variables from the API when the project is linked, instead of prompting to run `vercel pull` first. A local `.vercel/project.json` / `.vercel/.env.<target>.local` still takes precedence, so offline and deliberately pulled builds are unchanged. The post-link "Pull development environment variables into .env.local?" prompt has also been removed.
+`vercel build` now resolves Project Settings and Environment Variables from the API when the project is linked, instead of prompting to run `vercel pull` first.
+
+Pulled env files now record what they were resolved for, so `vercel build` can tell whether a local file answers the request it is about to make. A file pulled for the same Environment and Git branch is used as-is; one pulled for a different Environment or branch is reported and the API is used instead. Files pulled by older CLI versions have no provenance recorded and are still trusted.
+
+`vercel build` and `vercel pull` now accept the same environment selection options: `--target` and `--environment` are aliases of each other in both, and both accept `--git-branch`. Passing `--git-branch` without an explicit environment resolves the Preview Environment, since branch overrides only exist there.
+
+The post-link "Pull development environment variables into .env.local?" prompt has been removed.

--- a/.changeset/lazy-pandas-listen.md
+++ b/.changeset/lazy-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+`vercel build` now resolves Project Settings and Environment Variables from the API when the project is linked, instead of prompting to run `vercel pull` first. A local `.vercel/project.json` / `.vercel/.env.<target>.local` still takes precedence, so offline and deliberately pulled builds are unchanged. The post-link "Pull development environment variables into .env.local?" prompt has also been removed.

--- a/packages/cli/.agents/skills/cli-ux/SKILL.md
+++ b/packages/cli/.agents/skills/cli-ux/SKILL.md
@@ -65,6 +65,7 @@ Load only what the task needs.
 | Destructive/production mutation  | `copy.md` → Clear + Consistent, Prompts; `core.md` → Dangerous Actions, Remote Work, Secrets    |
 | `vc link` or setup/link work     | [`references/command-contracts.md`](references/command-contracts.md) → Link Flow Contract       |
 | `vc env add` work                | `command-contracts.md` → Env Add Flow Contract                                                  |
+| Env/settings pulled to disk      | `command-contracts.md` → Env Files On Disk                                                      |
 | `vc`, `vc deploy`, deploy output | `command-contracts.md` → Deploy Flow Contract                                                   |
 | Tests, stale-copy sweeps, review | [`references/verification.md`](references/verification.md)                                      |
 

--- a/packages/cli/.agents/skills/cli-ux/references/command-contracts.md
+++ b/packages/cli/.agents/skills/cli-ux/references/command-contracts.md
@@ -120,10 +120,12 @@ Rules:
 
 Migration state:
 
-- Done: `vc build` resolves settings and env from the API and no longer prompts `No Project Settings found locally. Run vercel pull for retrieving them?`. Local `.vercel/project.json` and `.vercel/.env.<target>.local` remain as fallback.
+- Done: `vc build` resolves settings and env from the API and no longer prompts `No Project Settings found locally. Run vercel pull for retrieving them?`.
+- Done: pulled env files record provenance (`# vercel-env: target=… gitBranch=… pulledAt=…`, see `src/util/env/env-provenance.ts`). `vc build` uses a local file when its provenance matches the requested target and branch, and prefers the API when it doesn't. Files without provenance predate this and are still trusted. `.env.<target>.local` encodes only the target in its filename, so provenance is the only way to distinguish a `--git-branch` pull from a plain one.
+- Done: `vc build` and `vc pull` accept the same environment selection options. `--target` and `--environment` are aliases in both via `parseAliasedTarget` in `src/util/parse-target.ts`, both accept `--git-branch`, and `--git-branch` without an explicit environment implies `preview`.
 - Done: the post-link/post-create `Pull development environment variables into .env.local?` prompt and the `pullEnv` plumbing through `setupAndLink` / `linkFolderToProject` are removed.
 - Remaining: `vc link` still writes `VERCEL_OIDC_TOKEN` to `<root>/.env.local` via `refreshOidcTokenAfterLink()` in `src/commands/link/index.ts`. This is the last path that writes outside `.vercel/` as a link side effect. Removing it needs a decision on how local dev consumes the OIDC token without a file.
-- Remaining: precedence question in `vc build` — a local `.vercel/.env.<target>.local` currently wins over the API, so a stale pulled file silently shadows fresher values. Revisit whether the API should win once files are no longer produced implicitly.
+- Remaining: `vc dev` calls `pullEnvRecords` with neither `target` nor `gitBranch` (`src/commands/dev/dev.ts`), so it can't resolve branch-specific values the way `vc build` and `vc pull` now can.
 - Remaining: docs and skills still teach `vc pull` before `vc build` (`skills/vercel-cli/**`, `packages/cli/src/commands/agent/init.ts`). Update them as the file-writing paths retire.
 
 Stale-string sweep:

--- a/packages/cli/.agents/skills/cli-ux/references/command-contracts.md
+++ b/packages/cli/.agents/skills/cli-ux/references/command-contracts.md
@@ -23,7 +23,7 @@ When adding a durable contract, add a row to `SKILL.md` so agents load it only f
 3. Intended project: explicit `--project`, repo-root match, exact folder-name match, selected existing project, or new project.
 4. Project root: inferred root, selected root, or cwd.
 5. Settings: detected framework/settings, explicit overrides, or defaults.
-6. Mutations: create project if needed, write `.vercel/project.json`, update `.gitignore`, optional Git connection, optional env pull.
+6. Mutations: create project if needed, write `.vercel/project.json`, update `.gitignore`, optional Git connection.
 
 Rules:
 
@@ -55,7 +55,7 @@ Rules:
 - Link/setup primary completed-phase rows use `✓`: `✓ Linked`, `✓ Created`, `✓ Added`. Discovery, preview, progress, and secondary rows such as `Found existing project`, `Detected`, `Project`, `Directory`, `Config`, `Settings`, and `Source` keep the blank two-space gutter. Never use `▲` for setup/link rows.
 - Default human success output prints the user-facing completion receipt, such as `✓ Linked acme/web` or `✓ Created acme/web`.
 - Do not print `.vercel/project.json`, `.vercel/repo.json`, or a repeated `Directory` row in default human success output when the local target was already shown. Verify link files in tests and expose them through machine/debug/help surfaces when needed.
-- Offer `Pull development environment variables into .env.local?` after linking when TTY and safe.
+- Do not offer to pull environment variables after linking, and do not pull them as a side effect of linking. Env files are written only when the user explicitly asks (`vc env pull`, `vc pull`). See "Env files on disk" below.
 
 Current gaps to migrate incrementally:
 
@@ -67,17 +67,16 @@ Current gaps to migrate incrementally:
 
 Link prompt map:
 
-| State                              | Human prompt/output                                                                                                                                                                  | Non-interactive                        |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
-| Multiple teams                     | searchable `Which team?` before project discovery                                                                                                                                    | `action_required: missing_scope` unless explicit signal or single choice |
-| Single team                        | no prompt; aligned `Team` row, then project discovery                                                                                                                                | proceeds with that team                |
-| One folder-name project match      | `Which project?` with the match labeled `(folder name)`, then search/create choices                                                                                                  | link only for explicit/repo-root match |
-| One repository project match       | direct interactive: `Which project?` with the match labeled `(linked by git)`; other paths: `Found existing project`, aligned `Project`/`Source`, then `Link repository to project?` | link only for explicit/repo-root match |
-| No project match                   | `Which project?` with `Search all projects` / `Create a new project`, then `Name?` when creating                                                                                     | require `--yes` or `project_not_found` |
-| Root choices exist                 | `Code directory?`                                                                                                                                                                    | require root flag/config/payload       |
-| Settings differ                    | `Customize settings?`                                                                                                                                                                | require flags/config/payload           |
-| Optional env pull                  | `Pull development environment variables into .env.local?`                                                                                                                            | skip unless explicitly requested       |
-| Stale/deleted link                 | show stale link, then concrete relink choice                                                                                                                                         | `action_required: stale_link`          |
+| State                         | Human prompt/output                                                                                                                                                                  | Non-interactive                                                          |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Multiple teams                | searchable `Which team?` before project discovery                                                                                                                                    | `action_required: missing_scope` unless explicit signal or single choice |
+| Single team                   | no prompt; aligned `Team` row, then project discovery                                                                                                                                | proceeds with that team                                                  |
+| One folder-name project match | `Which project?` with the match labeled `(folder name)`, then search/create choices                                                                                                  | link only for explicit/repo-root match                                   |
+| One repository project match  | direct interactive: `Which project?` with the match labeled `(linked by git)`; other paths: `Found existing project`, aligned `Project`/`Source`, then `Link repository to project?` | link only for explicit/repo-root match                                   |
+| No project match              | `Which project?` with `Search all projects` / `Create a new project`, then `Name?` when creating                                                                                     | require `--yes` or `project_not_found`                                   |
+| Root choices exist            | `Code directory?`                                                                                                                                                                    | require root flag/config/payload                                         |
+| Settings differ               | `Customize settings?`                                                                                                                                                                | require flags/config/payload                                             |
+| Stale/deleted link            | show stale link, then concrete relink choice                                                                                                                                         | `action_required: stale_link`                                            |
 
 Link acceptance matrix:
 
@@ -106,6 +105,32 @@ Link acceptance matrix:
 - JSON-only stdout
 - `--yes` default path creates no duplicate resources on retry
 - primary completed-phase gutter: `✓ Linked`, `✓ Created`, or `✓ Added`; no `▲` on setup/link rows
+
+## Env Files On Disk
+
+Direction: the CLI is getting out of the business of writing env files to disk. Commands that need Project Settings or Environment Variables resolve them from the API in memory; files are written only when the user explicitly asks for a file.
+
+Rules:
+
+- Do not write, or offer to write, env files as a side effect of another command. No command outside `vc env pull` / `vc pull` may create `.env*` files.
+- When a command needs env values, fetch them with `pullEnvRecords` and keep them in memory (`vc dev`, `vc env run`, `vc build`).
+- When a command needs Project Settings, resolve them from the API for the linked project. Treat a local `.vercel/project.json` as a cache/offline fallback, never as a prerequisite the user must produce first.
+- Never require a preceding `vc pull` to make another command work. `vc pull` is a convenience for getting files on disk (offline work, non-Vercel tooling, `vc dev` parity), not a setup step.
+- Secrets belong in memory. Prefer not persisting values the build or dev server can fetch itself.
+
+Migration state:
+
+- Done: `vc build` resolves settings and env from the API and no longer prompts `No Project Settings found locally. Run vercel pull for retrieving them?`. Local `.vercel/project.json` and `.vercel/.env.<target>.local` remain as fallback.
+- Done: the post-link/post-create `Pull development environment variables into .env.local?` prompt and the `pullEnv` plumbing through `setupAndLink` / `linkFolderToProject` are removed.
+- Remaining: `vc link` still writes `VERCEL_OIDC_TOKEN` to `<root>/.env.local` via `refreshOidcTokenAfterLink()` in `src/commands/link/index.ts`. This is the last path that writes outside `.vercel/` as a link side effect. Removing it needs a decision on how local dev consumes the OIDC token without a file.
+- Remaining: precedence question in `vc build` — a local `.vercel/.env.<target>.local` currently wins over the API, so a stale pulled file silently shadows fresher values. Revisit whether the API should win once files are no longer produced implicitly.
+- Remaining: docs and skills still teach `vc pull` before `vc build` (`skills/vercel-cli/**`, `packages/cli/src/commands/agent/init.ts`). Update them as the file-writing paths retire.
+
+Stale-string sweep:
+
+```bash
+rg -n "Pull development environment variables into \.env\.local\?|No Project Settings found locally|Run .*pull.* for retrieving them|pullEnv" <paths>
+```
 
 ## Deploy Flow Contract
 

--- a/packages/cli/.agents/skills/cli-ux/references/verification.md
+++ b/packages/cli/.agents/skills/cli-ux/references/verification.md
@@ -44,6 +44,8 @@ Before editing shared prompt/output/link helpers, inspect call sites and tests f
 - `setupAndLink()` changes affect direct setup callers and unlinked flows reached through `ensureLink()`, including `vc dev`.
 - `linkFolderToProject()` changes affect any command that links before continuing work, including deploy, dev, pull/env, git connect/disconnect, open, target, and other project-scoped commands.
 - `printAlignedLabel()` changes affect deploy result rows and every command adopting aligned rows.
+- `toProjectLinkAndSettings()` changes affect both the `.vercel/project.json` written by `vc pull` and the settings `vc build` resolves from the API; keep the two in sync.
+- `pullEnvRecords()` / `envPullCommandLogic()` changes affect `vc build`, `vc dev`, `vc env run`, `vc env pull`, `vc pull`, and OIDC refresh. Check whether a change adds a new file write; see `command-contracts.md` → Env Files On Disk.
 
 Use `rg` before editing and testing:
 

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -33,7 +33,7 @@ export const buildCommand = {
     {
       ...yesOption,
       description:
-        'Skip the confirmation prompt about pulling environment variables and project settings when not found locally',
+        'Skip the confirmation prompts when the directory is not yet linked to a project',
     },
     {
       name: 'standalone',

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -23,6 +23,23 @@ export const buildCommand = {
       description: 'Specify the target environment',
     },
     {
+      name: 'environment',
+      shorthand: null,
+      type: String,
+      argument: 'TARGET',
+      deprecated: false,
+      description: 'Alias for `--target`',
+    },
+    {
+      name: 'git-branch',
+      description:
+        'Specify the Git branch to resolve branch-specific Environment Variables for',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+    },
+    {
       name: 'output',
       description: 'Directory where built assets will be written to',
       shorthand: null,
@@ -66,6 +83,10 @@ export const buildCommand = {
     {
       name: 'Build with deployment-scoped environment variables',
       value: `${packageName} build --id dpl_xxx`,
+    },
+    {
+      name: 'Build with branch-specific preview environment variables',
+      value: `${packageName} build --target=preview --git-branch=feature-branch`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -131,8 +131,12 @@ import { detectExplicitScope } from '../../util/get-scope';
 import {
   pickOverrides,
   readProjectSettings,
+  toProjectLinkAndSettings,
   type ProjectLinkAndSettings,
 } from '../../util/projects/project-settings';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import getOrgById from '../../util/projects/get-org-by-id';
+import { ProjectNotFound } from '../../util/errors-ts';
 import readJSONFile from '../../util/read-json-file';
 import { getStaticServiceSchedules } from '../../util/service-schedules';
 import { BuildTelemetryClient } from '../../util/telemetry/commands/build';
@@ -146,7 +150,6 @@ import {
 } from '../../util/compile-vercel-config';
 import { help } from '../help';
 import { ensureLink } from '../../util/link/ensure-link';
-import { pullCommandLogic } from '../pull';
 import { pullEnvRecords } from '../../util/env/get-env-records';
 import { buildCommand } from './command';
 import { validatePackageManifest } from '../../util/validate-package-manifest';
@@ -250,6 +253,70 @@ export interface BuildsManifest {
    * "nothing detected" and "did not run".
    */
   detectedFramework?: DetectedFramework;
+}
+
+/** Returns `undefined` when settings can't be resolved, so the caller can fall back. */
+async function fetchProjectSettings(
+  client: Client,
+  link: { projectId: string; orgId: string; repoRoot?: string } | null
+): Promise<ProjectLinkAndSettings | undefined> {
+  if (!link) {
+    return undefined;
+  }
+
+  try {
+    if (link.orgId.startsWith('team_')) {
+      client.config.currentTeam = link.orgId;
+    } else {
+      client.config.currentTeam = undefined;
+    }
+
+    const [project, org] = await Promise.all([
+      getProjectByNameOrId(client, link.projectId, link.orgId),
+      getOrgById(client, link.orgId),
+    ]);
+
+    if (project instanceof ProjectNotFound) {
+      output.debug(
+        `Project ${link.projectId} not found while fetching settings`
+      );
+      return undefined;
+    }
+    if (!org) {
+      output.debug(`Org ${link.orgId} not found while fetching settings`);
+      return undefined;
+    }
+
+    output.debug(`Resolved Project Settings for ${project.name} from the API`);
+    return toProjectLinkAndSettings(project, org, Boolean(link.repoRoot));
+  } catch (err: unknown) {
+    output.debug(`Failed to fetch Project Settings from the API: ${err}`);
+    return undefined;
+  }
+}
+
+/** Returns `undefined` when env vars can't be fetched, so the caller can fall back. */
+async function fetchProjectEnv(
+  client: Client,
+  link: { projectId: string; orgId: string } | null,
+  target: string
+): Promise<Record<string, string> | undefined> {
+  if (!link) {
+    return undefined;
+  }
+
+  try {
+    const { env } = await pullEnvRecords(
+      client,
+      link.projectId,
+      'vercel-cli:build',
+      { target }
+    );
+    return env;
+  } catch (err: unknown) {
+    output.debug(`Failed to fetch Environment Variables from the API: ${err}`);
+    return undefined;
+  }
 }
 
 export default async function main(client: Client): Promise<number> {
@@ -385,17 +452,15 @@ export default async function main(client: Client): Promise<number> {
     cwd = client.cwd = link.repoRoot;
   }
 
-  // TODO: read project settings from the API, fall back to local `project.json` if that fails
-
-  // Read project settings, and pull them from Vercel if necessary
+  // Settings come from the API when linked, so `vercel pull` is not required
+  // first. A local `project.json` still wins, for offline builds.
   const vercelDir = join(cwd, projectRootDirectory, VERCEL_DIR);
   let project = await rootSpan
     .child('vc.readProjectSettings')
     .trace(() => readProjectSettings(vercelDir));
   const isTTY = process.stdin.isTTY;
-  while (!project?.settings) {
-    let confirmed = yes;
-    if (!confirmed) {
+  if (!project?.settings) {
+    if (!link) {
       if (client.nonInteractive) {
         outputAgentError(
           client,
@@ -403,21 +468,18 @@ export default async function main(client: Client): Promise<number> {
             status: AGENT_STATUS.ERROR,
             reason: AGENT_REASON.PROJECT_SETTINGS_REQUIRED,
             message:
-              'No project settings found locally. Run pull to retrieve them, or re-run with --yes to pull automatically.',
+              'No project settings found. Link the project so settings can be resolved, or run pull to retrieve them locally.',
             next: [
+              {
+                command: buildCommandWithGlobalFlags('link --yes', client.argv),
+                when: 'link the project',
+              },
               {
                 command: buildCommandWithGlobalFlags(
                   `pull --yes --environment ${target}`,
                   client.argv
                 ),
-                when: 'retrieve project settings',
-              },
-              {
-                command: buildCommandWithGlobalFlags(
-                  'build --yes',
-                  client.argv
-                ),
-                when: 're-run build after pull',
+                when: 'retrieve project settings locally instead',
               },
             ],
           },
@@ -425,70 +487,38 @@ export default async function main(client: Client): Promise<number> {
         );
         return 1;
       }
-      if (!isTTY) {
+      if (!isTTY && !yes) {
         output.print(
-          `No Project Settings found locally. Run ${cli.getCommandName(
-            'pull --yes'
-          )} to retrieve them. In non-interactive mode, set VERCEL_TOKEN for authentication.`
+          `No Project Settings found. Run ${cli.getCommandName(
+            'link'
+          )} to link this directory to a project. In non-interactive mode, set VERCEL_TOKEN for authentication.`
         );
         return 1;
       }
 
-      // An unlinked directory gets the link flow first, so the pull
-      // question refers to a known project instead of linking as a side
-      // effect of the pull.
-      if (!link) {
-        const ensured = await ensureLink('build', client, cwd, {
-          projectName: projectNameOrId,
-          failIfNotFound: !!projectNameOrId,
-          pullEnv: false,
-        });
-        if (typeof ensured === 'number') {
-          return ensured;
-        }
-        link = await getProjectLink(client, cwd, projectNameOrId, true);
+      const ensured = await ensureLink('build', client, cwd, {
+        autoConfirm: yes,
+        projectName: projectNameOrId,
+        failIfNotFound: !!projectNameOrId,
+      });
+      if (typeof ensured === 'number') {
+        return ensured;
       }
+      link = await getProjectLink(client, cwd, projectNameOrId, true);
+    }
 
-      confirmed = await client.input.confirm(
-        `No Project Settings found locally. Run ${cli.getCommandName(
+    const resolved = await rootSpan
+      .child('vc.fetchProjectSettings')
+      .trace(() => fetchProjectSettings(client, link));
+    if (!resolved) {
+      output.error(
+        `Failed to resolve Project Settings. Run ${cli.getCommandName(
           'pull'
-        )} for retrieving them?`,
-        true
+        )} to retrieve them locally, then re-run the build.`
       );
+      return 1;
     }
-    if (!confirmed) {
-      if (!client.nonInteractive)
-        output.print(`Canceled. No Project Settings retrieved.\n`);
-      return 0;
-    }
-    const { argv: originalArgv } = client;
-    client.cwd = join(cwd, projectRootDirectory);
-    client.setArgv([
-      ...originalArgv.slice(0, 2),
-      'pull',
-      `--environment`,
-      target,
-    ]);
-    const result = await pullCommandLogic(
-      client,
-      client.cwd,
-      Boolean(parsedArgs.flags['--yes']),
-      target,
-      parsedArgs.flags,
-      projectNameOrId
-    );
-    if (result !== 0) {
-      return result;
-    }
-    client.cwd = cwd;
-    client.setArgv(originalArgv);
-    project = await readProjectSettings(vercelDir);
-  }
-
-  // The settings pull above may have just established the link; re-read it
-  // so the re-anchoring below sees it.
-  if (!link) {
-    link = await getProjectLink(client, cwd, projectNameOrId, true);
+    project = resolved;
   }
 
   // A per-directory link (`<dir>/.vercel/project.json`) doesn't report a
@@ -580,13 +610,14 @@ export default async function main(client: Client): Promise<number> {
           `Loaded ${Object.keys(buildEnv).length} environment variables from deployment ${deploymentId}`
         );
       } else {
+        // A locally pulled env file wins, so hand-edited values and offline
+        // builds keep working.
         const envPath = join(
           cwd,
           projectRootDirectory,
           VERCEL_DIR,
           `.env.${target}.local`
         );
-        // TODO (maybe?): load env vars from the API, fall back to the local file if that fails
         const dotenvResult = dotenv.config({
           path: envPath,
           debug: output.isDebugEnabled(),
@@ -600,6 +631,21 @@ export default async function main(client: Client): Promise<number> {
             envToUnset.add(key);
           }
           output.debug(`Loaded environment variables from "${envPath}"`);
+        }
+
+        if (!dotenvResult.parsed) {
+          const apiEnv = await fetchProjectEnv(client, link, target);
+          if (apiEnv) {
+            for (const [key, value] of Object.entries(apiEnv)) {
+              // The ambient environment is the more explicit signal.
+              if (key in process.env) continue;
+              envToUnset.add(key);
+              process.env[key] = value;
+            }
+            output.debug(
+              `Loaded ${Object.keys(apiEnv).length} environment variables from the API`
+            );
+          }
         }
       }
     } finally {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -117,7 +117,13 @@ import { staticFiles as getFiles } from '../../util/get-files';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import cmd from '../../util/output/cmd';
 import stamp from '../../util/output/stamp';
-import parseTarget from '../../util/parse-target';
+import { parseAliasedTarget } from '../../util/parse-target';
+import { isErrnoException } from '@vercel/error-utils';
+import humanizePath from '../../util/humanize-path';
+import {
+  compareEnvProvenance,
+  parseEnvProvenance,
+} from '../../util/env/env-provenance';
 import cliPkg from '../../util/pkg';
 import * as cli from '../../util/pkg-name';
 import {
@@ -299,7 +305,8 @@ async function fetchProjectSettings(
 async function fetchProjectEnv(
   client: Client,
   link: { projectId: string; orgId: string } | null,
-  target: string
+  target: string,
+  gitBranch: string | undefined
 ): Promise<Record<string, string> | undefined> {
   if (!link) {
     return undefined;
@@ -310,7 +317,7 @@ async function fetchProjectEnv(
       client,
       link.projectId,
       'vercel-cli:build',
-      { target }
+      { target, gitBranch }
     );
     return env;
   } catch (err: unknown) {
@@ -363,6 +370,10 @@ export default async function main(client: Client): Promise<number> {
     telemetryClient.trackCliFlagStandalone(parsedArgs.flags['--standalone']);
     telemetryClient.trackCliOptionId(parsedArgs.flags['--id']);
     telemetryClient.trackCliOptionProject(parsedArgs.flags['--project']);
+    telemetryClient.trackCliOptionGitBranch(parsedArgs.flags['--git-branch']);
+    telemetryClient.trackCliOptionEnvironment(
+      parsedArgs.flags['--environment']
+    );
   } catch (error) {
     printError(error);
     return 1;
@@ -375,11 +386,13 @@ export default async function main(client: Client): Promise<number> {
   }
 
   // Build `target` influences which environment variables will be used
-  const target =
-    parseTarget({
-      flagName: 'target',
-      flags: parsedArgs.flags,
-    }) || 'preview';
+  const target = parseAliasedTarget({
+    flags: parsedArgs.flags,
+    defaultTarget: 'preview',
+  });
+
+  // Resolves branch-specific Environment Variables for the build target
+  const gitBranch = parsedArgs.flags['--git-branch'];
 
   const yes = Boolean(parsedArgs.flags['--yes']);
 
@@ -511,6 +524,28 @@ export default async function main(client: Client): Promise<number> {
       .child('vc.fetchProjectSettings')
       .trace(() => fetchProjectSettings(client, link));
     if (!resolved) {
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: AGENT_STATUS.ERROR,
+            reason: AGENT_REASON.PROJECT_SETTINGS_REQUIRED,
+            message:
+              'Could not resolve project settings from Vercel. Run pull to retrieve them locally, then re-run the build.',
+            next: [
+              {
+                command: buildCommandWithGlobalFlags(
+                  `pull --yes --environment ${target}`,
+                  client.argv
+                ),
+                when: 'retrieve project settings locally',
+              },
+            ],
+          },
+          1
+        );
+        return 1;
+      }
       output.error(
         `Failed to resolve Project Settings. Run ${cli.getCommandName(
           'pull'
@@ -610,31 +645,62 @@ export default async function main(client: Client): Promise<number> {
           `Loaded ${Object.keys(buildEnv).length} environment variables from deployment ${deploymentId}`
         );
       } else {
-        // A locally pulled env file wins, so hand-edited values and offline
-        // builds keep working.
         const envPath = join(
           cwd,
           projectRootDirectory,
           VERCEL_DIR,
           `.env.${target}.local`
         );
-        const dotenvResult = dotenv.config({
-          path: envPath,
-          debug: output.isDebugEnabled(),
-        });
-        if (dotenvResult.error) {
-          output.debug(
-            `Failed loading environment variables: ${dotenvResult.error}`
-          );
-        } else if (dotenvResult.parsed) {
-          for (const key of Object.keys(dotenvResult.parsed)) {
-            envToUnset.add(key);
+
+        // A pulled file records what it was resolved for. When that matches
+        // this build, the file wins so `vercel pull --git-branch` and
+        // hand-edited values keep working. When it doesn't, the API wins so a
+        // file pulled for a different Environment or branch can't silently
+        // shadow the right values.
+        let localContents: string | undefined;
+        try {
+          localContents = await fs.readFile(envPath, 'utf8');
+        } catch (err: unknown) {
+          if (!isErrnoException(err) || err.code !== 'ENOENT') {
+            output.debug(`Failed reading "${envPath}": ${err}`);
           }
-          output.debug(`Loaded environment variables from "${envPath}"`);
+        }
+        const provenance = localContents
+          ? parseEnvProvenance(localContents)
+          : undefined;
+        const comparison = compareEnvProvenance(provenance, {
+          target,
+          gitBranch,
+        });
+
+        const isMismatch = comparison.status === 'mismatch';
+        if (localContents && isMismatch) {
+          output.warn(
+            `Ignoring ${humanizePath(envPath)} because ${comparison.reason}. Resolving Environment Variables from Vercel instead.`
+          );
         }
 
-        if (!dotenvResult.parsed) {
-          const apiEnv = await fetchProjectEnv(client, link, target);
+        // Files pulled by older CLI versions have no provenance. Trusting them
+        // preserves the previous behavior for anyone who hasn't re-pulled.
+        const useLocalFile = Boolean(localContents) && !isMismatch;
+
+        if (useLocalFile) {
+          const dotenvResult = dotenv.config({
+            path: envPath,
+            debug: output.isDebugEnabled(),
+          });
+          if (dotenvResult.error) {
+            output.debug(
+              `Failed loading environment variables: ${dotenvResult.error}`
+            );
+          } else if (dotenvResult.parsed) {
+            for (const key of Object.keys(dotenvResult.parsed)) {
+              envToUnset.add(key);
+            }
+            output.debug(`Loaded environment variables from "${envPath}"`);
+          }
+        } else {
+          const apiEnv = await fetchProjectEnv(client, link, target, gitBranch);
           if (apiEnv) {
             for (const [key, value] of Object.entries(apiEnv)) {
               // The ambient environment is the more explicit signal.

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -36,6 +36,7 @@ import {
   outputAgentError,
 } from '../../util/agent-output';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { formatEnvProvenance } from '../../util/env/env-provenance';
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
 
@@ -352,6 +353,13 @@ export async function envPullCommandLogic(
 
     contents =
       CONTENTS_PREFIX +
+      // Records what this file was resolved for, so `vercel build` can tell
+      // whether it answers the request it is about to make.
+      formatEnvProvenance({
+        target: environment,
+        gitBranch,
+        pulledAt: new Date().toISOString(),
+      }) +
       Object.keys(mergedRecords)
         .sort()
         .filter(key => !VARIABLES_TO_IGNORE.includes(key))

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -186,7 +186,6 @@ async function linkProject(client: Client) {
       projectName: parsedArgs.flags['--project'],
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
-      pullEnv: false,
     });
 
     if (typeof link === 'number') {

--- a/packages/cli/src/commands/pull/command.ts
+++ b/packages/cli/src/commands/pull/command.ts
@@ -25,6 +25,14 @@ export const pullCommand = {
       deprecated: false,
     },
     {
+      name: 'target',
+      description: 'Alias for `--environment`',
+      argument: 'TARGET',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+    },
+    {
       name: 'git-branch',
       description:
         'Specify the Git branch to pull specific Environment Variables for',

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -17,7 +17,7 @@ import humanizePath from '../../util/humanize-path';
 
 import { help } from '../help';
 import { pullCommand, type PullCommandFlags } from './command';
-import parseTarget from '../../util/parse-target';
+import { parseAliasedTarget } from '../../util/parse-target';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
@@ -86,17 +86,17 @@ export default async function main(client: Client) {
   const cwd = parsedArgs.args[1] || client.cwd;
   const autoConfirm = Boolean(parsedArgs.flags['--yes']);
   const isProduction = Boolean(parsedArgs.flags['--prod']);
-  const environment =
-    parseTarget({
-      flagName: 'environment',
-      flags: parsedArgs.flags,
-    }) || 'development';
+  const environment = parseAliasedTarget({
+    flags: parsedArgs.flags,
+    defaultTarget: 'development',
+  });
 
   telemetryClient.trackCliArgumentProjectPath(parsedArgs.args[1]);
   telemetryClient.trackCliFlagYes(autoConfirm);
   telemetryClient.trackCliFlagProd(isProduction);
   telemetryClient.trackCliOptionGitBranch(parsedArgs.flags['--git-branch']);
   telemetryClient.trackCliOptionEnvironment(parsedArgs.flags['--environment']);
+  telemetryClient.trackCliOptionTarget(parsedArgs.flags['--target']);
   telemetryClient.trackCliOptionProject(parsedArgs.flags['--project']);
 
   const returnCode = await pullCommandLogic(

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -125,7 +125,6 @@ export async function pullCommandLogic(
 ): Promise<number> {
   const link = await ensureLink('pull', client, cwd, {
     autoConfirm,
-    pullEnv: false,
     projectName: projectNameOrId,
     failIfNotFound: !!projectNameOrId,
   });

--- a/packages/cli/src/util/env/env-provenance.ts
+++ b/packages/cli/src/util/env/env-provenance.ts
@@ -1,0 +1,135 @@
+/**
+ * Provenance metadata recorded in pulled env files.
+ *
+ * `.vercel/.env.<target>.local` encodes only the target in its filename, so a
+ * file pulled with `--git-branch` is otherwise indistinguishable from a plain
+ * pull of the same target. Recording what was actually requested lets
+ * `vercel build` tell whether a local file answers the request it is about to
+ * make, instead of silently using values resolved for something else.
+ *
+ * The metadata is written as a comment on the second line, so the
+ * `# Created by Vercel CLI` first line stays byte-identical for the
+ * fixed-length head read that detects CLI-authored files.
+ */
+
+const PROVENANCE_PREFIX = '# vercel-env:';
+
+export interface EnvProvenance {
+  target?: string;
+  gitBranch?: string;
+  pulledAt?: string;
+}
+
+/**
+ * Renders a provenance comment line, including the trailing newline.
+ * Values are encoded so a branch containing spaces or newlines can't produce
+ * a line that parses as something else.
+ */
+export function formatEnvProvenance({
+  target,
+  gitBranch,
+  pulledAt,
+}: EnvProvenance): string {
+  const parts: string[] = [];
+  if (target) {
+    parts.push(`target=${encodeURIComponent(target)}`);
+  }
+  if (gitBranch) {
+    parts.push(`gitBranch=${encodeURIComponent(gitBranch)}`);
+  }
+  if (pulledAt) {
+    parts.push(`pulledAt=${encodeURIComponent(pulledAt)}`);
+  }
+  if (parts.length === 0) {
+    return '';
+  }
+  return `${PROVENANCE_PREFIX} ${parts.join(' ')}\n`;
+}
+
+/**
+ * Reads provenance out of env file contents. Returns `undefined` when the file
+ * has none, which is the case for files pulled by older CLI versions and for
+ * hand-written files.
+ */
+export function parseEnvProvenance(
+  contents: string
+): EnvProvenance | undefined {
+  for (const rawLine of contents.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+    if (!line.startsWith('#')) {
+      // Reached the first assignment; provenance only lives in the header.
+      return undefined;
+    }
+    if (!line.startsWith(PROVENANCE_PREFIX)) continue;
+
+    const provenance: EnvProvenance = {};
+    const body = line.slice(PROVENANCE_PREFIX.length).trim();
+    for (const token of body.split(/\s+/)) {
+      const eq = token.indexOf('=');
+      if (eq === -1) continue;
+      const key = token.slice(0, eq);
+      const value = decodeURIComponent(token.slice(eq + 1));
+      if (value === '') continue;
+      if (key === 'target') provenance.target = value;
+      else if (key === 'gitBranch') provenance.gitBranch = value;
+      else if (key === 'pulledAt') provenance.pulledAt = value;
+    }
+    return provenance;
+  }
+  return undefined;
+}
+
+export interface EnvProvenanceRequest {
+  target: string;
+  gitBranch?: string;
+}
+
+export type EnvProvenanceComparison =
+  | { status: 'unknown' }
+  | { status: 'match' }
+  | { status: 'mismatch'; reason: string };
+
+/**
+ * Compares recorded provenance against the env resolution a command is about to
+ * perform. `unknown` means the file predates provenance, so callers should fall
+ * back to their previous behavior rather than treating it as a mismatch.
+ */
+export function compareEnvProvenance(
+  provenance: EnvProvenance | undefined,
+  request: EnvProvenanceRequest
+): EnvProvenanceComparison {
+  if (!provenance || (!provenance.target && !provenance.gitBranch)) {
+    return { status: 'unknown' };
+  }
+
+  if (provenance.target && provenance.target !== request.target) {
+    return {
+      status: 'mismatch',
+      reason: `it was pulled for the \`${provenance.target}\` Environment, not \`${request.target}\``,
+    };
+  }
+
+  const pulledBranch = provenance.gitBranch;
+  const wantedBranch = request.gitBranch;
+  if (pulledBranch !== wantedBranch) {
+    if (pulledBranch && !wantedBranch) {
+      return {
+        status: 'mismatch',
+        reason: `it was pulled with overrides for branch \`${pulledBranch}\``,
+      };
+    }
+    if (!pulledBranch && wantedBranch) {
+      return {
+        status: 'mismatch',
+        reason: `it was pulled without overrides for branch \`${wantedBranch}\``,
+      };
+    }
+    return {
+      status: 'mismatch',
+      reason: `it was pulled for branch \`${pulledBranch}\`, not \`${wantedBranch}\``,
+    };
+  }
+
+  return { status: 'match' };
+}

--- a/packages/cli/src/util/env/get-env-records.ts
+++ b/packages/cli/src/util/env/get-env-records.ts
@@ -13,6 +13,7 @@ export type EnvRecordsSource =
   | 'vercel-cli:env:pull'
   | 'vercel-cli:env:run'
   | 'vercel-cli:dev'
+  | 'vercel-cli:build'
   | 'vercel-cli:pull'
   | 'vercel-cli:link'
   | 'vercel-cli:integration:add'

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -18,7 +18,6 @@ import { linkRepoProject } from './repo';
 import createProject from '../projects/create-project';
 import type Client from '../client';
 import { printError } from '../error';
-import pull from '../../commands/env/pull';
 import { parseGitConfig, pluckRemoteUrls } from '../create-git-meta';
 import {
   selectAndParseRemoteUrl,
@@ -69,7 +68,6 @@ export interface SetupAndLinkOptions {
   projectName?: string;
   /** When true, avoid prompts and return action_required payload when scope/project choice is needed */
   nonInteractive?: boolean;
-  pullEnv?: boolean;
   /** When true, indicates the project is being created from v0 (grants V0Builder permissions) */
   v0?: boolean;
   /**
@@ -186,63 +184,16 @@ export async function shouldPromptForRootDirectory(opts: {
   }
 }
 
-async function maybePullEnvAfterLink(
-  client: Client,
-  path: string,
-  autoConfirm: boolean,
-  pullEnv: boolean
-): Promise<void> {
-  if (!pullEnv || !client.stdin.isTTY || client.nonInteractive) {
-    return;
-  }
-
-  output.print('\n');
-
-  const pullEnvConfirmed =
-    autoConfirm ||
-    (await client.input.confirm(
-      'Pull development environment variables into .env.local?',
-      true
-    ));
-
-  if (!pullEnvConfirmed) {
-    return;
-  }
-
-  const originalCwd = client.cwd;
-  try {
-    client.cwd = path;
-    const args = autoConfirm ? ['--yes'] : [];
-    const exitCode = await pull(client, args, 'vercel-cli:link');
-
-    if (exitCode !== 0) {
-      output.error(
-        'Failed to pull environment variables. You can run `vc env pull` manually.'
-      );
-    }
-  } catch (_error) {
-    output.error(
-      'Failed to pull environment variables. You can run `vc env pull` manually.'
-    );
-  } finally {
-    client.cwd = originalCwd;
-  }
-}
-
 async function linkCrossTeamMatch({
   client,
   path,
   match,
   successEmoji,
-  autoConfirm,
-  pullEnv,
 }: {
   client: Client;
   path: string;
   match: CrossTeamMatch;
   successEmoji: EmojiLabel;
-  autoConfirm: boolean;
-  pullEnv: boolean;
 }): Promise<ProjectLinkResult> {
   client.config.currentTeam =
     match.org.type === 'team' ? match.org.id : undefined;
@@ -255,7 +206,6 @@ async function linkCrossTeamMatch({
       remoteName: match.repo.remoteName,
       successEmoji,
     });
-    await maybePullEnvAfterLink(client, path, autoConfirm, pullEnv);
     return {
       status: 'linked',
       org: match.org,
@@ -270,9 +220,7 @@ async function linkCrossTeamMatch({
     { projectId: match.project.id, orgId: match.org.id },
     match.project.name,
     match.org.slug,
-    successEmoji,
-    autoConfirm,
-    pullEnv
+    successEmoji
   );
   return { status: 'linked', org: match.org, project: match.project };
 }
@@ -288,7 +236,6 @@ export default async function setupAndLink(
     successEmoji = 'link',
     projectName,
     nonInteractive = false,
-    pullEnv = true,
     v0,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
@@ -450,8 +397,6 @@ export default async function setupAndLink(
       path,
       match: projectOrNewProjectName,
       successEmoji,
-      autoConfirm,
-      pullEnv,
     });
   } else {
     const project = projectOrNewProjectName;
@@ -465,9 +410,7 @@ export default async function setupAndLink(
       },
       project.name,
       org.slug,
-      successEmoji,
-      autoConfirm,
-      pullEnv
+      successEmoji
     );
     return { status: 'linked', org, project };
   }
@@ -659,8 +602,6 @@ export default async function setupAndLink(
       project.name,
       org.slug,
       successEmoji,
-      autoConfirm,
-      false, // don't prompt to pull env for newly created projects
       'Created'
     );
 

--- a/packages/cli/src/util/parse-target.ts
+++ b/packages/cli/src/util/parse-target.ts
@@ -34,3 +34,65 @@ export default function parseTarget<FlagName extends string>({
 
   return undefined;
 }
+
+export interface ParseAliasedTargetOptions {
+  flags: {
+    '--target'?: string;
+    '--environment'?: string;
+    '--prod'?: boolean;
+    '--git-branch'?: string;
+  };
+  /** Used when neither flag nor `--prod` is given and no branch is specified. */
+  defaultTarget: string;
+}
+
+/**
+ * Resolves the environment for commands that accept `--target` and
+ * `--environment` as aliases of each other.
+ *
+ * `--git-branch` only selects branch-specific overrides within the Preview
+ * Environment, so specifying a branch without an explicit environment implies
+ * `preview` rather than the command's usual default.
+ */
+export function parseAliasedTarget({
+  flags,
+  defaultTarget,
+}: ParseAliasedTargetOptions): string {
+  const targetValue = flags['--target'];
+  const environmentValue = flags['--environment'];
+
+  if (
+    typeof targetValue === 'string' &&
+    typeof environmentValue === 'string' &&
+    targetValue !== environmentValue
+  ) {
+    output.warn(
+      `Both \`--target\` and \`--environment\` detected with different values. Using \`--target ${targetValue}\`.`
+    );
+  }
+
+  const explicit =
+    typeof targetValue === 'string' ? targetValue : environmentValue;
+
+  if (typeof explicit === 'string') {
+    if (flags['--prod']) {
+      output.warn(
+        `Both \`--prod\` and an explicit environment detected. Ignoring \`--prod\`.`
+      );
+    }
+    output.debug(`Setting target to ${explicit}`);
+    return explicit;
+  }
+
+  if (flags['--prod']) {
+    output.debug('Setting target to production');
+    return 'production';
+  }
+
+  if (flags['--git-branch']) {
+    output.debug('Setting target to preview because `--git-branch` was given');
+    return 'preview';
+  }
+
+  return defaultTarget;
+}

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -25,7 +25,6 @@ import { addToGitIgnore } from '../link/add-to-gitignore';
 import type { RepoProjectConfig } from '../link/repo';
 import output from '../../output-manager';
 import { printAlignedLabel } from '../output/print-aligned-label';
-import pull from '../../commands/env/pull';
 import { resolveProjectCwd } from './find-project-root';
 
 const readFile = promisify(fs.readFile);
@@ -574,8 +573,6 @@ export async function linkFolderToProject(
   projectName: string,
   orgSlug: string,
   successEmoji: EmojiLabel = 'link',
-  autoConfirm: boolean = false,
-  pullEnv: boolean = true,
   resultLabel: 'Linked' | 'Created' = 'Linked'
 ) {
   // if the project is already linked, we skip linking
@@ -609,44 +606,4 @@ export async function linkFolderToProject(
 
   output.print('\n');
   printAlignedLabel(resultLabel, `${orgSlug}/${projectName}`, { gutter: '✓' });
-
-  if (!pullEnv) {
-    return;
-  }
-
-  // Skip env pull prompt in CI/non-TTY and in `--non-interactive` (agents, scripts).
-  if (!client.stdin.isTTY || client.nonInteractive) {
-    return;
-  }
-
-  output.print('\n');
-
-  const pullEnvConfirmed =
-    autoConfirm ||
-    (await client.input.confirm(
-      'Pull development environment variables into .env.local?',
-      true
-    ));
-
-  if (pullEnvConfirmed) {
-    const originalCwd = client.cwd;
-    try {
-      client.cwd = path;
-
-      const args = autoConfirm ? ['--yes'] : [];
-      const exitCode = await pull(client, args, 'vercel-cli:link');
-
-      if (exitCode !== 0) {
-        output.error(
-          'Failed to pull environment variables. You can run `vc env pull` manually.'
-        );
-      }
-    } catch (_error) {
-      output.error(
-        'Failed to pull environment variables. You can run `vc env pull` manually.'
-      );
-    } finally {
-      client.cwd = originalCwd;
-    }
-  }
 }

--- a/packages/cli/src/util/projects/project-settings.ts
+++ b/packages/cli/src/util/projects/project-settings.ts
@@ -21,15 +21,15 @@ export type ProjectLinkAndSettings = Partial<ProjectLink> & {
   };
 };
 
-// writeProjectSettings writes the project configuration to `vercel/project.json`
-// Write the project configuration to `.vercel/project.json`
-// that is needed for `vercel build` and `vercel dev` commands
-export async function writeProjectSettings(
-  cwd: string,
+/**
+ * Maps an API `Project` to the `.vercel/project.json` shape. Shared by
+ * `vercel pull` (persists it) and `vercel build` (resolves it in memory).
+ */
+export function toProjectLinkAndSettings(
   project: Project,
   org: Org,
   isRepoLinked: boolean
-) {
+): ProjectLinkAndSettings {
   let analyticsId: string | undefined;
   if (
     project.analytics?.id &&
@@ -40,7 +40,7 @@ export async function writeProjectSettings(
     analyticsId = project.analytics.id;
   }
 
-  const projectLinkAndSettings: ProjectLinkAndSettings = {
+  return {
     projectId: isRepoLinked ? undefined : project.id,
     orgId: isRepoLinked ? undefined : org.id,
     projectName: isRepoLinked ? undefined : project.name,
@@ -57,6 +57,22 @@ export async function writeProjectSettings(
       analyticsId,
     },
   };
+}
+
+// writeProjectSettings writes the project configuration to `vercel/project.json`
+// Write the project configuration to `.vercel/project.json`
+// that is needed for `vercel build` and `vercel dev` commands
+export async function writeProjectSettings(
+  cwd: string,
+  project: Project,
+  org: Org,
+  isRepoLinked: boolean
+) {
+  const projectLinkAndSettings = toProjectLinkAndSettings(
+    project,
+    org,
+    isRepoLinked
+  );
   const path = join(cwd, VERCEL_DIR, VERCEL_DIR_PROJECT);
   return await outputJSON(path, projectLinkAndSettings, {
     spaces: 2,

--- a/packages/cli/src/util/telemetry/commands/build/index.ts
+++ b/packages/cli/src/util/telemetry/commands/build/index.ts
@@ -50,4 +50,22 @@ export class BuildTelemetryClient
       });
     }
   }
+
+  trackCliOptionEnvironment(option: string | undefined) {
+    if (option) {
+      this.trackCliOption({
+        option: 'environment',
+        value: this.redactedTargetName(option),
+      });
+    }
+  }
+
+  trackCliOptionGitBranch(gitBranch: string | undefined) {
+    if (gitBranch) {
+      this.trackCliOption({
+        option: 'git-branch',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/pull/index.ts
+++ b/packages/cli/src/util/telemetry/commands/pull/index.ts
@@ -24,6 +24,15 @@ export class PullTelemetryClient
     }
   }
 
+  trackCliOptionTarget(target: string | undefined) {
+    if (target) {
+      this.trackCliOption({
+        option: 'target',
+        value: this.redactedTargetName(target),
+      });
+    }
+  }
+
   trackCliOptionGitBranch(gitBranch: string | undefined) {
     if (gitBranch) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -6220,6 +6220,8 @@ exports[`help command > pull help output snapshots > pull help column width 40 1
                                (defaults to  
                                the linked    
                                project)      
+       --target <TARGET>       Alias for     
+                               \`--environmen…
   -y,  --yes                   Skip questions
                                when setting  
                                up new project
@@ -6313,6 +6315,7 @@ exports[`help command > pull help output snapshots > pull help column width 80 1
        --git-branch <NAME>     Specify the Git branch to pull specific Environment   
                                Variables for                                         
        --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)   
+       --target <TARGET>       Alias for \`--environment\`                             
   -y,  --yes                   Skip questions when setting up new project using      
                                default scope and settings                            
 
@@ -6369,6 +6372,7 @@ exports[`help command > pull help output snapshots > pull help column width 120 
        --environment <TARGET>  Deployment environment [development]                                                          
        --git-branch <NAME>     Specify the Git branch to pull specific Environment Variables for                             
        --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
+       --target <TARGET>       Alias for \`--environment\`                                                                     
   -y,  --yes                   Skip questions when setting up new project using default scope and settings                   
 
 

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -404,7 +404,7 @@ describe.skipIf(flakey)('build', () => {
     ]);
   });
 
-  it('should pull "preview" env vars by default', async () => {
+  it('should resolve "preview" env vars from the API by default', async () => {
     const cwd = fixture('static-pull');
     useUser();
     useTeams('team_dummy');
@@ -414,31 +414,23 @@ describe.skipIf(flakey)('build', () => {
       name: 'vercel-pull-next',
     });
     const envFilePath = join(cwd, '.vercel', '.env.preview.local');
-    const projectJsonPath = join(cwd, '.vercel', 'project.json');
-    const originalProjectJson = await fs.readJSON(
-      join(cwd, '.vercel/project.json')
-    );
     try {
       client.cwd = cwd;
       client.setArgv('build', '--yes');
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
 
-      const previewEnv = await fs.readFile(envFilePath, 'utf8');
-      const envFileHasPreviewEnv = previewEnv.includes(
-        'REDIS_CONNECTION_STRING'
-      );
-      expect(envFileHasPreviewEnv).toBeTruthy();
+      // Resolved in memory for the build, not written to disk.
+      expect(await fs.pathExists(envFilePath)).toBe(false);
     } finally {
       await fs.remove(envFilePath);
-      await fs.writeJSON(projectJsonPath, originalProjectJson, { spaces: 2 });
     }
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'flag:yes', value: 'TRUE' },
     ]);
   });
 
-  it('should pull "production" env vars with `--prod`', async () => {
+  it('should resolve "production" env vars with `--prod`', async () => {
     const cwd = fixture('static-pull');
     useUser();
     useTeams('team_dummy');
@@ -448,28 +440,17 @@ describe.skipIf(flakey)('build', () => {
       name: 'vercel-pull-next',
     });
     const envFilePath = join(cwd, '.vercel', '.env.production.local');
-    const projectJsonPath = join(cwd, '.vercel', 'project.json');
-    const originalProjectJson = await fs.readJSON(
-      join(cwd, '.vercel/project.json')
-    );
     try {
       client.cwd = cwd;
       client.setArgv('build', '--yes', '--prod');
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
 
-      const prodEnv = await fs.readFile(envFilePath, 'utf8');
-      const envFileHasProductionEnv1 = prodEnv.includes(
-        'REDIS_CONNECTION_STRING'
-      );
-      expect(envFileHasProductionEnv1).toBeTruthy();
-      const envFileHasProductionEnv2 = prodEnv.includes(
-        'SQL_CONNECTION_STRING'
-      );
-      expect(envFileHasProductionEnv2).toBeTruthy();
+      const builds = await fs.readJSON(join(cwd, '.vercel/output/builds.json'));
+      expect(builds.target).toEqual('production');
+      expect(await fs.pathExists(envFilePath)).toBe(false);
     } finally {
       await fs.remove(envFilePath);
-      await fs.writeJSON(projectJsonPath, originalProjectJson, { spaces: 2 });
     }
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'flag:prod', value: 'TRUE' },
@@ -477,7 +458,7 @@ describe.skipIf(flakey)('build', () => {
     ]);
   });
 
-  it('should pull "production" env vars with `--target production`', async () => {
+  it('should resolve "production" env vars with `--target production`', async () => {
     const cwd = fixture('static-pull');
     useUser();
     useTeams('team_dummy');
@@ -487,28 +468,16 @@ describe.skipIf(flakey)('build', () => {
       name: 'vercel-pull-next',
     });
     const envFilePath = join(cwd, '.vercel', '.env.production.local');
-    const projectJsonPath = join(cwd, '.vercel', 'project.json');
-    const originalProjectJson = await fs.readJSON(
-      join(cwd, '.vercel/project.json')
-    );
     try {
       client.cwd = cwd;
       client.setArgv('build', '--yes', '--target', 'production');
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
 
-      const prodEnv = await fs.readFile(envFilePath, 'utf8');
-      const envFileHasProductionEnv1 = prodEnv.includes(
-        'REDIS_CONNECTION_STRING'
-      );
-      expect(envFileHasProductionEnv1).toBeTruthy();
-      const envFileHasProductionEnv2 = prodEnv.includes(
-        'SQL_CONNECTION_STRING'
-      );
-      expect(envFileHasProductionEnv2).toBeTruthy();
+      const builds = await fs.readJSON(join(cwd, '.vercel/output/builds.json'));
+      expect(builds.target).toEqual('production');
     } finally {
       await fs.remove(envFilePath);
-      await fs.writeJSON(projectJsonPath, originalProjectJson, { spaces: 2 });
     }
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       { key: 'option:target', value: 'production' },
@@ -516,7 +485,124 @@ describe.skipIf(flakey)('build', () => {
     ]);
   });
 
-  it('links before asking to pull settings in an unlinked directory', async () => {
+  it('should resolve "production" env vars with `--environment production`', async () => {
+    const cwd = fixture('static-pull');
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+    try {
+      client.cwd = cwd;
+      client.setArgv('build', '--yes', '--environment', 'production');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      const builds = await fs.readJSON(join(cwd, '.vercel/output/builds.json'));
+      expect(builds.target).toEqual('production');
+    } finally {
+      await fs.remove(join(cwd, '.vercel', '.env.production.local'));
+    }
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'flag:yes', value: 'TRUE' },
+      { key: 'option:environment', value: 'production' },
+    ]);
+  });
+
+  it('should target "preview" when `--git-branch` is given without an environment', async () => {
+    const cwd = fixture('static-pull');
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+    client.cwd = cwd;
+    client.setArgv('build', '--yes', '--git-branch', 'feature-branch');
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
+
+    const builds = await fs.readJSON(join(cwd, '.vercel/output/builds.json'));
+    expect(builds.target).toEqual('preview');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'flag:yes', value: 'TRUE' },
+      { key: 'option:git-branch', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('ignores a local env file pulled for a different git branch', async () => {
+    const cwd = fixture('static-pull');
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+    const envFilePath = join(cwd, '.vercel', '.env.preview.local');
+    try {
+      // Written as if by `vercel pull --environment=preview --git-branch=other`.
+      await fs.outputFile(
+        envFilePath,
+        '# Created by Vercel CLI\n' +
+          '# vercel-env: target=preview gitBranch=other\n' +
+          'STALE_ONLY_IN_FILE="from-other-branch"\n',
+        'utf8'
+      );
+
+      client.cwd = cwd;
+      client.setArgv('build', '--yes');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      expect(client.stderr.getFullOutput()).toContain(
+        'it was pulled with overrides for branch `other`'
+      );
+      expect(process.env.STALE_ONLY_IN_FILE).toBeUndefined();
+    } finally {
+      await fs.remove(envFilePath);
+      delete process.env.STALE_ONLY_IN_FILE;
+    }
+  });
+
+  it('uses a local env file whose provenance matches the build', async () => {
+    const cwd = fixture('static-pull');
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+    const envFilePath = join(cwd, '.vercel', '.env.preview.local');
+    try {
+      await fs.outputFile(
+        envFilePath,
+        '# Created by Vercel CLI\n' +
+          '# vercel-env: target=preview gitBranch=feature-branch\n' +
+          'MATCHED_ONLY_IN_FILE="from-matching-pull"\n',
+        'utf8'
+      );
+
+      client.cwd = cwd;
+      client.setArgv('build', '--yes', '--git-branch', 'feature-branch');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      // `envToUnset` clears loaded keys once the build finishes, so assert on
+      // the absence of the mismatch warning instead of `process.env`.
+      expect(client.stderr.getFullOutput()).not.toContain('Ignoring');
+      expect(client.stderr.getFullOutput()).not.toContain('it was pulled');
+    } finally {
+      await fs.remove(envFilePath);
+      delete process.env.MATCHED_ONLY_IN_FILE;
+    }
+  });
+
+  it('links then resolves settings without asking to pull in an unlinked directory', async () => {
     const cwd = setupUnitFixture('commands/build/static-pull');
     await fs.remove(join(cwd, '.vercel'));
 
@@ -535,17 +621,19 @@ describe.skipIf(flakey)('build', () => {
       client.setArgv('build');
       const exitCodePromise = build(client);
 
-      // The link flow runs before the pull question. The single team
-      // auto-selects; pick the detected folder-name match in the picker.
+      // The link flow runs, then settings resolve from the API directly.
+      // The single team auto-selects; pick the detected folder-name match.
       await expect(client.stderr).toOutput('Which project?');
       client.events.keypress('enter');
       await expect(client.stderr).toOutput('Linked');
 
-      await expect(client.stderr).toOutput('No Project Settings found locally');
-      client.stdin.write('y\n');
-
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+
+      // The removed prompt must not reappear.
+      expect(client.stderr.getFullOutput()).not.toContain(
+        'No Project Settings found locally'
+      );
 
       const projectJson = await fs.readJSON(join(cwd, '.vercel/project.json'));
       expect(projectJson.projectId).toEqual(basename(cwd));

--- a/packages/cli/test/unit/util/env/env-provenance.test.ts
+++ b/packages/cli/test/unit/util/env/env-provenance.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareEnvProvenance,
+  formatEnvProvenance,
+  parseEnvProvenance,
+} from '../../../../src/util/env/env-provenance';
+
+const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
+
+describe('formatEnvProvenance', () => {
+  it('renders target, branch and timestamp', () => {
+    const line = formatEnvProvenance({
+      target: 'preview',
+      gitBranch: 'feature-branch',
+      pulledAt: '2026-07-28T00:00:00.000Z',
+    });
+    expect(line).toBe(
+      '# vercel-env: target=preview gitBranch=feature-branch pulledAt=2026-07-28T00%3A00%3A00.000Z\n'
+    );
+  });
+
+  it('omits absent fields', () => {
+    expect(formatEnvProvenance({ target: 'production' })).toBe(
+      '# vercel-env: target=production\n'
+    );
+  });
+
+  it('returns an empty string when there is nothing to record', () => {
+    expect(formatEnvProvenance({})).toBe('');
+  });
+
+  it('keeps the created-by header byte-identical as the first line', () => {
+    // `env pull` detects CLI-authored files with a fixed-length head read of
+    // CONTENTS_PREFIX, so provenance must not shift or alter the first line.
+    const contents =
+      CONTENTS_PREFIX +
+      formatEnvProvenance({ target: 'preview' }) +
+      'FOO="bar"\n';
+    expect(contents.slice(0, CONTENTS_PREFIX.length)).toBe(CONTENTS_PREFIX);
+  });
+});
+
+describe('parseEnvProvenance', () => {
+  it('round-trips a formatted line', () => {
+    const provenance = {
+      target: 'preview',
+      gitBranch: 'feature-branch',
+      pulledAt: '2026-07-28T00:00:00.000Z',
+    };
+    const contents =
+      CONTENTS_PREFIX + formatEnvProvenance(provenance) + 'FOO="bar"\n';
+    expect(parseEnvProvenance(contents)).toEqual(provenance);
+  });
+
+  it('round-trips branches containing spaces and equals signs', () => {
+    const gitBranch = 'feat/a b=c';
+    const contents =
+      CONTENTS_PREFIX + formatEnvProvenance({ target: 'preview', gitBranch });
+    expect(parseEnvProvenance(contents)?.gitBranch).toBe(gitBranch);
+  });
+
+  it('returns undefined for files pulled before provenance existed', () => {
+    expect(parseEnvProvenance(`${CONTENTS_PREFIX}FOO="bar"\n`)).toBeUndefined();
+  });
+
+  it('returns undefined for hand-written files', () => {
+    expect(parseEnvProvenance('FOO="bar"\n')).toBeUndefined();
+  });
+
+  it('does not read a provenance-looking line after the assignments', () => {
+    const contents = `${CONTENTS_PREFIX}FOO="bar"\n# vercel-env: target=production\n`;
+    expect(parseEnvProvenance(contents)).toBeUndefined();
+  });
+});
+
+describe('compareEnvProvenance', () => {
+  it('reports unknown when there is no provenance', () => {
+    expect(compareEnvProvenance(undefined, { target: 'preview' })).toEqual({
+      status: 'unknown',
+    });
+  });
+
+  it('matches when target and branch agree', () => {
+    expect(
+      compareEnvProvenance(
+        { target: 'preview', gitBranch: 'feat' },
+        { target: 'preview', gitBranch: 'feat' }
+      )
+    ).toEqual({ status: 'match' });
+  });
+
+  it('matches a plain pull of the same target', () => {
+    expect(
+      compareEnvProvenance({ target: 'production' }, { target: 'production' })
+    ).toEqual({ status: 'match' });
+  });
+
+  it('flags a different target', () => {
+    const result = compareEnvProvenance(
+      { target: 'production' },
+      { target: 'preview' }
+    );
+    expect(result.status).toBe('mismatch');
+    expect(result).toHaveProperty('reason', expect.stringContaining('preview'));
+  });
+
+  it('flags a branch-specific file when no branch was requested', () => {
+    // The reported case: `pull --git-branch` writes `.env.preview.local`, which
+    // is otherwise indistinguishable from a plain preview pull.
+    const result = compareEnvProvenance(
+      { target: 'preview', gitBranch: 'feature-branch' },
+      { target: 'preview' }
+    );
+    expect(result.status).toBe('mismatch');
+    expect(result).toHaveProperty(
+      'reason',
+      expect.stringContaining('feature-branch')
+    );
+  });
+
+  it('flags a plain file when a branch was requested', () => {
+    const result = compareEnvProvenance(
+      { target: 'preview' },
+      { target: 'preview', gitBranch: 'feature-branch' }
+    );
+    expect(result.status).toBe('mismatch');
+  });
+
+  it('flags a mismatched branch', () => {
+    const result = compareEnvProvenance(
+      { target: 'preview', gitBranch: 'other' },
+      { target: 'preview', gitBranch: 'feature-branch' }
+    );
+    expect(result.status).toBe('mismatch');
+  });
+
+  it('ignores a timestamp-only record', () => {
+    expect(
+      compareEnvProvenance(
+        { pulledAt: '2026-07-28T00:00:00.000Z' },
+        { target: 'preview' }
+      )
+    ).toEqual({ status: 'unknown' });
+  });
+});

--- a/packages/cli/test/unit/util/parse-target.test.ts
+++ b/packages/cli/test/unit/util/parse-target.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
-import parseTarget from '../../../src/util/parse-target';
+import parseTarget, {
+  parseAliasedTarget,
+} from '../../../src/util/parse-target';
 import output from '../../../src/output-manager';
 
 describe('parseTarget', () => {
@@ -63,5 +65,116 @@ describe('parseTarget', () => {
       flags: { '--prod': false },
     });
     expect(result).toEqual(undefined);
+  });
+});
+
+describe('parseAliasedTarget', () => {
+  beforeEach(() => {
+    vi.spyOn(output, 'debug');
+    vi.spyOn(output, 'warn');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to the command default', () => {
+    expect(parseAliasedTarget({ flags: {}, defaultTarget: 'preview' })).toEqual(
+      'preview'
+    );
+    expect(
+      parseAliasedTarget({ flags: {}, defaultTarget: 'development' })
+    ).toEqual('development');
+  });
+
+  it('accepts `--target` and `--environment` interchangeably', () => {
+    expect(
+      parseAliasedTarget({
+        flags: { '--target': 'production' },
+        defaultTarget: 'preview',
+      })
+    ).toEqual('production');
+    expect(
+      parseAliasedTarget({
+        flags: { '--environment': 'production' },
+        defaultTarget: 'preview',
+      })
+    ).toEqual('production');
+  });
+
+  it('accepts a custom environment slug', () => {
+    expect(
+      parseAliasedTarget({
+        flags: { '--environment': 'my-custom-env' },
+        defaultTarget: 'preview',
+      })
+    ).toEqual('my-custom-env');
+  });
+
+  it('infers `preview` from `--git-branch`', () => {
+    expect(
+      parseAliasedTarget({
+        flags: { '--git-branch': 'feature-branch' },
+        defaultTarget: 'development',
+      })
+    ).toEqual('preview');
+  });
+
+  it('lets an explicit environment win over `--git-branch` inference', () => {
+    expect(
+      parseAliasedTarget({
+        flags: { '--git-branch': 'feature-branch', '--target': 'production' },
+        defaultTarget: 'development',
+      })
+    ).toEqual('production');
+  });
+
+  it('warns and prefers `--target` when the aliases disagree', () => {
+    const result = parseAliasedTarget({
+      flags: { '--target': 'production', '--environment': 'preview' },
+      defaultTarget: 'development',
+    });
+    expect(result).toEqual('production');
+    expect(output.warn).toHaveBeenCalledWith(
+      'Both `--target` and `--environment` detected with different values. Using `--target production`.'
+    );
+  });
+
+  it('does not warn when the aliases agree', () => {
+    const result = parseAliasedTarget({
+      flags: { '--target': 'preview', '--environment': 'preview' },
+      defaultTarget: 'development',
+    });
+    expect(result).toEqual('preview');
+    expect(output.warn).not.toHaveBeenCalled();
+  });
+
+  it('resolves `--prod` to production', () => {
+    expect(
+      parseAliasedTarget({
+        flags: { '--prod': true },
+        defaultTarget: 'preview',
+      })
+    ).toEqual('production');
+  });
+
+  it('prefers an explicit environment over `--prod`', () => {
+    const result = parseAliasedTarget({
+      flags: { '--prod': true, '--environment': 'preview' },
+      defaultTarget: 'development',
+    });
+    expect(result).toEqual('preview');
+    expect(output.warn).toHaveBeenCalledWith(
+      'Both `--prod` and an explicit environment detected. Ignoring `--prod`.'
+    );
+  });
+
+  it('prefers `--prod` over `--git-branch` inference', () => {
+    expect(
+      parseAliasedTarget({
+        flags: { '--prod': true, '--git-branch': 'feature-branch' },
+        defaultTarget: 'development',
+      })
+    ).toEqual('production');
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **Not ready to merge.** This is a working exploration to get a feel for the scope. See [Open questions](#open-questions) and [Verification gaps](#verification-gaps) before reviewing in depth.

## Problem

`vc build` prompted this whenever `.vercel/project.json` was missing:

```
? No Project Settings found locally. Run `vercel pull` for retrieving them? (Y/n)
```

That made `vc pull` a required setup step before building. The prompt was also gating an env-var pull, so it couldn't just be deleted.

## What this does

**1. `vc build` resolves from the API.** Project Settings and Environment Variables are fetched for the linked project and kept in memory. No prompt, no required `vc pull`. `.vercel/project.json` becomes a fallback rather than a prerequisite.

**2. Env files now record provenance.** This is the part worth reviewing closely.

`.vercel/.env.<target>.local` encodes only the *target* in its filename. So after:

```bash
vercel pull --environment=preview --git-branch=feature-branch
```

...the resulting `.env.preview.local` is **byte-indistinguishable** from a plain preview pull. Nothing on disk records the branch — `toProjectLinkAndSettings` writes only link fields and build settings, no environment, no branch, no timestamp.

That means neither "API always wins" nor "file always wins" is correct:
- File-first → a stale or differently-scoped file silently shadows fresher values.
- API-first → `vercel pull --git-branch` has no way to reach `vc build` at all.

So pulled files now record what they were resolved for, as a comment on line 2:

```
# Created by Vercel CLI
# vercel-env: target=preview gitBranch=feature-branch pulledAt=2026-07-28T16:47:56.003Z
API_URL="branch-specific-value"
```

`vc build` compares that against the request it's about to make:

| Local file | `vc build` invocation | Result |
|---|---|---|
| `target=preview gitBranch=feature-branch` | `--git-branch feature-branch` | file used |
| `target=preview gitBranch=feature-branch` | (plain) | warns, uses API |
| `target=preview gitBranch=feature-branch` | `--git-branch other` | warns, uses API |
| `target=production` | `--target preview` | warns, uses API |
| no provenance (older CLI) | anything | file used (unchanged behavior) |

Line 1 stays byte-identical, so the fixed-length head read that detects CLI-authored files (and drives the overwrite prompt) is unaffected. `dotenv` ignores comments.

**3. Option parity between `build` and `pull`.** These had diverged:

| | `pull` before | `build` before | both now |
|---|---|---|---|
| `--environment` | ✅ | ❌ | ✅ |
| `--target` | ❌ | ✅ | ✅ |
| `--git-branch` | ✅ | ❌ | ✅ |

`--target` and `--environment` are aliases in both (warns if given conflicting values). `--git-branch` without an explicit environment resolves `preview`, since branch overrides only exist there — matching the `branch_requires_preview_only` rule `vc env add` already enforces.

**4. Removed the post-link env prompt.** `Pull development environment variables into .env.local?` and the `pullEnv` plumbing through `setupAndLink` / `linkFolderToProject`.

**5. Drive-by fix.** Non-interactive settings-resolution failure emitted human prose instead of agent JSON; now returns `project_settings_required`.

## Things found along the way

- **Defaults never matched.** `vc pull` defaults to `development`, `vc build` to `preview`. So plain `vercel pull && vercel build` never shared env vars, even before this PR — only explicit `--environment` / `--prod` pulls fed the build. The backwards-compat surface here is narrower than it looks.
- **`parseEnvironment` is dead code** in `src/` — its only callers are test mocks. Custom environment slugs flow through both commands unvalidated today; `pullEnvRecords` passes target as a URL path segment, so they work.

## Open questions

1. **Is `gitBranch` meaningful with custom environments?** `getEnvRecords` sets `customEnvironmentId` and `gitBranch` as independent query params, implying the API allows both. `vc env add` forbids the combination. I made `--git-branch` *infer* `preview` only when no environment is given explicitly, so `--git-branch x --target my-custom-env` still passes both through. Needs an API-side answer.
2. **Should provenance mismatch be an error rather than a warning?** Currently warns and proceeds with API values. Failing loudly might be better for CI.
3. **Should `vc dev` get the same treatment?** It calls `pullEnvRecords` with neither `target` nor `gitBranch`, so it can't resolve branch-specific values at all.
4. **Is a comment line the right carrier for provenance?** Alternative: a sidecar file in `.vercel/`. A comment keeps it attached to the values it describes and survives copying, but it is user-visible and hand-editable.

## Verification gaps

Ran and green:
- `test/unit/util/env/env-provenance.test.ts` — 17/17 (new)
- `test/unit/util/parse-target.test.ts` — 16/16 (extended)
- `test/unit/commands/env/pull.test.ts` — 40/40
- `test/unit/commands/pull/` — 16/16
- `test/unit/commands/help.test.ts` — 143/143 (3 `pull` snapshots updated, additive)
- `test/unit/commands/build/monorepo.test.ts` — 12/12
- `test/unit/commands/build/emit-flags-definitions.test.ts` — 11/11
- `pnpm type-check` — clean except 2 pre-existing unbuilt-dep errors (`@vercel/backends`, `@vercel/go`), confirmed identical with changes stashed

**Not fully verified:**
- `test/unit/commands/build/index.test.ts` last showed **1 unidentified failure** (`expected undefined to be defined`) in a full-directory run. It does not reproduce in `monorepo.test.ts` or `emit-flags-definitions.test.ts` individually, and I did not isolate which test in `index.test.ts` it belongs to. **This needs to be identified before merge.**
- Two other failures in that directory are environmental, not from this change: one needs a valid `~/.config/uv/uv.toml` (Python fixture), and the trace-spans test passes in isolation but fails under full-suite cross-test pollution.
- The three rewritten env tests now assert in-memory resolution and `builds.json` target instead of files on disk. Reviewers should sanity-check that they still assert something meaningful.
- No e2e run.

## Rewritten tests

`should pull "preview"/"production" env vars` asserted `.vercel/.env.*.local` existing on disk — exactly what this PR stops doing. They now assert the resolved build target and the absence of the file. Added coverage for `--environment`, `--git-branch` preview inference, provenance match, and provenance mismatch.
