### PR TITLE
[cli] Preserve Claude Desktop sessions during AI Gateway setup

### DIFF
--- a/.changeset/claude-desktop-session-migration.md
+++ b/.changeset/claude-desktop-session-migration.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Preserve existing Claude Desktop sessions when configuring the Vercel AI Gateway.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -73,12 +73,18 @@ export const claudeCode: CodingAgent = {
         },
       ],
       envExports,
-      notes: ctx.useKeychain
-        ? [
-            'The Anthropic auth token is read from your shell environment (Keychain-backed).',
-            'Open a new terminal so ANTHROPIC_AUTH_TOKEN is loaded, then restart Claude Code.',
-          ]
-        : ['Restart Claude Code to pick up the new settings.'],
+      notes: [
+        ...(ctx.useKeychain
+          ? [
+              'The Anthropic auth token is read from your shell environment (Keychain-backed).',
+              'Open a new terminal so ANTHROPIC_AUTH_TOKEN is loaded, then restart Claude Code.',
+            ]
+          : ['Restart Claude Code to pick up the new settings.']),
+        // The desktop app's provider switch cannot be automated (its gateway
+        // credentials live in an app-encrypted store), so guide the two-step:
+        // switch in-app, then re-run to copy the now-orphaned sessions.
+        'The Claude Desktop app switches providers in its own settings (Developer → Configure Third-Party Inference…). After its first gateway launch, re-run this command to copy your existing desktop sessions over.',
+      ],
     };
   },
 };

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -5,6 +5,7 @@ import {
   GATEWAY_CLAUDE_CODE_BASE_URL,
   resolveGatewayBaseUrl,
 } from '../gateway';
