### PR TITLE
fix(build-utils): preserve 4-byte UTF-8 in FileBlob streams

### DIFF
--- a/.changeset/fix-fileblob-utf8-stream.md
+++ b/.changeset/fix-fileblob-utf8-stream.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Preserve 4-byte UTF-8 characters when streaming string `FileBlob` contents (fixes Edge Function corruption during `vercel build`).

--- a/packages/build-utils/src/file-blob.ts
+++ b/packages/build-utils/src/file-blob.ts
@@ -59,6 +59,14 @@ export default class FileBlob implements FileBase {
   }
 
   toStream(): NodeJS.ReadableStream {
-    return intoStream(this.data);
+    // Encode strings before streaming. into-stream@5 slices strings with
+    // String#slice at the ~16KiB highWaterMark; a UTF-16 surrogate pair
+    // (any 4-byte UTF-8 character) on that boundary is split and each half
+    // becomes U+FFFD when re-encoded, corrupting Edge Function bundles.
+    const data =
+      typeof this.data === 'string'
+        ? Buffer.from(this.data, 'utf8')
+        : this.data;
+    return intoStream(data);
   }
 }

--- a/packages/build-utils/test/unit.download.test.ts
+++ b/packages/build-utils/test/unit.download.test.ts
@@ -280,6 +280,34 @@ describe('download()', () => {
     strictEqual(linkTarget, 'b.txt');
   });
 
+  it('should preserve 4-byte UTF-8 characters at the 16KiB stream boundary', async () => {
+    // into-stream@5 slices string FileBlob data at highWaterMark (~16384
+    // UTF-16 code units). A surrogate pair starting at offset 16383 is
+    // split across chunks and each half becomes U+FFFD when encoded.
+    const astral = '\u{10437}';
+    const source = `${'a'.repeat(16383)}${astral}b`;
+    const expected = Buffer.from(source, 'utf8');
+    expect(expected.includes(Buffer.from('efbfbd', 'hex'))).toBe(false);
+
+    const outDir = path.join(__dirname, 'utf8-stream-out');
+    await fs.remove(outDir);
+
+    await download(
+      {
+        'index.js': new FileBlob({
+          mode: S_IFREG,
+          contentType: 'application/javascript',
+          data: source,
+        }),
+      },
+      outDir
+    );
+
+    const written = await fs.readFile(path.join(outDir, 'index.js'));
+    expect(written.equals(expected)).toBe(true);
+    expect(written.includes(Buffer.from('efbfbd', 'hex'))).toBe(false);
+  });
+
   it('should create empty directory entries', async () => {
     const outDir = path.join(__dirname, 'symlinks-out');
     await fs.remove(outDir);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [PIPE-6954](https://linear.app/vercel/issue/PIPE-6954): `vercel build` can corrupt 4-byte UTF-8 characters in Edge Function bundles, causing intermittent `vercel deploy --prebuilt` failures (e.g. esbuild `Expected identifier but found "�"` when an astral character from libraries like `he` lands in an unquoted object key).

### Root cause

`@vercel/next` stores Edge Function `index.js` as a string `FileBlob`. During `vercel build`, the CLI writes that blob via `download()` → `FileBlob.toStream()` → `into-stream@5` → `createWriteStream`.

`into-stream@5` slices string input with `String#slice` using the stream highWaterMark (~16384 UTF-16 code units). A UTF-16 surrogate pair (any 4-byte UTF-8 character) that straddles that boundary is split across chunks; each half is then UTF-8-encoded alone and becomes `U+FFFD` (`ef bf bd`).

That matches the report:
- only 4-byte UTF-8 characters are affected
- intermittent (depends on whether an astral char sits at offset 16383 / 32767 / …)
- `next build` is clean (does not go through `FileBlob` + `into-stream`)
- `vercel build` corrupts `.vercel/output/functions/**/index.js`
- Linux repro / macOS miss can be alignment/path-length luck

### Fix

Encode string `FileBlob` data to a `Buffer` before handing it to `into-stream`, so chunk boundaries are byte-based and astral characters stay intact.

### Test

New unit test places a 4-byte UTF-8 character at offset 16383 in a string `FileBlob`, downloads it, and asserts the written file matches `Buffer.from(source, 'utf8')` with no `U+FFFD` bytes.

## Test plan

- [x] Reproduce corruption with `into-stream@5` + string at offset 16383; confirm Buffer path is clean
- [x] `@vercel/build-utils` unit test `should preserve 4-byte UTF-8 characters at the 16KiB stream boundary`
- [x] Related download unit tests pass (`test/unit.download.test.ts`: 8/8)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77ad28de-a200-495c-9f3f-84cdbeeea1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77ad28de-a200-495c-9f3f-84cdbeeea1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

