### PR TITLE
[vercel] Stream logs --follow from project request logs

### DIFF
--- a/.changeset/logs-follow-request-logs.md
+++ b/.changeset/logs-follow-request-logs.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Stream `vercel logs --follow` from project request logs so live follow works across deployments with `--environment`, `--branch`, and `--no-branch`. Follow `--json` now emits typed `request_started` / `log` / `request_finished` events instead of raw runtime-log rows.

--- a/packages/cli/docs/logs-follow-request-logs.md
+++ b/packages/cli/docs/logs-follow-request-logs.md
@@ -1,0 +1,104 @@
+# Implementation Plan: `vc logs --follow` via request-logs
+
+## Goal
+
+Drop the single-deployment requirement for `vercel logs --follow` so users can stream live request logs across a project with the same filters as historical logs:
+
+```bash
+vercel logs --follow --environment preview
+vercel logs --follow --no-branch
+vercel logs --follow --branch feature-x
+vercel logs --follow --deployment dpl_xxx   # still supported
+```
+
+## Locked decisions
+
+1. **Backend:** `--follow` always polls `GET https://vercel.com/api/logs/request-logs` (live mode). It does **not** use `/runtime-logs`.
+2. **Poll interval:** 2 seconds (dashboard live default).
+3. **CLI-only for v1:** No `api` / `front` changes required. ClickHouse and request-logs already treat `deploymentId` as optional; live mode is `endDate` omitted.
+4. **Human output:** Append-only lifecycle with `[id]` prefixes (last 4 of `requestId`, lengthened on collision):
+   - `Request started` (full method/path/host details; status `---` until finished)
+   - Log blocks (summary + separator + message)
+   - `Request finished (Nms)` with final status
+   - No “waiting for response” lines
+5. **`--json` (follow only):** Typed NDJSON event stream (`request_started` / `log` / `request_finished`). Historical non-follow `--json` stays as one `RequestLogEntry` per request.
+
+## Behavior matrix
+
+| Invocation | Scope |
+|---|---|
+| `vc logs --follow` | Linked project; auto branch filter when in a git repo |
+| `vc logs --follow --no-branch` | Linked project; all branches |
+| `vc logs --follow --environment preview` | All matching preview requests |
+| `vc logs --follow --branch X` | Requests on branch X |
+| `vc logs --follow dpl_…` / URL | Single deployment via `deploymentId` filter |
+| `vc logs` (no `--follow`) | Historical request-logs (unchanged) |
+
+Incompatible with `--follow` (unchanged): `--level`, `--status-code`, `--source`, `--since`, `--until`, `--limit`, `--query`, `--search`, `--request-id`.
+
+## Architecture
+
+```
+logs/index.ts
+  └─ followRequestLogs (util/logs-follow.ts)
+       └─ fetchRequestLogs (util/logs-v2.ts)  // live: true → omit endDate
+            └─ GET /api/logs/request-logs
+```
+
+### Poller (`logs-follow.ts`)
+
+- Lookback: 10s on start; cursor advances with 5s overlap so late-settling rows are not missed.
+- State machine (`processFollowRows`): per-`requestId` track emitted log count + finished flag.
+- Settled = `requestDurationMs` is present (incomplete live rows omit it / use `-1` upstream).
+- Human/JSON formatters share the same event objects.
+
+### Client (`logs-v2.ts`)
+
+- Map `requestDurationMs` and `eventsCount`.
+- Support absolute `startDate` / `endDate`.
+- `live: true` omits `endDate` so the API includes in-progress requests.
+
+## Output contracts
+
+### Human (follow)
+
+```text
+[a1b2] 15:42:05.02  ℹ️  POST  ---  host  ƒ  /api/checkout  Request started
+[a1b2] 15:42:05.10  ℹ️  POST  ---  host  ƒ  /api/checkout
+[a1b2] --------------------------------------------------------------------------------
+[a1b2] creating payment intent
+[a1b2] 15:42:05.91  🚫  POST  402  host  ƒ  /api/checkout  Request finished (890ms)
+```
+
+### JSON (follow)
+
+```json
+{"type":"request_started","requestId":"…","deploymentId":"…","projectId":"…","environment":"preview",…}
+{"type":"log","requestId":"…","message":"…",…}
+{"type":"request_finished","requestId":"…","responseStatusCode":402,"durationMs":890,…}
+```
+
+**Breaking:** previous `--follow --json` passed through raw `RuntimeLog` rows. Consumers must switch to the typed lifecycle events.
+
+## Implementation steps
+
+1. Extend `logs-v2` with duration/live fields.
+2. Add `logs-follow` poller + formatters + unit tests.
+3. Wire `logs/index.ts` follow path; update help/examples.
+4. Rewrite command tests off `/runtime-logs` / deployment resolution.
+5. Ship this plan doc + changeset.
+
+## Risks
+
+- **Breaking `--follow --json` shape** — intentional; document in changeset.
+- **Polling cost** — 2s cadence matches dashboard; still N requests while the command runs.
+- **Prefix collisions** — mitigated by lengthening the `[id]` suffix.
+- **Incomplete rows** — rely on live mode + duration settle signal; overlap window covers late updates.
+
+## Success criteria
+
+- `vc logs --follow --environment preview` and `--no-branch` stream without picking a single deployment.
+- Deployment URL/ID + `--follow` still works via `deploymentId` filter.
+- Human output shows started / log / finished lifecycle with request prefixes.
+- `--follow --json` emits typed events; historical `--json` unchanged.
+- Unit tests cover poller state machine and command wiring.

