### PR TITLE
[cli] Codex Desktop session-migration engine

### DIFF
--- a/.changeset/codex-session-migration-engine.md
+++ b/.changeset/codex-session-migration-engine.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add the Codex Desktop session-migration engine: a deterministic, atomic copy of Codex rollout sessions into the Vercel AI Gateway provider (UUIDv5 destinations, no-clobber writes, originals never modified). This is the internal capability; it is wired into `ai-gateway coding-agents setup` in a follow-up.

--- a/packages/cli/src/util/ai-gateway/coding-agents/migrations/codex-sessions.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/migrations/codex-sessions.ts
@@ -4,6 +4,13 @@ import * as fs from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import type { SessionMigrationPlan } from '../types';
+
+// RFC 4122's predefined URL namespace, used to derive each copy's UUIDv5 from
+// its source session id. Any fixed namespace works; the standard one avoids
+// minting a custom constant. Determinism is what matters: the same source
+// always yields the same destination id, so reruns skip existing copies
+// instead of duplicating them, and the `--apply prompt` path reproduces
+// identical ids to what a direct apply would write.
 const UUID_NAMESPACE = '6ba7b8119dad11d180b400c04fd430c8';
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -232,7 +239,7 @@ export async function planCodexSessionMigration(
   }
   if (files.some(file => file.path.endsWith('.jsonl.zst'))) {
     throw new Error(
-      'Found compressed Codex sessions; decompress them first, or pass --no-migrate-sessions to leave them unchanged'
+      'Found compressed Codex sessions; decompress them first, or pass --no-session-migration to leave them unchanged'
     );
   }
   const copies: SessionCopy[] = [];

