### PR TITLE
[cli] Fix e2e tests: new Next.js functions warning message and stale fixture project links

### DIFF
--- a/.changeset/fix-e2e-next-functions-warning.md
+++ b/.changeset/fix-e2e-next-functions-warning.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fixed CLI e2e tests: updated the Next.js unsupported functions warning assertion to include `maxConcurrency`, and made retried runs remove stale project links from reused fixtures.

--- a/packages/cli/test/helpers/setup-e2e-fixture.ts
+++ b/packages/cli/test/helpers/setup-e2e-fixture.ts
@@ -7,13 +7,27 @@ function getTmpFixturesDir() {
   return path.join(getGlobalDir(), 'tmp-fixtures');
 }
 
-export async function setupE2EFixture(name: string) {
+export async function setupE2EFixture(
+  name: string,
+  opts: { removeProjectLink?: boolean } = {}
+) {
   const directory = path.join(getTmpFixturesDir(), name);
   const config = path.join(directory, 'project.json');
 
   // We need to remove it, otherwise we can't re-use fixtures
   if (fs.existsSync(config)) {
     fs.unlinkSync(config);
+  }
+
+  // Deploys from a previous (retried CI) run leave a project link behind,
+  // which would make the CLI reuse the old session's project instead of
+  // creating one for the current session. Opt-in because some fixtures
+  // intentionally ship their own `.vercel/project.json`.
+  if (opts.removeProjectLink) {
+    const linkConfig = path.join(directory, '.vercel', 'project.json');
+    if (fs.existsSync(linkConfig)) {
+      fs.unlinkSync(linkConfig);
+    }
   }
 
   return directory;

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -334,7 +334,9 @@ test('ensure we render a prompt when deploying home directory', async () => {
 });
 
 test('ensure the `scope` property works with email', async () => {
-  const directory = await setupE2EFixture('config-scope-property-email');
+  const directory = await setupE2EFixture('config-scope-property-email', {
+    removeProjectLink: true,
+  });
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     directory,
@@ -363,7 +365,9 @@ test('ensure the `scope` property works with email', async () => {
 
 test('ensure the `scope` property works with username', async () => {
   const team = await teamPromise;
-  const directory = await setupE2EFixture('config-scope-property-username');
+  const directory = await setupE2EFixture('config-scope-property-username', {
+    removeProjectLink: true,
+  });
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     directory,
@@ -442,7 +446,9 @@ test('try to create a builds deployments with wrong `build.env` property', async
 });
 
 test('create a builds deployments with no actual builds', async () => {
-  const directory = await setupE2EFixture('builds-no-list');
+  const directory = await setupE2EFixture('builds-no-list', {
+    removeProjectLink: true,
+  });
 
   const { exitCode, stdout, stderr } = await execCli(binaryPath, [
     directory,
@@ -850,7 +856,7 @@ test('next unsupported functions config shows warning link', async () => {
 
   expect(output.exitCode, formatOutput(output)).toBe(0);
   expect(output.stderr).toMatch(
-    /Ignoring function property `runtime`\. When using Next\.js, only `memory` and `maxDuration` can be used\./gm
+    /Ignoring function property `runtime`\. When using Next\.js, only `memory`, `maxDuration`, and `maxConcurrency` can be used\./gm
   );
   expect(output.stderr).toMatch(
     /Learn More: https:\/\/vercel\.link\/functions-property-next/gm


### PR DESCRIPTION
## Summary

CI e2e run [30495387006](https://github.com/vercel/vercel/actions/runs/30495387006) surfaced two issues in `packages/cli/test/integration-3.test.ts`:

1. **API message change**: the Next.js unsupported functions warning now reads `only \`memory\`, \`maxDuration\`, and \`maxConcurrency\` can be used`. Updated the regex to match.

2. **Retry flakiness**: when the CI chunk is retried, fixtures in the persistent `tmp-fixtures` dir still contain `.vercel/project.json` from the previous attempt's deploys. The new attempt generates a new `session` id, so the CLI reuses the old session's project and assertions like `expect(host.split('-')[0]).toBe(session)` fail (e.g. `expected '72i586h90h8' to be '4jx9eciowts'`). `setupE2EFixture` now accepts an opt-in `removeProjectLink` flag (opt-in because some fixtures intentionally ship their own `.vercel/project.json`), used by the three affected tests.

## Testing

- `pnpm prettier` and `pnpm type-check` in `packages/cli` pass
- e2e behavior verified by CI (requires deploy credentials)