### PR TITLE
[python] wait_until

### DIFF
--- a/.changeset/python-runtime-wait-until.md
+++ b/.changeset/python-runtime-wait-until.md
@@ -1,0 +1,8 @@
+---
+'@vercel/python-runtime': minor
+---
+
+Add invocation-scoped `wait_until` to the Python runtime. Awaitables attached
+during a request are drained after the response is sent, bounded by the
+Function's maximum duration, and exposed to the SDK's
+`vercel.functions.wait_until()` through the invocation context.

--- a/python/vercel-runtime/pyproject.toml
+++ b/python/vercel-runtime/pyproject.toml
@@ -27,6 +27,7 @@ build-backend = "uv_build"
 [dependency-groups]
 test = [
     "attrs~=25.3.0",
+    "vercel~=0.5",
     "basedpyright~=1.37.0",
     "mypy~=1.19.0",
     "pytest~=9.0.2",

--- a/python/vercel-runtime/src/vercel_runtime/cache.py
+++ b/python/vercel-runtime/src/vercel_runtime/cache.py
@@ -161,8 +161,8 @@ def clear_runtime_cache_context() -> None:
 # we'll configure caches, otherwise we skip the behaviour
 def _load_vercel_cache_modules() -> Any | None:
     with contextlib.suppress(ImportError):
-        import vercel.cache.cache_build as cache_build  # type: ignore[import-not-found]  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-        import vercel.cache.context as context  # type: ignore[import-not-found]  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        import vercel.cache.cache_build as cache_build  # noqa: PLC0415  # pyright: ignore[reportMissingTypeStubs]
+        import vercel.cache.context as context  # noqa: PLC0415  # pyright: ignore[reportMissingTypeStubs]
 
         return cache_build, context
     return None

--- a/python/vercel-runtime/src/vercel_runtime/dev.py
+++ b/python/vercel-runtime/src/vercel_runtime/dev.py
@@ -18,6 +18,12 @@ from vercel_runtime.routing import (
     apply_service_route_prefix_to_asgi_scope,
     strip_service_route_prefix,
 )
+from vercel_runtime.wait_until import (
+    WaitUntilCollector,
+    begin_wait_until,
+    finish_wait_until,
+    finish_wait_until_async,
+)
 from vercel_runtime.workers import (
     bootstrap_queue_service_app,
     install_queue_integrations,
@@ -28,7 +34,7 @@ from vercel_runtime.workers import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Iterable, Iterator
     from wsgiref.types import WSGIApplication
 
     from vercel_runtime.asgi import ASGI
@@ -304,7 +310,33 @@ async def asgi_app(
             pass
 
     assert _asgi_user_app is not None
-    await _asgi_user_app(effective_scope, receive, send)
+    if (
+        effective_scope.get("type") == "http"
+        and effective_scope.get("path") == "/_vercel/ping"
+    ):
+        await _asgi_user_app(effective_scope, receive, send)
+        return
+
+    wait_until = begin_wait_until()
+    try:
+        await _asgi_user_app(effective_scope, receive, send)
+    finally:
+        await finish_wait_until_async(wait_until)
+
+
+def _wait_until_wsgi_result(
+    result: Iterable[bytes],
+    wait_until: WaitUntilCollector,
+) -> Iterator[bytes]:
+    try:
+        yield from result
+    finally:
+        try:
+            close = getattr(result, "close", None)
+            if callable(close):
+                close()
+        finally:
+            finish_wait_until(wait_until)
 
 
 def wsgi_app(
@@ -353,7 +385,16 @@ def wsgi_app(
 
     # Otherwise, delegate to user's WSGI app
     assert _wsgi_user_app is not None
-    return _wsgi_user_app(environ, start_response)
+    if environ.get("PATH_INFO") == "/_vercel/ping":
+        return _wsgi_user_app(environ, start_response)
+
+    wait_until = begin_wait_until()
+    try:
+        user_result = _wsgi_user_app(environ, start_response)
+    except BaseException:
+        finish_wait_until(wait_until)
+        raise
+    return _wait_until_wsgi_result(user_result, wait_until)
 
 
 def _start_wsgi(host: str, port: int) -> None:

--- a/python/vercel-runtime/src/vercel_runtime/vc_init.py
+++ b/python/vercel-runtime/src/vercel_runtime/vc_init.py
@@ -53,6 +53,13 @@ from vercel_runtime.routing import (
     split_request_target,
 )
 from vercel_runtime.utils import read_wsgi_request_body
+from vercel_runtime.wait_until import (
+    WaitUntilCollector,
+    begin_wait_until,
+    clear_wait_until_context,
+    finish_wait_until,
+    finish_wait_until_async,
+)
 from vercel_runtime.workers import (
     install_queue_integrations,
     is_worker_service,
@@ -650,29 +657,33 @@ class ASGIMiddleware:
         )
         set_vercel_headers_from_asgi_pairs(new_headers)
         set_runtime_cache_from_asgi_pairs(sc_pairs)
+        wait_until = begin_wait_until()
 
         request_finished = False
 
-        def finish_request() -> None:
+        async def finish_request() -> None:
             nonlocal request_finished
             if request_finished:
                 return
 
             request_finished = True
-            clear_runtime_cache_context()
-            clear_vercel_headers_context()
-            storage.reset(token)
-            send_message(
-                {
-                    "type": "end",
-                    "payload": {
-                        "context": {
-                            "invocationId": invocation_id,
-                            "requestId": request_id,
-                        }
-                    },
-                }
-            )
+            try:
+                await finish_wait_until_async(wait_until)
+            finally:
+                clear_runtime_cache_context()
+                clear_vercel_headers_context()
+                storage.reset(token)
+                send_message(
+                    {
+                        "type": "end",
+                        "payload": {
+                            "context": {
+                                "invocationId": invocation_id,
+                                "requestId": request_id,
+                            }
+                        },
+                    }
+                )
 
         async def send_wrapper(message: dict[str, Any]) -> None:
             await send(message)
@@ -684,23 +695,23 @@ class ASGIMiddleware:
             if message_type == "websocket.accept":
                 # End the request lifecycle once the 101 is sent so the
                 # platform can begin bidirectional WebSocket streaming.
-                finish_request()
+                await finish_request()
                 return
 
             if message_type == "websocket.close":
-                finish_request()
+                await finish_request()
                 return
 
             if (
                 message_type == "websocket.http.response.body"
                 and not message.get("more_body")
             ):
-                finish_request()
+                await finish_request()
 
         try:
             await self.app(new_scope, receive, send_wrapper)
         finally:
-            finish_request()
+            await finish_request()
 
 
 if "VERCEL_IPC_PATH" in os.environ:
@@ -783,30 +794,36 @@ if "VERCEL_IPC_PATH" in os.environ:
             if getattr(self, "_vc_end_sent", False):
                 return
             self._vc_end_sent = True
-            clear_runtime_cache_context()
-            clear_vercel_headers_context()
-            token = getattr(self, "_vc_end_token", None)
-            if token is not None:
-                storage.reset(token)
-            send_message(
-                {
-                    "type": "end",
-                    "payload": {
-                        "context": {
-                            "invocationId": getattr(
-                                self, "_vc_invocation_id", "0"
-                            ),
-                            "requestId": getattr(self, "_vc_request_id", 0),
-                        }
-                    },
-                }
-            )
+            try:
+                wait_until = getattr(self, "_vc_wait_until", None)
+                if isinstance(wait_until, WaitUntilCollector):
+                    finish_wait_until(wait_until)
+            finally:
+                clear_runtime_cache_context()
+                clear_vercel_headers_context()
+                token = getattr(self, "_vc_end_token", None)
+                if token is not None:
+                    storage.reset(token)
+                send_message(
+                    {
+                        "type": "end",
+                        "payload": {
+                            "context": {
+                                "invocationId": getattr(
+                                    self, "_vc_invocation_id", "0"
+                                ),
+                                "requestId": getattr(self, "_vc_request_id", 0),
+                            }
+                        },
+                    }
+                )
 
         # Re-implementation of handle_one_request to send
         # the end message after the response is fully sent.
         def handle_one_request(self) -> None:
             self._vc_end_sent = False
             self._vc_end_token = None
+            self._vc_wait_until = None
             self.raw_requestline = self.rfile.readline(65537)
             if not self.raw_requestline:
                 self.close_connection = True
@@ -887,6 +904,7 @@ if "VERCEL_IPC_PATH" in os.environ:
                 }
             )
             set_vercel_headers_from_http_headers(self.headers)
+            self._vc_wait_until = begin_wait_until()
 
             try:
                 self.handle_request()  # type: ignore[attr-defined]
@@ -1115,42 +1133,51 @@ if (
         if sc_no_header_leak:
             for sc_header in SC_HEADERS_STRIP_ON_NO_LEAK:
                 headers.pop(sc_header, None)
-
-        # `_thread.start_new_thread` does not propagate contextvars
-        captured_ctx = contextvars.copy_context()
-        _thread.start_new_thread(
-            captured_ctx.run,
-            (server.handle_request,),  # type: ignore[attr-defined]
-        )
-        clear_runtime_cache_context()
-
-        if (body is not None and len(body) > 0) and (
-            encoding is not None and encoding == "base64"
-        ):
-            body = base64.b64decode(body)
-
-        request_body = body.encode("utf-8") if isinstance(body, str) else body
-        conn = http.client.HTTPConnection("127.0.0.1", port)
+        set_vercel_headers_from_http_headers(headers)
+        wait_until = begin_wait_until()
         try:
-            conn.request(method, path, headers=headers, body=request_body)
-        except (OSError, http.client.HTTPException) as ex:
-            _stderr(f"Request Error: {ex}")
-        res = conn.getresponse()
+            # `_thread.start_new_thread` does not propagate contextvars
+            captured_ctx = contextvars.copy_context()
+            _thread.start_new_thread(
+                captured_ctx.run,
+                (server.handle_request,),  # type: ignore[attr-defined]
+            )
 
-        return_dict: dict[str, Any] = {
-            "statusCode": res.status,
-            "headers": format_headers(res.headers),
-        }
+            if (body is not None and len(body) > 0) and (
+                encoding is not None and encoding == "base64"
+            ):
+                body = base64.b64decode(body)
 
-        data = res.read()
+            request_body = (
+                body.encode("utf-8") if isinstance(body, str) else body
+            )
+            conn = http.client.HTTPConnection("127.0.0.1", port)
+            try:
+                conn.request(method, path, headers=headers, body=request_body)
+            except (OSError, http.client.HTTPException) as ex:
+                _stderr(f"Request Error: {ex}")
+            res = conn.getresponse()
 
-        try:
-            return_dict["body"] = data.decode("utf-8")
-        except UnicodeDecodeError:
-            return_dict["body"] = base64.b64encode(data).decode("utf-8")
-            return_dict["encoding"] = "base64"
+            return_dict: dict[str, Any] = {
+                "statusCode": res.status,
+                "headers": format_headers(res.headers),
+            }
 
-        return return_dict
+            data = res.read()
+
+            try:
+                return_dict["body"] = data.decode("utf-8")
+            except UnicodeDecodeError:
+                return_dict["body"] = base64.b64encode(data).decode("utf-8")
+                return_dict["encoding"] = "base64"
+
+            return return_dict
+        finally:
+            try:
+                finish_wait_until(wait_until)
+            finally:
+                clear_runtime_cache_context()
+                clear_vercel_headers_context()
 
 else:
     try:
@@ -1257,11 +1284,15 @@ else:
                     environ[env_key] = value
 
             set_vercel_headers_from_http_headers(raw_headers)
+            wait_until = begin_wait_until()
             try:
                 response = Response.from_app(wsgi_user_app, environ)
             finally:
-                clear_runtime_cache_context()
-                clear_vercel_headers_context()
+                try:
+                    finish_wait_until(wait_until)
+                finally:
+                    clear_runtime_cache_context()
+                    clear_vercel_headers_context()
 
             return_dict: dict[str, Any] = {
                 "statusCode": response.status_code,
@@ -1408,7 +1439,10 @@ else:
                 )
 
                 asgi_instance = app(self.scope, self.receive, self.send)
-                _asgi_runner.run(asgi_instance)
+                _asgi_runner.run(
+                    asgi_instance,
+                    context=contextvars.copy_context(),
+                )
                 return self.response
 
             def put_message(self, message: dict[str, Any]) -> None:
@@ -1554,10 +1588,15 @@ else:
             }
 
             set_vercel_headers_from_http_headers(headers)
+            wait_until = begin_wait_until()
             try:
                 asgi_cycle = ASGICycle(scope)
                 response = asgi_cycle(asgi_user_app, body)
                 return response
             finally:
-                clear_runtime_cache_context()
-                clear_vercel_headers_context()
+                try:
+                    _asgi_runner.run(finish_wait_until_async(wait_until))
+                finally:
+                    clear_wait_until_context()
+                    clear_runtime_cache_context()
+                    clear_vercel_headers_context()

--- a/python/vercel-runtime/src/vercel_runtime/wait_until.py
+++ b/python/vercel-runtime/src/vercel_runtime/wait_until.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+import inspect
+import logging
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _PendingAwaitable:
+    awaitable: Awaitable[object]
+    context: contextvars.Context
+
+
+class WaitUntilCollector:
+    """Invocation-scoped collection of post-response work."""
+
+    def __init__(self) -> None:
+        self._pending: dict[int, _PendingAwaitable] = {}
+        self._closed = False
+        self._lock = threading.Lock()
+
+    def wait_until(self, awaitable: Awaitable[object]) -> None:
+        if not inspect.isawaitable(awaitable):
+            msg = (
+                "wait_until can only be called with an awaitable, "
+                f"got {type(awaitable).__name__}"
+            )
+            raise TypeError(msg)
+
+        with self._lock:
+            if self._closed:
+                _close_coroutine(awaitable)
+                msg = "wait_until cannot be called after the invocation ended"
+                raise RuntimeError(msg)
+            self._pending.setdefault(
+                id(awaitable),
+                _PendingAwaitable(
+                    awaitable=awaitable,
+                    context=contextvars.copy_context(),
+                ),
+            )
+
+        if isinstance(awaitable, asyncio.Future):
+            awaitable.add_done_callback(_consume_future_exception)
+
+    async def drain(self) -> None:
+        while True:
+            with self._lock:
+                batch = list(self._pending.values())
+                self._pending.clear()
+                if not batch:
+                    self._closed = True
+                    return
+
+            tasks = [
+                pending.context.run(
+                    asyncio.ensure_future,
+                    pending.awaitable,
+                )
+                for pending in batch
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, asyncio.CancelledError):
+                    logger.error("wait_until task was cancelled")
+                elif isinstance(result, BaseException):
+                    logger.error(
+                        "wait_until task failed",
+                        exc_info=(
+                            type(result),
+                            result,
+                            result.__traceback__,
+                        ),
+                    )
+
+
+def begin_wait_until() -> WaitUntilCollector:
+    collector = WaitUntilCollector()
+    _set_public_wait_until(collector.wait_until)
+    return collector
+
+
+async def finish_wait_until_async(collector: WaitUntilCollector) -> None:
+    try:
+        await collector.drain()
+    finally:
+        _set_public_wait_until(None)
+
+
+def finish_wait_until(collector: WaitUntilCollector) -> None:
+    try:
+        asyncio.run(collector.drain())
+    finally:
+        clear_wait_until_context()
+
+
+def clear_wait_until_context() -> None:
+    _set_public_wait_until(None)
+
+
+def _set_public_wait_until(
+    callback: Callable[[Awaitable[object]], None] | None,
+) -> None:
+    with contextlib.suppress(ImportError):
+        from vercel.cache.context import (  # noqa: PLC0415  # pyright: ignore[reportMissingTypeStubs]
+            get_context,
+            set_context,
+        )
+
+        set_context(wait_until=callback)
+        if callback is None and get_context().wait_until is not None:
+            # vercel-cache versions before its UNSET sentinel treated None as
+            # "leave unchanged". Replace the completed collector with a
+            # stateless no-op so a warm worker cannot retain the invocation.
+            set_context(wait_until=_discard_wait_until)
+
+
+def _consume_future_exception(future: asyncio.Future[Any]) -> None:
+    if not future.cancelled():
+        with contextlib.suppress(BaseException):
+            future.exception()
+
+
+def _close_coroutine(awaitable: Awaitable[object]) -> None:
+    if inspect.iscoroutine(awaitable):
+        awaitable.close()
+
+
+def _discard_wait_until(awaitable: Awaitable[object]) -> None:
+    _close_coroutine(awaitable)

--- a/python/vercel-runtime/tests/fixtures/wait_until_asgi.py
+++ b/python/vercel-runtime/tests/fixtures/wait_until_asgi.py
@@ -1,0 +1,46 @@
+"""ASGI fixture proving wait_until runs after the response."""
+
+import asyncio
+import json
+import os
+
+from vercel.cache.context import get_context
+from vercel.headers import get_headers
+
+observed_tokens: list[str | None] = []
+
+
+async def capture_oidc_token() -> None:
+    await asyncio.sleep(0)
+    headers = get_headers() or {}
+    token = headers.get("x-vercel-oidc-token")
+    observed_tokens.append(token)
+    output_path = os.environ.get("WAIT_UNTIL_OUTPUT")
+    if output_path:
+        with open(output_path, "a") as output:
+            output.write(f"{token}\n")
+
+
+async def app(scope, receive, send):
+    del receive
+    if scope["type"] != "http":
+        return
+
+    callback = get_context().wait_until
+    assert callback is not None
+    callback(capture_oidc_token())
+    body = json.dumps(observed_tokens).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json")],
+        }
+    )
+    await send(
+        {
+            "type": "http.response.body",
+            "body": body,
+            "more_body": False,
+        }
+    )

--- a/python/vercel-runtime/tests/fixtures/wait_until_wsgi.py
+++ b/python/vercel-runtime/tests/fixtures/wait_until_wsgi.py
@@ -1,0 +1,31 @@
+"""WSGI fixture proving wait_until sees request-scoped headers."""
+
+import asyncio
+import json
+import os
+
+from vercel.cache.context import get_context
+from vercel.headers import get_headers
+
+observed_tokens: list[str | None] = []
+
+
+async def capture_oidc_token() -> None:
+    await asyncio.sleep(0)
+    headers = get_headers() or {}
+    token = headers.get("x-vercel-oidc-token")
+    observed_tokens.append(token)
+    output_path = os.environ.get("WAIT_UNTIL_OUTPUT")
+    if output_path:
+        with open(output_path, "a") as output:
+            output.write(f"{token}\n")
+
+
+def app(environ, start_response):
+    del environ
+    callback = get_context().wait_until
+    assert callback is not None
+    callback(capture_oidc_token())
+    body = json.dumps(observed_tokens).encode()
+    start_response("200 OK", [("Content-Type", "application/json")])
+    return [body]

--- a/python/vercel-runtime/tests/test_runtime.py
+++ b/python/vercel-runtime/tests/test_runtime.py
@@ -137,6 +137,7 @@ async def _invoke_lambda(
     module_name: str,
     event: dict[str, Any],
     variable_name: str = "app",
+    extra_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Run vc_init.py in legacy mode and call vc_handler.
 
@@ -151,6 +152,8 @@ async def _invoke_lambda(
         "__VC_HANDLER_VARIABLE_NAME": variable_name,
     }
     env.pop("VERCEL_IPC_PATH", None)
+    if extra_env:
+        env.update(extra_env)
 
     result_r, result_w = os.pipe()
     env["_RESULT_FD"] = str(result_w)
@@ -677,6 +680,50 @@ class TestWSGIApp(_RuntimeTestCase):
                 "GET /search?q=test",
             )
 
+    async def test_wait_until_runs_after_response_with_request_oidc(
+        self,
+    ) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "wait_until_wsgi.py",
+            self.tmp_path,
+        )
+        async with _run_runtime(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            ipc_socket_path=self.n1.socket_path,
+        ):
+            ss = await self.n1.wait_for_message(
+                ServerStartedMessage,
+                timeout=10.0,
+            )
+            port = ss.payload.http_port
+
+            first = await _http_get(
+                port,
+                "/",
+                headers={
+                    "x-vercel-internal-oidc-token": "first-request-token",
+                },
+            )
+            self.assertEqual(
+                json.loads(first.read()),
+                [],
+            )
+            await self.n1.wait_for_message(EndMessage, timeout=5.0)
+
+            second = await _http_get(
+                port,
+                "/",
+                headers={
+                    "x-vercel-internal-oidc-token": "second-request-token",
+                },
+            )
+            self.assertEqual(
+                json.loads(second.read()),
+                ["first-request-token"],
+            )
+
     async def test_wsgi_chunked_post_without_content_length(self) -> None:
         ep_abs, ep_rel, mod = _make_entrypoint(
             "wsgi_echo_app.py", self.tmp_path
@@ -944,6 +991,47 @@ class TestASGIApp(_RuntimeTestCase):
             conn.request("GET", "/_vercel/ping")
             resp = conn.getresponse()
             self.assertEqual(resp.status, 200)
+
+    async def test_wait_until_runs_after_response_with_request_oidc(
+        self,
+    ) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "wait_until_asgi.py",
+            self.tmp_path,
+        )
+        async with _run_runtime(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            ipc_socket_path=self.n1.socket_path,
+        ):
+            ss = await self.n1.wait_for_message(
+                ServerStartedMessage,
+                timeout=10.0,
+            )
+            port = ss.payload.http_port
+
+            first = await _http_get(
+                port,
+                "/",
+                headers={
+                    "x-vercel-internal-oidc-token": "first-request-token",
+                },
+            )
+            self.assertEqual(json.loads(first.read()), [])
+            await self.n1.wait_for_message(EndMessage, timeout=5.0)
+
+            second = await _http_get(
+                port,
+                "/",
+                headers={
+                    "x-vercel-internal-oidc-token": "second-request-token",
+                },
+            )
+            self.assertEqual(
+                json.loads(second.read()),
+                ["first-request-token"],
+            )
 
     async def test_invalid_utf8_header(self) -> None:
         ep_abs, ep_rel, mod = _make_entrypoint("asgi_app.py", self.tmp_path)
