### PR TITLE
fix(skills): correct Vercel CLI project context guidance

### DIFF
--- a/.changeset/quiet-spoons-check.md
+++ b/.changeset/quiet-spoons-check.md
@@ -1,4 +1,5 @@
 ---
+'vercel': patch
 ---
 
-Corrected Vercel CLI skill guidance for project resolution, pull outputs, and browser authentication flows.
+Made non-interactive project inspection fail instead of linking when project context is unresolved, and corrected Vercel CLI skill guidance for project resolution, pull outputs, and browser authentication flows.

--- a/.changeset/quiet-spoons-check.md
+++ b/.changeset/quiet-spoons-check.md
@@ -1,0 +1,4 @@
+---
+---
+
+Corrected Vercel CLI skill guidance for project resolution, pull outputs, and browser authentication flows.

--- a/packages/cli/src/commands/project/inspect.ts
+++ b/packages/cli/src/commands/project/inspect.ts
@@ -53,6 +53,7 @@ export default async function inspect(
     client,
     commandName: 'project inspect',
     projectNameOrId: name,
+    forReadOnlyCommand: true,
   });
 
   const org = await getTeamById(client, project.accountId);

--- a/packages/cli/src/commands/project/inspect.ts
+++ b/packages/cli/src/commands/project/inspect.ts
@@ -13,6 +13,27 @@ import stamp from '../../util/output/stamp';
 import getTeamById from '../../util/teams/get-team-by-id';
 import formatDate from '../../util/format-date';
 import type Client from '../../util/client';
