### PR TITLE
[passport] prepare 1.0.0 release

### DIFF
--- a/.changeset/stable-passport-release.md
+++ b/.changeset/stable-passport-release.md
@@ -1,0 +1,5 @@
+---
+'@vercel/passport': major
+---
+
+Promote `@vercel/passport` to a stable 1.0.0 release.

--- a/packages/passport/test/unit/index.test.ts
+++ b/packages/passport/test/unit/index.test.ts
@@ -44,8 +44,35 @@ const payload = {
   typ: 'passport',
 };
 
+const realisticPayload = {
+  ...payload,
+  aud: 'owner:team_example:project:prj_example:environment:production',
+  connector_id: 'scl_example',
+  email: 'person@example.com',
+  email_verified: true,
+  exp: 1_700_043_200,
+  external_iss: 'https://idp.example.com',
+  external_sub: '00u_example_user',
+  iat: 1_700_000_000,
+  iss: 'https://passport.vercel.com/example-team',
+  name: 'Example Person',
+  nbf: 1_700_000_000,
+  owner: 'example-team',
+  owner_id: 'team_example',
+  plan: 'enterprise',
+  project: 'example-project',
+  project_id: 'prj_example',
+  scope: 'owner:team_example:project:prj_example:host:example.vercel.app',
+  sid: 'oauth_example-session',
+  sub: 'owner:team_example:connector:scl_example:principal:00u_example_user',
+};
+
 const SYMBOL_FOR_REQ_CONTEXT = Symbol.for('@vercel/request-context');
 const verifyOptions = { environment: 'production', projectId: 'prj_123' };
