### PR TITLE
Bump vercel (patch) to trigger release

### DIFF
--- a/.changeset/bump-vercel-publish.md
+++ b/.changeset/bump-vercel-publish.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Trigger a new release to publish versions that were skipped by the failed release run.


### PR DESCRIPTION
Adds a patch changeset for `vercel` so the next Version Packages release publishes the versions that were blocked by the failed release run (natives guard, now bypassed via #17317). npm is currently at vercel@58.4.0 / @vercel/node@5.9.2 while main is at 58.4.3.