### PR TITLE
[functions] Add custom metric helper

### DIFF
--- a/.changeset/fast-metrics-report.md
+++ b/.changeset/fast-metrics-report.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': minor
+---
+
+Add a `metric()` helper for reporting custom metrics from Vercel Functions.

--- a/packages/functions/docs/index/README.md
+++ b/packages/functions/docs/index/README.md
@@ -37,6 +37,7 @@
 - [invalidateBySrcImage](functions/invalidateBySrcImage.md)
 - [invalidateByTag](functions/invalidateByTag.md)
 - [ipAddress](functions/ipAddress.md)
+- [metric](functions/metric.md)
 - [next](functions/next.md)
 - [rewrite](functions/rewrite.md)
 - [waitUntil](functions/waitUntil.md)

--- a/packages/functions/docs/index/functions/metric.md
+++ b/packages/functions/docs/index/functions/metric.md
@@ -1,0 +1,45 @@
+[**@vercel/functions**](../../README.md)
+
+***
+
+# Function: metric()
+
+> **metric**(`name`, `value`, `tags?`): `void`
+
+Defined in: packages/functions/src/metric.ts:28
+
+Reports a custom metric for the current Vercel Function invocation.
+
+## Parameters
+
+### name
+
+`string`
+
+The name of the metric.
+
+### value
+
+`number`
+
+The numeric value of the metric.
+
+### tags?
+
+[`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type)\<`string`, `string`\>
+
+Optional tags to attach to the metric.
+
+## Returns
+
+`void`
+
+## Example
+
+```js
+import { metric } from '@vercel/functions';
+
+metric('tinybird.query_ms', 100, {
+  query: 'getUser',
+});
+```

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -2,6 +2,7 @@ export type { Request, Geo } from './headers';
 export { geolocation, ipAddress } from './headers';
 export { getEnv } from './get-env';
 export { waitUntil } from './wait-until';
+export { metric } from './metric';
 export { rewrite, next } from './middleware';
 export { getCache } from './cache';
 export {

--- a/packages/functions/src/metric.ts
+++ b/packages/functions/src/metric.ts
@@ -1,0 +1,38 @@
+interface RustyRuntimeIpc {
+  sendMetric?: (
+    name: string,
+    value: number,
+    tags?: Record<string, string>
+  ) => void;
+}
+
+const RUSTY_RUNTIME_IPC_SYMBOL = Symbol.for('@vercel/rusty-runtime-ipc');
+
+/**
+ * Reports a custom metric for the current Vercel Function invocation.
+ *
+ * @param name The name of the metric.
+ * @param value The numeric value of the metric.
+ * @param tags Optional tags to attach to the metric.
+ *
+ * @example
+ *
+ * ```js
+ * import { metric } from '@vercel/functions';
+ *
+ * metric('tinybird.query_ms', 100, {
+ *   query: 'getUser',
+ * });
+ * ```
+ */
+export function metric(
+  name: string,
+  value: number,
+  tags?: Record<string, string>
+): void {
+  const ipc = (
+    globalThis as unknown as Record<symbol, RustyRuntimeIpc | undefined>
+  )[RUSTY_RUNTIME_IPC_SYMBOL];
+
+  ipc?.sendMetric?.(name, value, tags);
+}

--- a/packages/functions/test/unit/index.test.ts
+++ b/packages/functions/test/unit/index.test.ts
@@ -19,6 +19,7 @@ describe('@vercel/functions', () => {
     'invalidateBySrcImage',
     'invalidateByTag',
     'ipAddress',
+    'metric',
     'next',
     'rewrite',
     'waitUntil',

--- a/packages/functions/test/unit/metric.test.ts
+++ b/packages/functions/test/unit/metric.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { metric } from '../../src/metric';
+
+const RUSTY_RUNTIME_IPC_SYMBOL = Symbol.for('@vercel/rusty-runtime-ipc');
+const globalSymbols = globalThis as unknown as Record<symbol, unknown>;
+
+describe('metric', () => {
+  afterEach(() => {
+    delete globalSymbols[RUSTY_RUNTIME_IPC_SYMBOL];
+  });
+
+  test('sends a metric through the rusty runtime IPC hook', () => {
+    const sendMetric = vi.fn();
+    globalSymbols[RUSTY_RUNTIME_IPC_SYMBOL] = { sendMetric };
+
+    metric('tinybird.query_ms', 100, {
+      query: 'getUser',
+    });
+
+    expect(sendMetric).toHaveBeenCalledOnce();
+    expect(sendMetric).toHaveBeenCalledWith('tinybird.query_ms', 100, {
+      query: 'getUser',
+    });
+  });
+
+  test('supports metrics without tags', () => {
+    const sendMetric = vi.fn();
+    globalSymbols[RUSTY_RUNTIME_IPC_SYMBOL] = { sendMetric };
+
+    metric('tinybird.query_ms', 100);
+
+    expect(sendMetric).toHaveBeenCalledWith(
+      'tinybird.query_ms',
+      100,
+      undefined
+    );
+  });
+
+  test('is a no-op when the runtime does not support metrics', () => {
+    expect(() => metric('tinybird.query_ms', 100)).not.toThrow();
+
+    globalSymbols[RUSTY_RUNTIME_IPC_SYMBOL] = {};
+
+    expect(() => metric('tinybird.query_ms', 100)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- add a public `metric(name, value, tags?)` helper to `@vercel/functions`
- forward metrics unchanged through `globalThis[Symbol.for('@vercel/rusty-runtime-ipc')]?.sendMetric?.(...)`
- no-op when the runtime hook is unavailable
- add focused forwarding/export coverage, generated API docs, and a minor changeset

## Example

```ts
import { metric } from '@vercel/functions';

metric('tinybird.query_ms', 100, {
  query: 'getUser',
});
```

## Validation

- `pnpm turbo run build --filter=@vercel/functions`
- `pnpm --filter @vercel/functions exec vitest run test/unit/metric.test.ts test/unit/index.test.ts` (11 tests passed)
- targeted Biome lint and Prettier checks
- `git diff --check`

The full package test invocation also exercises network-dependent E2E tests and currently reports unrelated failures in existing DB/cache/OIDC tests and DNS resolution for `vercel-functions-e2e.vercel.app`; the new metric and package-export tests pass.
