### PR TITLE
feat(cli): add --protection-password to project protection enable

### DIFF
--- a/.changeset/cli-project-protection-password.md
+++ b/.changeset/cli-project-protection-password.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `--protection-password` to `vercel project protection enable` so deployment protection passwords can be set from the CLI when used with `--password`.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -438,6 +438,15 @@ export const protectionSubcommand = {
       deprecated: false,
     },
     {
+      name: 'protection-password',
+      shorthand: null,
+      type: String,
+      argument: 'PASSWORD',
+      description:
+        'Password value when enabling password protection (max 72 characters). Requires --password.',
+      deprecated: false,
+    },
+    {
       name: 'customer-support-code-visibility',
       shorthand: null,
       type: Boolean,
@@ -501,6 +510,10 @@ export const protectionSubcommand = {
     {
       name: 'Enable password protection',
       value: `${packageName} project protection enable my-app --password`,
+    },
+    {
+      name: 'Enable password protection with a password',
+      value: `${packageName} project protection enable my-app --password --protection-password <password>`,
     },
     {
       name: 'Enable customer support code visibility',

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -19,6 +19,27 @@ const PROTECTION_ACTIONS = ['enable', 'disable'] as const;
 type ProtectionAction = (typeof PROTECTION_ACTIONS)[number];
 const DEFAULT_SKEW_PROTECTION_MAX_AGE = 2592000;
 const ENABLED_DEPLOYMENT_TYPE = 'prod_deployment_urls_and_all_previews';
+const MAX_PROTECTION_PASSWORD_LENGTH = 72;
+
+function validateProtectionPassword(
+  value: string
+): { ok: true; password: string } | { ok: false; message: string } {
+  const password = value.trim();
+  if (password === '') {
+    return {
+      ok: false,
+      message:
+        'Invalid --protection-password: expected a non-empty password string.',
+    };
+  }
+  if (password.length > MAX_PROTECTION_PASSWORD_LENGTH) {
+    return {
+      ok: false,
+      message: `Invalid --protection-password: password must be at most ${MAX_PROTECTION_PASSWORD_LENGTH} characters.`,
+    };
+  }
+  return { ok: true, password };
+}
 
 function parseSkewMaxAgeSeconds(
   value: string
@@ -200,6 +221,9 @@ export default async function protection(
 
   const ssoSelected = Boolean(parsedArgs.flags['--sso']);
   const passwordSelected = Boolean(parsedArgs.flags['--password']);
+  const protectionPasswordFlag = parsedArgs.flags['--protection-password'] as
+    | string
+    | undefined;
   const customerSupportCodeVisibilitySelected = Boolean(
     parsedArgs.flags['--customer-support-code-visibility']
   );
@@ -211,6 +235,79 @@ export default async function protection(
   const gitForkProtectionSelected = Boolean(
     parsedArgs.flags['--git-fork-protection']
   );
+
+  if (protectionPasswordFlag !== undefined && !passwordSelected) {
+    const msg =
+      '`--protection-password` requires `--password`. Usage: `vercel project protection enable [name] --password --protection-password <password>`';
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+        hint: 'Pass --password together with --protection-password when enabling password protection.',
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'project protection enable --password --protection-password <password>'
+            ),
+            when: 'Replace <password> with the deployment protection password',
+          },
+        ],
+      },
+      2
+    );
+    output.error(msg);
+    return 2;
+  }
+
+  if (action === 'disable' && protectionPasswordFlag !== undefined) {
+    const msg =
+      '`--protection-password` can only be used with `project protection enable`.';
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+        hint: 'Use `project protection disable ... --password` to turn password protection off.',
+      },
+      2
+    );
+    output.error(msg);
+    return 2;
+  }
+
+  let protectionPassword: string | undefined;
+  if (action === 'enable' && protectionPasswordFlag !== undefined) {
+    const parsed = validateProtectionPassword(protectionPasswordFlag);
+    if (!parsed.ok) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: parsed.message,
+          hint: `Pass a password string up to ${MAX_PROTECTION_PASSWORD_LENGTH} characters.`,
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                'project protection enable --password --protection-password <password>'
+              ),
+              when: 'Replace <password> with a valid deployment protection password',
+            },
+          ],
+        },
+        1
+      );
+      output.error(parsed.message);
+      return 1;
+    }
+    protectionPassword = parsed.password;
+  }
+
   if (
     action &&
     !ssoSelected &&
@@ -366,7 +463,10 @@ export default async function protection(
     if (passwordSelected) {
       patchBody.passwordProtection =
         action === 'enable'
-          ? { deploymentType: ENABLED_DEPLOYMENT_TYPE }
+          ? {
+              deploymentType: ENABLED_DEPLOYMENT_TYPE,
+              ...(protectionPassword ? { password: protectionPassword } : {}),
+            }
           : null;
     }
     if (customerSupportCodeVisibilitySelected) {

--- a/packages/cli/test/unit/commands/project/protection.test.ts
+++ b/packages/cli/test/unit/commands/project/protection.test.ts
@@ -259,6 +259,125 @@ describe('project protection (password)', () => {
       passwordProtection: true,
     });
   });
+
+  it('enables password protection with --protection-password', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
+      expect(req.body).toEqual({
+        passwordProtection: {
+          deploymentType: 'prod_deployment_urls_and_all_previews',
+          password: 's3cret',
+        },
+      });
+      res.json({ id: 'prj_123' });
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'enable',
+      'my-project',
+      '--password',
+      '--protection-password',
+      's3cret'
+    );
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Deployment protection enabled');
+  });
+
+  it('requires --password when --protection-password is set', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'enable',
+      'my-project',
+      '--protection-password',
+      's3cret'
+    );
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput('requires `--password`');
+  });
+
+  it('rejects --protection-password with disable', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'disable',
+      'my-project',
+      '--password',
+      '--protection-password',
+      's3cret'
+    );
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput('can only be used with');
+  });
+
+  it('rejects empty --protection-password', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'enable',
+      'my-project',
+      '--password',
+      '--protection-password',
+      '   '
+    );
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput('Invalid --protection-password');
+  });
+
+  it('rejects --protection-password longer than 72 characters', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.setArgv(
+      'project',
+      'protection',
+      'enable',
+      'my-project',
+      '--password',
+      '--protection-password',
+      'a'.repeat(73)
+    );
+    const exitCode = await project(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput('Invalid --protection-password');
+  });
 });
 
 describe('project protection (customer support code visibility)', () => {


### PR DESCRIPTION
## Summary
- Adds `--protection-password` to `vercel project protection enable` so deployment protection passwords can be set from the CLI
- Requires `--password` alongside `--protection-password`, validates non-empty values up to 72 characters, and rejects the flag on `disable`
- Keeps existing behavior when enabling password protection without a password value

## Usage

```bash
vercel project protection enable my-app --password --protection-password <password>
```

## Test plan
- [x] `npm test -- test/unit/commands/project/protection.test.ts` (30 tests passing)
- [ ] Enable password protection with a custom password on a project with an eligible plan
- [ ] Confirm `vercel project protection enable --protection-password` without `--password` errors clearly
- [ ] Confirm `vercel project protection disable --password --protection-password` is rejected


Made with [Cursor](https://cursor.com)