### PR TITLE
Stop setting VERCEL_DEPLOYMENT_ID=dpl_dev in `vc dev`

### DIFF
--- a/.changeset/three-eels-admire.md
+++ b/.changeset/three-eels-admire.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Stop setting VERCEL_DEPLOYMENT_ID=dpl_dev when running vc dev. Workflows interpreted that as running on a real deployment.

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -244,7 +244,6 @@ export default class DevServer {
       VERCEL_QUEUE_BASE_URL: `${this.address.origin}/_svc/_queues`,
       VERCEL_QUEUE_TOKEN: 'vc-dev-token',
       VERCEL_REGION: 'dev1',
-      VERCEL_DEPLOYMENT_ID: 'dpl_dev',
     };
   }
 

--- a/packages/cli/src/util/dev/services-orchestrator.ts
+++ b/packages/cli/src/util/dev/services-orchestrator.ts
@@ -700,7 +700,6 @@ export class ServicesOrchestrator {
       env.VERCEL_QUEUE_BASE_URL = `${this.proxyOrigin}/_svc/_queues`;
       env.VERCEL_QUEUE_TOKEN = 'vc-dev-token';
       env.VERCEL_REGION = 'dev1';
-      env.VERCEL_DEPLOYMENT_ID = 'dpl_dev';
     }
 
     if (service.routePrefix && service.routePrefix !== '/') {
@@ -779,7 +778,6 @@ export class ServicesOrchestrator {
       env.VERCEL_QUEUE_BASE_URL = `${this.proxyOrigin}/_svc/_queues`;
       env.VERCEL_QUEUE_TOKEN = 'vc-dev-token';
       env.VERCEL_REGION = 'dev1';
-      env.VERCEL_DEPLOYMENT_ID = 'dpl_dev';
     }
 
     const root = service.root || '.';

--- a/packages/cli/test/unit/util/dev/services-orchestrator.test.ts
+++ b/packages/cli/test/unit/util/dev/services-orchestrator.test.ts
@@ -50,7 +50,6 @@ describe('ServicesOrchestrator', () => {
       VERCEL_QUEUE_BASE_URL: 'http://localhost:3000/_svc/_queues',
       VERCEL_QUEUE_TOKEN: 'vc-dev-token',
       VERCEL_REGION: 'dev1',
-      VERCEL_DEPLOYMENT_ID: 'dpl_dev',
     });
   });
 });


### PR DESCRIPTION
This was introduced in #17236. It breaks python workflows in `vc dev`
because workflow thinks it is running on vercel. (I think it also
breaks JS workflows but I don't know if anybody would use `vc dev`
there...)

Still a draft because I need to check on if it breaks anything else.