+import { planClaudeDesktopSessionMigration } from '../migrations/claude-desktop-sessions';
 
 /**
  * Claude Code reads env vars from the `env` object in `~/.claude/settings.json`.
@@ -28,6 +29,12 @@ function claudeDir(home: string): string {
 export const claudeCode: CodingAgent = {
   id: 'claude-code',
   displayName: 'Claude Code',
+  // CLI sessions are keyed by project directory and survive the provider
+  // switch untouched; only the desktop app's identity-keyed session store
+  // needs a copy (see migrations/claude-desktop-sessions.ts).
+  sessionMigration: {
+    plan: ({ home }) => planClaudeDesktopSessionMigration(home),
+  },
 
   async detect(home) {
     return pathExists(claudeDir(home));

--- a/packages/cli/src/util/ai-gateway/coding-agents/migrations/claude-desktop-sessions.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/migrations/claude-desktop-sessions.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { SessionMigrationPlan } from '../types';
+
+/**
+ * Claude Desktop keeps one session-record store per signed-in identity:
+ *
+ *   <app-support>/Claude/claude-code-sessions/<accountUuid>/<orgUuid>/*.json
+ *
+ * Switching Claude Code to the AI Gateway makes the desktop app run as a
+ * separate "third-party auth" identity with its own profile directory,
+ * `<app-support>/Claude-3p`, whose store starts empty — so every session
+ * created under the claude.ai subscription identity disappears from the
+ * app's session list even though the records (and the transcripts in
+ * `~/.claude/projects`, which are identity-agnostic) are untouched.
+ *
+ * The migration copies each per-session JSON record into the third-party
+ * identity's store, rewriting the `model` field from the subscription's bare
+ * slug (`claude-opus-4-8`) to the gateway id the 3p mode uses
+ * (`anthropic/claude-opus-4-8`). Originals are never modified, so switching
+ * back to the subscription still shows the original sessions.
+ *
+ * The third-party account directory is created by the app on its first
+ * gateway-mode launch and is not derivable beforehand, so this plans a
+ * migration only once that identity exists; `coding-agents setup` is
+ * idempotent, so re-running it after the first launch completes the copy.
+ */
+
+const MAX_RECORD_BYTES = 1024 * 1024;
+const RECORD_PATTERN = /\.json$/;
+
+interface PlannedCopy {
+  source: string;
+  destination: string;
+  bytes: number;
+}
+
+/** Platform-specific root that contains the `Claude` and `Claude-3p` dirs. */
+export function claudeAppSupportRoot(home: string): string {
+  if (process.platform === 'darwin') {
+    return join(home, 'Library', 'Application Support');
+  }
+  if (process.platform === 'win32') {
+    return process.env.APPDATA || join(home, 'AppData', 'Roaming');
+  }
+  return join(home, '.config');
+}
+
+/** `claude-opus-4-8` → `anthropic/claude-opus-4-8`; gateway ids pass through. */
+export function toGatewayModelId(model: string): string {
+  return model.includes('/') ? model : `anthropic/${model}`;
+}
+
+async function listSubdirectories(path: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(path, { withFileTypes: true });
+    return entries.filter(e => e.isDirectory()).map(e => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The identity directory (`<account>/<org>`) the app most recently used,
+ * measured by the store directory's mtime — new session records touch it.
+ */
+async function findDestinationIdentity(root: string): Promise<string | null> {
+  let best: { path: string; mtime: number } | null = null;
+  for (const account of await listSubdirectories(root)) {
+    for (const org of await listSubdirectories(join(root, account))) {
+      const path = join(root, account, org);
+      try {
+        const stat = await fs.stat(path);
+        if (!best || stat.mtimeMs > best.mtime) {
+          best = { path, mtime: stat.mtimeMs };
+        }
+      } catch {
+        // Unreadable identity dirs are skipped, not fatal.
+      }
+    }
+  }
+  return best?.path ?? null;
+}
+
+async function readRecord(
+  path: string
+): Promise<{ record: Record<string, unknown>; bytes: number } | null> {
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(path);
+  } catch {
+    return null;
+  }
+  if (!stat.isFile() || stat.size > MAX_RECORD_BYTES) return null;
+  try {
+    const raw = await fs.readFile(path, 'utf8');
+    const record: unknown = JSON.parse(raw);
+    if (
+      typeof record !== 'object' ||
+      record === null ||
+      Array.isArray(record)
+    ) {
+      return null;
+    }
+    return { record: record as Record<string, unknown>, bytes: stat.size };
+  } catch {
+    // Records the app cannot have written (unreadable/malformed) are skipped.
+    return null;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Atomic, no-clobber write mirroring the Codex copier: temp file + link. */
+async function writeRecordNoClobber(
+  destination: string,
+  contents: string
+): Promise<'copied' | 'skipped'> {
+  if (await pathExists(destination)) return 'skipped';
+  await fs.mkdir(dirname(destination), { recursive: true });
+  const temp = join(dirname(destination), `.migrate-${randomUUID()}.tmp`);
+  await fs.writeFile(temp, contents, { mode: 0o600 });
+  try {
+    await fs.link(temp, destination);
+    return 'copied';
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') return 'skipped';
+    throw error;
+  } finally {
+    await fs.unlink(temp).catch(() => {});
+  }
+}
+
+export async function planClaudeDesktopSessionMigration(
+  home: string,
+  appSupportRoot: string = claudeAppSupportRoot(home)
+): Promise<SessionMigrationPlan | null> {
+  const subscriptionRoot = join(
+    appSupportRoot,
+    'Claude',
+    'claude-code-sessions'
+  );
+  const gatewayRoot = join(appSupportRoot, 'Claude-3p', 'claude-code-sessions');
+
+  // The 3p identity directory only exists after the app's first gateway-mode
+  // launch; without it there is nowhere to copy to yet (see module doc).
+  const destinationDir = await findDestinationIdentity(gatewayRoot);
+  if (!destinationDir) return null;
+
+  const copies: PlannedCopy[] = [];
+  let totalBytes = 0;
+  for (const account of await listSubdirectories(subscriptionRoot)) {
+    for (const org of await listSubdirectories(
+      join(subscriptionRoot, account)
+    )) {
+      const identityDir = join(subscriptionRoot, account, org);
+      let names: string[];
+      try {
+        names = await fs.readdir(identityDir);
+      } catch {
+        continue;
+      }
+      for (const name of names) {
+        if (!RECORD_PATTERN.test(name)) continue;
+        const source = join(identityDir, name);
+        const destination = join(destinationDir, name);
+        if (await pathExists(destination)) continue;
+        const read = await readRecord(source);
+        if (!read) continue;
+        copies.push({ source, destination, bytes: read.bytes });
+        totalBytes += read.bytes;
+      }
+    }
+  }
+  if (copies.length === 0) return null;
+
+  return {
+    label: 'Claude Desktop sessions',
+    itemCount: copies.length,
+    totalBytes,
+    sourceRoots: [subscriptionRoot],
+    destinationRoots: [destinationDir],
+    prompt: [
+      `Copy the ${copies.length} Claude Desktop session record${
+        copies.length === 1 ? '' : 's'
+      } (per-session \`.json\` files) under \`${subscriptionRoot}\` into \`${destinationDir}\`, keeping each filename.`,
+      'In each copy, rewrite the top-level `model` field to its AI Gateway id by prefixing `anthropic/` when the value has no provider prefix (e.g. `claude-opus-4-8` → `anthropic/claude-opus-4-8`); keep any suffix such as `[1m]` intact. Leave every other field unchanged.',
+      'Use atomic, no-clobber writes with mode 0600; skip records whose destination already exists. Never move, edit, delete, or overwrite an original record.',
+    ],
+    async apply() {
+      let copied = 0;
+      let skipped = 0;
+      const errors: string[] = [];
+      for (const copy of copies) {
+        try {
+          const read = await readRecord(copy.source);
+          if (!read) {
+            skipped += 1;
+            continue;
+          }
+          const record = { ...read.record };
+          if (typeof record.model === 'string') {
+            record.model = toGatewayModelId(record.model);
+          }
+          const outcome = await writeRecordNoClobber(
+            copy.destination,
+            `${JSON.stringify(record)}\n`
+          );
+          if (outcome === 'copied') copied += 1;
+          else skipped += 1;
+        } catch (error) {
+          errors.push(
+            `${copy.source}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+      return errors.length > 0
+        ? { copied, skipped, errors }
+        : { copied, skipped };
+    },
+  };
+}

--- a/packages/cli/test/unit/util/ai-gateway/coding-agents/claude-desktop-session-migration.test.ts
+++ b/packages/cli/test/unit/util/ai-gateway/coding-agents/claude-desktop-session-migration.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  planClaudeDesktopSessionMigration,
+  toGatewayModelId,
+} from '../../../../../src/util/ai-gateway/coding-agents/migrations/claude-desktop-sessions';
+
+const SUBSCRIPTION_IDENTITY = [
+  'b901475a-0957-4b05-aebb-7aea4a2f495e',
+  'c952b4b3-4aa2-4fc3-abac-16fcd50f8204',
+];
+const GATEWAY_IDENTITY = [
+  '862d6ac7-5221-4d92-8829-8600ea649530',
+  '00000000-0000-4000-8000-000000000001',
+];
+
+let home: string;
+let root: string;
+let subscriptionDir: string;
+let gatewayDir: string;
+
+function record(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'local_00000000-0000-4000-8000-00000000000a',
+    cwd: '/tmp/project',
+    createdAt: 1751000000000,
+    model: 'claude-opus-4-8',
+    title: 'Test session',
+    ...overrides,
+  };
+}
+
+async function writeSourceRecord(
+  name: string,
+  contents: Record<string, unknown> | string
+) {
+  await fs.mkdir(subscriptionDir, { recursive: true });
+  await fs.writeFile(
+    join(subscriptionDir, name),
+    typeof contents === 'string' ? contents : JSON.stringify(contents)
+  );
+}
+
+beforeEach(async () => {
+  home = mkdtempSync(join(tmpdir(), 'vc-claude-desktop-'));
+  root = join(home, 'app-support');
+  subscriptionDir = join(
+    root,
+    'Claude',
+    'claude-code-sessions',
+    ...SUBSCRIPTION_IDENTITY
+  );
+  gatewayDir = join(
+    root,
+    'Claude-3p',
+    'claude-code-sessions',
+    ...GATEWAY_IDENTITY
+  );
+});
+
+describe('toGatewayModelId', () => {
+  it('prefixes bare slugs and preserves suffixes', () => {
+    expect(toGatewayModelId('claude-opus-4-8')).toBe(
+      'anthropic/claude-opus-4-8'
+    );
+    expect(toGatewayModelId('claude-fable-5[1m]')).toBe(
+      'anthropic/claude-fable-5[1m]'
+    );
+    expect(toGatewayModelId('anthropic/claude-opus-4-8')).toBe(
+      'anthropic/claude-opus-4-8'
+    );
+  });
+});
+
+describe('planClaudeDesktopSessionMigration', () => {
+  it('returns null before the third-party identity exists', async () => {
+    await writeSourceRecord('local_a.json', record());
+    expect(await planClaudeDesktopSessionMigration(home, root)).toBeNull();
+  });
+
+  it('copies records into the 3p store with gateway model ids, originals untouched', async () => {
+    const source = record();
+    await writeSourceRecord('local_a.json', source);
+    await writeSourceRecord(
+      'local_b.json',
+      record({ model: 'claude-fable-5[1m]' })
+    );
+    await fs.mkdir(gatewayDir, { recursive: true });
+
+    const plan = await planClaudeDesktopSessionMigration(home, root);
+    expect(plan).not.toBeNull();
+    expect(plan?.label).toBe('Claude Desktop sessions');
+    expect(plan?.itemCount).toBe(2);
+    expect(plan?.destinationRoots).toEqual([gatewayDir]);
+    expect(plan?.prompt.join('\n')).toContain('anthropic/');
+
+    const result = await plan?.apply();
+    expect(result).toMatchObject({ copied: 2, skipped: 0 });
+
+    const copyA = JSON.parse(
+      await fs.readFile(join(gatewayDir, 'local_a.json'), 'utf8')
+    );
+    expect(copyA.model).toBe('anthropic/claude-opus-4-8');
+    expect(copyA.sessionId).toBe(source.sessionId);
+    expect(copyA.title).toBe(source.title);
+    const copyB = JSON.parse(
+      await fs.readFile(join(gatewayDir, 'local_b.json'), 'utf8')
+    );
+    expect(copyB.model).toBe('anthropic/claude-fable-5[1m]');
+
+    // Originals byte-for-byte untouched.
+    expect(
+      JSON.parse(
+        await fs.readFile(join(subscriptionDir, 'local_a.json'), 'utf8')
+      ).model
+    ).toBe('claude-opus-4-8');
+
+    // Idempotent: nothing left to copy on rerun.
+    expect(await planClaudeDesktopSessionMigration(home, root)).toBeNull();
+  });
+
+  it('never overwrites records already in the 3p store', async () => {
+    await writeSourceRecord('local_a.json', record());
+    await fs.mkdir(gatewayDir, { recursive: true });
+    await fs.writeFile(
+      join(gatewayDir, 'local_a.json'),
+      JSON.stringify(record({ title: 'created after the switch' }))
+    );
+
+    expect(await planClaudeDesktopSessionMigration(home, root)).toBeNull();
+    const kept = JSON.parse(
+      await fs.readFile(join(gatewayDir, 'local_a.json'), 'utf8')
+    );
+    expect(kept.title).toBe('created after the switch');
+  });
+
+  it('skips malformed and non-record files', async () => {
+    await writeSourceRecord('local_bad.json', 'not json{');
+    await writeSourceRecord('local_array.json', '[1,2,3]');
+    await writeSourceRecord('notes.txt', 'ignore me');
+    await fs.mkdir(gatewayDir, { recursive: true });
+    expect(await planClaudeDesktopSessionMigration(home, root)).toBeNull();
+  });
+});


### PR DESCRIPTION
> ⚠️ **PR 3 of 3, stacked on #17256** (which stacks on #17275). Review order: #17275 → #17256 → this.

## Summary

Claude Code **CLI** sessions are keyed by project directory and survive the provider switch untouched. But Claude **Desktop** keeps its session list as per-identity JSON records (`~/Library/Application Support/Claude/claude-code-sessions/<account>/<org>/*.json`) — and switching to the AI Gateway makes the app run as a separate "third-party auth" identity (`claude-desktop-3p`) with its own profile dir (`Claude-3p`) whose store starts empty. Every subscription-identity session disappears from the app's list, even though the records and the `~/.claude/projects` transcripts are untouched. (Repro credit: the danabra.mov report.)

This piggybacks on the `sessionMigration` hook from #17275/#17256 — the Claude Code agent now plans a migration that:

- copies each per-session record into the 3p identity's store, keeping filenames
- rewrites the `model` field to its gateway id (`claude-opus-4-8` → `anthropic/claude-opus-4-8`; suffixes like `[1m]` preserved; already-prefixed ids pass through)
- writes atomically, no-clobber, mode 0600 — sessions created after the switch are never overwritten, and **originals are never modified**, so switching back to the subscription still shows everything

The existing setup flow provides the prompt/opt-out (`--no-session-migration`), dry-run JSON, machine output, and `--apply prompt` mode for free.

## The one wrinkle

The 3p identity directory is created by the app on its **first gateway-mode launch** and isn't derivable beforehand (the org dir is the hardcoded sentinel `00000000-0000-4000-8000-000000000001`, but the account UUID is app-assigned). So the migration plans only once that identity exists; since setup is idempotent, re-running it after the first launch completes the copy. For a user who already switched (the repro case), it works on the first run.

## Testing

- New unit suite (5 tests): copy + model-id rewrite (incl. `[1m]` suffix), originals untouched, idempotent rerun, no-clobber against post-switch sessions, malformed/non-record skips, pre-launch guard (`null` before the 3p identity exists).
- Full migration suites still green: 108/108 across the three test files.
- Live check on a real machine with 13 subscription records and no `Claude-3p`: dry-run correctly plans no migration (the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)