### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/cli-evals.yml
+++ b/.github/workflows/cli-evals.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Install pnpm
         run: npm i -g pnpm@10.29.3

--- a/.github/workflows/update-remix-run-dev.yml
+++ b/.github/workflows/update-remix-run-dev.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - name: Enable corepack
         run: corepack enable pnpm
       - name: Update @remix-run/dev


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `22`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `22` (using `22` where a concrete pin is needed).

- `.github/workflows/cli-evals.yml`
  - `node-version: 20.x` → `node-version: 22.x`
- `.github/workflows/update-remix-run-dev.yml`
  - `node-version: 16` → `node-version: 22`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `22`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
