### PR TITLE
[backends] Fix output directory discovery after build command

### DIFF
--- a/.changeset/output-dir-discovery-fixes.md
+++ b/.changeset/output-dir-discovery-fixes.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Fix output directory discovery after the build command: the `dist`/`build`/`output` fallback was unreachable dead code, and `outputDirectory` was only read from `config.outputDirectory`, missing `config.projectSettings.outputDirectory` (the key wrapper builders use).

--- a/packages/backends/src/build.ts
+++ b/packages/backends/src/build.ts
@@ -24,16 +24,30 @@ async function findEntrypointInOutputDir(
   }
 }
 
+/**
+ * `outputDirectory` reaches the builder as `config.outputDirectory` for
+ * zero-config builds (copied from project settings by `fs-detectors`), but
+ * wrapper builders (e.g. `@vercel/express`) read
+ * `config.projectSettings.outputDirectory` — accept both.
+ */
+export const getOutputDirectorySetting = (
+  config: BuildOptions['config']
+): string | undefined => {
+  const setting =
+    config.outputDirectory ?? config.projectSettings?.outputDirectory;
+  return typeof setting === 'string' && setting !== '' ? setting : undefined;
+};
+
 export const maybeDoBuildCommand = async (
   args: BuildOptions,
   downloadResult: Awaited<ReturnType<typeof downloadInstallAndBundle>>
 ) => {
   const buildCommandResult = await maybeExecBuildCommand(args, downloadResult);
-  const outputSetting = args.config.outputDirectory;
+  const outputSetting = getOutputDirectorySetting(args.config);
 
   let outputDir: string | undefined;
   let entrypoint: string | undefined;
-  if (buildCommandResult && outputSetting) {
+  if (buildCommandResult) {
     if (outputSetting) {
       const _outputDir = join(args.workPath, outputSetting);
       // Skip when `outputDirectory` is the project root itself (e.g. `.`):

--- a/packages/backends/test/unit.build.test.ts
+++ b/packages/backends/test/unit.build.test.ts
@@ -1,0 +1,140 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { BuildOptions } from '@vercel/build-utils';
+import { getOutputDirectorySetting, maybeDoBuildCommand } from '../src/build';
+
+describe('getOutputDirectorySetting', () => {
+  it('reads config.outputDirectory', () => {
+    expect(getOutputDirectorySetting({ outputDirectory: 'dist' })).toBe('dist');
+  });
+
+  it('falls back to config.projectSettings.outputDirectory', () => {
+    expect(
+      getOutputDirectorySetting({
+        projectSettings: { outputDirectory: 'build' },
+      })
+    ).toBe('build');
+  });
+
+  it('prefers config.outputDirectory over projectSettings', () => {
+    expect(
+      getOutputDirectorySetting({
+        outputDirectory: 'dist',
+        projectSettings: { outputDirectory: 'build' },
+      })
+    ).toBe('dist');
+  });
+
+  it('returns undefined when unset or empty', () => {
+    expect(getOutputDirectorySetting({})).toBeUndefined();
+    expect(getOutputDirectorySetting({ outputDirectory: '' })).toBeUndefined();
+    expect(getOutputDirectorySetting({ projectSettings: {} })).toBeUndefined();
+  });
+});
+
+describe('maybeDoBuildCommand', () => {
+  let workPath: string;
+
+  beforeEach(async () => {
+    workPath = await mkdtemp(join(tmpdir(), 'backends-build-'));
+  });
+
+  afterEach(async () => {
+    await rm(workPath, { recursive: true, force: true });
+  });
+
+  const makeArgs = (config: BuildOptions['config']): BuildOptions =>
+    ({
+      files: {},
+      entrypoint: 'package.json',
+      workPath,
+      repoRootPath: workPath,
+      config,
+      meta: {},
+    }) as unknown as BuildOptions;
+
+  const downloadResult = {
+    spawnEnv: { ...process.env },
+  } as Parameters<typeof maybeDoBuildCommand>[1];
+
+  it('discovers entrypoint in configured outputDirectory after build command runs', async () => {
+    await mkdir(join(workPath, 'out'), { recursive: true });
+    await writeFile(join(workPath, 'out', 'index.js'), '// server', 'utf-8');
+
+    const result = await maybeDoBuildCommand(
+      makeArgs({
+        outputDirectory: 'out',
+        projectSettings: { buildCommand: 'true' },
+      }),
+      downloadResult
+    );
+
+    expect(result.outputDir).toBe(join(workPath, 'out'));
+    expect(result.handler).toBe('index.js');
+    expect(result.files).toBeDefined();
+  });
+
+  it('discovers entrypoint via projectSettings.outputDirectory', async () => {
+    await mkdir(join(workPath, 'out'), { recursive: true });
+    await writeFile(join(workPath, 'out', 'index.js'), '// server', 'utf-8');
+
+    const result = await maybeDoBuildCommand(
+      makeArgs({
+        projectSettings: { buildCommand: 'true', outputDirectory: 'out' },
+      }),
+      downloadResult
+    );
+
+    expect(result.outputDir).toBe(join(workPath, 'out'));
+    expect(result.handler).toBe('index.js');
+  });
+
+  it('falls back to common output directories when no outputDirectory is set', async () => {
+    // Previously unreachable: the dist/build/output fallback was gated behind
+    // `buildCommandResult && outputSetting` with an `if (outputSetting)` that
+    // made the `else` branch dead code.
+    await mkdir(join(workPath, 'dist'), { recursive: true });
+    await writeFile(join(workPath, 'dist', 'index.js'), '// server', 'utf-8');
+
+    const result = await maybeDoBuildCommand(
+      makeArgs({ projectSettings: { buildCommand: 'true' } }),
+      downloadResult
+    );
+
+    expect(result.outputDir).toBe(join(workPath, 'dist'));
+    expect(result.handler).toBe('index.js');
+  });
+
+  it('skips output directory discovery when outputDirectory is the project root', async () => {
+    await writeFile(join(workPath, 'index.js'), '// server', 'utf-8');
+
+    const result = await maybeDoBuildCommand(
+      makeArgs({
+        outputDirectory: '.',
+        projectSettings: { buildCommand: 'true' },
+      }),
+      downloadResult
+    );
+
+    expect(result.outputDir).toBeUndefined();
+    expect(result.handler).toBeUndefined();
+  });
+
+  it('returns no output dir when the build command does not run', async () => {
+    await mkdir(join(workPath, 'dist'), { recursive: true });
+    await writeFile(join(workPath, 'dist', 'index.js'), '// server', 'utf-8');
+    // No buildCommand and no package.json `build` script.
+    await writeFile(
+      join(workPath, 'package.json'),
+      JSON.stringify({ name: 'x' }),
+      'utf-8'
+    );
+
+    const result = await maybeDoBuildCommand(makeArgs({}), downloadResult);
+
+    expect(result.outputDir).toBeUndefined();
+    expect(result.handler).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description

Two bugs in `maybeDoBuildCommand` in `@vercel/backends`:

1. **Dead-code fallback**: the `dist`/`build`/`output` common-directory discovery was unreachable. The outer condition required `outputSetting` to be truthy (`if (buildCommandResult && outputSetting)`), so the inner `else` branch handling the no-setting case could never execute.

2. **Wrong config key**: `outputDirectory` was only read from `config.outputDirectory`. Wrapper builders (`@vercel/express` etc.) read `config.projectSettings.outputDirectory`; the builder now accepts both keys via `getOutputDirectorySetting()`.

No new detection semantics — this makes the already-intended behavior reachable. First in a series of incremental PRs bringing `@vercel/backends` to parity with the wrapper builders it is meant to replace.

### Tests

- New `test/unit.build.test.ts` with 9 tests covering both fixes, the project-root (`.`) guard, and the no-build-command case.
- `pnpm vitest-run --run test/unit.build.test.ts` — 9 passed
- `pnpm vitest-run --run test/unit.find-entrypoint.test.ts` — 6 passed
- `pnpm type-check` — clean