### PR TITLE
[functions] Add optimizeImageFromBytes and optimizeImageFromUrl

### DIFF
--- a/.changeset/oidc-token-payload-export.md
+++ b/.changeset/oidc-token-payload-export.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': minor
+---
+
+Export `getTokenPayload` and the `TokenPayload` type for decoding a Vercel OIDC token's claims (without signature verification) from all runtime entrypoints.

--- a/.changeset/spicy-images-optimize.md
+++ b/.changeset/spicy-images-optimize.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': minor
+---
+
+Add `optimizeImageFromBytes` and `optimizeImageFromUrl` to optimize images via the Vercel Image Optimization API using the ambient OIDC token, without requiring a deployment or `next/image` configuration.

--- a/packages/functions/docs/index/README.md
+++ b/packages/functions/docs/index/README.md
@@ -8,6 +8,9 @@
 
 - [DangerouslyDeleteOptions](interfaces/DangerouslyDeleteOptions.md)
 - [Geo](interfaces/Geo.md)
+- [OptimizedImage](interfaces/OptimizedImage.md)
+- [OptimizeImageFromBytesOptions](interfaces/OptimizeImageFromBytesOptions.md)
+- [OptimizeImageOptions](interfaces/OptimizeImageOptions.md)
 - [PurgeApi](interfaces/PurgeApi.md)
 - [Request](interfaces/Request.md)
 - [RuntimeCache](interfaces/RuntimeCache.md)
@@ -17,6 +20,7 @@
 ## Type Aliases
 
 - [AddCacheTagApi](type-aliases/AddCacheTagApi.md)
+- [OptimizeImageFormat](type-aliases/OptimizeImageFormat.md)
 - [WebSocket](type-aliases/WebSocket.md)
 - [WebSocketData](type-aliases/WebSocketData.md)
 
@@ -38,5 +42,7 @@
 - [invalidateByTag](functions/invalidateByTag.md)
 - [ipAddress](functions/ipAddress.md)
 - [next](functions/next.md)
+- [optimizeImageFromBytes](functions/optimizeImageFromBytes.md)
+- [optimizeImageFromUrl](functions/optimizeImageFromUrl.md)
 - [rewrite](functions/rewrite.md)
 - [waitUntil](functions/waitUntil.md)

