### PR TITLE
feat(cli): support full URLs in httpstat

### DIFF
--- a/.changeset/swift-clocks-httpstat.md
+++ b/.changeset/swift-clocks-httpstat.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow `vercel httpstat` to accept deployment URLs and bare hostnames with automatic protection bypass.

--- a/packages/cli/src/commands/curl/index.ts
+++ b/packages/cli/src/commands/curl/index.ts
@@ -37,6 +37,7 @@ export async function runCurl(
 
   const setup = setupCurlLikeCommand(client, curlCommand, telemetryClient, {
     allowFullUrl: true,
+    passthroughToolFlags: true,
     args,
   });
 

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -167,11 +167,15 @@ export function setupCurlLikeCommand(
   client: Client,
   command: Command,
   telemetryClient: CommandTelemetryClient,
-  options: { allowFullUrl?: boolean; args?: string[] } = {}
+  options: {
+    allowFullUrl?: boolean;
+    passthroughToolFlags?: boolean;
+    args?: string[];
+  } = {}
 ): CommandSetupResult | number {
   const { print } = output;
 
-  if (options.allowFullUrl) {
+  if (options.passthroughToolFlags) {
     const parsed = parseCurlLikeArgs(
       options.args ?? client.argv.slice(2),
       command.name

--- a/packages/cli/src/commands/httpstat/command.ts
+++ b/packages/cli/src/commands/httpstat/command.ts
@@ -38,6 +38,10 @@ export const httpstatCommand = {
   ],
   examples: [
     {
+      name: 'Visualize timing for a protected deployment URL',
+      value: `${packageName} httpstat https://your-project-abc123.vercel.app/api/hello`,
+    },
+    {
       name: 'Visualize timing for a GET request to an API endpoint',
       value: `${packageName} httpstat /api/hello`,
     },

--- a/packages/cli/src/commands/httpstat/index.ts
+++ b/packages/cli/src/commands/httpstat/index.ts
@@ -4,7 +4,11 @@ import { httpstatCommand } from './command';
 import output from '../../output-manager';
 import { requoteArgs } from '../curl/utils';
 import { HttpstatTelemetryClient } from '../../util/telemetry/commands/httpstat';
-import { getDeploymentUrlAndToken, setupCurlLikeCommand } from '../curl/shared';
+import {
+  getDeploymentUrlAndToken,
+  getFullUrlAndToken,
+  setupCurlLikeCommand,
+} from '../curl/shared';
 
 export default async function httpstat(client: Client): Promise<number> {
   const telemetryClient = new HttpstatTelemetryClient({
@@ -13,19 +17,24 @@ export default async function httpstat(client: Client): Promise<number> {
     },
   });
 
-  const setup = setupCurlLikeCommand(client, httpstatCommand, telemetryClient);
+  const setup = setupCurlLikeCommand(client, httpstatCommand, telemetryClient, {
+    allowFullUrl: true,
+  });
 
   if (typeof setup === 'number') {
     return setup;
   }
 
-  const { path, deploymentFlag, protectionBypassFlag, toolFlags } = setup;
+  const { path, isFullUrl, deploymentFlag, protectionBypassFlag, toolFlags } =
+    setup;
 
-  const result = await getDeploymentUrlAndToken(client, 'httpstat', path, {
-    deploymentFlag,
-    protectionBypassFlag,
-    autoConfirm: setup.yes,
-  });
+  const result = isFullUrl
+    ? await getFullUrlAndToken(client, path, protectionBypassFlag)
+    : await getDeploymentUrlAndToken(client, 'httpstat', path, {
+        deploymentFlag,
+        protectionBypassFlag,
+        autoConfirm: setup.yes,
+      });
 
   if (typeof result === 'number') {
     return result;

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -61,7 +61,7 @@ export const help = () => `
       edge-config          [cmd]       Manage Edge Config stores
       firewall             [cmd]       Manages Vercel Firewall configuration and custom rules
       flags                [cmd]       Manage feature flags for a Vercel project
-      httpstat             path        Visualize HTTP timing statistics for deployments
+      httpstat             [url|path]  Visualize HTTP timing statistics for deployments
       logs                 [url]       Displays the logs for a deployment
       metrics              <metric>    Queries observability metrics for your project or team
       mcp                              Set up MCP agents and configuration

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -56,7 +56,7 @@ exports[`base level help output > help 1`] = `
       edge-config          [cmd]       Manage Edge Config stores
       firewall             [cmd]       Manages Vercel Firewall configuration and custom rules
       flags                [cmd]       Manage feature flags for a Vercel project
-      httpstat             path        Visualize HTTP timing statistics for deployments
+      httpstat             [url|path]  Visualize HTTP timing statistics for deployments
       logs                 [url]       Displays the logs for a deployment
       metrics              <metric>    Queries observability metrics for your project or team
       mcp                              Set up MCP agents and configuration

--- a/packages/cli/test/unit/commands/httpstat/index.test.ts
+++ b/packages/cli/test/unit/commands/httpstat/index.test.ts
@@ -98,6 +98,9 @@ describe('httpstat', () => {
       expect(client.getFullOutput()).toContain(
         'Execute httpstat with automatic deployment URL and protection bypass'
       );
+      expect(client.getFullOutput()).toContain(
+        'vercel httpstat https://your-project-abc123.vercel.app/api/hello'
+      );
     });
   });
 
@@ -106,14 +109,14 @@ describe('httpstat', () => {
       client.setArgv('httpstat');
       const exitCode = await httpstat(client);
       expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('requires an API path');
+      await expect(client.stderr).toOutput('requires a URL or API path');
     });
 
     it('should reject when only -- is provided without a path', async () => {
       client.setArgv('httpstat', '--', '-H', 'Content-Type: application/json');
       const exitCode = await httpstat(client);
       expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('requires an API path');
+      await expect(client.stderr).toOutput('requires a URL or API path');
     });
 
     it('should accept / as a valid path', async () => {
@@ -136,18 +139,36 @@ describe('httpstat', () => {
       ]);
     });
 
-    it('should reject when a full https URL is provided as the path', async () => {
-      client.setArgv('httpstat', 'https://example.com/api/hello');
+    it('should accept when a full https URL is provided as the path', async () => {
+      client.setArgv(
+        'httpstat',
+        'https://example.com/api/hello',
+        '--protection-bypass',
+        'test-secret'
+      );
       const exitCode = await httpstat(client);
-      expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('must be a relative API path');
+      expect(exitCode).toEqual(0);
+      expect(spawnMock).toHaveBeenCalledWith(
+        'httpstat',
+        expect.arrayContaining(['https://example.com/api/hello']),
+        expect.any(Object)
+      );
     });
 
-    it('should reject when a full http URL is provided as the path', async () => {
-      client.setArgv('httpstat', 'http://localhost:3000/');
+    it('should accept a bare host as the path', async () => {
+      client.setArgv(
+        'httpstat',
+        'example.vercel.app/api/hello',
+        '--protection-bypass',
+        'test-secret'
+      );
       const exitCode = await httpstat(client);
-      expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('must be a relative API path');
+      expect(exitCode).toEqual(0);
+      expect(spawnMock).toHaveBeenCalledWith(
+        'httpstat',
+        expect.arrayContaining(['https://example.vercel.app/api/hello']),
+        expect.any(Object)
+      );
     });
 
     it('should reject unrecognized flags before --', async () => {


### PR DESCRIPTION
Allows vercel httpstat to accept deployment URLs and bare hostnames with automatic protection bypass, matching curl behavior while preserving strict flag validation.