--- a/packages/cli/src/util/ai-gateway/coding-agents/migrations/codex-sessions.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/migrations/codex-sessions.ts
@@ -1,0 +1,272 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import type { SessionMigrationPlan } from '../types';
+const UUID_NAMESPACE = '6ba7b8119dad11d180b400c04fd430c8';
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ROLLOUT_PATTERN = /^rollout-.*\.jsonl(?:\.zst)?$/;
+const MAX_METADATA_BYTES = 1024 * 1024;
+type Metadata = {
+  record: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  id: string;
+  delimiter: string;
+  restOffset: number;
+};
+type SessionCopy = {
+  source: string;
+  destination: string;
+  sourceId: string;
+  destinationId: string;
+  bytes: number;
+  root: string;
+};
+function hasCode(error: unknown, code: string): boolean {
+  return (error as NodeJS.ErrnoException).code === code;
+}
+function uuidV5(name: string): string {
+  const hash = createHash('sha1')
+    .update(UUID_NAMESPACE, 'hex')
+    .update(name)
+    .digest('hex');
+  const hex =
+    `${hash.slice(0, 12)}5${hash.slice(13, 16)}` +
+    `${((Number.parseInt(hash[16], 16) & 3) | 8).toString(16)}` +
+    hash.slice(17, 32);
+  return hex.replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, '$1-$2-$3-$4-$5');
+}
+async function readMeta(
+  path: string,
+  gateway = false
+): Promise<Metadata | null> {
+  const handle = await fs.open(path, 'r');
+  const buffer = new Uint8Array(MAX_METADATA_BYTES + 1);
+  let length = 0;
+  let newline = -1;
+  try {
+    while (length < buffer.length && newline < 0) {
+      const start = length;
+      const read = await handle.read(
+        buffer,
+        start,
+        buffer.length - start,
+        start
+      );
+      if (read.bytesRead === 0) break;
+      length += read.bytesRead;
+      newline = buffer.indexOf(0x0a, start);
+    }
+  } finally {
+    await handle.close();
+  }
+  if (newline < 0 && length > MAX_METADATA_BYTES)
+    throw new Error(`${basename(path)} metadata exceeds 1 MiB`);
+  const lineEnd = newline < 0 ? length : newline;
+  const carriageReturn = buffer[lineEnd - 1] === 0x0d;
+  let record: Record<string, unknown>;
+  try {
+    record = JSON.parse(
+      new TextDecoder().decode(
+        buffer.subarray(0, carriageReturn ? lineEnd - 1 : lineEnd)
+      )
+    );
+  } catch {
+    return null;
+  }
+  const payload = record.payload as Record<string, unknown> | undefined;
+  const id =
+    typeof payload?.id === 'string'
+      ? payload.id
+      : typeof payload?.session_id === 'string'
+        ? payload.session_id
+        : '';
+  if (
+    record.type !== 'session_meta' ||
+    !payload ||
+    !UUID_PATTERN.test(id) ||
+    (typeof payload.session_id === 'string' && payload.session_id !== id) ||
+    (payload.originator !== 'Codex Desktop' &&
+      !(payload.originator == null && payload.source === 'vscode')) ||
+    (gateway
+      ? payload.model_provider !== 'vercel'
+      : payload.model_provider === 'vercel')
+  ) {
+    return null;
+  }
+  return {
+    record,
+    payload,
+    id,
+    delimiter: newline < 0 ? '' : carriageReturn ? '\r\n' : '\n',
+    restOffset: newline < 0 ? length : newline + 1,
+  };
+}
+async function findRollouts(root: string): Promise<string[]> {
+  const files: string[] = [];
+  async function visit(directory: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if (hasCode(error, 'ENOENT')) return;
+      throw error;
+    }
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile() && ROLLOUT_PATTERN.test(entry.name))
+        files.push(path);
+    }
+  }
+  await visit(root);
+  return files;
+}
+async function planCopy(
+  path: string,
+  root: string
+): Promise<SessionCopy | null> {
+  const metadata = await readMeta(path);
+  const filename = basename(path);
+  if (!metadata || !filename.toLowerCase().includes(metadata.id.toLowerCase()))
+    return null;
+  const destinationId = uuidV5(
+    `vercel-ai-gateway/codex/${metadata.id.toLowerCase()}/vercel`
+  );
+  const destination = join(
+    dirname(path),
+    filename.replace(new RegExp(metadata.id, 'i'), destinationId)
+  );
+  const item = {
+    source: path,
+    destination,
+    sourceId: metadata.id,
+    destinationId,
+    bytes: (await fs.stat(path)).size,
+    root,
+  };
+  try {
+    await fs.stat(destination);
+    await validateDestination(item);
+    return null;
+  } catch (error) {
+    if (!hasCode(error, 'ENOENT')) throw error;
+  }
+  return item;
+}
+async function bodyHash(path: string, start: number): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(path, { start }), hash);
+  return hash.digest('hex');
+}
+async function validateDestination(item: SessionCopy): Promise<void> {
+  const [source, destination] = await Promise.all([
+    readMeta(item.source),
+    readMeta(item.destination, true),
+  ]);
+  const bodies = await Promise.all([
+    bodyHash(item.source, source?.restOffset ?? 0),
+    bodyHash(item.destination, destination?.restOffset ?? 0),
+  ]);
+  const valid =
+    source && destination?.id === item.destinationId && bodies[0] === bodies[1];
+  if (!valid)
+    throw new Error(
+      `Existing destination ${basename(item.destination)} is invalid`
+    );
+}
+async function copySession(item: SessionCopy): Promise<boolean> {
+  const metadata = await readMeta(item.source);
+  if (!metadata) throw new Error('Codex session metadata is no longer valid');
+  if (metadata.id !== item.sourceId)
+    throw new Error('Codex session metadata changed after planning');
+  const updated = {
+    ...metadata.record,
+    payload: {
+      ...metadata.payload,
+      id: item.destinationId,
+      session_id: item.destinationId,
+      model_provider: 'vercel',
+    },
+  };
+  const temporary = `${item.destination}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    await fs.writeFile(
+      temporary,
+      `${JSON.stringify(updated)}${metadata.delimiter}`,
+      { flag: 'wx', mode: 0o600 }
+    );
+    await pipeline(
+      createReadStream(item.source, { start: metadata.restOffset }),
+      createWriteStream(temporary, { flags: 'a', mode: 0o600 })
+    );
+    await fs.chmod(temporary, 0o600);
+    try {
+      await fs.link(temporary, item.destination);
+      return true;
+    } catch (error) {
+      if (hasCode(error, 'EEXIST')) {
+        await validateDestination(item);
+        return false;
+      }
+      throw error;
+    }
+  } finally {
+    await fs.unlink(temporary).catch(error => {
+      if (!hasCode(error, 'ENOENT')) throw error;
+    });
+  }
+}
+export async function planCodexSessionMigration(
+  home: string
+): Promise<SessionMigrationPlan | null> {
+  const codexHome = process.env.CODEX_HOME || join(home, '.codex');
+  const roots = ['sessions', 'archived_sessions'].map(root =>
+    join(codexHome, root)
+  );
+  const files: Array<{ path: string; root: string }> = [];
+  for (const root of roots) {
+    files.push(...(await findRollouts(root)).map(path => ({ path, root })));
+  }
+  if (files.some(file => file.path.endsWith('.jsonl.zst'))) {
+    throw new Error(
+      'Found compressed Codex sessions; decompress them first, or pass --no-migrate-sessions to leave them unchanged'
+    );
+  }
+  const copies: SessionCopy[] = [];
+  for (const file of files) {
+    const copy = await planCopy(file.path, file.root);
+    if (copy) copies.push(copy);
+  }
+  if (copies.length === 0) return null;
+  const sourceRoots = [...new Set(copies.map(copy => copy.root))];
+  return {
+    label: 'Codex Desktop sessions',
+    itemCount: copies.length,
+    totalBytes: copies.reduce((total, copy) => total + copy.bytes, 0),
+    sourceRoots,
+    destinationRoots: sourceRoots,
+    prompt: [
+      `Before changing the provider, copy the ${copies.length} top-level Codex Desktop rollout${copies.length === 1 ? '' : 's'} with a non-\`vercel\` provider under ${sourceRoots.map(root => `\`${root}\``).join(', ')}. Do not copy subagent rollouts whose \`session_id\` differs from \`id\`.`,
+      'For each copy, derive a deterministic UUID v5 using the URL namespace `6ba7b811-9dad-11d1-80b4-00c04fd430c8` and name `vercel-ai-gateway/codex/<source-id>/vercel`. Replace the filename UUID and `session_meta.payload.id`/`session_id`, set `model_provider` to `vercel`, and preserve every later JSONL byte.',
+      'Use atomic, no-clobber writes with mode 0600; skip an existing deterministic destination only after validating its metadata and body. Never move, edit, delete, or overwrite an original session file.',
+    ],
+    async apply() {
+      let copied = 0;
+      let skipped = 0;
+      const errors: string[] = [];
+      for (const item of copies) {
+        try {
+          (await copySession(item)) ? copied++ : skipped++;
+        } catch (error) {
+          errors.push(
+            `${basename(item.source)}: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
+      return { copied, skipped, errors };
+    },
+  };
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/types.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/types.ts
@@ -28,6 +28,26 @@ export interface AgentPlan {
   notes: string[];
 }
 
+export interface SessionMigrationContext {
+  home: string;
+}
+
+export interface SessionMigrationResult {
+  copied: number;
+  skipped: number;
+  errors?: string[];
+}
+
+export interface SessionMigrationPlan {
+  label: string;
+  itemCount: number;
+  totalBytes: number;
+  sourceRoots: string[];
+  destinationRoots: string[];
+  prompt: string[];
+  apply(): Promise<SessionMigrationResult>;
+}
+
 /**
  * Context available before a key exists or any setup question has been asked —
  * warnings run first so the user can bail before the key interview.
@@ -53,4 +73,7 @@ export interface CodingAgent {
   configPath(ctx: SetupContext): string;
   buildPlan(ctx: SetupContext): AgentPlan;
   warnings?(ctx: WarningContext): Promise<AgentWarning[]>;
+  sessionMigration?: {
+    plan(ctx: SessionMigrationContext): Promise<SessionMigrationPlan | null>;
+  };
 }

--- a/packages/cli/test/unit/util/ai-gateway/coding-agents/codex-session-migration.test.ts
+++ b/packages/cli/test/unit/util/ai-gateway/coding-agents/codex-session-migration.test.ts
@@ -1,0 +1,129 @@
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { planCodexSessionMigration } from '../../../../../src/util/ai-gateway/coding-agents/migrations/codex-sessions';
+const SOURCE_ID = '019e944c-b55e-7af2-9ed6-013d2e573834';
+const DESTINATION_ID = '0a3177c2-57d7-5a55-a907-6164c5df6850';
+describe('planCodexSessionMigration', () => {
+  let home: string;
+  beforeEach(async () => {
+    home = await fs.mkdtemp(join(tmpdir(), 'vercel-codex-sessions-'));
+    vi.stubEnv('CODEX_HOME', '');
+  });
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(home, { recursive: true, force: true });
+  });
+  async function createRollout(
+    directory: string,
+    id = SOURCE_ID,
+    payload = {},
+    rest = '{"type":"event","payload":"unchanged"}\n'
+  ): Promise<{ path: string; content: Buffer }> {
+    await fs.mkdir(directory, { recursive: true });
+    const path = join(directory, `rollout-2026-07-27T00-00-00-${id}.jsonl`);
+    const content = Buffer.from(
+      `${JSON.stringify({
+        type: 'session_meta',
+        payload: {
+          id,
+          session_id: id,
+          originator: 'Codex Desktop',
+          model_provider: 'openai',
+          ...payload,
+        },
+      })}\n${rest}`
+    );
+    await fs.writeFile(path, content.toString('utf8'), { mode: 0o640 });
+    return { path, content };
+  }
+  it('finds only eligible Desktop rollouts and respects CODEX_HOME', async () => {
+    const codexHome = join(home, 'custom-codex');
+    vi.stubEnv('CODEX_HOME', codexHome);
+    const sessions = join(codexHome, 'sessions');
+    await createRollout(
+      join(sessions, 'older'),
+      '22222222-2222-4222-8222-222222222222',
+      { originator: undefined, source: 'vscode' }
+    );
+    await fs.writeFile(join(sessions, 'rollout-cold.jsonl.zst'), 'compressed');
+    await expect(planCodexSessionMigration(home)).rejects.toThrow(
+      '--no-migrate-sessions'
+    );
+    await fs.unlink(join(sessions, 'rollout-cold.jsonl.zst'));
+    await createRollout(join(sessions, 'huge'), SOURCE_ID, {
+      padding: 'x'.repeat(1024 ** 2),
+    });
+    await expect(planCodexSessionMigration(home)).rejects.toThrow(
+      'metadata exceeds 1 MiB'
+    );
+  });
+  it('copies atomically without changing the source or rollout body', async () => {
+    const directory = join(home, '.codex', 'sessions', '2026', '07', '27');
+    const source = await createRollout(
+      directory,
+      SOURCE_ID,
+      {},
+      '{"type":"event","payload":"keep  \\t"}\r\nlast-line'
+    );
+    const plan = await planCodexSessionMigration(home);
+    await expect(plan!.apply()).resolves.toEqual({
+      copied: 1,
+      skipped: 0,
+      errors: [],
+    });
+    const destination = join(
+      directory,
+      `rollout-2026-07-27T00-00-00-${DESTINATION_ID}.jsonl`
+    );
+    const [sourceAfter, destinationContent] = await Promise.all([
+      fs.readFile(source.path),
+      fs.readFile(destination),
+    ]);
+    expect(sourceAfter).toEqual(source.content);
+    expect(
+      destinationContent.subarray(destinationContent.indexOf(0x0a) + 1)
+    ).toEqual(source.content.subarray(source.content.indexOf(0x0a) + 1));
+    const metadata = JSON.parse(
+      destinationContent
+        .subarray(0, destinationContent.indexOf(0x0a))
+        .toString()
+    );
+    expect(metadata.payload).toMatchObject({
+      id: DESTINATION_ID,
+      session_id: DESTINATION_ID,
+      model_provider: 'vercel',
+    });
+    // Windows has no Unix file modes — 0o600 comes back as 0o666.
+    if (process.platform !== 'win32') {
+      expect((await fs.stat(destination)).mode & 0o777).toBe(0o600);
+    }
+    expect(await planCodexSessionMigration(home)).toBeNull();
+  });
+  it('includes archived sessions and never overwrites a new destination', async () => {
+    const archived = join(home, '.codex', 'archived_sessions');
+    await createRollout(archived);
+    const removed = await createRollout(
+      join(home, '.codex', 'sessions'),
+      '22222222-2222-4222-8222-222222222222'
+    );
+    const plan = await planCodexSessionMigration(home);
+    const destination = join(
+      archived,
+      `rollout-2026-07-27T00-00-00-${DESTINATION_ID}.jsonl`
+    );
+    await fs.writeFile(destination, 'existing destination', 'utf8');
+    await fs.unlink(removed.path);
+    await expect(plan!.apply()).resolves.toMatchObject({
+      copied: 0,
+      skipped: 0,
+      errors: [
+        expect.stringContaining('ENOENT'),
+        expect.stringContaining('is invalid'),
+      ],
+    });
+    expect(await fs.readFile(destination, 'utf8')).toBe('existing destination');
+    await expect(planCodexSessionMigration(home)).rejects.toThrow('is invalid');
+  });
+});

--- a/packages/cli/test/unit/util/ai-gateway/coding-agents/codex-session-migration.test.ts
+++ b/packages/cli/test/unit/util/ai-gateway/coding-agents/codex-session-migration.test.ts
@@ -49,7 +49,7 @@ describe('planCodexSessionMigration', () => {
     );
     await fs.writeFile(join(sessions, 'rollout-cold.jsonl.zst'), 'compressed');
     await expect(planCodexSessionMigration(home)).rejects.toThrow(
-      '--no-migrate-sessions'
+      '--no-session-migration'
     );
     await fs.unlink(join(sessions, 'rollout-cold.jsonl.zst'));
     await createRollout(join(sessions, 'huge'), SOURCE_ID, {


### PR DESCRIPTION
Splits the session-migration work into two reviewable PRs. **This is PR 1 of 2 — the pure engine.**

## What
Adds the deterministic, atomic engine that copies Codex Desktop rollout sessions into the Vercel AI Gateway provider so switching providers no longer orphans chats:

- `migrations/codex-sessions.ts` — discovers top-level Codex rollouts, derives a deterministic **UUIDv5** destination id per session, and writes a new `model_provider: "vercel"` copy with **no-clobber, atomic** writes (temp file + link, mode 0600). The `openai` originals are **never** modified, so both providers keep their history.
- `SessionMigration*` types + an optional `sessionMigration` hook on the `CodingAgent` interface.
- Unit tests for the engine (`codex-session-migration.test.ts`).

## What's NOT here
No user-facing behavior — nothing calls the engine yet. The `ai-gateway coding-agents setup` wiring (flags, prompts, machine output, warning→migration swap) is **PR 2**, stacked on this one: #17256.

## Test
`pnpm test test/unit/util/ai-gateway/coding-agents/codex-session-migration.test.ts` — green; type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)