### PR TITLE
fix(cli): fall back from incompatible native binary

### DIFF
--- a/.changeset/native-linux-glibc-fallback.md
+++ b/.changeset/native-linux-glibc-fallback.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fall back to the JavaScript CLI when an opted-in native binary is incompatible with the Linux host's glibc runtime.

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -19,6 +19,32 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// The current Linux native artifact embeds a Node runtime built on Ubuntu 24
+// and requires glibc 2.38. Keep opted-in users on the JS CLI when the binary
+// cannot run on their host, including Amazon Linux 2023 and musl-based distros.
+const NATIVE_LINUX_MIN_GLIBC = [2, 38];
+
+function isNativeBinaryRuntimeSupported() {
+  if (process.platform !== 'linux') return true;
+
+  try {
+    const version = process.report?.getReport()?.header?.glibcVersionRuntime;
+    if (typeof version !== 'string') return false;
+
+    const [major, minor] = version
+      .split('.', NATIVE_LINUX_MIN_GLIBC.length)
+      .map(Number);
+    if (!Number.isInteger(major) || !Number.isInteger(minor)) return false;
+
+    const [minimumMajor, minimumMinor] = NATIVE_LINUX_MIN_GLIBC;
+    return (
+      major > minimumMajor || (major === minimumMajor && minor >= minimumMinor)
+    );
+  } catch {
+    return false;
+  }
+}
+
 function resolveNative() {
   // Already running inside the native binary — never trampoline again.
   if (process.env.VERCEL_VC_NATIVE === '1') return null;
@@ -79,7 +105,11 @@ async function isNativeBinaryOptedIn() {
 
 const bin = resolveNative();
 
-if (bin && (await isNativeBinaryOptedIn())) {
+if (
+  bin &&
+  (await isNativeBinaryOptedIn()) &&
+  isNativeBinaryRuntimeSupported()
+) {
   process.env.VERCEL_VC_NATIVE = '1';
   const r = spawnSync(bin, process.argv.slice(2), {
     stdio: 'inherit',

--- a/packages/cli/test/unit/esm/native-trampoline.test.ts
+++ b/packages/cli/test/unit/esm/native-trampoline.test.ts
@@ -102,6 +102,21 @@ function optOutEnv() {
   return { ...cleanEnv(), VERCEL_CLI_USE_NATIVE_BINARY: '0' };
 }
 
+function linuxGlibcEnv(root: string, version?: string) {
+  const preload = join(root, 'linux-glibc-runtime.cjs');
+  writeFileSync(
+    preload,
+    [
+      "Object.defineProperty(process, 'platform', { value: 'linux' });",
+      `process.report.getReport = () => ({ header: { glibcVersionRuntime: ${JSON.stringify(
+        version
+      )} } });`,
+      '',
+    ].join('\n')
+  );
+  return { ...optInEnv(), NODE_OPTIONS: `--require=${preload}` };
+}
+
 describe('dist/vc.js native resolution', () => {
   it('no-ops to JS when no native package is installed', () => {
     const { vcJs } = buildInstall({
@@ -148,6 +163,64 @@ describe('dist/vc.js native resolution', () => {
         encoding: 'utf8',
         env: optInEnv(),
       });
+      expect(r.status).toBe(7);
+      expect(r.stdout.trim()).toBe('NATIVE_RAN');
+    }
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'falls through to JS when Linux glibc is older than the native binary requires',
+    () => {
+      const { root, vcJs } = buildInstall({
+        platform: 'linux',
+        arch: process.arch,
+        body: '#!/bin/sh\necho NATIVE_RAN\nexit 7\n',
+      });
+      const r = spawnSync(process.execPath, [vcJs, '--version'], {
+        encoding: 'utf8',
+        env: linuxGlibcEnv(root, '2.34'),
+      });
+
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe(cliVersion);
+      expect(r.stdout).not.toContain('NATIVE_RAN');
+      expect(r.stderr).not.toContain('(native)');
+    }
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'falls through to JS when Linux does not report a glibc runtime',
+    () => {
+      const { root, vcJs } = buildInstall({
+        platform: 'linux',
+        arch: process.arch,
+        body: '#!/bin/sh\necho NATIVE_RAN\nexit 7\n',
+      });
+      const r = spawnSync(process.execPath, [vcJs, '--version'], {
+        encoding: 'utf8',
+        env: linuxGlibcEnv(root),
+      });
+
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe(cliVersion);
+      expect(r.stdout).not.toContain('NATIVE_RAN');
+      expect(r.stderr).not.toContain('(native)');
+    }
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'spawns the native binary when Linux meets the minimum glibc version',
+    () => {
+      const { root, vcJs } = buildInstall({
+        platform: 'linux',
+        arch: process.arch,
+        body: '#!/bin/sh\necho NATIVE_RAN\nexit 7\n',
+      });
+      const r = spawnSync(process.execPath, [vcJs, '--version'], {
+        encoding: 'utf8',
+        env: linuxGlibcEnv(root, '2.38'),
+      });
+
       expect(r.status).toBe(7);
       expect(r.stdout.trim()).toBe('NATIVE_RAN');
     }


### PR DESCRIPTION
## Summary

- detect the Linux glibc runtime before launching the opted-in native CLI
- fall back silently to the JavaScript CLI on glibc older than 2.38 or when glibc is unavailable (for example, musl)
- cover glibc 2.34, missing glibc, and the supported 2.38 boundary with subprocess tests

## Root cause

#17209 auto-opted members of the `vercel` team into the native trampoline. #17235 then made 58.3.0 the first normal `vercel` release that reliably installed the platform-native optional dependency.

The Linux native artifact embeds a Node runtime built on Ubuntu 24 and requires glibc 2.38. Vercel Sandbox runs Amazon Linux 2023 with glibc 2.34, so the first JS CLI command persisted `useNativeBinary: true` and later invocations failed in the dynamic loader before the CLI could start.

This guard also repairs installations that have already persisted `useNativeBinary: true`. It preserves existing stdout, stderr, and exit-code contracts by staying on the JS CLI before the native process is launched.

## Verification

- `pnpm --filter vercel build`
- `pnpm --filter vercel test test/unit/esm/native-trampoline.test.ts` — 9 tests passed
- `pnpm exec biome lint packages/cli/src/vc.js packages/cli/test/unit/esm/native-trampoline.test.ts`
- `pnpm prettier --check packages/cli/src/vc.js packages/cli/test/unit/esm/native-trampoline.test.ts .changeset/native-linux-glibc-fallback.md`
- pre-commit lint-staged hooks passed

`pnpm --filter vercel type-check` was attempted but is currently blocked by unrelated workspace type skew on `DevQueueSubscription`, `VercelConfig.proxy`, and the existing `GlobalConfig.useNativeBinary` declarations.