--- a/packages/cli/src/commands/logs/command.ts
+++ b/packages/cli/src/commands/logs/command.ts
@@ -10,7 +10,7 @@ export const logsCommand = {
   aliases: ['log'],
   description:
     'Display request logs for a project.\n\n' +
-    'With --follow, stream live runtime logs from a deployment. When no deployment is specified, resolves in order: latest deployment on the current git branch, then your latest deployment, then the latest production deployment. Use --environment production to always stream the latest production deployment.\n\n' +
+    'With --follow, stream live request logs for the project using the same filters as historical logs (deployment, environment, branch). When no deployment is specified, follows matching requests across deployments. Use --environment, --branch, or --no-branch to narrow the stream.\n\n' +
     'Source types: λ = serverless, ε = edge/middleware, ◇ = static/external',
   arguments: [
     {
@@ -34,7 +34,7 @@ export const logsCommand = {
       type: String,
       deprecated: false,
       description:
-        'Filter by environment: production or preview. With --follow, selects which environment to stream (production always streams the latest production deployment)',
+        'Filter by environment: production or preview. With --follow, streams matching requests in that environment',
     },
     {
       name: 'level',
@@ -92,7 +92,7 @@ export const logsCommand = {
       type: Boolean,
       deprecated: false,
       description:
-        'Stream live runtime logs. Without a deployment, follows the latest deployment on the current git branch, then your latest deployment, then the latest production deployment',
+        'Stream live request logs. Uses the same deployment/environment/branch filters as historical logs; without a deployment, follows matching project requests',
     },
     {
       name: 'no-follow',
@@ -151,12 +151,20 @@ export const logsCommand = {
   ],
   examples: [
     {
-      name: 'Stream live logs for your most recent deployment',
+      name: 'Stream live request logs for the linked project',
       value: `${packageName} logs --follow`,
     },
     {
-      name: 'Stream live logs for the latest production deployment',
-      value: `${packageName} logs --follow --environment production`,
+      name: 'Stream live preview request logs across deployments',
+      value: `${packageName} logs --follow --environment preview`,
+    },
+    {
+      name: 'Stream live request logs for all branches',
+      value: `${packageName} logs --follow --no-branch`,
+    },
+    {
+      name: 'Stream live request logs as JSON Lines',
+      value: `${packageName} logs --follow --json`,
     },
     {
       name: 'Stream live logs for a deployment URL',

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -16,28 +16,18 @@ import {
   InvalidDeploymentId,
   ProjectNotFound,
 } from '../../util/errors-ts';
-import { displayRuntimeLogs } from '../../util/logs';
+import { followRequestLogs } from '../../util/logs-follow';
 import {
   fetchAllRequestLogs,
   type RequestLogEntry,
   type RequestLogMessage,
 } from '../../util/logs-v2';
 import getDeployment from '../../util/get-deployment';
-import getUser from '../../util/get-user';
 import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
 import { LogsTelemetryClient } from '../../util/telemetry/commands/logs';
 import { help } from '../help';
 import { logsCommand } from './command';
 import output from '../../output-manager';
-
-interface LatestDeployment {
-  id: string;
-  url: string;
-}
-
-interface DeploymentResponse {
-  deployments: Array<{ uid: string; url: string }>;
-}
 
 type LogsTargetSource = 'deployment' | 'explicit-project' | 'linked-project';
 
@@ -57,39 +47,6 @@ interface ResolveLogsTargetOptions {
 }
 
 type ResolveLogsTargetResult = LogsTarget | { exitCode: number };
-
-async function getLatestDeployment(
-  client: Client,
-  projectId: string,
-  filters: { branch?: string; userId?: string; target?: string } = {}
-): Promise<LatestDeployment | null> {
-  const query = new URLSearchParams();
-  query.set('projectId', projectId);
-  query.set('limit', '1');
-  query.set('state', 'READY');
-  if (filters.branch) {
-    query.set('branch', filters.branch);
-  }
-  if (filters.userId) {
-    query.set('users', filters.userId);
-  }
-  if (filters.target) {
-    query.set('target', filters.target);
-  }
-
-  const { deployments } = await client.fetch<DeploymentResponse>(
-    `/v6/deployments?${query}`
-  );
-
-  if (deployments.length === 0) {
-    return null;
-  }
-
-  return {
-    id: deployments[0].uid,
-    url: deployments[0].url,
-  };
-}
 
 interface ResolveBranchFilterOptions {
   client: Client;
@@ -125,122 +82,6 @@ async function resolveBranchFilter({
   } catch {
     // Not in a git repo or git not available, continue without branch filter
   }
-}
-
-interface ResolveFollowDeploymentOptions {
-  branch?: string;
-  client: Client;
-  environment?: string;
-  logsTarget: LogsTarget;
-}
-
-type ResolveFollowDeploymentResult =
-  | { deploymentId: string; label: string }
-  | { exitCode: number };
-
-async function resolveFollowDeployment({
-  branch,
-  client,
-  environment,
-  logsTarget,
-}: ResolveFollowDeploymentOptions): Promise<ResolveFollowDeploymentResult> {
-  const { deployment, orgSlug, projectId, projectSlug } = logsTarget;
-
-  if (deployment?.id) {
-    return { deploymentId: deployment.id, label: 'deployment' };
-  }
-
-  if (environment === 'production') {
-    output.spinner('Finding latest production deployment', 1000);
-    const productionDeployment = await getLatestDeployment(client, projectId, {
-      target: 'production',
-    });
-    output.stopSpinner();
-
-    if (!productionDeployment) {
-      output.error(
-        `No READY production deployments found for ${formatProject(orgSlug, projectSlug)}. Deploy to production first or specify a deployment with ${chalk.bold('--deployment')}.`
-      );
-      return { exitCode: 1 };
-    }
-
-    output.debug(
-      `Found latest production deployment ${productionDeployment.id} (${productionDeployment.url})`
-    );
-    return {
-      deploymentId: productionDeployment.id,
-      label: 'latest production deployment',
-    };
-  }
-
-  const target = environment;
-
-  if (branch) {
-    output.spinner(`Finding latest deployment for branch "${branch}"`, 1000);
-    const branchDeployment = await getLatestDeployment(client, projectId, {
-      branch,
-      target,
-    });
-    output.stopSpinner();
-
-    if (branchDeployment) {
-      output.debug(
-        `Found deployment ${branchDeployment.id} for branch ${branch}`
-      );
-      return {
-        deploymentId: branchDeployment.id,
-        label: `latest deployment on branch "${branch}"`,
-      };
-    }
-
-    output.debug(`No deployments found for branch "${branch}"`);
-  }
-
-  const user = await getUser(client);
-  output.spinner('Finding your latest deployment', 1000);
-  const userDeployment = await getLatestDeployment(client, projectId, {
-    userId: user.id,
-    target,
-  });
-  output.stopSpinner();
-
-  if (userDeployment) {
-    output.debug(
-      `Found latest deployment ${userDeployment.id} (${userDeployment.url}) created by current user`
-    );
-    return {
-      deploymentId: userDeployment.id,
-      label: 'your latest deployment',
-    };
-  }
-
-  if (environment === 'preview') {
-    output.error(
-      `No READY preview deployments found for ${formatProject(orgSlug, projectSlug)}. Deploy a preview first or specify a deployment with ${chalk.bold('--deployment')}.`
-    );
-    return { exitCode: 1 };
-  }
-
-  output.spinner('Finding latest production deployment', 1000);
-  const productionDeployment = await getLatestDeployment(client, projectId, {
-    target: 'production',
-  });
-  output.stopSpinner();
-
-  if (!productionDeployment) {
-    output.error(
-      `No READY deployments found for ${formatProject(orgSlug, projectSlug)}. Deploy first or specify a deployment with ${chalk.bold('--deployment')}.`
-    );
-    return { exitCode: 1 };
-  }
-
-  output.debug(
-    `Found latest production deployment ${productionDeployment.id} (${productionDeployment.url})`
-  );
-  return {
-    deploymentId: productionDeployment.id,
-    label: 'latest production deployment',
-  };
 }
 
 const TIME_ONLY_FORMAT = 'HH:mm:ss.SS';
@@ -705,31 +546,18 @@ export default async function logs(client: Client) {
   }
 
   if (followOption) {
-    const followDeployment = await resolveFollowDeployment({
-      branch: branchOption,
-      client,
-      environment: environmentOption,
-      logsTarget,
-    });
-    if ('exitCode' in followDeployment) {
-      return followDeployment.exitCode;
-    }
-
-    if (!jsonOption) {
-      output.print(
-        `Streaming logs for ${followDeployment.label} ${chalk.bold(followDeployment.deploymentId)} starting from ${chalk.bold(format(Date.now(), TIME_ONLY_FORMAT))}\n\n`
-      );
-    }
     const abortController = new AbortController();
-    return await displayRuntimeLogs(
-      client,
-      {
-        deploymentId: followDeployment.deploymentId,
-        projectId,
-        parse: !jsonOption,
-      },
-      abortController
-    );
+    return await followRequestLogs(client, {
+      projectId,
+      projectSlug,
+      orgSlug,
+      ownerId,
+      deploymentId,
+      environment: environmentOption,
+      branch: branchOption,
+      json: jsonOption,
+      abortController,
+    });
   }
 
   const validLevels = ['error', 'warning', 'info', 'fatal'];

--- a/packages/cli/src/util/logs-follow.ts
+++ b/packages/cli/src/util/logs-follow.ts
@@ -1,0 +1,490 @@
+import chalk from 'chalk';
+import format from 'date-fns/format';
+import ms from 'ms';
+import { setTimeout as delay } from 'node:timers/promises';
+import type Client from './client';
+import { CommandTimeout } from '../commands/logs/command';
+import { formatProject } from './projects/format-project';
+import output from '../output-manager';
+import {
+  fetchRequestLogs,
+  type RequestLogEntry,
+} from './logs-v2';
+
+export const FOLLOW_POLL_INTERVAL_MS = 2000;
+export const FOLLOW_LOOKBACK_MS = 10_000;
+export const FOLLOW_OVERLAP_MS = 5_000;
+
+const DATE_TIME_FORMAT = 'HH:mm:ss.SS';
+const moreSymbol = '\u2026';
+const statusWidth = 3;
+const followSpinnerMessage = 'waiting for new logs...';
+
+export type FollowEventType =
+  | 'request_started'
+  | 'log'
+  | 'request_finished';
+
+export interface FollowEventBase {
+  type: FollowEventType;
+  timestamp: number;
+  requestId: string;
+  deploymentId: string;
+  projectId: string;
+  environment: 'production' | 'preview';
+  branch?: string;
+  domain: string;
+  requestMethod: string;
+  requestPath: string;
+  source: RequestLogEntry['source'];
+  level: RequestLogEntry['level'];
+  responseStatusCode: number | null;
+}
+
+export interface FollowRequestStartedEvent extends FollowEventBase {
+  type: 'request_started';
+}
+
+export interface FollowLogEvent extends FollowEventBase {
+  type: 'log';
+  message: string;
+  messageTruncated?: boolean;
+}
+
+export interface FollowRequestFinishedEvent extends FollowEventBase {
+  type: 'request_finished';
+  responseStatusCode: number | null;
+  durationMs?: number;
+}
+
+export type FollowEvent =
+  | FollowRequestStartedEvent
+  | FollowLogEvent
+  | FollowRequestFinishedEvent;
+
+interface RequestFollowState {
+  logsEmitted: number;
+  finished: boolean;
+  prefix: string;
+}
+
+export interface FollowRequestLogsOptions {
+  projectId: string;
+  projectSlug: string;
+  orgSlug: string;
+  ownerId: string;
+  deploymentId?: string;
+  environment?: string;
+  branch?: string;
+  json?: boolean;
+  abortController: AbortController;
+  pollIntervalMs?: number;
+  lookbackMs?: number;
+  overlapMs?: number;
+  now?: () => number;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  fetchLogs?: typeof fetchRequestLogs;
+  /** Test helper: stop after N successful polls. */
+  maxPolls?: number;
+}
+
+function isSettled(row: RequestLogEntry): boolean {
+  // Incomplete live rows use requestDurationMs = -1 upstream, which maps to undefined.
+  return typeof row.requestDurationMs === 'number';
+}
+
+function statusOrNull(statusCode: number): number | null {
+  return statusCode > 0 ? statusCode : null;
+}
+
+function levelFromStatus(
+  statusCode: number | null,
+  fallback: RequestLogEntry['level']
+): RequestLogEntry['level'] {
+  if (statusCode !== null && statusCode >= 500) return 'error';
+  if (statusCode !== null && statusCode >= 400) return 'warning';
+  return fallback;
+}
+
+function baseFromRow(
+  row: RequestLogEntry,
+  overrides: Partial<FollowEventBase> = {}
+): Omit<FollowEventBase, 'type'> {
+  const responseStatusCode =
+    overrides.responseStatusCode !== undefined
+      ? overrides.responseStatusCode
+      : statusOrNull(row.responseStatusCode);
+  return {
+    timestamp: overrides.timestamp ?? row.timestamp,
+    requestId: row.id,
+    deploymentId: row.deploymentId,
+    projectId: row.projectId,
+    environment: row.environment,
+    branch: row.branch,
+    domain: row.domain,
+    requestMethod: row.requestMethod,
+    requestPath: row.requestPath,
+    source: row.source,
+    level:
+      overrides.level ??
+      levelFromStatus(responseStatusCode, row.level || 'info'),
+    responseStatusCode,
+  };
+}
+
+function shortPrefix(requestId: string, length = 4): string {
+  if (!requestId) return '????';
+  const cleaned = requestId.replace(/[^a-zA-Z0-9]/g, '');
+  if (cleaned.length <= length) return cleaned.padStart(length, '0');
+  return cleaned.slice(-length);
+}
+
+export function assignRequestPrefix(
+  requestId: string,
+  activePrefixes: Map<string, string>
+): string {
+  let length = 4;
+  while (length <= Math.max(4, requestId.length)) {
+    const candidate = shortPrefix(requestId, length);
+    const owner = [...activePrefixes.entries()].find(
+      ([id, prefix]) => id !== requestId && prefix === candidate
+    );
+    if (!owner) {
+      activePrefixes.set(requestId, candidate);
+      return candidate;
+    }
+    length += 1;
+  }
+  const fallback = requestId.slice(-8) || 'unknown';
+  activePrefixes.set(requestId, fallback);
+  return fallback;
+}
+
+/**
+ * Diff incoming request-log rows against prior follow state and emit events.
+ * Pure/testable core of the follow poller.
+ */
+export function processFollowRows(
+  rows: RequestLogEntry[],
+  state: Map<string, RequestFollowState>,
+  activePrefixes: Map<string, string>
+): FollowEvent[] {
+  const events: FollowEvent[] = [];
+  const sorted = [...rows].sort((a, b) => {
+    if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp;
+    return a.id.localeCompare(b.id);
+  });
+
+  for (const row of sorted) {
+    if (!row.id) continue;
+
+    let entry = state.get(row.id);
+    if (!entry) {
+      const prefix = assignRequestPrefix(row.id, activePrefixes);
+      entry = { logsEmitted: 0, finished: false, prefix };
+      state.set(row.id, entry);
+      events.push({
+        type: 'request_started',
+        ...baseFromRow(row),
+      });
+    }
+
+    const newLogs = row.logs.slice(entry.logsEmitted);
+    for (const log of newLogs) {
+      events.push({
+        type: 'log',
+        ...baseFromRow(row, {
+          level: (log.level as RequestLogEntry['level']) || row.level || 'info',
+          // Log lines keep --- until the finished event carries the final status.
+          responseStatusCode: entry.finished
+            ? statusOrNull(row.responseStatusCode)
+            : null,
+        }),
+        message: log.message,
+        messageTruncated: log.messageTruncated,
+      });
+    }
+    entry.logsEmitted = row.logs.length;
+
+    if (!entry.finished && isSettled(row)) {
+      entry.finished = true;
+      const responseStatusCode = statusOrNull(row.responseStatusCode);
+      events.push({
+        type: 'request_finished',
+        ...baseFromRow(row, {
+          responseStatusCode,
+          level: levelFromStatus(responseStatusCode, row.level || 'info'),
+        }),
+        durationMs: row.requestDurationMs,
+      });
+      activePrefixes.delete(row.id);
+    }
+  }
+
+  return events;
+}
+
+function getLevelIcon(level: string) {
+  return level === 'error' || level === 'fatal'
+    ? '🚫'
+    : level === 'warning'
+      ? '⚠️'
+      : 'ℹ️';
+}
+
+function getSourceIcon(source: string) {
+  if (source === 'edge-function') return 'ന';
+  if (source === 'edge-middleware') return 'ɛ';
+  if (source === 'serverless') return 'ƒ';
+  if (source === 'static') return '◇';
+  return ' ';
+}
+
+function formatStatus(status: number | null): string {
+  return status === null || status <= 0 ? '---' : String(status);
+}
+
+function formatSummaryLine(
+  event: FollowEventBase,
+  suffix?: string
+): {
+  detailsLine: string;
+  separator: string;
+} {
+  const date = format(event.timestamp, DATE_TIME_FORMAT);
+  const levelIcon = getLevelIcon(event.level);
+  const sourceIcon = getSourceIcon(event.source);
+  const status = formatStatus(event.responseStatusCode);
+  const suffixPart = suffix ? `  ${suffix}` : '';
+  const detailsLine = `${chalk.dim(date)}  ${levelIcon}  ${chalk.bold(
+    event.requestMethod || '—'
+  )}  ${chalk.grey(status)}  ${chalk.dim(
+    event.domain || ''
+  )}  ${sourceIcon}  ${event.requestPath || ''}${suffixPart}`;
+  const separator = '-'.repeat(
+    [
+      date.length,
+      levelIcon.length,
+      (event.requestMethod || '—').length,
+      statusWidth,
+      (event.domain || '').length,
+      sourceIcon.length,
+      (event.requestPath || '').length,
+    ].reduce((sum, length) => sum + 2 + length)
+  );
+  return { detailsLine, separator };
+}
+
+export function getFollowPrefix(
+  requestId: string,
+  state: Map<string, RequestFollowState>,
+  activePrefixes: Map<string, string>
+): string {
+  return (
+    state.get(requestId)?.prefix ??
+    activePrefixes.get(requestId) ??
+    shortPrefix(requestId)
+  );
+}
+
+export function formatFollowHuman(
+  event: FollowEvent,
+  prefix: string
+): string {
+  const tag = `[${prefix}]`;
+  if (event.type === 'request_started') {
+    const { detailsLine } = formatSummaryLine(event, 'Request started');
+    return `${tag} ${detailsLine}\n`;
+  }
+
+  if (event.type === 'request_finished') {
+    const duration =
+      typeof event.durationMs === 'number' ? ` (${event.durationMs}ms)` : '';
+    const { detailsLine } = formatSummaryLine(
+      event,
+      `Request finished${duration}`
+    );
+    return `${tag} ${detailsLine}\n`;
+  }
+
+  const { detailsLine, separator } = formatSummaryLine(event);
+  const message = `${event.message.replace(/\n$/, '')}${
+    event.messageTruncated ? moreSymbol : ''
+  }`;
+  return `${tag} ${detailsLine}\n${tag} ${separator}\n${tag} ${message}\n\n`;
+}
+
+export function formatFollowJson(event: FollowEvent): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    type: event.type,
+    timestamp: event.timestamp,
+    requestId: event.requestId,
+    deploymentId: event.deploymentId,
+    projectId: event.projectId,
+    environment: event.environment,
+    branch: event.branch,
+    domain: event.domain,
+    requestMethod: event.requestMethod,
+    requestPath: event.requestPath,
+    source: event.source,
+    level: event.level,
+    responseStatusCode: event.responseStatusCode,
+  };
+
+  if (event.type === 'log') {
+    base.message = event.message;
+    base.messageTruncated = event.messageTruncated ?? false;
+  }
+
+  if (event.type === 'request_finished') {
+    if (typeof event.durationMs === 'number') {
+      base.durationMs = event.durationMs;
+    }
+  }
+
+  return base;
+}
+
+function buildScopeLabel(options: {
+  environment?: string;
+  branch?: string;
+  deploymentId?: string;
+}): string {
+  const parts: string[] = [];
+  if (options.deploymentId) {
+    parts.push(`deployment ${options.deploymentId}`);
+  }
+  if (options.environment) {
+    parts.push(options.environment);
+  }
+  if (options.branch) {
+    parts.push(`branch ${options.branch}`);
+  } else if (!options.deploymentId) {
+    parts.push('all branches');
+  }
+  return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+}
+
+async function defaultSleep(msValue: number, signal?: AbortSignal) {
+  await delay(msValue, undefined, { signal }).catch((err: unknown) => {
+    if (signal?.aborted) return;
+    throw err;
+  });
+}
+
+export async function followRequestLogs(
+  client: Client,
+  options: FollowRequestLogsOptions
+): Promise<number> {
+  const {
+    projectId,
+    projectSlug,
+    orgSlug,
+    ownerId,
+    deploymentId,
+    environment,
+    branch,
+    json = false,
+    abortController,
+    pollIntervalMs = FOLLOW_POLL_INTERVAL_MS,
+    lookbackMs = FOLLOW_LOOKBACK_MS,
+    overlapMs = FOLLOW_OVERLAP_MS,
+    now = Date.now,
+    sleep = defaultSleep,
+    fetchLogs = fetchRequestLogs,
+    maxPolls,
+  } = options;
+
+  const { print, spinner, stopSpinner, warn, debug } = output;
+  const state = new Map<string, RequestFollowState>();
+  const activePrefixes = new Map<string, string>();
+
+  let cursor = now() - lookbackMs;
+  const startedAt = now();
+  let polls = 0;
+
+  if (!json) {
+    print(
+      `Streaming request logs for ${formatProject(orgSlug, projectSlug)}${buildScopeLabel(
+        { environment, branch, deploymentId }
+      )} starting from ${chalk.bold(format(startedAt, DATE_TIME_FORMAT))}\n\n`
+    );
+  }
+
+  const timeout = setTimeout(() => {
+    abortController.abort();
+    warn(
+      `${chalk.bold(
+        `Command automatically interrupted after ${CommandTimeout}.`
+      )}\n`
+    );
+  }, ms(CommandTimeout));
+
+  const emit = (event: FollowEvent) => {
+    const prefix = getFollowPrefix(event.requestId, state, activePrefixes);
+    if (json) {
+      client.stdout.write(`${JSON.stringify(formatFollowJson(event))}\n`);
+    } else {
+      print(formatFollowHuman(event, prefix));
+    }
+  };
+
+  try {
+    while (!abortController.signal.aborted) {
+      if (!json) {
+        spinner(followSpinnerMessage);
+      }
+
+      const tickNow = now();
+      let rows: RequestLogEntry[] = [];
+      try {
+        const response = await fetchLogs(client, {
+          projectId,
+          ownerId,
+          deploymentId,
+          environment,
+          branch,
+          startDate: cursor,
+          live: true,
+          // Follow polls the latest window only; one page is enough.
+          page: 0,
+        });
+        rows = response.logs;
+      } catch (err) {
+        if (abortController.signal.aborted) break;
+        stopSpinner();
+        const message = err instanceof Error ? err.message : String(err);
+        debug(`Request logs follow poll error: ${message}`);
+        await sleep(pollIntervalMs, abortController.signal);
+        continue;
+      }
+
+      stopSpinner();
+
+      const events = processFollowRows(rows, state, activePrefixes);
+      for (const event of events) {
+        emit(event);
+      }
+
+      if (rows.length > 0) {
+        const latest = Math.max(...rows.map(row => row.timestamp));
+        cursor = Math.max(cursor, latest - overlapMs);
+      } else {
+        // Keep a small lookback so late-arriving incomplete rows can settle.
+        cursor = Math.max(cursor, tickNow - overlapMs);
+      }
+
+      polls += 1;
+      if (typeof maxPolls === 'number' && polls >= maxPolls) {
+        break;
+      }
+
+      await sleep(pollIntervalMs, abortController.signal);
+    }
+  } finally {
+    clearTimeout(timeout);
+    stopSpinner();
+  }
+
+  return abortController.signal.aborted ? 1 : 0;
+}

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -27,6 +27,9 @@ export interface RequestLogEntry {
   traceId?: string;
   messageTruncated?: boolean;
   logs: RequestLogMessage[];
+  eventsCount: number;
+  /** Present when the request has settled (incomplete live rows omit this). */
+  requestDurationMs?: number;
 }
 
 export interface RequestLogsResponse {
@@ -47,6 +50,15 @@ export interface FetchRequestLogsOptions {
   source?: string[];
   since?: string;
   until?: string;
+  /** Absolute start time in ms. Takes precedence over `since`. */
+  startDate?: number;
+  /** Absolute end time in ms. Takes precedence over `until`. */
+  endDate?: number;
+  /**
+   * When true, omit `endDate` so the request-logs API runs in live mode
+   * (includes in-progress requests). Takes precedence over `endDate`/`until`.
+   */
+  live?: boolean;
   limit?: number;
   search?: string;
   requestId?: string;
@@ -119,6 +131,9 @@ export async function fetchRequestLogs(
     source,
     since,
     until,
+    startDate,
+    endDate,
+    live,
     search,
     requestId,
     branch,
@@ -134,9 +149,17 @@ export async function fetchRequestLogs(
   query.set('page', String(page));
   query.set(
     'startDate',
-    String(since ? parseRelativeTime(since) : defaultStartDate)
+    String(
+      startDate ?? (since ? parseRelativeTime(since) : defaultStartDate)
+    )
   );
-  query.set('endDate', String(until ? parseRelativeTime(until) : now));
+  // Omit endDate for live mode so the API includes in-progress requests.
+  if (!live) {
+    query.set(
+      'endDate',
+      String(endDate ?? (until ? parseRelativeTime(until) : now))
+    );
+  }
 
   if (deploymentId) {
     query.set('deploymentId', deploymentId);
@@ -192,6 +215,7 @@ export async function fetchRequestLogs(
     cacheReason?: string;
     pprState?: string;
     traceId?: string;
+    requestDurationMs?: number;
     logs?: Array<{
       level?: string;
       message?: string;
@@ -214,6 +238,7 @@ export async function fetchRequestLogs(
     }));
     const displayLog = getDisplayLog(requestLogs, options.level);
     const firstEvent = row.events?.[0];
+    const statusCode = row.statusCode ?? 0;
     return {
       id: row.requestId || '',
       timestamp: row.timestamp ? new Date(row.timestamp).getTime() : Date.now(),
@@ -226,7 +251,7 @@ export async function fetchRequestLogs(
       domain: row.domain || '',
       requestMethod: row.requestMethod || '',
       requestPath: row.requestPath || '',
-      responseStatusCode: row.statusCode || 0,
+      responseStatusCode: statusCode,
       environment:
         (row.environment as RequestLogEntry['environment']) || 'production',
       branch: row.branch,
@@ -235,6 +260,11 @@ export async function fetchRequestLogs(
       pprState: row.pprState,
       traceId: row.traceId,
       logs: requestLogs,
+      eventsCount: row.events?.length ?? 0,
+      requestDurationMs:
+        typeof row.requestDurationMs === 'number' && row.requestDurationMs >= 0
+          ? row.requestDurationMs
+          : undefined,
     };
   });
 

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -3,9 +3,30 @@ import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useTeam, useTeams } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
-import { useDeployment, useRuntimeLogs } from '../../../mocks/deployment';
+import { useDeployment } from '../../../mocks/deployment';
 import logs from '../../../../src/commands/logs';
 import { join } from 'path';
+import * as logsFollow from '../../../../src/util/logs-follow';
+
+vi.mock('../../../../src/util/logs-follow', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../../src/util/logs-follow')>();
+  return {
+    ...actual,
+    followRequestLogs: vi.fn(
+      (
+        followClient: Parameters<typeof actual.followRequestLogs>[0],
+        opts: Parameters<typeof actual.followRequestLogs>[1]
+      ) =>
+        actual.followRequestLogs(followClient, {
+          ...opts,
+          maxPolls: 1,
+          pollIntervalMs: 0,
+          sleep: async () => {},
+        })
+    ),
+  };
+});
 
 const logsFixturesDir = join(__dirname, '../../../fixtures/unit/commands/logs');
 
@@ -50,6 +71,7 @@ interface ApiLogEntry {
   statusCode?: number;
   environment?: string;
   domain?: string;
+  requestDurationMs?: number;
   logs?: Array<{
     level?: string;
     message?: string;
@@ -67,6 +89,7 @@ function createMockLog(
     environment?: string;
     deploymentId?: string;
     responseStatusCode?: number;
+    requestDurationMs?: number;
   } = {}
 ): ApiLogEntry {
   return {
@@ -78,6 +101,7 @@ function createMockLog(
     statusCode: overrides.responseStatusCode ?? 200,
     environment: overrides.environment ?? 'production',
     domain: 'test.vercel.app',
+    requestDurationMs: overrides.requestDurationMs,
     logs: [
       {
         level: overrides.level ?? 'info',
@@ -311,82 +335,33 @@ describe('logs', () => {
       expect(receivedBranch).toEqual('feature-branch');
     });
 
-    it('should follow your latest deployment for an explicit project', async () => {
-      let requestedProjectId: string | undefined;
-      let requestedLimit: string | undefined;
-      let requestedState: string | undefined;
-      let requestedUsers: string | undefined;
-      let latestDeployment: ReturnType<typeof useDeployment>;
-
-      client.scenario.get('/v6/deployments', (req, res) => {
-        requestedProjectId = req.query.projectId as string | undefined;
-        requestedLimit = req.query.limit as string | undefined;
-        requestedState = req.query.state as string | undefined;
-        requestedUsers = req.query.users as string | undefined;
-        res.json({
-          deployments: [
-            {
-              uid: latestDeployment.id,
-              url: latestDeployment.url,
-            },
-          ],
-        });
-      });
-
-      latestDeployment = useDeployment({
-        creator: user,
-        project: {
-          ...defaultProject,
-          id: 'prj_explicit',
-          name: 'explicit-project',
-        },
-      });
-      useRuntimeLogs({
-        deployment: latestDeployment,
-        logProducer: async function* () {},
+    it('should follow request logs for an explicit project without resolving a deployment', async () => {
+      let receivedProjectId: string | undefined;
+      let receivedOwnerId: string | undefined;
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedProjectId = req.query.projectId as string;
+        receivedOwnerId = req.query.ownerId as string;
+        receivedDeploymentId = req.query.deploymentId as string | undefined;
+        res.json({ rows: [], hasMoreRows: false });
       });
 
       client.setArgv('logs', '--project', 'explicit-project', '--follow');
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
-      expect(requestedProjectId).toEqual('prj_explicit');
-      expect(requestedLimit).toEqual('1');
-      expect(requestedState).toEqual('READY');
-      expect(requestedUsers).toEqual(user.id);
-      await expect(client.stderr).toOutput(
-        `Streaming logs for your latest deployment ${latestDeployment.id}`
-      );
+      expect(receivedProjectId).toEqual('prj_explicit');
+      expect(receivedOwnerId).toEqual(logsProject.accountId);
+      expect(receivedDeploymentId).toBeUndefined();
+      expect(logsFollow.followRequestLogs).toHaveBeenCalled();
+      await expect(client.stderr).toOutput('Streaming request logs for');
     });
 
-    it('should follow the latest production deployment with --environment production', async () => {
-      const deploymentQueries: Array<Record<string, unknown>> = [];
-      let productionDeployment: ReturnType<typeof useDeployment>;
-
-      client.scenario.get('/v6/deployments', (req, res) => {
-        deploymentQueries.push({ ...req.query });
-        res.json({
-          deployments: [
-            {
-              uid: productionDeployment.id,
-              url: productionDeployment.url,
-            },
-          ],
-        });
-      });
-
-      productionDeployment = useDeployment({
-        creator: user,
-        project: {
-          ...defaultProject,
-          id: 'prj_explicit',
-          name: 'explicit-project',
-        },
-        target: 'production',
-      });
-      useRuntimeLogs({
-        deployment: productionDeployment,
-        logProducer: async function* () {},
+    it('should pass --environment production through to request-logs while following', async () => {
+      let receivedEnvironment: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedEnvironment = req.query.environment as string;
+        res.json({ rows: [], hasMoreRows: false });
       });
 
       client.setArgv(
@@ -400,13 +375,8 @@ describe('logs', () => {
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
-      expect(deploymentQueries).toHaveLength(1);
-      expect(deploymentQueries[0].target).toEqual('production');
-      expect(deploymentQueries[0].users).toBeUndefined();
-      expect(deploymentQueries[0].branch).toBeUndefined();
-      await expect(client.stderr).toOutput(
-        `Streaming logs for latest production deployment ${productionDeployment.id}`
-      );
+      expect(receivedEnvironment).toEqual('production');
+      await expect(client.stderr).toOutput('Streaming request logs for');
     });
 
     it('should track telemetry for --project option', async () => {
@@ -997,23 +967,32 @@ describe('logs', () => {
       expect(receivedDeploymentId).toEqual(deployment.id);
     });
 
-    it('should stream logs when --follow is specified for a deployment ID', async () => {
+    it('should stream request logs when --follow is specified for a deployment ID', async () => {
       const user = useUser();
       const deployment = useLogsDeployment(user);
 
-      client.scenario.get(
-        `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
-        (_req, res) => {
-          res.status(200);
-          res.end();
-        }
-      );
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [
+            createMockLog({
+              deploymentId: deployment.id,
+              requestDurationMs: 5,
+            }),
+          ],
+          hasMoreRows: false,
+        });
+      });
 
       client.cwd = fixture('linked-project');
       client.setArgv('logs', deployment.id, '--follow');
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual(deployment.id);
+      await expect(client.stderr).toOutput('Streaming request logs for');
+      await expect(client.stderr).toOutput(`deployment ${deployment.id}`);
     });
 
     it('should show deployment error and skip runtime logs for errored deployment', async () => {
@@ -1171,19 +1150,31 @@ describe('logs', () => {
       expect(receivedDeploymentId).toEqual(deployment.id);
     });
 
-    it('should stream logs for a deployment URL without a linked project', async () => {
+    it('should stream request logs for a deployment URL without a linked project', async () => {
       const user = useUser();
       const deployment = useLogsDeployment(user);
 
-      let receivedTeamId: string | undefined;
-      client.scenario.get(
-        `/v1/projects/prj_logstest/deployments/${deployment.id}/runtime-logs`,
-        (req, res) => {
-          receivedTeamId = req.query.teamId as string;
-          res.status(200);
-          res.end();
-        }
-      );
+      let receivedQuery:
+        | {
+            deploymentId?: string;
+            teamId?: string;
+          }
+        | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedQuery = {
+          deploymentId: req.query.deploymentId as string,
+          teamId: req.query.teamId as string,
+        };
+        res.json({
+          rows: [
+            createMockLog({
+              deploymentId: deployment.id,
+              requestDurationMs: 8,
+            }),
+          ],
+          hasMoreRows: false,
+        });
+      });
 
       client.config.currentTeam = logsTeam.id;
       client.cwd = logsFixturesDir;
@@ -1191,7 +1182,12 @@ describe('logs', () => {
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
-      expect(receivedTeamId).toEqual(logsProject.accountId);
+      expect(receivedQuery).toEqual({
+        deploymentId: deployment.id,
+        teamId: logsProject.accountId,
+      });
+      await expect(client.stderr).toOutput('Streaming request logs for');
+      await expect(client.stderr).toOutput(`deployment ${deployment.id}`);
     });
 
     it('should fetch historical logs for a deployment URL without a linked project', async () => {
@@ -1374,12 +1370,8 @@ describe('logs', () => {
   });
 
   describe('--follow option', () => {
-    // The scenario router serves the first-registered `/v2/user` handler, so
-    // tests that assert on the current user's id must reuse this user instead
-    // of calling useUser() again.
-    let user: ReturnType<typeof useUser>;
     beforeEach(() => {
-      user = useUser();
+      useUser();
       useTeams('team_dummy');
       useProject({
         ...defaultProject,
@@ -1388,87 +1380,75 @@ describe('logs', () => {
       });
     });
 
-    it('should fall back to the latest production deployment when no deployments match the branch', async () => {
-      const user = useUser();
-
-      // Register before useLogsDeployment(), whose catch-all
-      // `/:version/deployments` route would otherwise handle this path
-      let productionDeployment: ReturnType<typeof useLogsDeployment>;
-      const deploymentQueries: Array<Record<string, unknown>> = [];
-      client.scenario.get('/v6/deployments', (req, res) => {
-        deploymentQueries.push({ ...req.query });
-        if (req.query.target === 'production') {
-          res.json({
-            deployments: [
-              { uid: productionDeployment.id, url: productionDeployment.url },
-            ],
-          });
-          return;
-        }
-        res.json({ deployments: [] });
-      });
-
-      productionDeployment = useLogsDeployment(user);
-
-      client.scenario.get(
-        `/v1/projects/prj_logstest/deployments/${productionDeployment.id}/runtime-logs`,
-        (_req, res) => {
-          res.status(200);
-          res.end();
-        }
-      );
-
-      client.cwd = fixture('linked-project');
-      client.setArgv('logs', '--follow', '--branch', 'main');
-      const exitCode = await logs(client);
-
-      expect(exitCode).toEqual(0);
-      expect(deploymentQueries.some(q => q.branch === 'main')).toEqual(true);
-      expect(deploymentQueries.some(q => q.users !== undefined)).toEqual(true);
-      expect(deploymentQueries.some(q => q.target === 'production')).toEqual(
-        true
-      );
-      await expect(client.stderr).toOutput(
-        `Streaming logs for latest production deployment ${productionDeployment.id}`
-      );
-    });
-
-    it('should stream your latest deployment with --no-branch', async () => {
-      // Register before useLogsDeployment(), whose catch-all
-      // `/:version/deployments` route would otherwise handle this path
-      let latestDeployment: ReturnType<typeof useLogsDeployment>;
-      let requestedUsers: string | undefined;
-      let requestedBranch: string | undefined;
-      client.scenario.get('/v6/deployments', (req, res) => {
-        requestedUsers = req.query.users as string | undefined;
-        requestedBranch = req.query.branch as string | undefined;
+    it('should stream request logs for the linked project without resolving a deployment', async () => {
+      let receivedDeploymentId: string | undefined;
+      let receivedEndDate: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string | undefined;
+        receivedEndDate = req.query.endDate as string | undefined;
         res.json({
-          deployments: [
-            { uid: latestDeployment.id, url: latestDeployment.url },
+          rows: [
+            createMockLog({
+              id: 'follow-req-1',
+              message: 'hello from follow',
+              requestDurationMs: 12,
+            }),
           ],
+          hasMoreRows: false,
         });
       });
-
-      latestDeployment = useLogsDeployment(user);
-
-      client.scenario.get(
-        `/v1/projects/prj_logstest/deployments/${latestDeployment.id}/runtime-logs`,
-        (_req, res) => {
-          res.status(200);
-          res.end();
-        }
-      );
 
       client.cwd = fixture('linked-project');
       client.setArgv('logs', '--follow', '--no-branch');
       const exitCode = await logs(client);
 
       expect(exitCode).toEqual(0);
-      expect(requestedUsers).toEqual(user.id);
-      expect(requestedBranch).toBeUndefined();
-      await expect(client.stderr).toOutput(
-        `Streaming logs for your latest deployment ${latestDeployment.id}`
+      expect(receivedDeploymentId).toBeUndefined();
+      expect(receivedEndDate).toBeUndefined();
+      await expect(client.stderr).toOutput('Streaming request logs for');
+      await expect(client.stderr).toOutput('all branches');
+      await expect(client.stderr).toOutput('Request started');
+      await expect(client.stderr).toOutput('hello from follow');
+      await expect(client.stderr).toOutput('Request finished');
+    });
+
+    it('should pass --environment through to request-logs while following', async () => {
+      let receivedEnvironment: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedEnvironment = req.query.environment as string;
+        res.json({ rows: [], hasMoreRows: false });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv(
+        'logs',
+        '--follow',
+        '--no-branch',
+        '--environment',
+        'preview'
       );
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedEnvironment).toEqual('preview');
+      await expect(client.stderr).toOutput('Streaming request logs for');
+      await expect(client.stderr).toOutput('preview');
+    });
+
+    it('should pass an explicit --branch through to request-logs while following', async () => {
+      let receivedBranch: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedBranch = req.query.branch as string;
+        res.json({ rows: [], hasMoreRows: false });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logs', '--follow', '--branch', 'feature-x');
+      const exitCode = await logs(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedBranch).toEqual('feature-x');
+      await expect(client.stderr).toOutput('branch feature-x');
     });
 
     it('should error when --follow is used with --level', async () => {
@@ -1538,31 +1518,9 @@ describe('logs', () => {
     });
 
     it('should track telemetry for --follow flag', async () => {
-      const user = useUser();
-
-      // Register before useLogsDeployment(), whose catch-all
-      // `/:version/deployments` route would otherwise handle this path
-      let productionDeployment: ReturnType<typeof useLogsDeployment>;
-      client.scenario.get('/v6/deployments', (_req, res) => {
-        res.json({
-          deployments: [
-            { uid: productionDeployment.id, url: productionDeployment.url },
-          ],
-        });
-      });
-
-      productionDeployment = useLogsDeployment(user);
-
-      client.scenario.get(
-        `/v1/projects/prj_logstest/deployments/${productionDeployment.id}/runtime-logs`,
-        (_req, res) => {
-          res.status(200);
-          res.end();
-        }
-      );
+      useRequestLogs([]);
 
       client.cwd = fixture('linked-project');
-      // Use --no-branch to avoid branch detection and deployment lookup
       client.setArgv('logs', '--follow', '--no-branch');
       await logs(client);
 

--- a/packages/cli/test/unit/commands/logs/index.test.ts
+++ b/packages/cli/test/unit/commands/logs/index.test.ts
@@ -351,10 +351,10 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(0);
       expect(receivedProjectId).toEqual('prj_explicit');
-      expect(receivedOwnerId).toEqual(logsProject.accountId);
+      expect(receivedOwnerId).toEqual(defaultProject.accountId);
       expect(receivedDeploymentId).toBeUndefined();
       expect(logsFollow.followRequestLogs).toHaveBeenCalled();
-      await expect(client.stderr).toOutput('Streaming request logs for');
+      expect(client.getFullOutput()).toContain('Streaming request logs for');
     });
 
     it('should pass --environment production through to request-logs while following', async () => {
@@ -376,7 +376,7 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(0);
       expect(receivedEnvironment).toEqual('production');
-      await expect(client.stderr).toOutput('Streaming request logs for');
+      expect(client.getFullOutput()).toContain('Streaming request logs for');
     });
 
     it('should track telemetry for --project option', async () => {
@@ -991,8 +991,9 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(0);
       expect(receivedDeploymentId).toEqual(deployment.id);
-      await expect(client.stderr).toOutput('Streaming request logs for');
-      await expect(client.stderr).toOutput(`deployment ${deployment.id}`);
+      const output = client.getFullOutput();
+      expect(output).toContain('Streaming request logs for');
+      expect(output).toContain(`deployment ${deployment.id}`);
     });
 
     it('should show deployment error and skip runtime logs for errored deployment', async () => {
@@ -1186,8 +1187,9 @@ describe('logs', () => {
         deploymentId: deployment.id,
         teamId: logsProject.accountId,
       });
-      await expect(client.stderr).toOutput('Streaming request logs for');
-      await expect(client.stderr).toOutput(`deployment ${deployment.id}`);
+      const output = client.getFullOutput();
+      expect(output).toContain('Streaming request logs for');
+      expect(output).toContain(`deployment ${deployment.id}`);
     });
 
     it('should fetch historical logs for a deployment URL without a linked project', async () => {
@@ -1405,11 +1407,12 @@ describe('logs', () => {
       expect(exitCode).toEqual(0);
       expect(receivedDeploymentId).toBeUndefined();
       expect(receivedEndDate).toBeUndefined();
-      await expect(client.stderr).toOutput('Streaming request logs for');
-      await expect(client.stderr).toOutput('all branches');
-      await expect(client.stderr).toOutput('Request started');
-      await expect(client.stderr).toOutput('hello from follow');
-      await expect(client.stderr).toOutput('Request finished');
+      const output = client.getFullOutput();
+      expect(output).toContain('Streaming request logs for');
+      expect(output).toContain('all branches');
+      expect(output).toContain('Request started');
+      expect(output).toContain('hello from follow');
+      expect(output).toContain('Request finished');
     });
 
     it('should pass --environment through to request-logs while following', async () => {
@@ -1431,8 +1434,9 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(0);
       expect(receivedEnvironment).toEqual('preview');
-      await expect(client.stderr).toOutput('Streaming request logs for');
-      await expect(client.stderr).toOutput('preview');
+      const output = client.getFullOutput();
+      expect(output).toContain('Streaming request logs for');
+      expect(output).toContain('preview');
     });
 
     it('should pass an explicit --branch through to request-logs while following', async () => {
@@ -1448,7 +1452,7 @@ describe('logs', () => {
 
       expect(exitCode).toEqual(0);
       expect(receivedBranch).toEqual('feature-x');
-      await expect(client.stderr).toOutput('branch feature-x');
+      expect(client.getFullOutput()).toContain('branch feature-x');
     });
 
     it('should error when --follow is used with --level', async () => {

--- a/packages/cli/test/unit/util/logs-follow.test.ts
+++ b/packages/cli/test/unit/util/logs-follow.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assignRequestPrefix,
+  formatFollowHuman,
+  formatFollowJson,
+  processFollowRows,
+  type FollowEvent,
+} from '../../../src/util/logs-follow';
+import type { RequestLogEntry } from '../../../src/util/logs-v2';
+
+function createRow(
+  overrides: Partial<RequestLogEntry> & { id: string }
+): RequestLogEntry {
+  return {
+    timestamp: 1_753_714_925_020,
+    deploymentId: 'dpl_test',
+    projectId: 'prj_test',
+    level: 'info',
+    message: '',
+    source: 'serverless',
+    domain: 'example.vercel.app',
+    requestMethod: 'GET',
+    requestPath: '/api/test',
+    responseStatusCode: 0,
+    environment: 'preview',
+    branch: 'main',
+    logs: [],
+    eventsCount: 0,
+    ...overrides,
+  };
+}
+
+describe('logs-follow', () => {
+  describe('processFollowRows', () => {
+    it('emits started, logs, then finished as a request settles', () => {
+      const state = new Map();
+      const prefixes = new Map<string, string>();
+
+      const first = processFollowRows(
+        [
+          createRow({
+            id: 'req_aaaa',
+            logs: [{ level: 'info', message: 'hello' }],
+            eventsCount: 0,
+            responseStatusCode: 0,
+          }),
+        ],
+        state,
+        prefixes
+      );
+
+      expect(first.map(e => e.type)).toEqual(['request_started', 'log']);
+      expect(first[0]).toMatchObject({
+        type: 'request_started',
+        requestId: 'req_aaaa',
+        responseStatusCode: null,
+      });
+      expect(first[1]).toMatchObject({
+        type: 'log',
+        message: 'hello',
+      });
+
+      const second = processFollowRows(
+        [
+          createRow({
+            id: 'req_aaaa',
+            logs: [{ level: 'info', message: 'hello' }],
+            responseStatusCode: 200,
+            requestDurationMs: 45,
+          }),
+        ],
+        state,
+        prefixes
+      );
+
+      expect(second.map(e => e.type)).toEqual(['request_finished']);
+      expect(second[0]).toMatchObject({
+        type: 'request_finished',
+        responseStatusCode: 200,
+        durationMs: 45,
+      });
+    });
+
+    it('does not re-emit logs across overlapping polls', () => {
+      const state = new Map();
+      const prefixes = new Map<string, string>();
+      const row = createRow({
+        id: 'req_bbbb',
+        logs: [
+          { level: 'info', message: 'one' },
+          { level: 'info', message: 'two' },
+        ],
+        responseStatusCode: 200,
+        requestDurationMs: 10,
+      });
+
+      const first = processFollowRows([row], state, prefixes);
+      expect(first.map(e => e.type)).toEqual([
+        'request_started',
+        'log',
+        'log',
+        'request_finished',
+      ]);
+
+      const second = processFollowRows([row], state, prefixes);
+      expect(second).toEqual([]);
+    });
+
+    it('keeps interleaved requests attributable by requestId', () => {
+      const state = new Map();
+      const prefixes = new Map<string, string>();
+
+      const events = processFollowRows(
+        [
+          createRow({
+            id: 'req_checkout_a1b2',
+            requestMethod: 'POST',
+            requestPath: '/api/checkout',
+            timestamp: 100,
+            logs: [{ level: 'info', message: 'creating payment intent' }],
+          }),
+          createRow({
+            id: 'req_cart_c3d4',
+            requestMethod: 'GET',
+            requestPath: '/api/cart',
+            timestamp: 101,
+            logs: [{ level: 'info', message: 'loaded cart' }],
+            eventsCount: 1,
+            responseStatusCode: 200,
+            requestDurationMs: 20,
+          }),
+        ],
+        state,
+        prefixes
+      );
+
+      expect(events.filter(e => e.requestId.endsWith('a1b2')).map(e => e.type)).toEqual([
+        'request_started',
+        'log',
+      ]);
+      expect(events.filter(e => e.requestId.endsWith('c3d4')).map(e => e.type)).toEqual([
+        'request_started',
+        'log',
+        'request_finished',
+      ]);
+    });
+
+    it('emits started and finished for silent requests', () => {
+      const state = new Map();
+      const prefixes = new Map<string, string>();
+      const events = processFollowRows(
+        [
+          createRow({
+            id: 'req_silent',
+            source: 'static',
+            eventsCount: 1,
+            responseStatusCode: 200,
+            requestDurationMs: 14,
+            logs: [],
+          }),
+        ],
+        state,
+        prefixes
+      );
+
+      expect(events.map(e => e.type)).toEqual([
+        'request_started',
+        'request_finished',
+      ]);
+    });
+  });
+
+  describe('assignRequestPrefix', () => {
+    it('uses the last 4 characters by default', () => {
+      const active = new Map<string, string>();
+      expect(assignRequestPrefix('iad1::abc-1234-a1b2', active)).toEqual('a1b2');
+    });
+
+    it('lengthens prefixes on collision', () => {
+      const active = new Map<string, string>([['other', 'a1b2']]);
+      expect(assignRequestPrefix('xxxxa1b2', active)).toEqual('xa1b2');
+    });
+  });
+
+  describe('formatters', () => {
+    const started: FollowEvent = {
+      type: 'request_started',
+      timestamp: 1_753_714_925_020,
+      requestId: 'req_a1b2',
+      deploymentId: 'dpl_1',
+      projectId: 'prj_1',
+      environment: 'preview',
+      branch: 'main',
+      domain: 'example.vercel.app',
+      requestMethod: 'POST',
+      requestPath: '/api/checkout',
+      source: 'serverless',
+      level: 'info',
+      responseStatusCode: null,
+    };
+
+    it('formats human started/finished with full details', () => {
+      const startedText = formatFollowHuman(started, 'a1b2');
+      expect(startedText).toContain('[a1b2]');
+      expect(startedText).toContain('POST');
+      expect(startedText).toContain('/api/checkout');
+      expect(startedText).toContain('Request started');
+
+      const finishedText = formatFollowHuman(
+        {
+          ...started,
+          type: 'request_finished',
+          responseStatusCode: 402,
+          level: 'error',
+          durationMs: 890,
+        },
+        'a1b2'
+      );
+      expect(finishedText).toContain('402');
+      expect(finishedText).toContain('Request finished (890ms)');
+    });
+
+    it('formats human log blocks like current follow output', () => {
+      const text = formatFollowHuman(
+        {
+          ...started,
+          type: 'log',
+          message: 'creating payment intent',
+          level: 'info',
+        },
+        'a1b2'
+      );
+      expect(text).toContain('[a1b2]');
+      expect(text).toContain('creating payment intent');
+      expect(text).toContain('---');
+    });
+
+    it('formats JSON event stream objects', () => {
+      expect(formatFollowJson(started)).toMatchObject({
+        type: 'request_started',
+        requestId: 'req_a1b2',
+        responseStatusCode: null,
+      });
+      expect(
+        formatFollowJson({
+          ...started,
+          type: 'log',
+          message: 'hi',
+          messageTruncated: false,
+        })
+      ).toMatchObject({
+        type: 'log',
+        message: 'hi',
+      });
+      expect(
+        formatFollowJson({
+          ...started,
+          type: 'request_finished',
+          responseStatusCode: 200,
+          durationMs: 12,
+        })
+      ).toMatchObject({
+        type: 'request_finished',
+        responseStatusCode: 200,
+        durationMs: 12,
+      });
+    });
+  });
+});

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -20,6 +20,7 @@ interface ApiLogEntry {
   cache?: string;
   cacheReason?: string;
   pprState?: string;
+  requestDurationMs?: number;
   logs?: Array<{
     level?: string;
     message?: string;
@@ -101,6 +102,61 @@ describe('logs-v2 utility', () => {
         ownerId: 'team_test',
         deploymentId: 'dpl_specific',
       });
+    });
+
+    it('should prefer absolute startDate/endDate over since/until', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.startDate).toEqual('1000');
+        expect(req.query.endDate).toEqual('2000');
+        res.json({ rows: [], hasMoreRows: false });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        ownerId: 'team_test',
+        since: '1h',
+        until: 'now',
+        startDate: 1000,
+        endDate: 2000,
+      });
+    });
+
+    it('should omit endDate in live mode', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.startDate).toEqual('1000');
+        expect(req.query.endDate).toBeUndefined();
+        res.json({ rows: [], hasMoreRows: false });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        ownerId: 'team_test',
+        startDate: 1000,
+        endDate: 2000,
+        live: true,
+      });
+    });
+
+    it('should map eventsCount and requestDurationMs', async () => {
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        res.json({
+          rows: [
+            createMockApiLog({
+              events: [{ source: 'serverless' }, { source: 'static' }],
+              requestDurationMs: 42,
+            }),
+          ],
+          hasMoreRows: false,
+        });
+      });
+
+      const result = await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        ownerId: 'team_test',
+      });
+
+      expect(result.logs[0].eventsCount).toEqual(2);
+      expect(result.logs[0].requestDurationMs).toEqual(42);
     });
 
     it('should include environment filter in query', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`vercel logs --follow` previously required a single deployment (latest / resolved), so users could not stream live logs across preview deployments or all branches the way historical `vercel logs` already can.

## Summary

- `--follow` polls live request-logs (`endDate` omitted) with the same deployment / environment / branch filters as historical logs
- No longer uses `/runtime-logs` for follow
- Human output: append-only request lifecycle with `[id]` prefixes (`Request started` / logs / `Request finished`)
- `--follow --json`: typed NDJSON events (`request_started` / `log` / `request_finished`) — breaking vs prior raw runtime-log passthrough
- Implementation plan: `packages/cli/docs/logs-follow-request-logs.md`

## Validation

- Unit coverage for poller state machine and command wiring (`logs-follow`, `logs` command, `logs-v2` live mode)
- Manual: `vercel logs --follow --environment preview` and `--no-branch` stream without resolving one deployment

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38e25bcf-b43c-45cd-b223-2fb860225a4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38e25bcf-b43c-45cd-b223-2fb860225a4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

