### PR TITLE
[backends] Align entrypoint detection with wrapper builders (permissive union)

### DIFF
--- a/.changeset/entrypoint-detection-parity.md
+++ b/.changeset/entrypoint-detection-parity.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Align entrypoint detection with the framework wrapper builders as a permissive union: framework-import-gated well-known filenames win over `package.json#main`, NestJS prefers `src/main`, `koa` is recognized, `outputDirectory` is searched first when configured, and error messages match the wrapper builders. Historical backends behaviors are kept where they accept more projects (`main` without a framework import, `main`/`src/main` filenames for all frameworks, fallthrough to the source tree when the output directory has no entrypoint).

--- a/packages/backends/src/find-entrypoint.ts
+++ b/packages/backends/src/find-entrypoint.ts
@@ -3,16 +3,61 @@ import { readFile } from 'node:fs/promises';
 import { join, relative, resolve, sep } from 'node:path';
 import type { DetectEntrypointFn } from '@vercel/build-utils';
 
-const frameworks = [
-  'express',
-  'hono',
-  'elysia',
-  'fastify',
-  '@nestjs/core',
-  'h3',
+/**
+ * Entrypoint detection modeled on the framework wrapper builders
+ * (`@vercel/express`, `@vercel/hono`, ... — see
+ * `packages/build-utils/src/generate-node-builder-functions.ts`), but
+ * deliberately a *permissive union* with this builder's historical behavior
+ * so that neither wrapper migrations nor existing `@vercel/backends` flag
+ * users start failing:
+ *
+ * 1. If `outputDirectory` is configured, search there first (wrapper
+ *    preference) — but fall through to the source tree instead of erroring
+ *    when nothing is found (historical backends behavior: `outputDirectory`
+ *    never blocked detection).
+ * 2. Search well-known filenames in the project root, requiring the file to
+ *    import the detected framework (wrapper behavior).
+ * 3. Fall back to `package.json#main` when it points at an existing file —
+ *    without requiring a framework import (historical backends behavior;
+ *    the wrappers additionally gate `main` on the import, but relaxing the
+ *    gate only accepts more projects, never fewer).
+ *
+ * When no framework dependency is recognized, the framework-import gate is
+ * skipped and the first existing well-known file (or `main`) wins.
+ */
+
+const entrypointExtensions = ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'];
+
+/**
+ * Wrapper builders search app/index/server (+src). Historical backends also
+ * searched main/src/main for every framework; keep them appended so
+ * existing users don't lose their entrypoint.
+ */
+const DEFAULT_FILENAMES = [
+  'app',
+  'index',
+  'server',
+  'src/app',
+  'src/index',
+  'src/server',
+  'main',
+  'src/main',
 ];
 
-const entrypointFilenames = [
+/** NestJS conventionally uses `src/main.ts`; its wrapper prefers `src/` first. */
+const NESTJS_FILENAMES = [
+  'src/main',
+  'src/app',
+  'src/index',
+  'src/server',
+  'main',
+  'app',
+  'index',
+  'server',
+];
+
+/** Used when no framework dependency is recognized (historical backends order). */
+const GENERIC_FILENAMES = [
   'app',
   'index',
   'server',
@@ -23,21 +68,140 @@ const entrypointFilenames = [
   'src/main',
 ];
 
-const entrypointExtensions = ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'];
+type FrameworkSpec = {
+  /** npm package whose import gates entrypoint candidates. */
+  dependency: string;
+  /** Name used in error messages (the wrapper builders' `frameworkName`). */
+  name: string;
+  filenames: string[];
+};
 
-const entrypoints = entrypointFilenames.flatMap(filename =>
-  entrypointExtensions.map(extension => `${filename}.${extension}`)
-);
+/**
+ * `@nestjs/core` is listed first: Nest apps commonly also depend on `express`
+ * (via `@nestjs/platform-express`), and their entrypoints import
+ * `@nestjs/core`, not `express`.
+ */
+const FRAMEWORKS: FrameworkSpec[] = [
+  { dependency: '@nestjs/core', name: 'nestjs', filenames: NESTJS_FILENAMES },
+  { dependency: 'express', name: 'express', filenames: DEFAULT_FILENAMES },
+  { dependency: 'hono', name: 'hono', filenames: DEFAULT_FILENAMES },
+  { dependency: 'elysia', name: 'elysia', filenames: DEFAULT_FILENAMES },
+  { dependency: 'fastify', name: 'fastify', filenames: DEFAULT_FILENAMES },
+  { dependency: 'koa', name: 'koa', filenames: DEFAULT_FILENAMES },
+  { dependency: 'h3', name: 'h3', filenames: DEFAULT_FILENAMES },
+];
 
-const createFrameworkRegex = (framework: string) =>
+const toCandidates = (filenames: string[]) =>
+  filenames.flatMap(filename =>
+    entrypointExtensions.map(extension => `${filename}.${extension}`)
+  );
+
+const entrypointsForMessage = (filenames: string[]) =>
+  filenames
+    .map(filename => `- ${filename}.{${entrypointExtensions.join(',')}}`)
+    .join('\n');
+
+const createFrameworkRegex = (dependency: string) =>
   new RegExp(
-    `(?:from|require|import)\\s*(?:\\(\\s*)?["']${framework}["']\\s*(?:\\))?`,
+    `(?:from|require|import)\\s*(?:\\(\\s*)?["']${dependency}["']\\s*(?:\\))?`,
     'g'
   );
 
-export const findEntrypoint = async (
-  cwd: string
+const pluralize = (word: string, count: number) =>
+  count === 1 ? word : `${word}s`;
+
+/** Returns true/false for readable files, null when unreadable/missing. */
+const matchesFramework = async (
+  absolutePath: string,
+  spec: FrameworkSpec
+): Promise<boolean | null> => {
+  try {
+    const content = await readFile(absolutePath, 'utf-8');
+    return content.match(createFrameworkRegex(spec.dependency)) !== null;
+  } catch {
+    return null;
+  }
+};
+
+type FindEntrypointOptions = {
+  /**
+   * Project setting `outputDirectory`. When set, the search is exclusive to
+   * that directory, matching the wrapper builders.
+   */
+  outputDirectory?: string;
+};
+
+type Resolution =
+  | { entrypoint: string; error?: undefined }
+  | { entrypoint?: undefined; error: Error };
+
+const searchDirectory = async (
+  dir: string,
+  framework: FrameworkSpec | undefined,
+  filenames: string[]
+): Promise<{
+  entrypoint: string | undefined;
+  entrypointsNotMatchingRegex: string[];
+}> => {
+  const existing = toCandidates(filenames).filter(candidate =>
+    existsSync(join(dir, candidate))
+  );
+
+  if (!framework) {
+    return { entrypoint: existing[0], entrypointsNotMatchingRegex: [] };
+  }
+
+  const matching: string[] = [];
+  const entrypointsNotMatchingRegex: string[] = [];
+  for (const candidate of existing) {
+    const matches = await matchesFramework(join(dir, candidate), framework);
+    if (matches === true) {
+      matching.push(candidate);
+    } else if (matches === false) {
+      entrypointsNotMatchingRegex.push(candidate);
+    }
+  }
+
+  const entrypoint = matching[0];
+  if (matching.length > 1) {
+    console.warn(
+      `Multiple entrypoints found: ${matching.join(', ')}. Using ${entrypoint}.`
+    );
+  }
+  return { entrypoint, entrypointsNotMatchingRegex };
+};
+
+const findMainEntrypoint = async (
+  cwd: string,
+  packageJsonObject: { main?: unknown } | null
 ): Promise<string | undefined> => {
+  const main =
+    packageJsonObject && typeof packageJsonObject.main === 'string'
+      ? packageJsonObject.main.trim()
+      : '';
+  if (!main) return undefined;
+
+  const abs = resolve(cwd, main);
+  const rel = relative(cwd, abs);
+  if (rel.startsWith('..') || rel === '') return undefined;
+  if (!existsSync(abs)) return undefined;
+
+  // Historical backends behavior: accept `main` whenever it points at a
+  // readable file, without requiring a framework import. (The wrapper
+  // builders gate `main` on the framework regex; skipping that gate only
+  // accepts more projects.)
+  try {
+    await readFile(abs, 'utf-8');
+  } catch {
+    return undefined;
+  }
+  return rel.split(sep).join('/');
+};
+
+const resolveEntrypoint = async (
+  cwd: string,
+  options?: FindEntrypointOptions
+): Promise<Resolution> => {
   let packageJsonObject: {
     main?: string;
     dependencies?: Record<string, string>;
@@ -49,82 +213,100 @@ export const findEntrypoint = async (
     // ignore
   }
 
-  if (packageJsonObject) {
-    const main =
-      typeof packageJsonObject.main === 'string'
-        ? packageJsonObject.main.trim()
-        : '';
-    if (main) {
-      const abs = resolve(cwd, main);
-      const rel = relative(cwd, abs);
-      if (!rel.startsWith('..') && rel !== '') {
-        try {
-          await readFile(abs, 'utf-8');
-          return rel.split(sep).join('/');
-        } catch {
-          // main missing or unreadable; fall through to filename heuristics
-        }
-      }
-    }
-  }
+  const framework = packageJsonObject
+    ? FRAMEWORKS.find(
+        spec => packageJsonObject!.dependencies?.[spec.dependency]
+      )
+    : undefined;
+  const filenames = framework ? framework.filenames : GENERIC_FILENAMES;
+  const searchedForMessage = entrypointsForMessage(filenames);
 
-  let framework: string | undefined;
-  if (packageJsonObject) {
-    framework = frameworks.find(
-      framework => packageJsonObject!.dependencies?.[framework]
+  // Match the wrapper builders' errors verbatim (including the trailing
+  // space quirk in the output-directory variant).
+  const noMatchingImportError = (candidates: string[]) =>
+    new Error(
+      `No entrypoint found which imports ${framework!.name}. Found possible ${pluralize('entrypoint', candidates.length)}: ${candidates.join(', ')}`
     );
-  }
 
-  if (!framework) {
-    for (const entrypoint of entrypoints) {
-      const entrypointPath = join(cwd, entrypoint);
-      try {
-        await readFile(entrypointPath, 'utf-8');
-        return entrypoint;
-      } catch (_) {
-        // ignore
-      }
+  // Prefer the configured output directory (wrapper behavior), but fall
+  // through to the source tree instead of erroring when nothing is found —
+  // historical backends never let `outputDirectory` block detection, and a
+  // shared static/server project may keep only client assets there.
+  const dir = options?.outputDirectory?.replace(/^\/+|\/+$/g, '');
+  if (dir) {
+    const { entrypoint: outputDirEntrypoint } = await searchDirectory(
+      join(cwd, dir),
+      framework,
+      filenames
+    );
+    if (outputDirEntrypoint) {
+      return {
+        entrypoint: join(dir, outputDirEntrypoint).split(sep).join('/'),
+      };
     }
   }
 
-  const regex = framework ? createFrameworkRegex(framework) : undefined;
-
-  for (const entrypoint of entrypoints) {
-    const entrypointPath = join(cwd, entrypoint);
-    try {
-      const content = await readFile(entrypointPath, 'utf-8');
-      if (regex) {
-        if (regex.test(content)) {
-          return entrypoint;
-        }
-      }
-    } catch (_) {
-      // ignore
-    }
+  const { entrypoint, entrypointsNotMatchingRegex } = await searchDirectory(
+    cwd,
+    framework,
+    filenames
+  );
+  if (entrypoint) {
+    return { entrypoint };
   }
-  return undefined;
+
+  const mainEntrypoint = await findMainEntrypoint(cwd, packageJsonObject);
+  if (mainEntrypoint) {
+    return { entrypoint: mainEntrypoint };
+  }
+
+  if (framework && entrypointsNotMatchingRegex.length > 0) {
+    return { error: noMatchingImportError(entrypointsNotMatchingRegex) };
+  }
+  if (framework) {
+    return {
+      error: new Error(
+        `No entrypoint found. Searched for:\n${searchedForMessage}`
+      ),
+    };
+  }
+  return {
+    error: new Error(
+      `No entrypoint found in "${cwd}". Set package.json "main" to a server file, or add one of: ${toCandidates(filenames).join(', ')}`
+    ),
+  };
 };
 
-export const findEntrypointOrThrow = async (cwd: string): Promise<string> => {
-  const entrypoint = await findEntrypoint(cwd);
-  if (!entrypoint) {
-    throw new Error(
-      `No entrypoint found in "${cwd}". Set package.json "main" to a server file, or add one of: ${entrypoints.join(', ')}`
-    );
+export const findEntrypoint = async (
+  cwd: string,
+  options?: FindEntrypointOptions
+): Promise<string | undefined> => {
+  const result = await resolveEntrypoint(cwd, options);
+  return result.entrypoint;
+};
+
+export const findEntrypointOrThrow = async (
+  cwd: string,
+  options?: FindEntrypointOptions
+): Promise<string> => {
+  const result = await resolveEntrypoint(cwd, options);
+  if (result.error) {
+    throw result.error;
   }
-  return entrypoint;
+  return result.entrypoint;
 };
 
 export const findEntrypointWithHintOrThrow = async (
   workPath: string,
-  configured: string | undefined
+  configured: string | undefined,
+  options?: FindEntrypointOptions
 ): Promise<string> => {
   const explicit =
     configured && configured !== 'package.json' ? configured : null;
   if (explicit && existsSync(join(workPath, explicit))) {
     return explicit;
   }
-  return findEntrypointOrThrow(workPath);
+  return findEntrypointOrThrow(workPath, options);
 };
 
 /**

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -44,7 +44,7 @@ export type {
 import { rolldown } from './rolldown/index.js';
 import { introspection } from './rolldown/introspection.js';
 import { nft } from './rolldown/nft.js';
-import { maybeDoBuildCommand } from './build.js';
+import { maybeDoBuildCommand, getOutputDirectorySetting } from './build.js';
 import { typescript } from './typescript.js';
 import { Colors as c } from './cervel/utils.js';
 
@@ -110,9 +110,12 @@ export const build: BuildV2 = async args => {
     // pointing into `dist/`) are found.
     const userBuildResult = await maybeDoBuildCommand(args, downloadResult);
 
+    // When `outputDirectory` is configured, prefer entrypoints inside it
+    // (wrapper-builder behavior), falling back to the source tree.
     const entrypoint = await findEntrypointWithHintOrThrow(
       args.workPath,
-      args.entrypoint
+      args.entrypoint,
+      { outputDirectory: getOutputDirectorySetting(args.config) }
     );
     debug('Entrypoint', entrypoint);
     args.entrypoint = entrypoint;

--- a/packages/backends/test/unit.find-entrypoint.test.ts
+++ b/packages/backends/test/unit.find-entrypoint.test.ts
@@ -8,9 +8,11 @@ import {
   findEntrypointOrThrow,
 } from '../src/find-entrypoint';
 
+const makeDir = () => mkdtemp(join(tmpdir(), 'be-entry-'));
+
 describe('findEntrypoint', () => {
-  it('resolves package.json main when the file exists', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'be-main-'));
+  it('resolves package.json main when no well-known file exists (no framework)', async () => {
+    const dir = await makeDir();
     try {
       await writeFile(
         join(dir, 'package.json'),
@@ -28,8 +30,77 @@ describe('findEntrypoint', () => {
     }
   });
 
+  it('prefers a framework-importing well-known file over package.json main', async () => {
+    // Matches the wrapper builders: root glob wins, `main` is a fallback.
+    const dir = await makeDir();
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({
+          name: 'x',
+          main: './other.js',
+          dependencies: { express: '^4' },
+        }),
+        'utf-8'
+      );
+      await writeFile(join(dir, 'other.js'), `require('express')`, 'utf-8');
+      await writeFile(
+        join(dir, 'server.js'),
+        `const express = require('express')`,
+        'utf-8'
+      );
+      await expect(findEntrypoint(dir)).resolves.toBe('server.js');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts package.json main without a framework import (historical backends behavior)', async () => {
+    // More permissive than the wrapper builders, which gate `main` on the
+    // framework regex — kept so existing @vercel/backends users don't break.
+    const dir = await makeDir();
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({
+          name: 'x',
+          main: './cli.js',
+          dependencies: { express: '^4' },
+        }),
+        'utf-8'
+      );
+      await writeFile(
+        join(dir, 'cli.js'),
+        `console.log('not a server')`,
+        'utf-8'
+      );
+      await expect(findEntrypoint(dir)).resolves.toBe('cli.js');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('still finds main/src/main for non-nest frameworks (historical backends behavior)', async () => {
+    const dir = await makeDir();
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: 'x', dependencies: { hono: '^4' } }),
+        'utf-8'
+      );
+      await writeFile(
+        join(dir, 'main.ts'),
+        `import { Hono } from 'hono'\n`,
+        'utf-8'
+      );
+      await expect(findEntrypoint(dir)).resolves.toBe('main.ts');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('falls through when main points to a missing file', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'be-main-miss-'));
+    const dir = await makeDir();
     try {
       await writeFile(
         join(dir, 'package.json'),
@@ -52,7 +123,7 @@ describe('findEntrypoint', () => {
   });
 
   it('rejects main paths outside cwd', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'be-main-out-'));
+    const dir = await makeDir();
     try {
       await writeFile(
         join(dir, 'package.json'),
@@ -67,11 +138,140 @@ describe('findEntrypoint', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('requires framework import for well-known files when a framework is present', async () => {
+    const dir = await makeDir();
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: 'x', dependencies: { fastify: '^4' } }),
+        'utf-8'
+      );
+      await writeFile(join(dir, 'index.js'), `// no import here`, 'utf-8');
+      await writeFile(
+        join(dir, 'server.js'),
+        `import fastify from 'fastify'`,
+        'utf-8'
+      );
+      await expect(findEntrypoint(dir)).resolves.toBe('server.js');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers src/main for nestjs projects', async () => {
+    const dir = await makeDir();
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({
+          name: 'x',
+          dependencies: { '@nestjs/core': '^10', express: '^4' },
+        }),
+        'utf-8'
+      );
+      await mkdir(join(dir, 'src'), { recursive: true });
+      await writeFile(
+        join(dir, 'src', 'main.ts'),
+        `import { NestFactory } from '@nestjs/core'`,
+        'utf-8'
+      );
+      await writeFile(
+        join(dir, 'index.ts'),
+        `import { NestFactory } from '@nestjs/core'`,
+        'utf-8'
+      );
+      await expect(findEntrypoint(dir)).resolves.toBe('src/main.ts');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  describe('outputDirectory', () => {
+    it('searches only the output directory when configured', async () => {
+      const dir = await makeDir();
+      try {
+        await writeFile(
+          join(dir, 'package.json'),
+          JSON.stringify({ name: 'x', dependencies: { express: '^4' } }),
+          'utf-8'
+        );
+        // Root entrypoint exists but must be ignored.
+        await writeFile(join(dir, 'server.js'), `require('express')`, 'utf-8');
+        await mkdir(join(dir, 'dist'), { recursive: true });
+        await writeFile(
+          join(dir, 'dist', 'index.js'),
+          `require('express')`,
+          'utf-8'
+        );
+        await expect(
+          findEntrypoint(dir, { outputDirectory: 'dist' })
+        ).resolves.toBe('dist/index.js');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('falls through to the source tree when the output directory has no entrypoint', async () => {
+      // More permissive than the wrapper builders (which error out here) —
+      // historical backends never let `outputDirectory` block detection.
+      const dir = await makeDir();
+      try {
+        await writeFile(
+          join(dir, 'package.json'),
+          JSON.stringify({ name: 'x', dependencies: { express: '^4' } }),
+          'utf-8'
+        );
+        await writeFile(join(dir, 'server.js'), `require('express')`, 'utf-8');
+        await mkdir(join(dir, 'dist'), { recursive: true });
+        await expect(
+          findEntrypointOrThrow(dir, { outputDirectory: 'dist' })
+        ).resolves.toBe('server.js');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('error messages (wrapper-builder parity)', () => {
+    it('reports candidates that do not import the framework', async () => {
+      const dir = await makeDir();
+      try {
+        await writeFile(
+          join(dir, 'package.json'),
+          JSON.stringify({ name: 'x', dependencies: { express: '^4' } }),
+          'utf-8'
+        );
+        await writeFile(join(dir, 'index.js'), `// nope`, 'utf-8');
+        await expect(findEntrypointOrThrow(dir)).rejects.toThrow(
+          'No entrypoint found which imports express. Found possible entrypoint: index.js'
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('lists searched filenames when no candidates exist', async () => {
+      const dir = await makeDir();
+      try {
+        await writeFile(
+          join(dir, 'package.json'),
+          JSON.stringify({ name: 'x', dependencies: { hono: '^4' } }),
+          'utf-8'
+        );
+        await expect(findEntrypointOrThrow(dir)).rejects.toThrow(
+          /No entrypoint found\. Searched for:\n- app\.\{js,cjs,mjs,ts,cts,mts\}/
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });
 
 describe('findEntrypointOrThrow', () => {
-  it('throws a message that mentions package.json main', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'be-throw-'));
+  it('throws a message that mentions package.json main (no framework)', async () => {
+    const dir = await makeDir();
     try {
       await writeFile(
         join(dir, 'package.json'),
@@ -89,7 +289,7 @@ describe('findEntrypointOrThrow', () => {
 
 describe('detectEntrypoint (normalized)', () => {
   it('emits a file-kind result wrapping the discovered entrypoint', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'be-detect-'));
+    const dir = await makeDir();
     try {
       await writeFile(
         join(dir, 'package.json'),
@@ -111,7 +311,7 @@ describe('detectEntrypoint (normalized)', () => {
   });
 
   it('returns null when no entrypoint is discoverable', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'be-detect-empty-'));
+    const dir = await makeDir();
     try {
       await expect(detectEntrypoint({ workPath: dir })).resolves.toBeNull();
     } finally {


### PR DESCRIPTION
### Description

Stacked on #17284 (which is stacked on #17283).

Reworks `findEntrypoint` to model the wrapper builders (`packages/build-utils/src/generate-node-builder-functions.ts`) while keeping every case the old backends logic accepted — a permissive union, so neither wrapper migrations nor existing `@vercel/backends` flag users start failing.

**Wrapper parity gained:**
- Framework-import-gated well-known files now take precedence over `package.json#main` (previously `main` always won, even when it pointed at a CLI file).
- NestJS gets its own filename order preferring `src/main`, and `@nestjs/core` is checked before `express` so Nest apps that also depend on express detect correctly.
- `koa` added to the recognized frameworks.
- `outputDirectory` is searched first when configured (wired through `build()` using `getOutputDirectorySetting` from #17283).
- Error messages match the wrapper builders ("No entrypoint found which imports X…", "Searched for:" list).
- Multiple matching entrypoints log a warning and use the first, same as the wrappers.

**Kept permissive (historical backends behavior):**
- `main` accepted without a framework import as a fallback.
- `main`/`src/main` searched for every framework, not just Nest.
- Fallthrough to the source tree when `outputDirectory` has no entrypoint (wrappers hard-error here).

### Tests

- `test/unit.find-entrypoint.test.ts` expanded from 6 to 15 tests: precedence, Nest ordering, framework gate, `outputDirectory` inclusion/fallthrough, wrapper-parity error messages.
- `pnpm vitest-run --run test/unit.find-entrypoint.test.ts test/unit.build.test.ts test/unit.post-build-entrypoint.test.ts` — 25 passed
- `test/unit.start-dev-server.test.ts`, `test/unit.resolve-format.test.ts` — 7 passed
- Cron + diagnostics suites — 85 passed
- `pnpm type-check` — clean