--- a/packages/functions/docs/index/functions/optimizeImageFromBytes.md
+++ b/packages/functions/docs/index/functions/optimizeImageFromBytes.md
@@ -1,0 +1,49 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Function: optimizeImageFromBytes()
+
+> **optimizeImageFromBytes**(`bytes`, `options`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`OptimizedImage`](../interfaces/OptimizedImage.md)\>
+
+Defined in: packages/functions/src/image-optimization/index.ts:153
+
+Optimize an image from its raw bytes using Vercel Image Optimization,
+without requiring a deployment or the `next/image` configuration.
+
+Authenticates with the ambient Vercel OIDC token (available in Vercel
+Functions automatically, or locally via `vercel env pull`), scoped to the
+token's project.
+
+## Parameters
+
+### bytes
+
+[`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) \| [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)\<`ArrayBufferLike`\>
+
+The source image bytes (max 5MB).
+
+### options
+
+[`OptimizeImageFromBytesOptions`](../interfaces/OptimizeImageFromBytesOptions.md)
+
+Width, quality, and output format.
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`OptimizedImage`](../interfaces/OptimizedImage.md)\>
+
+The optimized image bytes and content type.
+
+## Example
+
+```js
+import { optimizeImageFromBytes } from '@vercel/functions';
+
+const res = await fetch('https://example.com/logo.png');
+const { data } = await optimizeImageFromBytes(await res.bytes(), {
+  width: 512,
+  quality: 75,
+  format: 'webp',
+});
+```

--- a/packages/functions/docs/index/functions/optimizeImageFromUrl.md
+++ b/packages/functions/docs/index/functions/optimizeImageFromUrl.md
@@ -1,0 +1,49 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Function: optimizeImageFromUrl()
+
+> **optimizeImageFromUrl**(`url`, `options`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`OptimizedImage`](../interfaces/OptimizedImage.md)\>
+
+Defined in: packages/functions/src/image-optimization/index.ts:200
+
+Optimize an image fetched from a URL using Vercel Image Optimization,
+without requiring a deployment or the `next/image` configuration.
+
+The URL is fetched server-side by Vercel; it must be a publicly reachable
+`http(s)` URL. Authenticates with the ambient Vercel OIDC token (available
+in Vercel Functions automatically, or locally via `vercel env pull`),
+scoped to the token's project.
+
+## Parameters
+
+### url
+
+`string`
+
+The URL of the source image to optimize.
+
+### options
+
+[`OptimizeImageOptions`](../interfaces/OptimizeImageOptions.md)
+
+Width, quality, and output format.
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`OptimizedImage`](../interfaces/OptimizedImage.md)\>
+
+The optimized image bytes and content type.
+
+## Example
+
+```js
+import { optimizeImageFromUrl } from '@vercel/functions';
+
+const { data } = await optimizeImageFromUrl('https://example.com/logo.png', {
+  width: 512,
+  quality: 75,
+  format: 'webp',
+});
+```

--- a/packages/functions/docs/index/interfaces/OptimizeImageFromBytesOptions.md
+++ b/packages/functions/docs/index/interfaces/OptimizeImageFromBytesOptions.md
@@ -1,0 +1,84 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Interface: OptimizeImageFromBytesOptions
+
+Defined in: packages/functions/src/image-optimization/index.ts:33
+
+Options for [optimizeImageFromBytes](../functions/optimizeImageFromBytes.md).
+
+## Extends
+
+- [`OptimizeImageOptions`](OptimizeImageOptions.md)
+
+## Properties
+
+### contentType?
+
+> `optional` **contentType?**: `string`
+
+Defined in: packages/functions/src/image-optimization/index.ts:38
+
+The media type of the source image bytes (e.g. `image/png`). When
+omitted, the optimizer sniffs the type from the bytes.
+
+***
+
+### fileName?
+
+> `optional` **fileName?**: `string`
+
+Defined in: packages/functions/src/image-optimization/index.ts:43
+
+A file name to attribute the source image to in usage reporting
+(e.g. `logo.png`).
+
+***
+
+### format?
+
+> `optional` **format?**: [`OptimizeImageFormat`](../type-aliases/OptimizeImageFormat.md)
+
+Defined in: packages/functions/src/image-optimization/index.ts:27
+
+The desired output format. When omitted, the original format is
+preserved.
+
+#### Inherited from
+
+[`OptimizeImageOptions`](OptimizeImageOptions.md).[`format`](OptimizeImageOptions.md#format)
+
+***
+
+### quality?
+
+> `optional` **quality?**: `number`
+
+Defined in: packages/functions/src/image-optimization/index.ts:22
+
+The desired quality of the optimized image (1-100).
+
+#### Default
+
+```ts
+75
+```
+
+#### Inherited from
+
+[`OptimizeImageOptions`](OptimizeImageOptions.md).[`quality`](OptimizeImageOptions.md#quality)
+
+***
+
+### width
+
+> **width**: `number`
+
+Defined in: packages/functions/src/image-optimization/index.ts:17
+
+The desired width of the optimized image in pixels (1-8192).
+
+#### Inherited from
+
+[`OptimizeImageOptions`](OptimizeImageOptions.md).[`width`](OptimizeImageOptions.md#width)

--- a/packages/functions/docs/index/interfaces/OptimizeImageOptions.md
+++ b/packages/functions/docs/index/interfaces/OptimizeImageOptions.md
@@ -1,0 +1,50 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Interface: OptimizeImageOptions
+
+Defined in: packages/functions/src/image-optimization/index.ts:13
+
+Options for image optimization.
+
+## Extended by
+
+- [`OptimizeImageFromBytesOptions`](OptimizeImageFromBytesOptions.md)
+
+## Properties
+
+### format?
+
+> `optional` **format?**: [`OptimizeImageFormat`](../type-aliases/OptimizeImageFormat.md)
+
+Defined in: packages/functions/src/image-optimization/index.ts:27
+
+The desired output format. When omitted, the original format is
+preserved.
+
+***
+
+### quality?
+
+> `optional` **quality?**: `number`
+
+Defined in: packages/functions/src/image-optimization/index.ts:22
+
+The desired quality of the optimized image (1-100).
+
+#### Default
+
+```ts
+75
+```
+
+***
+
+### width
+
+> **width**: `number`
+
+Defined in: packages/functions/src/image-optimization/index.ts:17
+
+The desired width of the optimized image in pixels (1-8192).

--- a/packages/functions/docs/index/interfaces/OptimizedImage.md
+++ b/packages/functions/docs/index/interfaces/OptimizedImage.md
@@ -1,0 +1,29 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Interface: OptimizedImage
+
+Defined in: packages/functions/src/image-optimization/index.ts:49
+
+The optimized image returned by the image optimization API.
+
+## Properties
+
+### contentType
+
+> **contentType**: `string`
+
+Defined in: packages/functions/src/image-optimization/index.ts:57
+
+The media type of the optimized image (e.g. `image/webp`).
+
+***
+
+### data
+
+> **data**: [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
+
+Defined in: packages/functions/src/image-optimization/index.ts:53
+
+The optimized image bytes.

--- a/packages/functions/docs/index/type-aliases/OptimizeImageFormat.md
+++ b/packages/functions/docs/index/type-aliases/OptimizeImageFormat.md
@@ -1,0 +1,11 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Type Alias: OptimizeImageFormat
+
+> **OptimizeImageFormat** = `"jpeg"` \| `"png"` \| `"webp"` \| `"avif"`
+
+Defined in: packages/functions/src/image-optimization/index.ts:8
+
+Output format for the optimized image.

--- a/packages/functions/src/image-optimization/index.ts
+++ b/packages/functions/src/image-optimization/index.ts
@@ -1,0 +1,206 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+
+const DEFAULT_API_URL = 'https://api.vercel.com';
+
+/**
+ * Output format for the optimized image.
+ */
+export type OptimizeImageFormat = 'jpeg' | 'png' | 'webp' | 'avif';
+
+/**
+ * Options for image optimization.
+ */
+export interface OptimizeImageOptions {
+  /**
+   * The desired width of the optimized image in pixels (1-8192).
+   */
+  width: number;
+  /**
+   * The desired quality of the optimized image (1-100).
+   * @default 75
+   */
+  quality?: number;
+  /**
+   * The desired output format. When omitted, the original format is
+   * preserved.
+   */
+  format?: OptimizeImageFormat;
+}
+
+/**
+ * Options for {@link optimizeImageFromBytes}.
+ */
+export interface OptimizeImageFromBytesOptions extends OptimizeImageOptions {
+  /**
+   * The media type of the source image bytes (e.g. `image/png`). When
+   * omitted, the optimizer sniffs the type from the bytes.
+   */
+  contentType?: string;
+  /**
+   * A file name to attribute the source image to in usage reporting
+   * (e.g. `logo.png`).
+   */
+  fileName?: string;
+}
+
+/**
+ * The optimized image returned by the image optimization API.
+ */
+export interface OptimizedImage {
+  /**
+   * The optimized image bytes.
+   */
+  data: Uint8Array;
+  /**
+   * The media type of the optimized image (e.g. `image/webp`).
+   */
+  contentType: string;
+}
+
+class ImageOptimizationError extends Error {
+  constructor(
+    public status: number,
+    body: string
+  ) {
+    super(`Image optimization request failed with status ${status}: ${body}`);
+    this.name = 'ImageOptimizationError';
+  }
+}
+
+function decodeTokenClaims(token: string): Record<string, unknown> {
+  const payload = token.split('.')[1];
+  if (!payload) {
+    throw new Error('Malformed OIDC token: missing payload');
+  }
+  const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    '='
+  );
+  return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
+}
+
+async function requestOptimize(
+  path: string,
+  searchParams: URLSearchParams,
+  options: OptimizeImageOptions,
+  init: { headers?: Record<string, string>; body?: Uint8Array<ArrayBuffer> }
+): Promise<OptimizedImage> {
+  const token = await getVercelOidcToken();
+  const claims = decodeTokenClaims(token);
+  const projectId = claims.project_id;
+  if (typeof projectId !== 'string' || !projectId) {
+    throw new Error('OIDC token is missing the "project_id" claim');
+  }
+
+  searchParams.set('width', String(options.width));
+  searchParams.set('quality', String(options.quality ?? 75));
+  if (options.format) {
+    searchParams.set('format', `image/${options.format}`);
+  }
+
+  const apiUrl = process.env.VERCEL_IMAGE_OPTIMIZATION_API_URL?.length
+    ? process.env.VERCEL_IMAGE_OPTIMIZATION_API_URL
+    : DEFAULT_API_URL;
+  const url = `${apiUrl}/v1/projects/${encodeURIComponent(
+    projectId
+  )}/image-optimization/${path}?${searchParams}`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...init.headers,
+    },
+    body: init.body,
+  });
+
+  if (!res.ok) {
+    throw new ImageOptimizationError(res.status, await res.text());
+  }
+
+  return {
+    data: new Uint8Array(await res.arrayBuffer()),
+    contentType: res.headers.get('content-type') ?? 'application/octet-stream',
+  };
+}
+
+/**
+ * Optimize an image from its raw bytes using Vercel Image Optimization,
+ * without requiring a deployment or the `next/image` configuration.
+ *
+ * Authenticates with the ambient Vercel OIDC token (available in Vercel
+ * Functions automatically, or locally via `vercel env pull`), scoped to the
+ * token's project.
+ *
+ * @example
+ *
+ * ```js
+ * import { optimizeImageFromBytes } from '@vercel/functions';
+ *
+ * const res = await fetch('https://example.com/logo.png');
+ * const { data } = await optimizeImageFromBytes(await res.bytes(), {
+ *   width: 512,
+ *   quality: 75,
+ *   format: 'webp',
+ * });
+ * ```
+ *
+ * @param bytes - The source image bytes (max 5MB).
+ * @param options - Width, quality, and output format.
+ * @returns The optimized image bytes and content type.
+ */
+export async function optimizeImageFromBytes(
+  bytes: Uint8Array | ArrayBuffer,
+  options: OptimizeImageFromBytesOptions
+): Promise<OptimizedImage> {
+  // The cast narrows ArrayBufferLike to ArrayBuffer, which fetch's BodyInit
+  // requires; SharedArrayBuffer-backed views are not supported here.
+  const body =
+    bytes instanceof Uint8Array
+      ? (bytes as Uint8Array<ArrayBuffer>)
+      : new Uint8Array(bytes);
+  const searchParams = new URLSearchParams();
+  if (options.fileName) {
+    searchParams.set('fileName', options.fileName);
+  }
+  return requestOptimize('optimize-from-bytes', searchParams, options, {
+    headers: {
+      'content-type': options.contentType ?? 'application/octet-stream',
+    },
+    body,
+  });
+}
+
+/**
+ * Optimize an image fetched from a URL using Vercel Image Optimization,
+ * without requiring a deployment or the `next/image` configuration.
+ *
+ * The URL is fetched server-side by Vercel; it must be a publicly reachable
+ * `http(s)` URL. Authenticates with the ambient Vercel OIDC token (available
+ * in Vercel Functions automatically, or locally via `vercel env pull`),
+ * scoped to the token's project.
+ *
+ * @example
+ *
+ * ```js
+ * import { optimizeImageFromUrl } from '@vercel/functions';
+ *
+ * const { data } = await optimizeImageFromUrl('https://example.com/logo.png', {
+ *   width: 512,
+ *   quality: 75,
+ *   format: 'webp',
+ * });
+ * ```
+ *
+ * @param url - The URL of the source image to optimize.
+ * @param options - Width, quality, and output format.
+ * @returns The optimized image bytes and content type.
+ */
+export async function optimizeImageFromUrl(
+  url: string,
+  options: OptimizeImageOptions
+): Promise<OptimizedImage> {
+  const searchParams = new URLSearchParams({ url });
+  return requestOptimize('optimize-from-url', searchParams, options, {});
+}

--- a/packages/functions/src/image-optimization/index.ts
+++ b/packages/functions/src/image-optimization/index.ts
@@ -1,4 +1,4 @@
-import { getVercelOidcToken } from '@vercel/oidc';
+import { getTokenPayload, getVercelOidcToken } from '@vercel/oidc';
 
 const DEFAULT_API_URL = 'https://api.vercel.com';
 
@@ -67,19 +67,6 @@ class ImageOptimizationError extends Error {
   }
 }
 
-function decodeTokenClaims(token: string): Record<string, unknown> {
-  const payload = token.split('.')[1];
-  if (!payload) {
-    throw new Error('Malformed OIDC token: missing payload');
-  }
-  const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = normalized.padEnd(
-    normalized.length + ((4 - (normalized.length % 4)) % 4),
-    '='
-  );
-  return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
-}
-
 async function requestOptimize(
   path: string,
   searchParams: URLSearchParams,
@@ -87,9 +74,8 @@ async function requestOptimize(
   init: { headers?: Record<string, string>; body?: Uint8Array<ArrayBuffer> }
 ): Promise<OptimizedImage> {
   const token = await getVercelOidcToken();
-  const claims = decodeTokenClaims(token);
-  const projectId = claims.project_id;
-  if (typeof projectId !== 'string' || !projectId) {
+  const { project_id: projectId } = getTokenPayload(token);
+  if (!projectId) {
     throw new Error('OIDC token is missing the "project_id" claim');
   }
 

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -18,6 +18,16 @@ export {
 export type { PurgeApi, DangerouslyDeleteOptions } from './purge/types';
 export { addCacheTag } from './addcachetag';
 export type { AddCacheTagApi } from './addcachetag/types';
+export {
+  optimizeImageFromBytes,
+  optimizeImageFromUrl,
+} from './image-optimization';
+export type {
+  OptimizeImageOptions,
+  OptimizeImageFromBytesOptions,
+  OptimizeImageFormat,
+  OptimizedImage,
+} from './image-optimization';
 export { experimental_upgradeWebSocket } from './websocket';
 export type { UpgradeWebSocketOptions } from './websocket';
 export type { WebSocket, RawData as WebSocketData } from 'ws';

--- a/packages/functions/test/unit/image-optimization.test.ts
+++ b/packages/functions/test/unit/image-optimization.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  optimizeImageFromBytes,
+  optimizeImageFromUrl,
+} from '../../src/image-optimization';
+
+const makeToken = (claims: Record<string, unknown>) => {
+  const encode = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${encode({ alg: 'none' })}.${encode({
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    ...claims,
+  })}.sig`;
+};
+
+const TOKEN = makeToken({ project_id: 'prj_123', owner_id: 'team_123' });
+
+const OPTIMIZED = new Uint8Array([1, 2, 3, 4]);
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  process.env.VERCEL_OIDC_TOKEN = TOKEN;
+  fetchMock = vi.fn(
+    async () =>
+      new Response(OPTIMIZED, {
+        status: 200,
+        headers: { 'content-type': 'image/webp' },
+      })
+  );
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  delete process.env.VERCEL_OIDC_TOKEN;
+  vi.unstubAllGlobals();
+});
+
+describe('optimizeImageFromBytes', () => {
+  test('sends bytes with OIDC bearer token and query params', async () => {
+    const source = new Uint8Array([9, 9, 9]);
+    const result = await optimizeImageFromBytes(source, {
+      width: 512,
+      quality: 80,
+      format: 'webp',
+      contentType: 'image/png',
+      fileName: 'house.jpg',
+    });
+
+    expect(result.data).toEqual(OPTIMIZED);
+    expect(result.contentType).toBe('image/webp');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(parsed.origin).toBe('https://api.vercel.com');
+    expect(parsed.pathname).toBe(
+      '/v1/projects/prj_123/image-optimization/optimize-from-bytes'
+    );
+    expect(parsed.searchParams.get('width')).toBe('512');
+    expect(parsed.searchParams.get('quality')).toBe('80');
+    expect(parsed.searchParams.get('format')).toBe('image/webp');
+    expect(parsed.searchParams.get('fileName')).toBe('house.jpg');
+    expect(init.method).toBe('POST');
+    expect(init.headers.authorization).toBe(`Bearer ${TOKEN}`);
+    expect(init.headers['content-type']).toBe('image/png');
+    expect(init.body).toEqual(source);
+  });
+
+  test('defaults quality to 75 and omits format when not provided', async () => {
+    await optimizeImageFromBytes(new Uint8Array([1]), { width: 128 });
+    const parsed = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(parsed.searchParams.get('quality')).toBe('75');
+    expect(parsed.searchParams.has('format')).toBe(false);
+    expect(parsed.searchParams.has('fileName')).toBe(false);
+  });
+
+  test('accepts an ArrayBuffer source', async () => {
+    const source = new Uint8Array([7, 8]).buffer;
+    await optimizeImageFromBytes(source, { width: 128 });
+    expect(fetchMock.mock.calls[0][1].body).toEqual(new Uint8Array([7, 8]));
+  });
+
+  test('throws with status and body on upstream error', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('Payload Too Large', { status: 413 })
+    );
+    await expect(
+      optimizeImageFromBytes(new Uint8Array([1]), { width: 128 })
+    ).rejects.toThrow(/413.*Payload Too Large/);
+  });
+
+  test('throws when the token has no project_id claim', async () => {
+    process.env.VERCEL_OIDC_TOKEN = makeToken({ owner_id: 'team_123' });
+    await expect(
+      optimizeImageFromBytes(new Uint8Array([1]), { width: 128 })
+    ).rejects.toThrow(/project_id/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('optimizeImageFromUrl', () => {
+  test('sends the source url as a query param with no body', async () => {
+    const result = await optimizeImageFromUrl(
+      'https://example.com/logo.png?v=2',
+      { width: 512, format: 'avif' }
+    );
+
+    expect(result.data).toEqual(OPTIMIZED);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe(
+      '/v1/projects/prj_123/image-optimization/optimize-from-url'
+    );
+    expect(parsed.searchParams.get('url')).toBe(
+      'https://example.com/logo.png?v=2'
+    );
+    expect(parsed.searchParams.get('format')).toBe('image/avif');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+    expect(init.headers.authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  test('respects VERCEL_IMAGE_OPTIMIZATION_API_URL override', async () => {
+    process.env.VERCEL_IMAGE_OPTIMIZATION_API_URL = 'https://api.example.test';
+    try {
+      await optimizeImageFromUrl('https://example.com/a.png', { width: 64 });
+      const parsed = new URL(String(fetchMock.mock.calls[0][0]));
+      expect(parsed.origin).toBe('https://api.example.test');
+    } finally {
+      delete process.env.VERCEL_IMAGE_OPTIMIZATION_API_URL;
+    }
+  });
+});

--- a/packages/oidc/docs/README.md
+++ b/packages/oidc/docs/README.md
@@ -13,6 +13,7 @@
 
 - [ExchangeVercelOidcTokenOptions](interfaces/ExchangeVercelOidcTokenOptions.md)
 - [GetVercelTokenOptions](interfaces/GetVercelTokenOptions.md)
+- [TokenPayload](interfaces/TokenPayload.md)
 
 ## Type Aliases
 
@@ -22,6 +23,7 @@
 
 - [exchangeVercelOidcToken](functions/exchangeVercelOidcToken.md)
 - [getContext](functions/getContext.md)
+- [getTokenPayload](functions/getTokenPayload.md)
 - [getVercelOidcToken](functions/getVercelOidcToken.md)
 - [~~getVercelOidcTokenSync~~](functions/getVercelOidcTokenSync.md)
 - [getVercelToken](functions/getVercelToken.md)

--- a/packages/oidc/docs/functions/getTokenPayload.md
+++ b/packages/oidc/docs/functions/getTokenPayload.md
@@ -1,0 +1,35 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Function: getTokenPayload()
+
+> **getTokenPayload**(`token`): [`TokenPayload`](../interfaces/TokenPayload.md)
+
+Defined in: packages/oidc/src/token-payload.ts:40
+
+Decodes the payload of a Vercel OIDC token without verifying its
+signature.
+
+Useful for reading the token's own claims (e.g. `project_id`, `exp`)
+before handing the token to an API that verifies it server-side. Do not
+use the returned claims to make trust decisions locally — use
+`verifyVercelOidcToken` for that.
+
+## Parameters
+
+### token
+
+`string`
+
+The OIDC token (a JWT).
+
+## Returns
+
+[`TokenPayload`](../interfaces/TokenPayload.md)
+
+The decoded token payload.
+
+## Throws
+
+If the token is not a well-formed JWT.

--- a/packages/oidc/docs/interfaces/TokenPayload.md
+++ b/packages/oidc/docs/interfaces/TokenPayload.md
@@ -1,0 +1,66 @@
+[**@vercel/oidc**](../README.md)
+
+---
+
+# Interface: TokenPayload
+
+Defined in: packages/oidc/src/token-payload.ts:9
+
+The decoded payload of a Vercel OIDC token.
+
+Note that [getTokenPayload](../functions/getTokenPayload.md) does not verify the token's signature —
+use `verifyVercelOidcToken` when the claims must be trusted locally.
+
+## Properties
+
+### environment?
+
+> `optional` **environment?**: `string`
+
+Defined in: packages/oidc/src/token-payload.ts:24
+
+The deployment environment the token was issued for.
+
+---
+
+### exp
+
+> **exp**: `number`
+
+Defined in: packages/oidc/src/token-payload.ts:12
+
+---
+
+### name
+
+> **name**: `string`
+
+Defined in: packages/oidc/src/token-payload.ts:11
+
+---
+
+### owner_id?
+
+> `optional` **owner_id?**: `string`
+
+Defined in: packages/oidc/src/token-payload.ts:16
+
+The team (owner) the token is scoped to.
+
+---
+
+### project_id?
+
+> `optional` **project_id?**: `string`
+
+Defined in: packages/oidc/src/token-payload.ts:20
+
+The project the token is scoped to.
+
+---
+
+### sub
+
+> **sub**: `string`
+
+Defined in: packages/oidc/src/token-payload.ts:10

--- a/packages/oidc/src/index-browser.ts
+++ b/packages/oidc/src/index-browser.ts
@@ -19,3 +19,6 @@ export function getVercelOidcTokenSync(): string {
 export async function getVercelToken(): Promise<string> {
   throw new Error('getVercelToken is not supported in browser environments');
 }
+
+export { getTokenPayload } from './token-payload';
+export type { TokenPayload } from './token-payload';

--- a/packages/oidc/src/index-edge-light.ts
+++ b/packages/oidc/src/index-edge-light.ts
@@ -42,3 +42,6 @@ export async function getVercelOidcToken(
 export async function getVercelToken(): Promise<string> {
   throw new Error('getVercelToken is not supported in Edge Runtime');
 }
+
+export { getTokenPayload } from './token-payload';
+export type { TokenPayload } from './token-payload';

--- a/packages/oidc/src/index.ts
+++ b/packages/oidc/src/index.ts
@@ -17,3 +17,6 @@ export {
   getVercelToken,
   type GetVercelTokenOptions,
 } from './token-util';
+
+export { getTokenPayload } from './token-payload';
+export type { TokenPayload } from './token-payload';

--- a/packages/oidc/src/token-payload.ts
+++ b/packages/oidc/src/token-payload.ts
@@ -1,0 +1,74 @@
+import { VercelOidcTokenError } from './token-error';
+
+/**
+ * The decoded payload of a Vercel OIDC token.
+ *
+ * Note that {@link getTokenPayload} does not verify the token's signature —
+ * use `verifyVercelOidcToken` when the claims must be trusted locally.
+ */
+export interface TokenPayload {
+  sub: string;
+  name: string;
+  exp: number;
+  /**
+   * The team (owner) the token is scoped to.
+   */
+  owner_id?: string;
+  /**
+   * The project the token is scoped to.
+   */
+  project_id?: string;
+  /**
+   * The deployment environment the token was issued for.
+   */
+  environment?: string;
+}
+
+/**
+ * Decodes the payload of a Vercel OIDC token without verifying its
+ * signature.
+ *
+ * Useful for reading the token's own claims (e.g. `project_id`, `exp`)
+ * before handing the token to an API that verifies it server-side. Do not
+ * use the returned claims to make trust decisions locally — use
+ * `verifyVercelOidcToken` for that.
+ *
+ * @param token - The OIDC token (a JWT).
+ * @returns The decoded token payload.
+ * @throws {VercelOidcTokenError} If the token is not a well-formed JWT.
+ */
+export function getTokenPayload(token: string): TokenPayload {
+  const tokenParts = token.split('.');
+  if (tokenParts.length !== 3) {
+    throw new VercelOidcTokenError('Invalid token.');
+  }
+
+  const base64 = tokenParts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    '='
+  );
+  return JSON.parse(decodeBase64(padded));
+}
+
+/**
+ * Returns whether the token payload is expired.
+ *
+ * @param token - The decoded token payload.
+ * @param bufferMs - Optional buffer in milliseconds before the actual expiry
+ * at which the token is already considered expired.
+ */
+export function isExpired(token: TokenPayload, bufferMs = 0): boolean {
+  return token.exp * 1000 < Date.now() + bufferMs;
+}
+
+function decodeBase64(value: string): string {
+  // Buffer exists in Node.js and Edge Runtime; fall back to atob in
+  // browser-like runtimes.
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value, 'base64').toString('utf8');
+  }
+  const binary = atob(value);
+  const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}

--- a/packages/oidc/src/token-util.ts
+++ b/packages/oidc/src/token-util.ts
@@ -239,26 +239,5 @@ export function loadToken(projectId: string): VercelTokenResponse | null {
   return token;
 }
 
-interface TokenPayload {
-  sub: string;
-  name: string;
-  exp: number;
-}
-
-export function getTokenPayload(token: string): TokenPayload {
-  const tokenParts = token.split('.');
-  if (tokenParts.length !== 3) {
-    throw new VercelOidcTokenError('Invalid token.');
-  }
-
-  const base64 = tokenParts[1].replace(/-/g, '+').replace(/_/g, '/');
-  const padded = base64.padEnd(
-    base64.length + ((4 - (base64.length % 4)) % 4),
-    '='
-  );
-  return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
-}
-
-export function isExpired(token: TokenPayload, bufferMs = 0): boolean {
-  return token.exp * 1000 < Date.now() + bufferMs;
-}
+export { getTokenPayload, isExpired } from './token-payload';
+export type { TokenPayload } from './token-payload';


### PR DESCRIPTION
## Why

Unlock agentic image optimization for code that isn't tied to a deployment's `next/image` config (AI Gateway outputs, blob workflows, functions optimizing arbitrary images). This is the Functions milestone of the standalone image-optimization API design:

```ts
import { optimizeImageFromBytes, optimizeImageFromUrl } from '@vercel/functions';

const { data } = await optimizeImageFromBytes(bytes, { width: 512, quality: 75, format: 'webp' });
const { data } = await optimizeImageFromUrl('https://me.com/logo.png', { width: 512, format: 'webp' });
```

- Calls `POST api.vercel.com/v1/projects/:id/image-optimization/optimize-from-{bytes,url}` authenticated with the ambient **Vercel OIDC token** via `@vercel/oidc` — zero configuration; the target project comes from the token's `project_id` claim, and the API enforces the token↔project binding server-side.
- Because `@vercel/oidc` also resolves tokens outside Vercel workloads (`vercel env pull`, CLI-based refresh), these methods work locally and in CI, not just inside functions.
- `optimizeImageFromBytes` supports optional `contentType` and `fileName` (forwarded for usage-fact attribution); bytes capped at 5MB by the API.

## Dependencies / rollout

The API endpoints are private, gated by the `enable-image-optimization-api` flag, and roll out via vercel/api#82465 (URL mode) → vercel/proxy#22438 (bytes upstream) → vercel/api#82432 (bytes mode). This SDK change is safe to land independently — calls simply 404 until a team is flag-enabled.

## Validation

- 7 unit tests covering query/header/body shaping for both methods, OIDC bearer forwarding, quality default, ArrayBuffer input, missing `project_id` claim, upstream error surfacing, and the API URL override used for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)