### PR TITLE
[build] Type container image function settings

### DIFF
--- a/.changeset/kind-images-share.md
+++ b/.changeset/kind-images-share.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Add shared function settings to container image build outputs.

--- a/.changeset/kind-images-share.md
+++ b/.changeset/kind-images-share.md
@@ -1,5 +1,6 @@
 ---
 '@vercel/build-utils': patch
+'vercel': patch
 ---
 
-Add shared function settings to container image build outputs.
+Type shared function settings in container image build outputs.

--- a/packages/build-utils/src/container-image.ts
+++ b/packages/build-utils/src/container-image.ts
@@ -1,18 +1,29 @@
+import type { LambdaOptionsBase } from './lambda';
 import type { Env, Files } from './types';
 
-export interface ContainerImageConfig {
+export interface ContainerImageConfig
+  extends Pick<
+    LambdaOptionsBase,
+    | 'handler'
+    | 'architecture'
+    | 'memory'
+    | 'maxDuration'
+    | 'environment'
+    | 'regions'
+    | 'functionFailoverRegions'
+    | 'experimentalTriggers'
+    | 'supportsCancellation'
+  > {
   /**
-   * The OCI image reference (e.g. `vcr.vercel.com/team/project/svc@sha256:...`).
-   * Carried in `handler` per the build-output contract; api-builds surfaces it
-   * as `image` downstream (see vercel/api#76729).
+   * The OCI image reference, for example
+   * `vcr.vercel.com/team/project/svc@sha256:...`.
+   * The build output contract carries this value in `handler`.
    */
-  handler: string;
   runtime: 'container';
   command?: string[];
-  environment?: Env;
 }
 
-export class ContainerImage {
+export class ContainerImage implements ContainerImageConfig {
   type: 'ContainerImage';
   files: Files;
   /** The OCI image reference, carried in `handler` (see ContainerImageConfig). */
@@ -20,13 +31,27 @@ export class ContainerImage {
   runtime: 'container';
   command?: string[];
   environment: Env;
+  architecture?: ContainerImageConfig['architecture'];
+  memory?: ContainerImageConfig['memory'];
+  maxDuration?: ContainerImageConfig['maxDuration'];
+  regions?: ContainerImageConfig['regions'];
+  functionFailoverRegions?: ContainerImageConfig['functionFailoverRegions'];
+  experimentalTriggers?: ContainerImageConfig['experimentalTriggers'];
+  supportsCancellation?: ContainerImageConfig['supportsCancellation'];
 
-  constructor(params: Omit<ContainerImage, 'type'>) {
+  constructor(params: ContainerImageConfig & { files: Files }) {
     this.type = 'ContainerImage';
     this.files = params.files;
     this.handler = params.handler;
     this.runtime = params.runtime;
     this.command = params.command;
-    this.environment = params.environment;
+    this.environment = params.environment ?? {};
+    this.architecture = params.architecture;
+    this.memory = params.memory;
+    this.maxDuration = params.maxDuration;
+    this.regions = params.regions;
+    this.functionFailoverRegions = params.functionFailoverRegions;
+    this.experimentalTriggers = params.experimentalTriggers;
+    this.supportsCancellation = params.supportsCancellation;
   }
 }

--- a/packages/build-utils/test/unit.container-image.test.ts
+++ b/packages/build-utils/test/unit.container-image.test.ts
@@ -1,0 +1,27 @@
+import { ContainerImage } from '../src/container-image';
+
+describe('ContainerImage', () => {
+  it('preserves function settings', () => {
+    const image = new ContainerImage({
+      files: {},
+      handler: 'docker.io/library/nginx:1.27',
+      runtime: 'container',
+      architecture: 'arm64',
+      memory: 2048,
+      maxDuration: 60,
+      regions: ['iad1'],
+      functionFailoverRegions: ['cle1'],
+      supportsCancellation: true,
+    });
+
+    expect(image).toMatchObject({
+      environment: {},
+      architecture: 'arm64',
+      memory: 2048,
+      maxDuration: 60,
+      regions: ['iad1'],
+      functionFailoverRegions: ['cle1'],
+      supportsCancellation: true,
+    });
+  });
+});

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -152,10 +152,15 @@ function isEdgeFunction(v: any): v is EdgeFunction {
   return v?.type === 'EdgeFunction';
 }
 
-function isContainerImage(v: any): v is ContainerImage {
+function isContainerImage(value: unknown): value is ContainerImage {
   // Container image outputs use `runtime: 'container'`. Detect by runtime so
   // they are handled before the generic Lambda path.
-  return v?.runtime === 'container';
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'runtime' in value &&
+    value.runtime === 'container'
+  );
 }
 
 export function isLambda(v: any): v is Lambda {
@@ -692,8 +697,8 @@ async function writeContainerImage(
 ) {
   const dest = join(outputDir, 'functions', `${path}.func`);
   // For `runtime: 'container'` the OCI image reference is carried in `handler`;
-  // the platform surfaces it as the container image downstream (vercel/api#76729).
-  const handler = (containerImage as any).handler;
+  // the platform uses it as the container image reference.
+  const handler = containerImage.handler;
   if (typeof handler !== 'string' || handler.length === 0) {
     throw new Error(
       `Container image output for "${path}" is missing "handler".`
@@ -701,22 +706,20 @@ async function writeContainerImage(
   }
 
   const architecture =
-    functionConfiguration?.architecture ?? (containerImage as any).architecture;
-  const memory =
-    functionConfiguration?.memory ?? (containerImage as any).memory;
+    functionConfiguration?.architecture ?? containerImage.architecture;
+  const memory = functionConfiguration?.memory ?? containerImage.memory;
   const maxDuration =
-    functionConfiguration?.maxDuration ?? (containerImage as any).maxDuration;
-  const regions =
-    functionConfiguration?.regions ?? (containerImage as any).regions;
+    functionConfiguration?.maxDuration ?? containerImage.maxDuration;
+  const regions = functionConfiguration?.regions ?? containerImage.regions;
   const functionFailoverRegions =
     functionConfiguration?.functionFailoverRegions ??
-    (containerImage as any).functionFailoverRegions;
+    containerImage.functionFailoverRegions;
   const experimentalTriggers =
     functionConfiguration?.experimentalTriggers ??
-    (containerImage as any).experimentalTriggers;
+    containerImage.experimentalTriggers;
   const supportsCancellation =
     functionConfiguration?.supportsCancellation ??
-    (containerImage as any).supportsCancellation;
+    containerImage.supportsCancellation;
 
   await fs.mkdirp(dest);
   await fs.writeJSON(
@@ -724,10 +727,8 @@ async function writeContainerImage(
     {
       handler,
       runtime: 'container',
-      environment: (containerImage as any).environment ?? {},
-      ...((containerImage as any).command
-        ? { command: (containerImage as any).command }
-        : {}),
+      environment: containerImage.environment ?? {},
+      ...(containerImage.command ? { command: containerImage.command } : {}),
       ...(architecture !== undefined ? { architecture } : {}),
       ...(memory !== undefined ? { memory } : {}),
       ...(maxDuration !== undefined ? { maxDuration } : {}),

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import {
   glob,
+  ContainerImage,
   FileBlob,
   FileFsRef,
   getWriteableDirectory,
@@ -112,8 +113,7 @@ describe('writeBuildResult()', () => {
         buildResult: {
           routes: [{ handle: 'filesystem' }, { src: '/(.*)', dest: '/index' }],
           output: {
-            index: {
-              type: 'Lambda',
+            index: new ContainerImage({
               files: {},
               handler: 'docker.io/library/nginx:1.27',
               runtime: 'container',
@@ -121,9 +121,9 @@ describe('writeBuildResult()', () => {
               memory: 2048,
               maxDuration: 60,
               regions: ['iad1'],
-            },
+            }),
           },
-        } as unknown as import('@vercel/build-utils').BuildResultV2,
+        },
         build,
         builder: runtimeBuilder,
         builderPkg: { name: '@vercel/container' },


### PR DESCRIPTION
Type shared function settings for `ContainerImage` and CLI build output.

`ContainerImageConfig` omitted settings that container image outputs already carry. This gap forced the CLI writer and its test to use unsafe casts.

This change extends selected `LambdaOptionsBase` fields. The class preserves those fields and defaults the optional environment to an empty object.

The CLI writer now uses the typed model. Its runtime guard accepts `unknown` input and validates the container runtime.

## Validation

1. The focused `ContainerImage` unit test passes.
2. The combined container and CLI writer tests pass on the stacked branch.
3. Selected Prettier and Biome checks pass.

## Landing order

1. This PR
2. #17177

Docs/knowledge: none needed — this change aligns existing public build output types.