+import { exitWithNonInteractiveError } from '../../util/agent-output';
+
+const getProjectForInspect = async (
+  client: Client,
+  projectNameOrId: string | undefined,
+  autoConfirm: boolean | undefined
+) => {
+  try {
+    return await getProjectByCwdOrLink({
+      autoConfirm,
+      client,
+      commandName: 'project inspect',
+      projectNameOrId,
+      forReadOnlyCommand: true,
+    });
+  } catch (error: unknown) {
+    exitWithNonInteractiveError(client, error, 1, { variant: 'inspect' });
+    printError(error);
+    return null;
+  }
+};
 
 export default async function inspect(
   client: Client,
@@ -48,13 +69,14 @@ export default async function inspect(
   }
 
   const inspectStamp = stamp();
-  const project = await getProjectByCwdOrLink({
-    autoConfirm: parsedArgs.flags['--yes'],
+  const project = await getProjectForInspect(
     client,
-    commandName: 'project inspect',
-    projectNameOrId: name,
-    forReadOnlyCommand: true,
-  });
+    name,
+    parsedArgs.flags['--yes']
+  );
+  if (!project) {
+    return 1;
+  }
 
   const org = await getTeamById(client, project.accountId);
   const projectSlugLink = formatProject(org.slug, project.name);

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -640,6 +640,7 @@ const EDGE_CONFIG_NON_INTERACTIVE_HINT =
 
 export type ExitWithNonInteractiveErrorVariant =
   | 'members'
+  | 'inspect'
   | 'access-groups'
   | 'access-summary'
   | 'protection'
@@ -737,10 +738,15 @@ function buildNextStepsForProjectSubcommands(
                       template: 'project checks add <name>' as const,
                       when: 'Create a deployment check by project name (replace <name>)',
                     }
-                  : {
-                      template: 'project members <name>' as const,
-                      when: 'List members by project name (replace <name>)',
-                    };
+                  : variant === 'inspect'
+                    ? {
+                        template: 'project inspect <name>' as const,
+                        when: 'Inspect a project by name (replace <name>)',
+                      }
+                    : {
+                        template: 'project members <name>' as const,
+                        when: 'List members by project name (replace <name>)',
+                      };
   return [
     {
       command: buildCommandWithGlobalFlags(client.argv, 'link'),

--- a/packages/cli/test/unit/commands/project/inspect.test.ts
+++ b/packages/cli/test/unit/commands/project/inspect.test.ts
@@ -2,11 +2,10 @@ import assert from 'node:assert';
 import { access, mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { frameworkList } from '@vercel/frameworks';
 import createLineIterator from 'line-async-iterator';
 import projects from '../../../../src/commands/project';
-import { LinkRequiredError } from '../../../../src/util/errors-ts';
 import { useUser } from '../../../mocks/user';
 import { useTeams } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
@@ -160,9 +159,24 @@ describe('inspect', () => {
     client.cwd = projectDirectory;
     client.nonInteractive = true;
     client.setArgv('project', 'inspect', '--non-interactive');
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as () => never);
 
     try {
-      await expect(projects(client)).rejects.toBeInstanceOf(LinkRequiredError);
+      await expect(projects(client)).rejects.toThrow('exit:1');
+
+      const payload = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'link_required',
+        message: expect.stringMatching(/linked|project name/i),
+      });
+      expect(
+        payload.next?.some((next: { command: string }) =>
+          /project inspect <name>/.test(next.command)
+        )
+      ).toBe(true);
       await expect(
         access(join(projectDirectory, '.vercel'))
       ).rejects.toMatchObject({ code: 'ENOENT' });

--- a/packages/cli/test/unit/commands/project/inspect.test.ts
+++ b/packages/cli/test/unit/commands/project/inspect.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert';
+import { access, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { frameworkList } from '@vercel/frameworks';
 import createLineIterator from 'line-async-iterator';
 import projects from '../../../../src/commands/project';
+import { LinkRequiredError } from '../../../../src/util/errors-ts';
 import { useUser } from '../../../mocks/user';
 import { useTeams } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
@@ -134,5 +138,37 @@ describe('inspect', () => {
     // empty line
     line = await lines.next();
     expect(line.value).toEqual('');
+  });
+
+  it('does not auto-link a matching project in non-interactive mode', async () => {
+    useUser();
+    const teams = useTeams('team_dummy');
+    assert(Array.isArray(teams));
+    const [team] = teams;
+    useProject({
+      ...defaultProject,
+      name: 'test_project',
+      accountId: team.id,
+    });
+
+    const temporaryDirectory = await mkdtemp(
+      join(tmpdir(), 'vc-cli-project-inspect-')
+    );
+    const projectDirectory = join(temporaryDirectory, 'test_project');
+    await mkdir(projectDirectory);
+    const previousCwd = client.cwd;
+    client.cwd = projectDirectory;
+    client.nonInteractive = true;
+    client.setArgv('project', 'inspect', '--non-interactive');
+
+    try {
+      await expect(projects(client)).rejects.toBeInstanceOf(LinkRequiredError);
+      await expect(
+        access(join(projectDirectory, '.vercel'))
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      client.cwd = previousCwd;
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
   });
 });

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -11,19 +11,19 @@ The installed CLI help is the source of truth for obscure or newly added flags. 
 
 Parse only stdout for URLs and JSON. Warnings, progress, and `--help` print to stderr; merge streams only when searching help text. Some help commands exit 2 after printing usage, so treat printed usage as a successful help read.
 
-In agent/non-interactive mode, many commands report errors and required confirmations as a single JSON object on stdout with `status`, `reason`, `hint`, and `next` (runnable follow-up commands). Prefer running a suggested `next` command over composing a retry. Read commands such as `list`, `logs`, `inspect`, and `api` keep their normal output shape.
+In agent/non-interactive mode, many commands report errors and required confirmations as a single JSON object on stdout with `status`, `reason`, `hint`, and `next` (runnable follow-up commands). Prefer a suggested `next` command over composing a retry only after confirming that it preserves the user's intended target and authorization; do not automatically run linking, authentication, or mutation follow-ups. Read commands such as `list`, `logs`, `inspect`, and `api` keep their normal output shape.
 
 ## Critical: Project Linking
 
-Project context depends on the command's working directory. Before a consequential read or mutation, run `vercel project inspect` from the intended directory and confirm the reported owner and project.
+Project context depends on the command's working directory. Before a consequential read or mutation, run `vercel project inspect --non-interactive` from the intended directory and confirm the reported owner and project. This command resolves only existing context in non-interactive mode; stop on `link_required` or a target mismatch instead of linking automatically.
 
 - **`<cwd>/.vercel/project.json`**: Created by `vercel link`. This exact working-directory link wins over a repository link. The CLI does not generally inherit a root `project.json` when run from an arbitrary subdirectory.
 - **`<repo-root>/.vercel/repo.json`**: Created by `vercel link --repo`. The CLI selects the deepest project directory that contains the working directory.
-- **Unmatched repository path**: If no repo mapping contains the working directory, interactive mode prompts among the configured projects. Non-interactive mode currently selects the only configured project, or fails when multiple choices remain.
+- **Unmatched repository path**: If no repo mapping contains the working directory, interactive repo resolution prompts among the configured projects. Non-interactive repo resolution currently selects the only configured project or remains unresolved when multiple choices exist. Commands that set up projects may then enter a linking flow, so non-interactive mode is not generally fail-closed.
 
 Being inside an app directory is not proof that the intended project was selected. Check the resolved project explicitly, especially when a repo mapping does not cover that directory.
 
-`vercel whoami` identifies the authenticated user and effective team; it does not verify the linked project. Read-only project commands can still require login or team SAML re-authentication and open a browser/device flow. Ask the user to complete that flow deliberately before continuing.
+`vercel whoami --format json` identifies the authenticated user and effective team; plain non-TTY `vercel whoami` prints only the username. Neither verifies the linked project. Read-only project commands can still require login or team SAML re-authentication and open a browser/device flow. Ask the user to complete that flow deliberately before continuing.
 
 ## Quick Start
 
@@ -77,8 +77,8 @@ Use this to route to the correct reference file:
 
 - **Wrong link type in monorepos with multiple projects**: `vercel link` creates `project.json`, which only tracks one project. Use `vercel link --repo` instead. When things break, check `.vercel/` first.
 - **Letting commands auto-link in monorepos**: Many commands implicitly run `vercel link` if `.vercel/` doesn't exist. This creates `project.json`, which may be wrong. Run `vercel link` (or `--repo`) explicitly first.
-- **Assuming an app subdirectory determines the project**: Verify with `vercel project inspect`; an unmatched repo path can currently fall back to the sole configured project in non-interactive mode.
-- **Using `vercel whoami` as linked-project verification**: It reports authentication and team context, not the selected project.
+- **Assuming an app subdirectory determines the project**: Verify with `vercel project inspect --non-interactive`; an unmatched repo path can currently fall back to the sole configured project in non-interactive mode.
+- **Using `vercel whoami` as linked-project verification**: `vercel whoami --format json` reports authentication and team context, not the selected project.
 - **Forgetting non-interactive flags in plain CI runs**: detected agents get `--non-interactive` by default, but plain CI does not — pass it explicitly there, and add `--yes` only for commands that require confirmation.
 - **Using `vercel deploy` after `vercel build` without `--prebuilt`**: The build output is ignored.
 - **Using `vercel redeploy` for no-cache rebuilds**: `vercel redeploy` does not expose a no-cache flag; use `vercel deploy --force` without `--with-cache` when you need a fresh deployment that does not retain build cache.

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -17,6 +17,8 @@ In agent/non-interactive mode, many commands report errors and required confirma
 
 Project context depends on the command's working directory. Before a consequential read or mutation, run `vercel project inspect --non-interactive` from the intended directory and confirm the reported owner and project. This command resolves only existing context in non-interactive mode; stop on `link_required` or a target mismatch instead of linking automatically.
 
+Many project-aware commands also accept `--project <name-or-id>` with `--scope <team>` for an explicit, one-command target. Confirm that target and scope preserve the user's intent before using them.
+
 - **`<cwd>/.vercel/project.json`**: Created by `vercel link`. This exact working-directory link wins over a repository link. The CLI does not generally inherit a root `project.json` when run from an arbitrary subdirectory.
 - **`<repo-root>/.vercel/repo.json`**: Created by `vercel link --repo`. The CLI selects the deepest project directory that contains the working directory.
 - **Unmatched repository path**: If no repo mapping contains the working directory, interactive repo resolution prompts among the configured projects. Non-interactive repo resolution currently selects the only configured project or remains unresolved when multiple choices exist. Commands that set up projects may then enter a linking flow, so non-interactive mode is not generally fail-closed.

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -15,14 +15,15 @@ In agent/non-interactive mode, many commands report errors and required confirma
 
 ## Critical: Project Linking
 
-Commands must be run from the directory containing the `.vercel` folder (or a subdirectory of it). How `.vercel` gets set up depends on your project structure:
+Project context depends on the command's working directory. Before a consequential read or mutation, run `vercel project inspect` from the intended directory and confirm the reported owner and project.
 
-- **`.vercel/project.json`**: Created by `vercel link`. Links a single project. Fine for single-project repos, and can work in monorepos if there's only one project.
-- **`.vercel/repo.json`**: Created by `vercel link --repo`. Links a repo that may contain multiple projects. Always a good idea when any project has a non-root directory (e.g., `apps/web`).
+- **`<cwd>/.vercel/project.json`**: Created by `vercel link`. This exact working-directory link wins over a repository link. The CLI does not generally inherit a root `project.json` when run from an arbitrary subdirectory.
+- **`<repo-root>/.vercel/repo.json`**: Created by `vercel link --repo`. The CLI selects the deepest project directory that contains the working directory.
+- **Unmatched repository path**: If no repo mapping contains the working directory, interactive mode prompts among the configured projects. Non-interactive mode currently selects the only configured project, or fails when multiple choices remain.
 
-Running from a project subdirectory (e.g., `apps/web/`) skips the "which project?" prompt since it's unambiguous.
+Being inside an app directory is not proof that the intended project was selected. Check the resolved project explicitly, especially when a repo mapping does not cover that directory.
 
-**When something goes wrong, check how things are linked first** — look at what's in `.vercel/` and whether it's `project.json` or `repo.json`. Also verify you're on the right team with `vercel whoami` — linking while on the wrong team is a common mistake.
+`vercel whoami` identifies the authenticated user and effective team; it does not verify the linked project. Read-only project commands can still require login or team SAML re-authentication and open a browser/device flow. Ask the user to complete that flow deliberately before continuing.
 
 ## Quick Start
 
@@ -76,7 +77,8 @@ Use this to route to the correct reference file:
 
 - **Wrong link type in monorepos with multiple projects**: `vercel link` creates `project.json`, which only tracks one project. Use `vercel link --repo` instead. When things break, check `.vercel/` first.
 - **Letting commands auto-link in monorepos**: Many commands implicitly run `vercel link` if `.vercel/` doesn't exist. This creates `project.json`, which may be wrong. Run `vercel link` (or `--repo`) explicitly first.
-- **Linking while on the wrong team**: Use `vercel whoami` to check, `vercel teams switch` to change.
+- **Assuming an app subdirectory determines the project**: Verify with `vercel project inspect`; an unmatched repo path can currently fall back to the sole configured project in non-interactive mode.
+- **Using `vercel whoami` as linked-project verification**: It reports authentication and team context, not the selected project.
 - **Forgetting non-interactive flags in plain CI runs**: detected agents get `--non-interactive` by default, but plain CI does not — pass it explicitly there, and add `--yes` only for commands that require confirmation.
 - **Using `vercel deploy` after `vercel build` without `--prebuilt`**: The build output is ignored.
 - **Using `vercel redeploy` for no-cache rebuilds**: `vercel redeploy` does not expose a no-cache flag; use `vercel deploy --force` without `--with-cache` when you need a fresh deployment that does not retain build cache.

--- a/skills/vercel-cli/command/vercel.md
+++ b/skills/vercel-cli/command/vercel.md
@@ -18,8 +18,9 @@ Based on task type, read `references/<topic>.md`. Use `vercel <command> --help` 
 
 **Key things to verify:**
 
-- Project is linked (`.vercel/` directory exists)
-- Env vars are pulled if needed (`vercel pull`)
+- Run `vercel project inspect --non-interactive` from the intended working directory and confirm the owner and project; stop on `link_required` or a mismatch instead of treating `.vercel/` existence as proof
+- Use `vercel pull` for project settings and environment data under `.vercel/`; use `vercel env pull` for `.env.local` or another file that is already excluded from source control
+- If login or team SAML re-authentication opens a browser/device flow, wait for deliberate user completion before continuing
 - Use `--non-interactive` for prompt-free runs and `--yes` only when confirmation is required
 - Use `VERCEL_TOKEN` env var for auth (not `--token`)
 - Use first-class CLI commands before `vercel api`

--- a/skills/vercel-cli/references/environment-variables.md
+++ b/skills/vercel-cli/references/environment-variables.md
@@ -42,7 +42,9 @@ vercel env pull                   # writes to .env.local
 vercel env pull .env.development  # writes to custom file
 ```
 
-`vercel pull` also downloads env vars along with project config.
+The CLI adds `.env*` to `.gitignore` only when writing the default `.env.local`. Before using another filename, verify that source control excludes it.
+
+`vercel pull` instead downloads environment data and project settings under `.vercel/`, including `.vercel/.env.<environment>.local`.
 
 ## Running with Env Vars
 

--- a/skills/vercel-cli/references/flags.md
+++ b/skills/vercel-cli/references/flags.md
@@ -42,6 +42,14 @@ vercel flags list --limit 25                               # first page of 25
 vercel flags list --limit 25 --next <cursor>              # next page
 ```
 
+## Version History
+
+```bash
+vercel flags versions my-feature                         # list version history
+vercel flags versions my-feature --environment production --json
+vercel flags versions diff my-feature --revision 4       # compare with the previous revision
+```
+
 ## Opening in Dashboard
 
 ```bash

--- a/skills/vercel-cli/references/getting-started.md
+++ b/skills/vercel-cli/references/getting-started.md
@@ -8,19 +8,20 @@ npm i -g vercel
 
 ## First-Time Setup
 
-1. **Authenticate** — `vercel login` (opens browser). For CI, use `VERCEL_TOKEN` env var instead.
-2. **Check your team** — `vercel whoami` to see current team. `vercel teams switch` to change. Linking on the wrong team is a common mistake.
-3. **Link your project** — `vercel link` (single project) or `vercel link --repo` (monorepo with multiple projects or non-root directories). Creates `.vercel/`.
-4. **Pull env vars** — `vercel pull` downloads project settings and env vars to `.env.local`.
-5. **Dev or deploy** — `vercel dev` (local server) or `vercel --prod` (production deploy).
+1. **Authenticate** - `vercel login` opens a browser/device flow. For CI, use the `VERCEL_TOKEN` environment variable instead. Wait for deliberate user completion when a browser flow starts.
+2. **Link your project** - `vercel link` for a working-directory project or `vercel link --repo` for repository directory mappings. Both create files under `.vercel/`.
+3. **Verify the target** - from the intended working directory, run `vercel project inspect` and confirm its owner and project. `vercel whoami` identifies the authenticated user and effective team, not the linked project.
+4. **Pull local data** - `vercel pull` writes project settings and environment data under `.vercel/`, including `.vercel/.env.<environment>.local`. Use `vercel env pull` to write `.env.local` or a named file instead.
+5. **Dev or deploy** - `vercel dev` starts a local server; `vercel --prod` deploys to production.
 
 ## Project Linking
 
-Commands must be run from the directory containing `.vercel/` or a subdirectory of it.
+Project resolution starts from the command's working directory:
 
-- **`.vercel/project.json`**: Created by `vercel link`. Links a single project. Fine for single-project repos, and can work in monorepos if there's only one project.
-- **`.vercel/repo.json`**: Created by `vercel link --repo`. Links a repo that may contain multiple projects. Always a good idea when any project has a non-root directory (e.g., `apps/web`).
+- **`<cwd>/.vercel/project.json`**: This exact working-directory link takes precedence. A root single-project link is not generally inherited by arbitrary subdirectories.
+- **`<repo-root>/.vercel/repo.json`**: The deepest configured directory containing the working directory wins.
+- **No matching repo directory**: Interactive mode prompts. Non-interactive mode currently selects the sole configured repo project, or fails when multiple projects remain.
 
-Running from a project subdirectory (e.g., `apps/web/`) skips the "which project?" prompt.
+An app subdirectory only identifies a project when the repo mapping covers it. Verify the result with `vercel project inspect` before operating on the project.
 
-**When something goes wrong, check how things are linked first** — look at `.vercel/` and whether it's `project.json` or `repo.json`.
+Read-only inspection can trigger login or team SAML re-authentication, open a browser/device flow, and wait for approval. Ask the user to complete the flow before retrying or continuing.

--- a/skills/vercel-cli/references/getting-started.md
+++ b/skills/vercel-cli/references/getting-started.md
@@ -10,8 +10,8 @@ npm i -g vercel
 
 1. **Authenticate** - `vercel login` opens a browser/device flow. For CI, use the `VERCEL_TOKEN` environment variable instead. Wait for deliberate user completion when a browser flow starts.
 2. **Link your project** - `vercel link` for a working-directory project or `vercel link --repo` for repository directory mappings. Both create files under `.vercel/`.
-3. **Verify the target** - from the intended working directory, run `vercel project inspect` and confirm its owner and project. `vercel whoami` identifies the authenticated user and effective team, not the linked project.
-4. **Pull local data** - `vercel pull` writes project settings and environment data under `.vercel/`, including `.vercel/.env.<environment>.local`. Use `vercel env pull` to write `.env.local` or a named file instead.
+3. **Verify the target** - from the intended working directory, run `vercel project inspect --non-interactive` and confirm its owner and project. Stop on `link_required` or a mismatch rather than linking automatically. `vercel whoami --format json` identifies the authenticated user and effective team, not the linked project.
+4. **Pull local data** - `vercel pull` writes project settings and environment data under `.vercel/`, including `.vercel/.env.<environment>.local`. Use `vercel env pull` to write `.env.local` or another file that is already excluded from source control.
 5. **Dev or deploy** - `vercel dev` starts a local server; `vercel --prod` deploys to production.
 
 ## Project Linking
@@ -20,8 +20,8 @@ Project resolution starts from the command's working directory:
 
 - **`<cwd>/.vercel/project.json`**: This exact working-directory link takes precedence. A root single-project link is not generally inherited by arbitrary subdirectories.
 - **`<repo-root>/.vercel/repo.json`**: The deepest configured directory containing the working directory wins.
-- **No matching repo directory**: Interactive mode prompts. Non-interactive mode currently selects the sole configured repo project, or fails when multiple projects remain.
+- **No matching repo directory**: Interactive repo resolution prompts. Non-interactive repo resolution currently selects the sole configured repo project or remains unresolved when multiple projects exist. Commands that set up projects may then enter a linking flow.
 
-An app subdirectory only identifies a project when the repo mapping covers it. Verify the result with `vercel project inspect` before operating on the project.
+An app subdirectory only identifies a project when the repo mapping covers it. Verify the result with `vercel project inspect --non-interactive` before operating on the project.
 
 Read-only inspection can trigger login or team SAML re-authentication, open a browser/device flow, and wait for approval. Ask the user to complete the flow before retrying or continuing.

--- a/skills/vercel-cli/references/local-development.md
+++ b/skills/vercel-cli/references/local-development.md
@@ -3,8 +3,8 @@
 ## Prerequisites
 
 1. **Link your project** - use `vercel link` for the current directory or `vercel link --repo` for repository directory mappings.
-2. **Verify the target** - run `vercel project inspect` from the directory where you will run development commands and confirm the reported owner and project. `vercel whoami` does not verify the project.
-3. **Pull local data** - use `vercel pull` for project settings and environment data under `.vercel/`, or `vercel env pull` for `.env.local` or a named file.
+2. **Verify the target** - run `vercel project inspect --non-interactive` from the directory where you will run development commands and confirm the reported owner and project. Stop on `link_required` or a mismatch rather than linking automatically. `vercel whoami --format json` reports authentication and team context, not the project.
+3. **Pull local data** - use `vercel pull` for project settings and environment data under `.vercel/`, or `vercel env pull` for `.env.local` or another file that is already excluded from source control.
 
 Inspection and pull commands can trigger login or team SAML re-authentication. If a browser/device flow opens, wait for the user to complete it deliberately.
 
@@ -19,10 +19,10 @@ vercel dev --listen 127.0.0.1:5000   # custom host and port
 ## Related Commands
 
 - `vercel link` - connect the current directory to a Vercel project. Use `--repo` for repository directory mappings.
-- `vercel project inspect` - report the resolved project's owner and settings.
+- `vercel project inspect --non-interactive` - report the resolved existing project's owner and settings without entering a linking flow.
 - `vercel pull` - download project settings and environment data to `.vercel/`, including `.vercel/.env.<environment>.local`.
-- `vercel env pull` - download environment variables to `.env.local` or a named file, not project settings.
+- `vercel env pull` - download environment variables to `.env.local` or another ignored file, not project settings.
 - `vercel init` - scaffold a new project from a Vercel example.
 - `vercel open` - open the Vercel dashboard for the linked project.
 
-With `repo.json`, the deepest configured directory containing the working directory wins. If no mapping matches, interactive mode prompts; non-interactive mode currently selects the sole configured project or fails when multiple projects remain. Do not infer the target from the app directory alone.
+With `repo.json`, the deepest configured directory containing the working directory wins. If no mapping matches, interactive repo resolution prompts; non-interactive repo resolution currently selects the sole configured project or remains unresolved when multiple projects exist. Commands that set up projects may then enter a linking flow, so do not infer the target from the app directory alone.

--- a/skills/vercel-cli/references/local-development.md
+++ b/skills/vercel-cli/references/local-development.md
@@ -2,8 +2,11 @@
 
 ## Prerequisites
 
-1. **Link your project** — `vercel link` or `vercel link --repo` (monorepo). Check your team first with `vercel whoami`.
-2. **Pull env vars** — `vercel pull` or `vercel env pull`
+1. **Link your project** - use `vercel link` for the current directory or `vercel link --repo` for repository directory mappings.
+2. **Verify the target** - run `vercel project inspect` from the directory where you will run development commands and confirm the reported owner and project. `vercel whoami` does not verify the project.
+3. **Pull local data** - use `vercel pull` for project settings and environment data under `.vercel/`, or `vercel env pull` for `.env.local` or a named file.
+
+Inspection and pull commands can trigger login or team SAML re-authentication. If a browser/device flow opens, wait for the user to complete it deliberately.
 
 ## Usage
 
@@ -15,10 +18,11 @@ vercel dev --listen 127.0.0.1:5000   # custom host and port
 
 ## Related Commands
 
-- `vercel link` — connect to a Vercel project. Use `--repo` for multi-project monorepos.
-- `vercel pull` — download project settings and env vars to `.env.local`
-- `vercel env pull` — download only env vars (not project settings)
-- `vercel init` — scaffold a new project from a Vercel example
-- `vercel open` — open the Vercel dashboard for the linked project
+- `vercel link` - connect the current directory to a Vercel project. Use `--repo` for repository directory mappings.
+- `vercel project inspect` - report the resolved project's owner and settings.
+- `vercel pull` - download project settings and environment data to `.vercel/`, including `.vercel/.env.<environment>.local`.
+- `vercel env pull` - download environment variables to `.env.local` or a named file, not project settings.
+- `vercel init` - scaffold a new project from a Vercel example.
+- `vercel open` - open the Vercel dashboard for the linked project.
 
-Run `vercel dev` from a project subdirectory (e.g., `apps/web/`) to skip the project selection prompt.
+With `repo.json`, the deepest configured directory containing the working directory wins. If no mapping matches, interactive mode prompts; non-interactive mode currently selects the sole configured project or fails when multiple projects remain. Do not infer the target from the app directory alone.

--- a/skills/vercel-cli/references/monitoring-and-debugging.md
+++ b/skills/vercel-cli/references/monitoring-and-debugging.md
@@ -66,6 +66,10 @@ vercel logs --since 2024-01-01                 # filter by time
 vercel logs --query "timeout"                  # search
 ```
 
+With `--follow` and no deployment, the CLI tries the latest deployment on the current Git branch, your latest deployment, then the latest production deployment. Use `--environment production` or `--environment preview` to constrain automatic resolution.
+
+In agents, pipes, and CI, log messages expand automatically; do not add `--expand` solely for non-TTY output.
+
 Use `--follow` only for live debugging. Historical log queries should be bounded with `--since`, `--until`, and `--limit`.
 
 ## Metrics

--- a/skills/vercel-cli/references/monorepos.md
+++ b/skills/vercel-cli/references/monorepos.md
@@ -6,10 +6,10 @@ Vercel auto-detects monorepo tools (Turborepo, Nx) and workspace managers (pnpm,
 
 ```bash
 vercel link --repo    # link the whole repo
-vercel project inspect # verify the selected owner and project
-vercel pull           # pull settings and env data into .vercel/
-vc dev                # local development
-vercel deploy         # deploy
+vercel project inspect --non-interactive # verify the selected owner and project
+vercel pull                             # pull settings and env data into .vercel/
+vc dev                                  # local development
+vercel deploy                           # deploy
 ```
 
 ## Linking
@@ -26,7 +26,7 @@ Use `vercel link --repo` to create `.vercel/repo.json`, which maps directories t
 }
 ```
 
-The deepest configured directory containing the working directory wins. If no mapping matches, interactive mode prompts among the configured projects; non-interactive mode currently selects the sole configured project or fails when multiple choices remain. Being inside an app directory does not by itself verify the target, so run `vercel project inspect` before consequential commands.
+The deepest configured directory containing the working directory wins. If no mapping matches, interactive repo resolution prompts among the configured projects; non-interactive repo resolution currently selects the sole configured project or remains unresolved when multiple choices exist. Commands that set up projects may then enter a linking flow. Being inside an app directory does not by itself verify the target, so run `vercel project inspect --non-interactive` and stop on `link_required` or a mismatch before consequential commands.
 
 ## Root Directory
 
@@ -131,4 +131,4 @@ export default app;
 - **Using `vercel link` instead of `vercel link --repo`**: Creates `project.json` which only tracks one project. Use `--repo` for monorepos.
 - **Missing `build` task in turbo.json/nx.json**: Vercel requires an explicit build task. Without it, the build fails.
 - **Adding a `build` script to package.json for transpilation**: Vercel handles TypeScript compilation. The turbo.json `build` task is for orchestration, not transpilation.
-- **Assuming an app directory proves project context**: Verify the resolved owner and project with `vercel project inspect`. `vercel whoami` reports authentication and team context, not the linked project.
+- **Assuming an app directory proves project context**: Verify the resolved owner and project with `vercel project inspect --non-interactive`. `vercel whoami --format json` reports authentication and team context, not the linked project.

--- a/skills/vercel-cli/references/monorepos.md
+++ b/skills/vercel-cli/references/monorepos.md
@@ -6,7 +6,8 @@ Vercel auto-detects monorepo tools (Turborepo, Nx) and workspace managers (pnpm,
 
 ```bash
 vercel link --repo    # link the whole repo
-vercel pull           # pull env vars
+vercel project inspect # verify the selected owner and project
+vercel pull           # pull settings and env data into .vercel/
 vc dev                # local development
 vercel deploy         # deploy
 ```
@@ -25,7 +26,7 @@ Use `vercel link --repo` to create `.vercel/repo.json`, which maps directories t
 }
 ```
 
-Running from a project subdirectory (e.g., `apps/web/`) skips the "which project?" prompt.
+The deepest configured directory containing the working directory wins. If no mapping matches, interactive mode prompts among the configured projects; non-interactive mode currently selects the sole configured project or fails when multiple choices remain. Being inside an app directory does not by itself verify the target, so run `vercel project inspect` before consequential commands.
 
 ## Root Directory
 
@@ -130,4 +131,4 @@ export default app;
 - **Using `vercel link` instead of `vercel link --repo`**: Creates `project.json` which only tracks one project. Use `--repo` for monorepos.
 - **Missing `build` task in turbo.json/nx.json**: Vercel requires an explicit build task. Without it, the build fails.
 - **Adding a `build` script to package.json for transpilation**: Vercel handles TypeScript compilation. The turbo.json `build` task is for orchestration, not transpilation.
-- **Linking while on the wrong team**: Use `vercel whoami` to check, `vercel teams switch` to change.
+- **Assuming an app directory proves project context**: Verify the resolved owner and project with `vercel project inspect`. `vercel whoami` reports authentication and team context, not the linked project.

--- a/skills/vercel-cli/references/platform-ops.md
+++ b/skills/vercel-cli/references/platform-ops.md
@@ -42,7 +42,7 @@ vercel telemetry status
 vercel telemetry enable
 vercel telemetry disable
 vercel upgrade
-vercel whoami
+vercel whoami --format json
 ```
 
 `vercel upgrade` changes the installed global CLI. Prefer the project-pinned CLI or package-manager invocation when one exists, unless the user asked to update a global install.

--- a/skills/vercel-cli/references/projects-and-teams.md
+++ b/skills/vercel-cli/references/projects-and-teams.md
@@ -26,7 +26,7 @@ vercel remove my-app --safe          # skip aliased deployments
 ## Teams
 
 ```bash
-vercel whoami                        # current user and team
+vercel whoami --format json          # current user and effective team
 vercel teams ls                      # list teams
 vercel teams switch                  # interactive team picker
 vercel teams switch my-team          # switch by slug
@@ -38,7 +38,7 @@ vercel teams invite user@example.com # invite member
 Use these commands when the user has not specified a team or project and the task is read-only:
 
 ```bash
-vercel whoami
+vercel whoami --format json
 vercel teams ls --format json
 vercel project ls --scope <team-slug> --format json
 vercel list <project-name> --scope <team-slug> --status READY --format json


### PR DESCRIPTION
## Problem

The canonical Vercel CLI skill currently implies that a parent `.vercel/project.json` applies to arbitrary subdirectories and that entering an app directory makes project selection unambiguous. With a repo link, an unmatched app directory can instead fall back to the sole configured project in non-interactive mode, so an agent may inspect, pull from, or mutate a different project without noticing.

The guidance also uses `vercel whoami` as project verification, conflates `vercel pull` with `vercel env pull`, and does not warn that a read-only inspection may open a browser for login or team SAML re-authentication.

## Changes

- Document exact working-directory `project.json` precedence and deepest-directory repo mapping behavior, including the current unmatched-path fallback.
- Require `vercel project inspect` to confirm the resolved owner and project; clarify that `vercel whoami` reports authentication and team context.
- Distinguish `.vercel/` output from `.env.local` or a named env file.
- Tell agents to pause for deliberate user completion when a browser/device authentication flow starts.
