### PR TITLE
[passport] link README to product page

### DIFF
--- a/.changeset/link-passport-product-page.md
+++ b/.changeset/link-passport-product-page.md
@@ -1,0 +1,5 @@
+---
+'@vercel/passport': patch
+---
+
+Link to Vercel Passport from the package README.

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -1,6 +1,7 @@
 # @vercel/passport
 
-Runtime helpers for reading and verifying Passport identity.
+Runtime helpers for reading and verifying
+[Passport](https://vercel.com/passport) identity.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Link the introductory Passport mention in the package README to `https://vercel.com/passport`.
- Add a patch changeset for `@vercel/passport`.

`@vercel/passport@1.0.0` is already published; this documentation follow-up will release as `1.0.1`.

## Validation

- `pnpm changeset status`
- `pnpm prettier --check packages/passport/README.md .changeset/link-passport-product-page.md`
- `git diff --check`
