### PR TITLE
[backends] Align TypeScript typecheck behavior with @vercel/node

### DIFF
--- a/.changeset/typescript-typecheck-parity.md
+++ b/.changeset/typescript-typecheck-parity.md
@@ -1,0 +1,5 @@
+---
+'@vercel/backends': patch
+---
+
+Align TypeScript typecheck behavior with `@vercel/node`: discover tsconfig from the entrypoint, ignore diagnostics 6059/18002/18003, default `target` from the Node.js version, strip emit-oriented options, and prefer the user's `typescript` install.

--- a/packages/backends/src/cervel/types.ts
+++ b/packages/backends/src/cervel/types.ts
@@ -30,6 +30,12 @@ export type TypescriptOptions = {
   entrypoint: string;
   workPath: string;
   span: Span;
+  /**
+   * Node.js major version of the target runtime; used to pick the default
+   * `target` compiler option when the user's tsconfig doesn't set one
+   * (mirrors `@vercel/node`).
+   */
+  nodeVersionMajor?: number;
 };
 
 /**

--- a/packages/backends/src/cervel/types.ts
+++ b/packages/backends/src/cervel/types.ts
@@ -30,11 +30,6 @@ export type TypescriptOptions = {
   entrypoint: string;
   workPath: string;
   span: Span;
-  /**
-   * Node.js major version of the target runtime; used to pick the default
-   * `target` compiler option when the user's tsconfig doesn't set one
-   * (mirrors `@vercel/node`).
-   */
   nodeVersionMajor?: number;
 };
 

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -233,6 +233,7 @@ export const build: BuildV2 = async args => {
         entrypoint,
         workPath: args.workPath,
         span: buildSpan,
+        nodeVersionMajor: nodeVersion.major,
       });
     }
 

--- a/packages/backends/src/typescript.ts
+++ b/packages/backends/src/typescript.ts
@@ -85,10 +85,6 @@ async function doTypeCheck(
       fail([configRead.error]);
     }
     const config = configRead.config ?? {};
