### PR TITLE
Skip native optionalDependencies injection when binary release is disabled

### DIFF
--- a/.changeset/skip-native-deps-guard.md
+++ b/.changeset/skip-native-deps-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Skip native optionalDependencies injection during publish while the binary release is disabled.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # While the binary job is disabled, publish `vercel` without native
+          # optionalDependencies instead of failing the missing-natives guard
+          # in utils/inject-native-optional-deps.mjs. Remove this when the
+          # binary job is re-enabled.
+          VERCEL_SKIP_NATIVE_DEPS: ${{ needs.binary.result == 'skipped' && '1' || '' }}
 
       # TODO: re-enable with a new bot token or GitHub App
       # - name: Trigger Update (if a Publish Happened)

--- a/utils/inject-native-optional-deps.mjs
+++ b/utils/inject-native-optional-deps.mjs
@@ -28,6 +28,18 @@ const execFileAsync = promisify(execFile);
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const cliPackageJsonPath = join(repoRoot, 'packages', 'cli', 'package.json');
 
+// Escape hatch: when the binary release is intentionally disabled (see the
+// `binary` job in .github/workflows/release.yml), skip both the injection and
+// the missing-natives guard so `vercel` publishes without native
+// optionalDependencies. `vc.js` falls back to the JS CLI when no native
+// package is present in node_modules.
+if (process.env.VERCEL_SKIP_NATIVE_DEPS === '1') {
+  console.log(
+    'VERCEL_SKIP_NATIVE_DEPS=1; skipping native optionalDependencies injection.'
+  );
+  process.exit(0);
+}
+
 const raw = await readFile(cliPackageJsonPath, 'utf8');
 const pkg = JSON.parse(raw);
 const version = pkg.version;


### PR DESCRIPTION
Follow-up to #17313. The release run on main failed at `ci:publish` because `utils/inject-native-optional-deps.mjs` hard-fails when the `@vercel/vc-native-*` packages for the version being published are missing from npm — which is now always the case while the binary job is disabled.

Failed run: https://github.com/vercel/vercel/actions/runs/30565299048/job/90948336609

Changes:
- `utils/inject-native-optional-deps.mjs`: add a `VERCEL_SKIP_NATIVE_DEPS=1` escape hatch that skips both the injection and the missing-natives guard. `vc.js` already falls back to the JS CLI when no native package is present, so `vercel` installs and works without the natives.
- `.github/workflows/release.yml`: set `VERCEL_SKIP_NATIVE_DEPS` on the changesets publish step when the binary job was skipped, so this is automatically active only while the binary release is disabled and reverts to the guarded behavior once it's re-enabled.

Verified locally: `VERCEL_SKIP_NATIVE_DEPS=1 node utils/inject-native-optional-deps.mjs` exits 0 without touching `packages/cli/package.json`, and the workflow YAML parses.