+const realisticVerifyOptions = {
+  environment: 'production',
+  projectId: 'prj_example',
+};
 
 describe('getIdentity', () => {
   test('reads Passport identity from Vercel request context', async () => {
@@ -201,6 +228,31 @@ describe('getIdentity', () => {
     });
   });
 
+  test('reads a realistic Passport identity payload', async () => {
+    const token = createToken(realisticPayload);
+    const identity = await getIdentity(
+      new Headers({ [PASSPORT_HEADER_NAME]: token }),
+      { verifyOptions: realisticVerifyOptions }
+    );
+
+    expect(identity).toMatchObject({
+      externalSubject: '00u_example_user',
+      owner: { id: 'team_example', slug: 'example-team' },
+      payload: {
+        aud: 'owner:team_example:project:prj_example:environment:production',
+        email_verified: true,
+        exp: 1_700_043_200,
+        iat: 1_700_000_000,
+        nbf: 1_700_000_000,
+        plan: 'enterprise',
+        scope: 'owner:team_example:project:prj_example:host:example.vercel.app',
+        sid: 'oauth_example-session',
+      },
+      project: { id: 'prj_example', name: 'example-project' },
+      verified: true,
+    });
+  });
+
   test('rejects Vercel OIDC issuer tokens', async () => {
     const token = createToken({
       ...payload,
@@ -335,6 +387,28 @@ describe('verifyIdentity', () => {
     );
   });
 
+  test('verifies a realistic Passport token payload', async () => {
+    const token = createToken(realisticPayload);
+    const identity = await verifyIdentity(token, realisticVerifyOptions);
+
+    expect(identity).toMatchObject({
+      externalSubject: '00u_example_user',
+      owner: { id: 'team_example', slug: 'example-team' },
+      payload: {
+        aud: 'owner:team_example:project:prj_example:environment:production',
+        email_verified: true,
+        exp: 1_700_043_200,
+        iat: 1_700_000_000,
+        nbf: 1_700_000_000,
+        plan: 'enterprise',
+        scope: 'owner:team_example:project:prj_example:host:example.vercel.app',
+        sid: 'oauth_example-session',
+      },
+      project: { id: 'prj_example', name: 'example-project' },
+      verified: true,
+    });
+  });
+
   test('verifies a Passport token from the authorization header', async () => {
     const token = createToken(payload);
     const identity = await verifyIdentity(
@@ -349,6 +423,150 @@ describe('verifyIdentity', () => {
       tokenSource: 'header',
       verified: true,
     });
+  });
+
+  test('verifies a Passport token from a request-like Passport header', async () => {
+    const token = createToken(payload);
+    const identity = await verifyIdentity(
+      new Request('https://api.example.com', {
+        headers: { [PASSPORT_HEADER_NAME]: token },
+      }),
+      verifyOptions
+    );
+
+    expect(identity).toMatchObject({
+      externalSubject: 'user_123',
+      token,
+      tokenSource: 'header',
+      verified: true,
+    });
+  });
+
+  test('verifies a Passport token from an explicit cookie', async () => {
+    const token = createToken(payload);
+    const identity = await verifyIdentity(
+      {
+        cookies: {
+          get: name =>
+            name === PASSPORT_COOKIE_NAME ? { value: token } : undefined,
+        },
+      },
+      verifyOptions
+    );
+
+    expect(identity).toMatchObject({
+      externalSubject: 'user_123',
+      token,
+      tokenSource: 'cookie',
+      verified: true,
+    });
+  });
+
+  test('supports wildcard project and environment verification with an owner', async () => {
+    const token = createToken(payload);
+    const identity = await verifyIdentity(token, {
+      environment: '*',
+      ownerId: 'team_123',
+      projectId: '*',
+    });
+
+    expect(identity.verified).toBe(true);
+  });
+
+  test('requires an owner or audience for wildcard project verification', async () => {
+    const token = createToken(payload);
+
+    await expect(
+      verifyIdentity(token, {
+        environment: '*',
+        projectId: '*',
+      })
+    ).rejects.toThrow(
+      "Expected ownerId or audience to be provided when projectId is '*'."
+    );
+  });
+
+  test('rejects tokens from a different project', async () => {
+    const token = createToken(payload);
+
+    await expect(
+      verifyIdentity(token, {
+        ...verifyOptions,
+        projectId: 'prj_other',
+      })
+    ).rejects.toThrow(
+      'Expected Passport token project_id claim to be "prj_other".'
+    );
+  });
+
+  test('rejects tokens from a different environment', async () => {
+    const token = createToken(payload);
+
+    await expect(
+      verifyIdentity(token, {
+        ...verifyOptions,
+        environment: 'preview',
+      })
+    ).rejects.toThrow(
+      'Expected Passport token environment claim to be "preview".'
+    );
+  });
+
+  test('rejects tokens from a different owner', async () => {
+    const token = createToken(payload);
+
+    await expect(
+      verifyIdentity(token, {
+        ...verifyOptions,
+        ownerId: 'team_other',
+      })
+    ).rejects.toThrow(
+      'Expected Passport token owner_id claim to be "team_other".'
+    );
+  });
+
+  test('rejects non-Passport-shaped verified tokens', async () => {
+    const token = createToken({
+      ...payload,
+      typ: 'vercel-oidc',
+    });
+
+    await expect(verifyIdentity(token, verifyOptions)).rejects.toThrow(
+      'Passport identity token is missing typ="passport".'
+    );
+  });
+
+  test('rejects verified tokens from a non-Passport issuer', async () => {
+    const token = createToken({
+      ...payload,
+      iss: 'https://oidc.vercel.com/team-slug',
+    });
+
+    await expect(verifyIdentity(token, verifyOptions)).rejects.toThrow(
+      'Expected Passport token iss claim to be "https://passport.vercel.com" scoped to an owner.'
+    );
+  });
+
+  test('rejects malformed authorization headers', async () => {
+    const token = createToken(payload);
+
+    await expect(
+      verifyIdentity(
+        new Headers({ authorization: `Basic ${token}` }),
+        verifyOptions
+      )
+    ).rejects.toThrow('Passport identity token was not found.');
+  });
+
+  test('propagates token verification failures', async () => {
+    const token = createToken(payload);
+    vi.mocked(jwtVerify).mockRejectedValueOnce(
+      new Error('signature verification failed')
+    );
+
+    await expect(verifyIdentity(token, verifyOptions)).rejects.toThrow(
+      'signature verification failed'
+    );
   });
 
   test('throws when no Passport token is provided', async () => {


### PR DESCRIPTION
## Summary

- Add a major changeset for `@vercel/passport`, promoting the current `0.1.3` package to a stable `1.0.0` release.
- Add a fully fictional Passport payload modeled on observed production claim structure, including owner/project-scoped audience, host-scoped scope, timing, session, plan, and email-verification claims.
- Expand the public API suite to 31 tests: 16 for `getIdentity` and 15 for `verifyIdentity`, including request sources, wildcard constraints, claim mismatches, malformed input, invalid Passport shape/issuer, and verification failures.

No production identity values or tokens are included.

## Validation

- `pnpm changeset status`
- `pnpm --filter @vercel/passport test`
- `pnpm --filter @vercel/passport type-check`
- `pnpm --filter @vercel/passport build`
- `pnpm exec biome lint packages/passport/test/unit/index.test.ts`
- `pnpm prettier --check packages/passport .changeset/stable-passport-release.md`
- `git diff --check`
