### PR TITLE
[python] fixes for Queues SDK vendoring

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -243,6 +243,8 @@ export default class DevServer {
       VERCEL_HAS_WORKER_SERVICES: '1',
       VERCEL_QUEUE_BASE_URL: `${this.address.origin}/_svc/_queues`,
       VERCEL_QUEUE_TOKEN: 'vc-dev-token',
+      VERCEL_REGION: 'dev1',
+      VERCEL_DEPLOYMENT_ID: 'dpl_dev',
     };
   }
 

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -699,6 +699,8 @@ export class ServicesOrchestrator {
     if (this.hasQueueServices) {
       env.VERCEL_QUEUE_BASE_URL = `${this.proxyOrigin}/_svc/_queues`;
       env.VERCEL_QUEUE_TOKEN = 'vc-dev-token';
+      env.VERCEL_REGION = 'dev1';
+      env.VERCEL_DEPLOYMENT_ID = 'dpl_dev';
     }
 
     if (service.routePrefix && service.routePrefix !== '/') {
@@ -776,6 +778,8 @@ export class ServicesOrchestrator {
     if (this.hasQueueServices) {
       env.VERCEL_QUEUE_BASE_URL = `${this.proxyOrigin}/_svc/_queues`;
       env.VERCEL_QUEUE_TOKEN = 'vc-dev-token';
+      env.VERCEL_REGION = 'dev1';
+      env.VERCEL_DEPLOYMENT_ID = 'dpl_dev';
     }
 
     const root = service.root || '.';

--- a/packages/cli/test/unit/util/dev/services-orchestrator.test.ts
+++ b/packages/cli/test/unit/util/dev/services-orchestrator.test.ts
@@ -49,6 +49,8 @@ describe('ServicesOrchestrator', () => {
       VERCEL_HAS_WORKER_SERVICES: '1',
       VERCEL_QUEUE_BASE_URL: 'http://localhost:3000/_svc/_queues',
       VERCEL_QUEUE_TOKEN: 'vc-dev-token',
+      VERCEL_REGION: 'dev1',
+      VERCEL_DEPLOYMENT_ID: 'dpl_dev',
     });
   });
 });

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -15,7 +15,9 @@ import type {
 } from '@vercel/build-utils';
 import {
   debug,
+  isQueueBackedService,
   isScheduleTriggeredService,
+  isWorkflowTriggeredService,
   NowBuildError,
 } from '@vercel/build-utils';
 import { buildCronRouteTable, getServiceCrons } from './crons';
@@ -962,16 +964,37 @@ export const startDevServer: StartDevServer = async opts => {
       );
     }
 
+    // Legacy vercel-workers projects run every dev process on the injected
+    // pinned vercel-workers, mirroring the build-time injection: both the
+    // worker bootstrap and publish-side send() need the pinned version
+    if (legacyProject) {
+      await installInjectedDevPackage(
+        {
+          name: 'vercel-workers',
+          pinnedVersion: VERCEL_WORKERS_VERSION,
+          envOverride: env.VERCEL_WORKERS_PYTHON,
+        },
+        devOpts
+      );
+    }
+
     // Queue sidecars (subscribers/workflows) are served through vercel-queue
     // when the project's SDK supports it, and through the legacy
     // vercel-workers bootstrap otherwise. Deliberately not keyed on
     // env.VERCEL_HAS_WORKER_SERVICES: the CLI sets that for every
-    // queue-service project regardless of SDK generation.
+    // queue-service project regardless of SDK generation. Besides pyproject
+    // sidecars (marked by the CLI via config.pythonQueueSidecar), this
+    // covers queue-backed experimentalServices (worker and queue/workflow
+    // triggered job services) until we fully get rid of them.
     const queueSidecarKind =
       config?.pythonQueueSidecar === 'subscriber' ||
       config?.pythonQueueSidecar === 'workflow'
         ? config.pythonQueueSidecar
