### PR TITLE
[cli] warn on unrecognized bulk-redirects CSV columns

### DIFF
--- a/packages/cli/src/commands/redirects/upload.ts
+++ b/packages/cli/src/commands/redirects/upload.ts
@@ -179,6 +179,9 @@ export default async function upload(client: Client, argv: string[]) {
         output.error(`Invalid CSV: ${csvValidation.error}`);
         return 1;
       }
+      for (const warning of csvValidation.warnings ?? []) {
+        output.warn(warning);
+      }
 
       const form = new FormData();
       form.append('teamId', teamId || org.id);

--- a/packages/cli/src/commands/redirects/validate-redirects.ts
+++ b/packages/cli/src/commands/redirects/validate-redirects.ts
@@ -9,6 +9,7 @@ interface ValidationOptions {
 interface ValidationResult {
   valid: boolean;
   error?: string;
+  warnings?: string[];
 }
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
@@ -16,6 +17,21 @@ const ALLOWED_EXTENSIONS = ['.csv', '.json'];
 const MAX_REDIRECTS = 1_000_000;
 const MAX_URL_LENGTH = 2048;
 const VALID_STATUS_CODES = [301, 302, 303, 307, 308];
+
+/**
+ * Columns the bulk-redirects CSV schema understands. Anything else is
+ * silently ignored server-side, which is dangerous: a typo like `status`
+ * instead of `statusCode` makes every row fall back to the default 307
+ * with no error (see #17261).
+ */
+const KNOWN_CSV_COLUMNS = new Set([
+  'source',
+  'destination',
+  'statuscode',
+  'permanent',
+  'casesensitive',
+  'preservequeryparams',
+]);
 
 export function validateUploadFile(
   filePath: string,
@@ -144,18 +160,33 @@ export function validateCSVStructure(content: string): ValidationResult {
     };
   }
 
-  const header = lines[0].toLowerCase();
-  const hasSource = header.includes('source');
-  const hasDestination = header.includes('destination');
+  const columns = lines[0]
+    .split(',')
+    .map(column => column.trim().replace(/^"|"$/g, ''));
+  const normalized = columns.map(column => column.toLowerCase());
 
-  if (!hasSource || !hasDestination) {
+  if (!normalized.includes('source') || !normalized.includes('destination')) {
     return {
       valid: false,
       error: 'CSV must have "source" and "destination" columns',
     };
   }
 
-  return { valid: true };
+  const warnings: string[] = [];
+  for (let i = 0; i < columns.length; i++) {
+    const column = normalized[i];
+    if (!column || KNOWN_CSV_COLUMNS.has(column)) {
+      continue;
+    }
+    let warning = `Unrecognized CSV column "${columns[i]}" will be ignored.`;
+    if (column === 'status') {
+      warning +=
+        ' Did you mean "statusCode"? Without it, redirects default to 307.';
+    }
+    warnings.push(warning);
+  }
+
+  return warnings.length > 0 ? { valid: true, warnings } : { valid: true };
 }
 
 export function validateVersionName(name: string): ValidationResult {

--- a/packages/cli/test/unit/commands/redirects/validate-redirects.test.ts
+++ b/packages/cli/test/unit/commands/redirects/validate-redirects.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { validateCSVStructure } from '../../../../src/commands/redirects/validate-redirects';
+
+describe('validateCSVStructure', () => {
+  it('accepts the documented bulk-redirects columns without warnings', () => {
+    const result = validateCSVStructure(
+      'source,destination,statusCode,permanent,caseSensitive,preserveQueryParams\n/a,/b,301,false,false,true'
+    );
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('still rejects a CSV missing source or destination', () => {
+    const result = validateCSVStructure('destination,statusCode\n/b,301');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe(
+      'CSV must have "source" and "destination" columns'
+    );
+  });
+
+  it('warns on unrecognized columns instead of silently ignoring them', () => {
+    const result = validateCSVStructure(
+      'source,destination,redirectType\n/a,/b,permanent'
+    );
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([
+      'Unrecognized CSV column "redirectType" will be ignored.',
+    ]);
+  });
+
+  it('suggests statusCode when the header uses status', () => {
+    // `status` parsed "successfully" but was never read, so every row
+    // silently fell back to 307 (#17261).
+    const result = validateCSVStructure(
+      'source,destination,status,caseSensitive,preserveQueryParams\n/old-path,/new-path,301,false,true'
+    );
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([
+      'Unrecognized CSV column "status" will be ignored. Did you mean "statusCode"? Without it, redirects default to 307.',
+    ]);
+  });
+
+  it('handles quoted and case-varied headers', () => {
+    const result = validateCSVStructure(
+      '"Source","Destination","StatusCode"\n/a,/b,308'
+    );
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Addresses #17261, reported by @floriannicolas.

`vercel redirects upload` silently ignores unrecognized CSV columns, so a file using `status` (instead of `statusCode`) uploads without complaint and every redirect quietly becomes a 307. The examples in the docs used `status` themselves.

This makes the CLI warn when a CSV header contains columns it does not recognize, naming the ignored columns and the accepted ones, so the `status` vs `statusCode` mistake is visible at upload time instead of after deployment.

The 132 redirects CLI tests pass locally; the new warning tests fail without the change.