@@ -1763,6 +1851,32 @@ class TestLambdaWSGI(_LambdaTestCase):
         body = base64.b64decode(result["body"]).decode()
         self.assertEqual(body, "GET /hello")
 
+    async def test_wait_until_drains_with_request_oidc(
+        self,
+    ) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "wait_until_wsgi.py",
+            self.tmp_path,
+        )
+        output_path = self.tmp_path / "wait-until-output.txt"
+        result = await _invoke_lambda(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            event=_lambda_event(
+                "GET",
+                "/",
+                headers={
+                    "x-vercel-internal-oidc-token": "request-token",
+                },
+            ),
+            extra_env={"WAIT_UNTIL_OUTPUT": str(output_path)},
+        )
+        self.assertEqual(result["statusCode"], 200)
+        body = base64.b64decode(result["body"]).decode()
+        self.assertEqual(json.loads(body), [])
+        self.assertEqual(output_path.read_text(), "request-token\n")
+
     async def test_query_string(self) -> None:
         ep_abs, ep_rel, mod = _make_entrypoint("wsgi_app.py", self.tmp_path)
         result = await _invoke_lambda(
@@ -1805,6 +1919,30 @@ class TestLambdaASGI(_LambdaTestCase):
         self.assertEqual(result["statusCode"], 200)
         body = base64.b64decode(result["body"]).decode()
         self.assertEqual(body, "GET /hello")
+
+    async def test_wait_until_drains_with_request_oidc(self) -> None:
+        ep_abs, ep_rel, mod = _make_entrypoint(
+            "wait_until_asgi.py",
+            self.tmp_path,
+        )
+        output_path = self.tmp_path / "wait-until-output.txt"
+        result = await _invoke_lambda(
+            entrypoint_abs=ep_abs,
+            entrypoint_rel=ep_rel,
+            module_name=mod,
+            event=_lambda_event(
+                "GET",
+                "/",
+                headers={
+                    "x-vercel-internal-oidc-token": "request-token",
+                },
+            ),
+            extra_env={"WAIT_UNTIL_OUTPUT": str(output_path)},
+        )
+        self.assertEqual(result["statusCode"], 200)
+        body = base64.b64decode(result["body"]).decode()
+        self.assertEqual(json.loads(body), [])
+        self.assertEqual(output_path.read_text(), "request-token\n")
 
     async def test_base64_body(self) -> None:
         ep_abs, ep_rel, mod = _make_entrypoint("asgi_app.py", self.tmp_path)

--- a/python/vercel-runtime/tests/test_wait_until.py
+++ b/python/vercel-runtime/tests/test_wait_until.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import unittest
+from contextvars import ContextVar
+
+from vercel_runtime.wait_until import (
+    WaitUntilCollector,
+    begin_wait_until,
+    finish_wait_until,
+)
+
+
+class TestWaitUntilCollector(unittest.IsolatedAsyncioTestCase):
+    async def test_drains_registered_awaitables(self) -> None:
+        calls: list[str] = []
+        collector = WaitUntilCollector()
+
+        async def work() -> None:
+            await asyncio.sleep(0)
+            calls.append("done")
+
+        collector.wait_until(work())
+        await collector.drain()
+
+        self.assertEqual(calls, ["done"])
+
+    async def test_deduplicates_the_same_awaitable(self) -> None:
+        calls = 0
+        collector = WaitUntilCollector()
+
+        async def work() -> None:
+            nonlocal calls
+            await asyncio.sleep(0)
+            calls += 1
+
+        coroutine = work()
+        collector.wait_until(coroutine)
+        collector.wait_until(coroutine)
+        await collector.drain()
+
+        self.assertEqual(calls, 1)
+
+    async def test_drains_work_registered_by_work(self) -> None:
+        calls: list[str] = []
+        collector = WaitUntilCollector()
+
+        async def child() -> None:
+            await asyncio.sleep(0)
+            calls.append("child")
+
+        async def parent() -> None:
+            await asyncio.sleep(0)
+            calls.append("parent")
+            collector.wait_until(child())
+
+        collector.wait_until(parent())
+        await collector.drain()
+
+        self.assertEqual(calls, ["parent", "child"])
+
+    async def test_logs_errors_without_raising(self) -> None:
+        collector = WaitUntilCollector()
+
+        async def fail() -> None:
+            await asyncio.sleep(0)
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        collector.wait_until(fail())
+        with self.assertLogs("vercel_runtime.wait_until", level="ERROR"):
+            await collector.drain()
+
+    async def test_captures_registration_context(self) -> None:
+        value: ContextVar[str] = ContextVar("value", default="unset")
+        observed: list[str] = []
+        collector = WaitUntilCollector()
+
+        async def work() -> None:
+            await asyncio.sleep(0)
+            observed.append(value.get())
+
+        value.set("registered")
+        collector.wait_until(work())
+        value.set("drained")
+        await collector.drain()
+
+        self.assertEqual(observed, ["registered"])
+
+    async def test_rejects_work_after_drain(self) -> None:
+        collector = WaitUntilCollector()
+        await collector.drain()
+
+        async def work() -> None:
+            await asyncio.sleep(0)
+
+        with self.assertRaisesRegex(RuntimeError, "invocation ended"):
+            collector.wait_until(work())
+
+    async def test_rejects_non_awaitable(self) -> None:
+        collector = WaitUntilCollector()
+        with self.assertRaisesRegex(TypeError, "awaitable"):
+            collector.wait_until(None)  # type: ignore[arg-type]
+
+    async def test_concurrent_registration_is_safe(self) -> None:
+        collector = WaitUntilCollector()
+        calls: list[int] = []
+
+        async def work(value: int) -> None:
+            await asyncio.sleep(0)
+            calls.append(value)
+
+        threads = [
+            threading.Thread(
+                target=collector.wait_until,
+                args=(work(value),),
+            )
+            for value in range(10)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        await collector.drain()
+        self.assertEqual(sorted(calls), list(range(10)))
+
+
+class TestWaitUntilContext(unittest.TestCase):
+    def test_sync_finish_clears_calling_context(self) -> None:
+        from vercel.cache.context import (  # pyright: ignore[reportMissingTypeStubs]
+            get_context,
+        )
+
+        collector = begin_wait_until()
+        self.assertIsNotNone(get_context().wait_until)
+
+        finish_wait_until(collector)
+
+        callback = get_context().wait_until
+        if callback is not None:
+
+            async def work() -> None:
+                await asyncio.sleep(0)
+
+            coroutine = work()
+            callback(coroutine)
+            coroutine.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/python/vercel-runtime/tests/test_wait_until.py
+++ b/python/vercel-runtime/tests/test_wait_until.py
@@ -126,6 +126,35 @@ class TestWaitUntilCollector(unittest.IsolatedAsyncioTestCase):
         await collector.drain()
         self.assertEqual(sorted(calls), list(range(10)))
 
+    async def test_registration_during_drain_joins_the_same_drain(self) -> None:
+        collector = WaitUntilCollector()
+        calls: list[str] = []
+        registered = threading.Event()
+
+        async def late_work() -> None:
+            await asyncio.sleep(0)
+            calls.append("late")
+
+        def register_from_thread() -> None:
+            # A WSGI worker thread registering while the invoking thread is
+            # already draining must land in that same drain.
+            collector.wait_until(late_work())
+            registered.set()
+
+        async def blocking_work() -> None:
+            thread = threading.Thread(target=register_from_thread)
+            thread.start()
+            await asyncio.to_thread(registered.wait, 5)
+            thread.join(timeout=5)
+            calls.append("blocking")
+
+        collector.wait_until(blocking_work())
+        await collector.drain()
+
+        self.assertEqual(sorted(calls), ["blocking", "late"])
+        with self.assertRaisesRegex(RuntimeError, "invocation ended"):
+            collector.wait_until(late_work())
+
 
 class TestWaitUntilContext(unittest.TestCase):
     def test_sync_finish_clears_calling_context(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P2D"
-
 [manifest]
 members = [
     "vercel-runtime",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
 [manifest]
 members = [
     "vercel-runtime",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
 [manifest]
 members = [
     "vercel-runtime",
@@ -1227,6 +1231,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "vercel" },
 ]
 
 [package.metadata]
@@ -1239,6 +1244,7 @@ test = [
     { name = "pytest", specifier = "~=9.0.2" },
     { name = "pytest-cov", specifier = "~=7.0.0" },
     { name = "ruff", specifier = "~=0.15.1" },
+    { name = "vercel", specifier = "~=0.5" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds invocation-scoped `wait_until` to the Python runtime, so Functions can run post-response work (analytics, cache writes) without holding the response. Pairs with `vercel.functions.wait_until()` in vercel/vercel-py#218.

## How it works

- A per-invocation `WaitUntilCollector` registers awaitables (thread-safe, deduplicated, each with its captured `contextvars` context so drained work still sees request headers/OIDC).
- Every server flavor (IPC ASGI/WSGI, Lambda ASGI/WSGI, `vercel dev`) drains the collector in a `finally` after the response is sent and before the invocation is reported finished (IPC `end` / Lambda return).
- Draining loops until no work remains, so work registered mid-drain — including from WSGI worker threads — still runs. Task failures are logged, never raised into the request. The context is always cleared afterwards, so a warm worker can't leak a closed collector into the next invocation.

