### PR TITLE
Trigger binary builds

### DIFF
--- a/.changeset/bright-hounds-repair.md
+++ b/.changeset/bright-hounds-repair.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Support binary versions, gated behind an opt-in flag (`vc upgrade --binary`)


### PR DESCRIPTION
The new release flow should now build the binaries before releasing, this PR should trigger the behavior.