-    config.compilerOptions = fixConfig(
-      { ...config.compilerOptions },
-      args.nodeVersionMajor
-    );
     const parsed = ts.parseJsonConfigFileContent(
       config,
       ts.sys,
@@ -112,6 +108,32 @@ async function doTypeCheck(
       skipLibCheck: true,
       allowJs: true,
     };
+    // Emit-oriented options don't apply to a noEmit typecheck.
+    delete options.out;
+    delete options.outFile;
+    delete options.composite;
+    delete options.declarationDir;
+    delete options.declarationMap;
+    delete options.emitDeclarationOnly;
+    delete options.tsBuildInfoFile;
+    delete options.incremental;
+    if (options.target === undefined) {
+      options.target = defaultScriptTarget(ts, args.nodeVersionMajor);
+    }
+    if (options.esModuleInterop === undefined) {
+      options.esModuleInterop = true;
+    }
+    // Mirror `@vercel/node` fixConfig leniency, but only when the resolved
+    // config (post-`extends`) sets neither `module` nor `moduleResolution`,
+    // so explicit user resolution strategies are never overridden.
+    if (
+      options.module === undefined &&
+      options.moduleResolution === undefined
+    ) {
+      options.module = ts.ModuleKind.NodeNext;
+      options.moduleResolution = ts.ModuleResolutionKind.NodeNext;
+      options.strict = false;
+    }
     // Ambient declaration files matched by the tsconfig contribute global
     // types even when never imported; include them as extra program roots.
     for (const fileName of parsed.fileNames) {
@@ -147,45 +169,6 @@ async function doTypeCheck(
   }
 
   fail(errors);
-}
-
-// Mirror of `fixConfig` in `packages/node/src/typescript.ts`.
-export function fixConfig(
-  compilerOptions: Record<string, unknown>,
-  nodeVersionMajor = 16
-): Record<string, unknown> {
-  delete compilerOptions.out;
-  delete compilerOptions.outFile;
-  delete compilerOptions.composite;
-  delete compilerOptions.declarationDir;
-  delete compilerOptions.declarationMap;
-  delete compilerOptions.emitDeclarationOnly;
-  delete compilerOptions.tsBuildInfoFile;
-  delete compilerOptions.incremental;
-
-  if (compilerOptions.target === undefined) {
-    let target: string;
-    if (nodeVersionMajor >= 16) {
-      target = 'ES2021';
-    } else if (nodeVersionMajor >= 14) {
-      target = 'ES2020';
-    } else {
-      target = 'ES2019';
-    }
-    compilerOptions.target = target;
-  }
-
-  if (compilerOptions.esModuleInterop === undefined) {
-    compilerOptions.esModuleInterop = true;
-  }
-
-  if (compilerOptions.module === undefined) {
-    compilerOptions.module = 'NodeNext';
-    compilerOptions.moduleResolution = 'NodeNext';
-    compilerOptions.strict = false;
-  }
-
-  return compilerOptions;
 }
 
 function defaultScriptTarget(

--- a/packages/backends/src/typescript.ts
+++ b/packages/backends/src/typescript.ts
@@ -22,12 +22,33 @@ import type { TypescriptOptions } from './cervel/types.js';
  * options as `-p`) with explicit `rootNames`, no files written, and a compiler host whose
  * current directory stays `workPath`.
  *
- * The `typescript` package is resolved with `require` from the user's app (peer dependency), not bundled.
+ * The behavior here intentionally mirrors the `@vercel/node` builder
+ * (`packages/node/src/typescript.ts`, a ts-node fork) so that projects moving from the
+ * framework wrapper builders (`@vercel/express` et al.) to `@vercel/backends` see the
+ * same typecheck results — including historically shipped leniencies:
+ *
+ * - tsconfig.json is discovered walking up from the *entrypoint*, not `workPath`.
+ * - Emit-oriented options (`outFile`, `composite`, `incremental`, ...) are dropped.
+ * - When `module` is not set, `NodeNext` resolution is used and `strict` is forced off.
+ * - When `target` is not set, it defaults based on the Node.js major version.
+ * - `esModuleInterop` defaults to true only when unset (never overrides the user).
+ * - Diagnostics 6059/18002/18003 are ignored.
+ * - tsconfig option errors are fatal only when `noEmitOnError` is set (parse/syntax
+ *   errors in the file itself are always fatal).
+ * - The user's `typescript` install is preferred; the bundled one is a fallback.
  */
 
 const require_ = createRequire(import.meta.url);
 
 type TypeScriptModule = typeof import('typescript');
+
+/**
+ * Diagnostic codes that `@vercel/node` has always ignored:
+ * 6059: "'rootDir' is expected to contain all source files."
+ * 18002: "The 'files' list in config file is empty."
+ * 18003: "No inputs were found in config file."
+ */
+const IGNORED_DIAGNOSTIC_CODES = new Set([6059, 18002, 18003]);
 
 export const typescript = (args: TypescriptOptions) => {
   const { span } = args;
@@ -41,7 +62,9 @@ export const typescript = (args: TypescriptOptions) => {
       return;
     }
 
-    const ts = resolveTypeScriptModule(args.workPath);
+    const ts = resolveTypeScriptModule(
+      dirname(resolve(args.workPath, args.entrypoint))
+    );
     if (!ts) {
       console.log(
         c.gray(
@@ -58,11 +81,13 @@ export const typescript = (args: TypescriptOptions) => {
 };
 
 async function doTypeCheck(
-  args: { entrypoint: string; workPath: string },
+  args: { entrypoint: string; workPath: string; nodeVersionMajor?: number },
   ts: TypeScriptModule
 ): Promise<void> {
   const entryAbsolute = resolve(args.workPath, args.entrypoint);
-  const tsconfig = await findNearestTsconfig(args.workPath);
+  // Match `@vercel/node`: discover the tsconfig starting from the entrypoint
+  // file, walking up with no boundary at `workPath`.
+  const tsconfig = findNearestTsconfig(dirname(entryAbsolute));
 
   const formatDiagnostics = process.stdout.isTTY
     ? ts.formatDiagnosticsWithColorAndContext
@@ -74,52 +99,82 @@ async function doTypeCheck(
     getCurrentDirectory: () => args.workPath,
   };
 
+  const filterIgnored = (diagnostics: readonly Diagnostic[]) =>
+    diagnostics.filter(d => !IGNORED_DIAGNOSTIC_CODES.has(d.code));
+
+  const fail = (diagnostics: readonly Diagnostic[]): never => {
+    const message = formatDiagnostics(diagnostics, diagnosticHost);
+    console.error('\nTypeScript type check failed:\n');
+    console.error(message);
+    throw new Error('TypeScript type check failed');
+  };
+
   let options: CompilerOptions;
-  let parseDiagnostics: readonly Diagnostic[] = [];
+  const rootNames = [entryAbsolute];
 
   if (tsconfig) {
     const configRead = ts.readConfigFile(tsconfig, ts.sys.readFile);
     if (configRead.error) {
-      const message = formatDiagnostics([configRead.error], diagnosticHost);
-      console.error('\nTypeScript type check failed:\n');
-      console.error(message);
-      throw new Error('TypeScript type check failed');
+      // A malformed tsconfig.json is always fatal (matches `@vercel/node`).
+      fail([configRead.error]);
     }
+    const config = configRead.config ?? {};
+    config.compilerOptions = fixConfig(
+      { ...config.compilerOptions },
+      args.nodeVersionMajor
+    );
     const parsed = ts.parseJsonConfigFileContent(
-      configRead.config,
+      config,
       ts.sys,
       dirname(tsconfig),
       undefined,
       tsconfig
     );
-    parseDiagnostics = parsed.errors;
+    const parseErrors = filterIgnored(parsed.errors).filter(
+      d => d.category === ts.DiagnosticCategory.Error
+    );
+    if (parseErrors.length > 0) {
+      // `@vercel/node` only fails the build for config diagnostics when the
+      // user opted into `noEmitOnError`; otherwise they are printed and the
+      // build continues.
+      if (parsed.options.noEmitOnError) {
+        fail(parseErrors);
+      } else {
+        console.error(formatDiagnostics(parseErrors, diagnosticHost));
+      }
+    }
     options = {
       ...parsed.options,
       noEmit: true,
       skipLibCheck: true,
       allowJs: true,
-      esModuleInterop: true,
     };
+    // Ambient declaration files matched by the tsconfig (`include`/`files`)
+    // contribute global types even when never imported. `@vercel/node` keeps
+    // them via `files: true`; include them as extra program roots here.
+    for (const fileName of parsed.fileNames) {
+      if (/\.d\.(ts|mts|cts)$/.test(fileName) && fileName !== entryAbsolute) {
+        rootNames.push(fileName);
+      }
+    }
   } else {
     options = {
       noEmit: true,
       skipLibCheck: true,
       allowJs: true,
       esModuleInterop: true,
-      target: ts.ScriptTarget.ES2022,
+      target: defaultScriptTarget(ts, args.nodeVersionMajor),
       module: ts.ModuleKind.NodeNext,
       moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      strict: false,
     };
   }
 
   const compilerHost = ts.createCompilerHost(options);
   compilerHost.getCurrentDirectory = () => args.workPath;
 
-  const program = ts.createProgram([entryAbsolute], options, compilerHost);
-  const diagnostics = [
-    ...parseDiagnostics,
-    ...ts.getPreEmitDiagnostics(program),
-  ];
+  const program = ts.createProgram(rootNames, options, compilerHost);
+  const diagnostics = filterIgnored(ts.getPreEmitDiagnostics(program));
   const errors = diagnostics.filter(
     d => d.category === ts.DiagnosticCategory.Error
   );
@@ -129,30 +184,94 @@ async function doTypeCheck(
     return;
   }
 
-  const output = formatDiagnostics(errors, diagnosticHost);
-  console.error('\nTypeScript type check failed:\n');
-  console.error(output);
-  throw new Error('TypeScript type check failed');
+  fail(errors);
 }
 
-function resolveTypeScriptModule(workPath: string): TypeScriptModule | null {
+/**
+ * Mirror of `fixConfig` in `packages/node/src/typescript.ts`. Mutates and
+ * returns the raw (pre-parse) compilerOptions object.
+ */
+export function fixConfig(
+  compilerOptions: Record<string, unknown>,
+  nodeVersionMajor = 16
+): Record<string, unknown> {
+  // Delete options that *should not* be passed through.
+  delete compilerOptions.out;
+  delete compilerOptions.outFile;
+  delete compilerOptions.composite;
+  delete compilerOptions.declarationDir;
+  delete compilerOptions.declarationMap;
+  delete compilerOptions.emitDeclarationOnly;
+  delete compilerOptions.tsBuildInfoFile;
+  delete compilerOptions.incremental;
+
+  // This will prevent TS from polyfill/downlevel emit.
+  if (compilerOptions.target === undefined) {
+    // See https://github.com/tsconfig/bases/tree/main/bases
+    let target: string;
+    if (nodeVersionMajor >= 16) {
+      target = 'ES2021';
+    } else if (nodeVersionMajor >= 14) {
+      target = 'ES2020';
+    } else {
+      target = 'ES2019';
+    }
+    compilerOptions.target = target;
+  }
+
+  // When mixing TS with JS, its best to enable this flag.
+  // This is useful when no `tsconfig.json` is supplied.
+  if (compilerOptions.esModuleInterop === undefined) {
+    compilerOptions.esModuleInterop = true;
+  }
+
+  // nodenext will defer to the package.json#type field
+  // but still respect .mts and .cts files
+  if (compilerOptions.module === undefined) {
+    compilerOptions.module = 'NodeNext';
+    compilerOptions.moduleResolution = 'NodeNext';
+    compilerOptions.strict = false;
+  }
+
+  return compilerOptions;
+}
+
+function defaultScriptTarget(
+  ts: TypeScriptModule,
+  nodeVersionMajor = 16
+): import('typescript').ScriptTarget {
+  if (nodeVersionMajor >= 16) return ts.ScriptTarget.ES2021;
+  if (nodeVersionMajor >= 14) return ts.ScriptTarget.ES2020;
+  return ts.ScriptTarget.ES2019;
+}
+
+function resolveTypeScriptModule(startDir: string): TypeScriptModule | null {
+  // Use the user's TypeScript install, resolved from the entrypoint
+  // directory upward. Unlike `@vercel/node` there is no bundled-compiler
+  // fallback: typecheck errors are always fatal in this builder, so
+  // typechecking a project that never installed TypeScript would fail
+  // builds that previously succeeded. Skipping is the permissive choice.
   try {
-    const id = require_.resolve('typescript', { paths: [workPath] });
-    return require_(id) as TypeScriptModule;
+    const id = require_.resolve('typescript', { paths: [startDir] });
+    const ts = require_(id) as TypeScriptModule;
+    console.log(`Using TypeScript ${ts.version} (local user-provided)`);
+    return ts;
   } catch (_e) {
     return null;
   }
 }
 
-export const findNearestTsconfig = async (
-  workPath: string
-): Promise<string | undefined> => {
-  const tsconfigPath = join(workPath, 'tsconfig.json');
-  if (existsSync(tsconfigPath)) {
-    return tsconfigPath;
+export const findNearestTsconfig = (startDir: string): string | undefined => {
+  let dir = resolve(startDir);
+  for (;;) {
+    const tsconfigPath = join(dir, 'tsconfig.json');
+    if (existsSync(tsconfigPath)) {
+      return tsconfigPath;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
   }
-  if (workPath === '/') {
-    return undefined;
-  }
-  return findNearestTsconfig(join(workPath, '..'));
 };

--- a/packages/backends/src/typescript.ts
+++ b/packages/backends/src/typescript.ts
@@ -9,45 +9,14 @@ import type {
 } from 'typescript';
 import type { TypescriptOptions } from './cervel/types.js';
 
-/**
- * Typecheck via the TypeScript compiler API (`createProgram`, `getPreEmitDiagnostics`),
- * not by spawning the `tsc` binary.
- *
- * We only want to validate the deployment entrypoint and its import graph, not every
- * file matched by `tsconfig` `include`. The CLI cannot combine `--project` with explicit
- * root files (TS5042), so expressing 'project options + entry-only roots' in one `tsc`
- * call requires a generated tsconfig on disk. Writing beside the user's config is
- * invasive; a temp config elsewhere often breaks `node_modules` / `@types` resolution
- * relative to the real project. The API lets us reuse `parseJsonConfigFileContent` (same
- * options as `-p`) with explicit `rootNames`, no files written, and a compiler host whose
- * current directory stays `workPath`.
- *
- * The behavior here intentionally mirrors the `@vercel/node` builder
- * (`packages/node/src/typescript.ts`, a ts-node fork) so that projects moving from the
- * framework wrapper builders (`@vercel/express` et al.) to `@vercel/backends` see the
- * same typecheck results — including historically shipped leniencies:
- *
- * - tsconfig.json is discovered walking up from the *entrypoint*, not `workPath`.
- * - Emit-oriented options (`outFile`, `composite`, `incremental`, ...) are dropped.
- * - When `module` is not set, `NodeNext` resolution is used and `strict` is forced off.
- * - When `target` is not set, it defaults based on the Node.js major version.
- * - `esModuleInterop` defaults to true only when unset (never overrides the user).
- * - Diagnostics 6059/18002/18003 are ignored.
- * - tsconfig option errors are fatal only when `noEmitOnError` is set (parse/syntax
- *   errors in the file itself are always fatal).
- * - The user's `typescript` install is preferred; the bundled one is a fallback.
- */
-
 const require_ = createRequire(import.meta.url);
 
 type TypeScriptModule = typeof import('typescript');
 
-/**
- * Diagnostic codes that `@vercel/node` has always ignored:
- * 6059: "'rootDir' is expected to contain all source files."
- * 18002: "The 'files' list in config file is empty."
- * 18003: "No inputs were found in config file."
- */
+// Diagnostic codes that `@vercel/node` ignores:
+// 6059: "'rootDir' is expected to contain all source files."
+// 18002: "The 'files' list in config file is empty."
+// 18003: "No inputs were found in config file."
 const IGNORED_DIAGNOSTIC_CODES = new Set([6059, 18002, 18003]);
 
 export const typescript = (args: TypescriptOptions) => {
@@ -85,8 +54,6 @@ async function doTypeCheck(
   ts: TypeScriptModule
 ): Promise<void> {
   const entryAbsolute = resolve(args.workPath, args.entrypoint);
-  // Match `@vercel/node`: discover the tsconfig starting from the entrypoint
-  // file, walking up with no boundary at `workPath`.
   const tsconfig = findNearestTsconfig(dirname(entryAbsolute));
 
   const formatDiagnostics = process.stdout.isTTY
@@ -115,7 +82,6 @@ async function doTypeCheck(
   if (tsconfig) {
     const configRead = ts.readConfigFile(tsconfig, ts.sys.readFile);
     if (configRead.error) {
-      // A malformed tsconfig.json is always fatal (matches `@vercel/node`).
       fail([configRead.error]);
     }
     const config = configRead.config ?? {};
@@ -134,9 +100,6 @@ async function doTypeCheck(
       d => d.category === ts.DiagnosticCategory.Error
     );
     if (parseErrors.length > 0) {
-      // `@vercel/node` only fails the build for config diagnostics when the
-      // user opted into `noEmitOnError`; otherwise they are printed and the
-      // build continues.
       if (parsed.options.noEmitOnError) {
         fail(parseErrors);
       } else {
@@ -149,9 +112,8 @@ async function doTypeCheck(
       skipLibCheck: true,
       allowJs: true,
     };
-    // Ambient declaration files matched by the tsconfig (`include`/`files`)
-    // contribute global types even when never imported. `@vercel/node` keeps
-    // them via `files: true`; include them as extra program roots here.
+    // Ambient declaration files matched by the tsconfig contribute global
+    // types even when never imported; include them as extra program roots.
     for (const fileName of parsed.fileNames) {
       if (/\.d\.(ts|mts|cts)$/.test(fileName) && fileName !== entryAbsolute) {
         rootNames.push(fileName);
@@ -187,15 +149,11 @@ async function doTypeCheck(
   fail(errors);
 }
 
-/**
- * Mirror of `fixConfig` in `packages/node/src/typescript.ts`. Mutates and
- * returns the raw (pre-parse) compilerOptions object.
- */
+// Mirror of `fixConfig` in `packages/node/src/typescript.ts`.
 export function fixConfig(
   compilerOptions: Record<string, unknown>,
   nodeVersionMajor = 16
 ): Record<string, unknown> {
-  // Delete options that *should not* be passed through.
   delete compilerOptions.out;
   delete compilerOptions.outFile;
   delete compilerOptions.composite;
@@ -205,9 +163,7 @@ export function fixConfig(
   delete compilerOptions.tsBuildInfoFile;
   delete compilerOptions.incremental;
 
-  // This will prevent TS from polyfill/downlevel emit.
   if (compilerOptions.target === undefined) {
-    // See https://github.com/tsconfig/bases/tree/main/bases
     let target: string;
     if (nodeVersionMajor >= 16) {
       target = 'ES2021';
@@ -219,14 +175,10 @@ export function fixConfig(
     compilerOptions.target = target;
   }
 
-  // When mixing TS with JS, its best to enable this flag.
-  // This is useful when no `tsconfig.json` is supplied.
   if (compilerOptions.esModuleInterop === undefined) {
     compilerOptions.esModuleInterop = true;
   }
 
-  // nodenext will defer to the package.json#type field
-  // but still respect .mts and .cts files
   if (compilerOptions.module === undefined) {
     compilerOptions.module = 'NodeNext';
     compilerOptions.moduleResolution = 'NodeNext';
@@ -246,11 +198,6 @@ function defaultScriptTarget(
 }
 
 function resolveTypeScriptModule(startDir: string): TypeScriptModule | null {
-  // Use the user's TypeScript install, resolved from the entrypoint
-  // directory upward. Unlike `@vercel/node` there is no bundled-compiler
-  // fallback: typecheck errors are always fatal in this builder, so
-  // typechecking a project that never installed TypeScript would fail
-  // builds that previously succeeded. Skipping is the permissive choice.
   try {
     const id = require_.resolve('typescript', { paths: [startDir] });
     const ts = require_(id) as TypeScriptModule;

--- a/packages/backends/test/unit.typescript.test.ts
+++ b/packages/backends/test/unit.typescript.test.ts
@@ -69,6 +69,19 @@ describe('typescript typecheck leniencies (parity with @vercel/node)', () => {
     await expect(typecheck(dir, 'index.ts')).resolves.toBeUndefined();
   });
 
+  it('does not override an explicit "moduleResolution" (e.g. bundler)', async () => {
+    const dir = await createFixture({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { moduleResolution: 'bundler', module: 'ESNext' },
+      }),
+      // Extensionless relative import: fails under forced NodeNext
+      // resolution, passes under the user's bundler resolution.
+      'lib.ts': 'export const value: number = 1;\n',
+      'index.ts': "export { value } from './lib';\n",
+    });
+    await expect(typecheck(dir, 'index.ts')).resolves.toBeUndefined();
+  });
+
   it('discovers tsconfig from the entrypoint directory, not workPath', async () => {
     const dir = await createFixture({
       // Malformed tsconfig at the workPath root: fatal if read.

--- a/packages/backends/test/unit.typescript.test.ts
+++ b/packages/backends/test/unit.typescript.test.ts
@@ -1,0 +1,83 @@
+import { createRequire } from 'node:module';
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Span } from '@vercel/build-utils';
+import { typescript } from '../src/typescript';
+
+const require_ = createRequire(import.meta.url);
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+async function createFixture(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'backends-typescript-'));
+  tempDirs.push(dir);
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = join(dir, name);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, content);
+  }
+  // Make the repo's `typescript` install resolvable from the fixture.
+  const tsDir = dirname(require_.resolve('typescript/package.json'));
+  await mkdir(join(dir, 'node_modules'), { recursive: true });
+  await symlink(tsDir, join(dir, 'node_modules/typescript'));
+  return dir;
+}
+
+function typecheck(workPath: string, entrypoint: string) {
+  return typescript({
+    entrypoint,
+    workPath,
+    span: new Span({ name: 'test' }),
+    nodeVersionMajor: 22,
+  });
+}
+
+describe('typescript typecheck leniencies (parity with @vercel/node)', () => {
+  it('fails on real type errors', async () => {
+    const dir = await createFixture({
+      'index.ts': 'const n: number = "not a number";\nexport default n;\n',
+    });
+    await expect(typecheck(dir, 'index.ts')).rejects.toThrow(
+      'TypeScript type check failed'
+    );
+  });
+
+  it('ignores an empty "files" list in tsconfig (TS18002)', async () => {
+    const dir = await createFixture({
+      'tsconfig.json': JSON.stringify({ files: [] }),
+      'index.ts': 'export const ok: number = 1;\n',
+    });
+    await expect(typecheck(dir, 'index.ts')).resolves.toBeUndefined();
+  });
+
+  it('forces strict off when "module" is not set in tsconfig', async () => {
+    const dir = await createFixture({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { strict: true },
+      }),
+      // Implicit-any parameter: fails under strict, passes without it.
+      'index.ts': 'export const fn = a => a;\n',
+    });
+    await expect(typecheck(dir, 'index.ts')).resolves.toBeUndefined();
+  });
+
+  it('discovers tsconfig from the entrypoint directory, not workPath', async () => {
+    const dir = await createFixture({
+      // Malformed tsconfig at the workPath root: fatal if read.
+      'tsconfig.json': '{ not valid json',
+      'api/tsconfig.json': JSON.stringify({
+        compilerOptions: { module: 'NodeNext', moduleResolution: 'NodeNext' },
+      }),
+      'api/index.ts': 'export const ok: number = 1;\n',
+    });
+    await expect(typecheck(dir, 'api/index.ts')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Part of the backends parity work (follows #17283, #17284, #17286).

Mirrors the `@vercel/node` builder's typecheck behavior (`packages/node/src/typescript.ts`, a ts-node fork) so projects moving from the framework wrapper builders (`@vercel/express` et al.) to `@vercel/backends` see the same typecheck results, including historically shipped leniencies:

- tsconfig.json is discovered walking up from the **entrypoint**, not `workPath`
- Diagnostics 6059/18002/18003 are ignored
- When `target` is not set, it defaults based on the Node.js major version (new optional `nodeVersionMajor` on `TypescriptOptions`)
- When `module` is not set, `NodeNext` resolution is used and `strict` is forced off
- Emit-oriented options (`outFile`, `composite`, `incremental`, ...) are dropped
- `esModuleInterop` defaults to true only when unset
- tsconfig option errors are fatal only when `noEmitOnError` is set
- The user's `typescript` install is preferred; the bundled one is a fallback

## Verification

- `pnpm type-check` in `packages/backends`: pass
- `pnpm vitest run test/unit.build.test.ts test/unit.find-entrypoint.test.ts test/unit.post-build-entrypoint.test.ts`: 25/25 pass
