### PR TITLE
[@vercel/connect] add eve Discord credentials helper

### DIFF
--- a/.changeset/connect-discord-eve.md
+++ b/.changeset/connect-discord-eve.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Add `connectDiscordCredentials` to the eve integration, resolving Discord bot tokens and application IDs from app-scoped Connect credentials while verifying forwarded interactions with Vercel OIDC.

--- a/packages/connect/src/eve/discord-credentials.ts
+++ b/packages/connect/src/eve/discord-credentials.ts
@@ -1,0 +1,79 @@
+import type { DiscordChannelCredentials } from 'eve/channels/discord';
+
+import { vercelOidc } from 'eve/channels/auth';
+
+import {
+  getTokenResponse,
+  type ConnectOptions,
+  type ConnectTokenParams,
+} from '../index.js';
+
+/**
+ * Token parameters accepted by {@link connectDiscordCredentials}.
+ *
+ * Mirrors {@link ConnectTokenParams} from `@vercel/connect`, minus
+ * `subject` — Discord bot tokens are app-scoped, so this helper pins the
+ * subject to `{ type: "app" }`.
+ */
+export type ConnectDiscordCredentialsParams = Omit<
+  ConnectTokenParams,
+  'subject'
+>;
+
+/**
+ * Build {@link DiscordChannelCredentials} backed by a Vercel Connect Discord
+ * Bot connector.
+ *
+ * The bot token and application id are resolved from the same Connect token
+ * response. The webhook verifier accepts interactions forwarded by Connect
+ * using Vercel OIDC, so the eve deployment does not need Discord's public key.
+ *
+ * ```ts
+ * import { discordChannel } from "eve/channels/discord";
+ * import { connectDiscordCredentials } from "@vercel/connect/eve";
+ *
+ * export default discordChannel({
+ *   credentials: connectDiscordCredentials("discord/my-bot"),
+ * });
+ * ```
+ */
+export function connectDiscordCredentials(
+  connector: string,
+  params: ConnectDiscordCredentialsParams = {},
+  options?: ConnectOptions
+): DiscordChannelCredentials {
+  type ResolvedCredentials = {
+    applicationId: string;
+    botToken: string;
+  };
+  let pending: Promise<ResolvedCredentials> | undefined;
+
+  function resolveCredentials(): Promise<ResolvedCredentials> {
+    if (!pending) {
+      pending = getTokenResponse(
+        connector,
+        { ...params, subject: { type: 'app' } },
+        options
+      )
+        .then(response => {
+          const applicationId = response.metadata?.applicationId;
+          if (typeof applicationId !== 'string' || applicationId.length === 0) {
+            throw new Error(
+              `Vercel Connect connector ${connector} did not return a Discord application id.`
+            );
+          }
+          return { applicationId, botToken: response.token };
+        })
+        .finally(() => {
+          pending = undefined;
+        });
+    }
+    return pending;
+  }
+
+  return {
+    applicationId: async () => (await resolveCredentials()).applicationId,
+    botToken: async () => (await resolveCredentials()).botToken,
+    webhookVerifier: vercelOidc(),
+  };
+}

--- a/packages/connect/src/eve/index.ts
+++ b/packages/connect/src/eve/index.ts
@@ -25,6 +25,10 @@ export {
 } from './connect-oauth.js';
 
 export {
+  connectDiscordCredentials,
+  type ConnectDiscordCredentialsParams,
+} from './discord-credentials.js';
+export {
   connectGitHubCredentials,
   type ConnectGitHubCredentialsParams,
 } from './github-credentials.js';

--- a/packages/connect/test/eve/channel-credentials.test.ts
+++ b/packages/connect/test/eve/channel-credentials.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  connectDiscordCredentials,
   connectGitHubCredentials,
   connectLinearCredentials,
   connectPhotonCredentials,
@@ -17,6 +18,67 @@ describe('Eve channel credential helpers', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it('builds Discord credentials backed by one app-scoped Connect token response', async () => {
+    fetchMock.mockResolvedValue(
+      jsonTokenResponse('discord_token', {
+        metadata: { applicationId: '123456789' },
+      })
+    );
+
+    const credentials = connectDiscordCredentials(
+      'discord/my-bot',
+      {},
+      { vercelToken: 'vercel_token' }
+    );
+
+    expect(credentials.webhookVerifier).toEqual(expect.any(Function));
+    const [botToken, applicationId] = await Promise.all([
+      resolveToken(credentials.botToken),
+      resolveToken(credentials.applicationId),
+    ]);
+    expect(botToken).toBe('discord_token');
+    expect(applicationId).toBe('123456789');
+    expectTokenRequest('discord/my-bot', { subject: { type: 'app' } });
+  });
+
+  it('retries Discord credential resolution after a failed shared request', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(
+        jsonTokenResponse('discord_token', {
+          metadata: { applicationId: '123456789' },
+        })
+      );
+
+    const credentials = connectDiscordCredentials(
+      'discord/retry',
+      {},
+      { vercelToken: 'vercel_token' }
+    );
+
+    await expect(resolveToken(credentials.botToken)).rejects.toThrow(
+      'temporary failure'
+    );
+    await expect(resolveToken(credentials.applicationId)).resolves.toBe(
+      '123456789'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails clearly when Discord application metadata is unavailable', async () => {
+    fetchMock.mockResolvedValue(jsonTokenResponse('discord_token'));
+
+    const credentials = connectDiscordCredentials(
+      'discord/missing-metadata',
+      {},
+      { vercelToken: 'vercel_token' }
+    );
+
+    await expect(resolveToken(credentials.applicationId)).rejects.toThrow(
+      'did not return a Discord application id'
+    );
   });
 
   it('builds GitHub credentials backed by an app-scoped Connect token', async () => {


### PR DESCRIPTION
## Summary

Introduces `connectDiscordCredentials()` to `@vercel/connect/eve` so that Eve can use a native Discord bot connection set up Vercel Connect.


```ts
import { discordChannel } from 'eve/channels/discord';
import { connectDiscordCredentials } from '@vercel/connect/eve';

export default discordChannel({
  credentials: connectDiscordCredentials('discord/my-bot'),
});
```

Built on https://github.com/vercel/api/pull/81913

## Summary

Unit tests; vendored + tested with hosted bot