-        : undefined;
+        : service && isQueueBackedService(service)
+          ? isWorkflowTriggeredService(service)
+            ? 'workflow'
+            : 'subscriber'
+          : undefined;
     let queueSubscriptions: DevQueueSubscription[] | undefined;
     if (queueSidecarKind) {
       let useQueueServing = !legacyProject;

--- a/packages/python/test/fixtures/75-dramatiq-subscriber/main.py
+++ b/packages/python/test/fixtures/75-dramatiq-subscriber/main.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import dramatiq
+from dramatiq.results import ResultMissing
+from fastapi import FastAPI
+from pydantic import BaseModel
+from vercel.cache import get_cache
+
+from tasks import MESSAGE_CACHE_NAMESPACE, QUEUE_NAME, process_job
+
+app = FastAPI()
+
+
+class EnqueueRequest(BaseModel):
+    request_id: str
+    x: int = 2
+    y: int = 3
+
+
+@app.get("/")
+def root():
+    return {"message": "dramatiq subscriber example", "queue": QUEUE_NAME}
+
+
+@app.post("/enqueue")
+def enqueue(body: EnqueueRequest):
+    message = process_job.send(body.request_id, body.x, body.y)
+    get_cache(namespace=MESSAGE_CACHE_NAMESPACE).set(
+        body.request_id,
+        {"message": message.encode().decode("utf-8")},
+        options={"ttl": 300},
+    )
+    return {"ok": True, "requestId": body.request_id, "messageId": message.message_id}
+
+
+@app.get("/status/{request_id}")
+def status(request_id: str):
+    stored = get_cache(namespace=MESSAGE_CACHE_NAMESPACE).get(request_id)
+    if stored is None:
+        return {"processed": False, "result": None}
+    message = dramatiq.Message.decode(stored["message"].encode("utf-8"))
+    try:
+        result = message.get_result()
+    except ResultMissing:
+        return {"processed": False, "result": None}
+    return {"processed": True, "result": result}

--- a/packages/python/test/fixtures/75-dramatiq-subscriber/probes.json
+++ b/packages/python/test/fixtures/75-dramatiq-subscriber/probes.json
@@ -1,0 +1,23 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "dramatiq"
+    },
+    {
+      "path": "/enqueue",
+      "method": "POST",
+      "body": { "request_id": "RANDOMNESS_PLACEHOLDER", "x": 2, "y": 3 },
+      "status": 200,
+      "mustContain": "RANDOMNESS_PLACEHOLDER"
+    },
+    {
+      "path": "/status/RANDOMNESS_PLACEHOLDER",
+      "status": 200,
+      "mustContain": "\"sum\":5",
+      "retries": 10,
+      "retryDelay": 3000
+    }
+  ]
+}

--- a/packages/python/test/fixtures/75-dramatiq-subscriber/pyproject.toml
+++ b/packages/python/test/fixtures/75-dramatiq-subscriber/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "dramatiq-subscriber"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi",
+    "dramatiq>=2.2",
+    "vercel",
+]
+
+[[tool.vercel.subscribers]]
+entrypoint = "worker:broker"
+topics = ["dramatiq*"]

--- a/packages/python/test/fixtures/75-dramatiq-subscriber/tasks.py
+++ b/packages/python/test/fixtures/75-dramatiq-subscriber/tasks.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import dramatiq
+from dramatiq.results import Results
+from vercel.integrations.dramatiq import VercelQueueBroker, VercelRuntimeCacheBackend
+
+QUEUE_NAME = "dramatiq"
+MESSAGE_CACHE_NAMESPACE = "dramatiq-messages"
+
+broker = VercelQueueBroker()
+broker.add_middleware(Results(backend=VercelRuntimeCacheBackend()))
+dramatiq.set_broker(broker)
+
+
+@dramatiq.actor(queue_name=QUEUE_NAME, store_results=True)
+def process_job(request_id: str, x: int, y: int) -> dict[str, object]:
+    return {"requestId": request_id, "sum": x + y}

--- a/packages/python/test/fixtures/75-dramatiq-subscriber/worker.py
+++ b/packages/python/test/fixtures/75-dramatiq-subscriber/worker.py
@@ -1,0 +1,6 @@
+# Subscriber entrypoint ("worker:broker"). Importing tasks declares the
+# Dramatiq actor's queues on the explicitly configured broker so the queue
+# trigger can execute it.
+from tasks import broker
+
+__all__ = ["broker"]


### PR DESCRIPTION
Fixes legacy path for `experimentalServices` with `vercel-workers`, adds missing env vars for new Queues SDK and adds explicit E2E test for dramatiq using new SDK