### PR TITLE
Temporarily skip binary publishing in release workflow

### DIFF
--- a/.changeset/skip-binary-release.md
+++ b/.changeset/skip-binary-release.md
@@ -1,0 +1,4 @@
+---
+---
+
+Temporarily skip the binary publishing job in the release workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
   binary:
     name: Binary release
     needs: determine
-    if: needs.determine.outputs.should-release-binary == 'true'
+    # Temporarily disabled: skip binary publishing for now.
+    # To re-enable, restore the original condition:
+    # if: needs.determine.outputs.should-release-binary == 'true'
+    if: false
     # Reusable workflow permissions are capped by the calling job, so
     # id-token: write must be granted here for npm trusted publishing
     # (OIDC) in the publish-npm job of release-binary.yml to work.


### PR DESCRIPTION
Disables the `binary` job in `.github/workflows/release.yml` by setting `if: false`, so binary publishing is skipped for now.

- The original condition is preserved in a comment for easy re-enabling.
- The downstream `release` job already runs when `binary` is skipped, and the `summary` job accepts a skipped result, so no other changes are needed.
- Includes an empty-frontmatter changeset per repo conventions for workflow-only changes.

Note: while this is disabled, a `vercel` publish would go out without freshly published `@vercel/vc-native-*` packages, so hold Version Packages merges if that ordering matters.