### PR TITLE
ci: grant id-token: write to binary release caller job for npm trusted publishing

### DIFF
--- a/.changeset/grumpy-donuts-publish.md
+++ b/.changeset/grumpy-donuts-publish.md
@@ -1,0 +1,4 @@
+---
+---
+
+Grant `id-token: write` to the binary release job in release.yml so npm trusted publishing (OIDC) works for the native packages published via the reusable release-binary.yml workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,12 @@ jobs:
     name: Binary release
     needs: determine
     if: needs.determine.outputs.should-release-binary == 'true'
+    # Reusable workflow permissions are capped by the calling job, so
+    # id-token: write must be granted here for npm trusted publishing
+    # (OIDC) in the publish-npm job of release-binary.yml to work.
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/release-binary.yml
     with:
       ref: ${{ github.sha }}


### PR DESCRIPTION
### Problem

The native npm package publish failed with `ENEEDAUTH` in the Release run:
https://github.com/vercel/vercel/actions/runs/30394844664/job/90408307030

`release-binary.yml` is invoked as a reusable workflow from `release.yml`. Reusable workflow permissions are capped by the calling job, and the `binary` job in `release.yml` declared no `permissions` block, so `id-token` defaulted to `none`. The `publish-npm` job could not mint an OIDC token, so npm trusted publishing never engaged and `npm publish` failed with no credentials.

### Fix

Grant `contents: read` and `id-token: write` on the `binary` caller job in `release.yml`.

### Related (npm-side, not in this PR)

npm validates trusted publishing against the **top-level** workflow (`release.yml`), not the reusable workflow containing `npm publish`. The trusted publisher configs for `@vercel/vc-native` and the five platform packages (`-darwin-arm64`, `-darwin-x64`, `-linux-arm64`, `-linux-x64`, `-win32-x64`) must be repointed from `release-binary.yml` to `release.yml` (environment: `release`). Both this PR and the npm config change are required.