### PR TITLE
[python] request invocation hooks

### DIFF
--- a/.changeset/python-runtime-invocation-hooks.md
+++ b/.changeset/python-runtime-invocation-hooks.md
@@ -2,7 +2,7 @@
 '@vercel/python-runtime': minor
 ---
 
-Add private invocation hooks: Vercel-owned integrations can register work
-that runs off the request's critical path once request-scoped credentials
-exist, with per-name deduplication, optional re-run intervals, and failure
-backoff.
+Add private invocation hooks: Vercel-owned integrations can call
+`run_on_next_invocation()` to run work once on an upcoming request, off the
+response path and with that request's context. Failures retry with backoff on
+later requests, and `repeat_after_seconds` re-arms a hook after each success.

--- a/.changeset/python-runtime-invocation-hooks.md
+++ b/.changeset/python-runtime-invocation-hooks.md
@@ -1,0 +1,8 @@
+---
+'@vercel/python-runtime': minor
+---
+
+Add private invocation hooks: Vercel-owned integrations can register work
+that runs off the request's critical path once request-scoped credentials
+exist, with per-name deduplication, optional re-run intervals, and failure
+backoff.

--- a/python/vercel-runtime/src/vercel_runtime/invocation_hooks.py
+++ b/python/vercel-runtime/src/vercel_runtime/invocation_hooks.py
@@ -21,7 +21,7 @@ type _WaitUntil = Callable[[Awaitable[object]], None]
 @dataclass(slots=True)
 class _InvocationHook:
     callback: _HookCallback
-    min_interval_seconds: float | None
+    repeat_after_seconds: float | None
     next_run_at: float = 0
     running: bool = False
     completed: bool = False
@@ -33,18 +33,26 @@ _hooks_lock = threading.Lock()
 _MAX_FAILURE_BACKOFF_SECONDS = 60.0
 
 
-def register_invocation_hook(
+def run_on_next_invocation(
     name: str,
     callback: _HookCallback,
     *,
-    min_interval_seconds: float | None = None,
+    repeat_after_seconds: float | None = None,
 ) -> None:
-    """Register a private integration hook to attach to a later invocation."""
+    """Run callback once, on an upcoming invocation, off the response path.
+
+    The callback executes in a thread after that invocation's response is
+    sent, with the request's context (headers, OIDC) ambient. Failures are
+    logged and retried on later invocations with capped backoff. After the
+    first success the hook is done — unless repeat_after_seconds is set, in
+    which case it becomes eligible again that long after each success,
+    still running only when a request arrives. Never a timer.
+    """
     if not name:
         msg = "invocation hook name must not be empty"
         raise ValueError(msg)
-    if min_interval_seconds is not None and min_interval_seconds <= 0:
-        msg = "min_interval_seconds must be greater than zero"
+    if repeat_after_seconds is not None and repeat_after_seconds <= 0:
+        msg = "repeat_after_seconds must be greater than zero"
         raise ValueError(msg)
 
     with _hooks_lock:
@@ -52,18 +60,19 @@ def register_invocation_hook(
         if existing is None:
             _hooks[name] = _InvocationHook(
                 callback=callback,
-                min_interval_seconds=min_interval_seconds,
+                repeat_after_seconds=repeat_after_seconds,
             )
             return
         if (
             existing.callback is not callback
-            or existing.min_interval_seconds != min_interval_seconds
+            or existing.repeat_after_seconds != repeat_after_seconds
         ):
             msg = f"invocation hook {name!r} is already registered differently"
             raise ValueError(msg)
 
 
-def schedule_invocation_hooks(wait_until: _WaitUntil) -> None:
+def attach_due_hooks(wait_until: _WaitUntil) -> None:
+    """Attach whatever hooks are due to the current invocation's drain."""
     now = monotonic()
     due: list[tuple[str, _InvocationHook]] = []
     with _hooks_lock:
@@ -91,11 +100,11 @@ async def _run_hook(name: str, hook: _InvocationHook) -> None:
                 hook.running = False
                 if succeeded:
                     hook.failures = 0
-                    if hook.min_interval_seconds is None:
+                    if hook.repeat_after_seconds is None:
                         hook.completed = True
                     else:
                         hook.next_run_at = (
-                            monotonic() + hook.min_interval_seconds
+                            monotonic() + hook.repeat_after_seconds
                         )
                 else:
                     hook.failures += 1

--- a/python/vercel-runtime/src/vercel_runtime/invocation_hooks.py
+++ b/python/vercel-runtime/src/vercel_runtime/invocation_hooks.py
@@ -1,0 +1,111 @@
+"""Private hooks for Vercel-owned integrations that need request context."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from dataclasses import dataclass
+from time import monotonic
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+type _HookCallback = Callable[[], None]
+type _WaitUntil = Callable[[Awaitable[object]], None]
+
+
+@dataclass(slots=True)
+class _InvocationHook:
+    callback: _HookCallback
+    min_interval_seconds: float | None
+    next_run_at: float = 0
+    running: bool = False
+    completed: bool = False
+    failures: int = 0
+
+
+_hooks: dict[str, _InvocationHook] = {}
+_hooks_lock = threading.Lock()
+_MAX_FAILURE_BACKOFF_SECONDS = 60.0
+
+
+def register_invocation_hook(
+    name: str,
+    callback: _HookCallback,
+    *,
+    min_interval_seconds: float | None = None,
+) -> None:
+    """Register a private integration hook to attach to a later invocation."""
+    if not name:
+        msg = "invocation hook name must not be empty"
+        raise ValueError(msg)
+    if min_interval_seconds is not None and min_interval_seconds <= 0:
+        msg = "min_interval_seconds must be greater than zero"
+        raise ValueError(msg)
+
+    with _hooks_lock:
+        existing = _hooks.get(name)
+        if existing is None:
+            _hooks[name] = _InvocationHook(
+                callback=callback,
+                min_interval_seconds=min_interval_seconds,
+            )
+            return
+        if (
+            existing.callback is not callback
+            or existing.min_interval_seconds != min_interval_seconds
+        ):
+            msg = f"invocation hook {name!r} is already registered differently"
+            raise ValueError(msg)
+
+
+def schedule_invocation_hooks(wait_until: _WaitUntil) -> None:
+    now = monotonic()
+    due: list[tuple[str, _InvocationHook]] = []
+    with _hooks_lock:
+        for name, hook in _hooks.items():
+            if hook.completed or hook.running or hook.next_run_at > now:
+                continue
+            hook.running = True
+            due.append((name, hook))
+
+    for name, hook in due:
+        wait_until(_run_hook(name, hook))
+
+
+async def _run_hook(name: str, hook: _InvocationHook) -> None:
+    succeeded = False
+    try:
+        await asyncio.to_thread(hook.callback)
+        succeeded = True
+    except Exception:
+        logger.exception("Invocation hook %r failed", name)
+    finally:
+        with _hooks_lock:
+            current = _hooks.get(name)
+            if current is hook:
+                hook.running = False
+                if succeeded:
+                    hook.failures = 0
+                    if hook.min_interval_seconds is None:
+                        hook.completed = True
+                    else:
+                        hook.next_run_at = (
+                            monotonic() + hook.min_interval_seconds
+                        )
+                else:
+                    hook.failures += 1
+                    hook.next_run_at = monotonic() + min(
+                        2 ** (hook.failures - 1),
+                        _MAX_FAILURE_BACKOFF_SECONDS,
+                    )
+
+
+def _reset_invocation_hooks() -> None:  # pyright: ignore[reportUnusedFunction]
+    """Clear the process-local registry for tests."""
+    with _hooks_lock:
+        _hooks.clear()

--- a/python/vercel-runtime/src/vercel_runtime/wait_until.py
+++ b/python/vercel-runtime/src/vercel_runtime/wait_until.py
@@ -9,6 +9,8 @@ import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from vercel_runtime.invocation_hooks import schedule_invocation_hooks
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -87,6 +89,7 @@ class WaitUntilCollector:
 def begin_wait_until() -> WaitUntilCollector:
     collector = WaitUntilCollector()
     _set_public_wait_until(collector.wait_until)
+    schedule_invocation_hooks(collector.wait_until)
     return collector
 
 

--- a/python/vercel-runtime/src/vercel_runtime/wait_until.py
+++ b/python/vercel-runtime/src/vercel_runtime/wait_until.py
@@ -9,7 +9,7 @@ import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from vercel_runtime.invocation_hooks import schedule_invocation_hooks
+from vercel_runtime.invocation_hooks import attach_due_hooks
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -89,7 +89,7 @@ class WaitUntilCollector:
 def begin_wait_until() -> WaitUntilCollector:
     collector = WaitUntilCollector()
     _set_public_wait_until(collector.wait_until)
-    schedule_invocation_hooks(collector.wait_until)
+    attach_due_hooks(collector.wait_until)
     return collector
 
 

--- a/python/vercel-runtime/tests/test_invocation_hooks.py
+++ b/python/vercel-runtime/tests/test_invocation_hooks.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 from vercel_runtime.invocation_hooks import (
     _reset_invocation_hooks,
-    register_invocation_hook,
-    schedule_invocation_hooks,
+    attach_due_hooks,
+    run_on_next_invocation,
 )
 from vercel_runtime.wait_until import WaitUntilCollector
 
@@ -26,12 +26,12 @@ class TestInvocationHooks(unittest.IsolatedAsyncioTestCase):
         def callback() -> None:
             calls.append("called")
 
-        register_invocation_hook("activate", callback)
+        run_on_next_invocation("activate", callback)
         first = WaitUntilCollector()
-        schedule_invocation_hooks(first.wait_until)
+        attach_due_hooks(first.wait_until)
         await first.drain()
         second = WaitUntilCollector()
-        schedule_invocation_hooks(second.wait_until)
+        attach_due_hooks(second.wait_until)
         await second.drain()
 
         self.assertEqual(calls, ["called"])
@@ -40,8 +40,8 @@ class TestInvocationHooks(unittest.IsolatedAsyncioTestCase):
         def callback() -> None:
             return
 
-        register_invocation_hook("activate", callback)
-        register_invocation_hook("activate", callback)
+        run_on_next_invocation("activate", callback)
+        run_on_next_invocation("activate", callback)
 
     async def test_conflicting_registration_is_rejected(self) -> None:
         def first() -> None:
@@ -50,9 +50,9 @@ class TestInvocationHooks(unittest.IsolatedAsyncioTestCase):
         def second() -> None:
             return
 
-        register_invocation_hook("activate", first)
+        run_on_next_invocation("activate", first)
         with self.assertRaisesRegex(ValueError, "differently"):
-            register_invocation_hook("activate", second)
+            run_on_next_invocation("activate", second)
 
     async def test_interval_hook_only_runs_when_due(self) -> None:
         calls: list[str] = []
@@ -64,14 +64,14 @@ class TestInvocationHooks(unittest.IsolatedAsyncioTestCase):
             "vercel_runtime.invocation_hooks.monotonic",
             side_effect=[100.0, 100.0, 100.0, 159.0, 160.0, 160.0],
         ):
-            register_invocation_hook(
+            run_on_next_invocation(
                 "activity",
                 callback,
-                min_interval_seconds=60,
+                repeat_after_seconds=60,
             )
             for _ in range(4):
                 collector = WaitUntilCollector()
-                schedule_invocation_hooks(collector.wait_until)
+                attach_due_hooks(collector.wait_until)
                 await collector.drain()
 
         self.assertEqual(calls, ["called", "called"])
@@ -87,14 +87,14 @@ class TestInvocationHooks(unittest.IsolatedAsyncioTestCase):
             entered.set()
             release.wait(timeout=5)
 
-        register_invocation_hook("activate", callback)
+        run_on_next_invocation("activate", callback)
         first = WaitUntilCollector()
-        schedule_invocation_hooks(first.wait_until)
+        attach_due_hooks(first.wait_until)
         first_drain = asyncio.create_task(first.drain())
         self.assertTrue(await asyncio.to_thread(entered.wait, 1))
 
         second = WaitUntilCollector()
-        schedule_invocation_hooks(second.wait_until)
+        attach_due_hooks(second.wait_until)
         await second.drain()
         release.set()
         await first_drain
@@ -115,9 +115,9 @@ class TestInvocationHooks(unittest.IsolatedAsyncioTestCase):
             "vercel_runtime.invocation_hooks.monotonic",
             side_effect=[100.0, 100.0, 101.0],
         ):
-            register_invocation_hook("retry", callback)
+            run_on_next_invocation("retry", callback)
             first = WaitUntilCollector()
-            schedule_invocation_hooks(first.wait_until)
+            attach_due_hooks(first.wait_until)
             with self.assertLogs(
                 "vercel_runtime.invocation_hooks",
                 level="ERROR",
@@ -125,7 +125,7 @@ class TestInvocationHooks(unittest.IsolatedAsyncioTestCase):
                 await first.drain()
 
             second = WaitUntilCollector()
-            schedule_invocation_hooks(second.wait_until)
+            attach_due_hooks(second.wait_until)
             await second.drain()
 
         self.assertEqual(attempts, 2)

--- a/python/vercel-runtime/tests/test_invocation_hooks.py
+++ b/python/vercel-runtime/tests/test_invocation_hooks.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import unittest
+from unittest.mock import patch
+
+from vercel_runtime.invocation_hooks import (
+    _reset_invocation_hooks,
+    register_invocation_hook,
+    schedule_invocation_hooks,
+)
+from vercel_runtime.wait_until import WaitUntilCollector
+
+
+class TestInvocationHooks(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        _reset_invocation_hooks()
+
+    def tearDown(self) -> None:
+        _reset_invocation_hooks()
+
+    async def test_one_shot_hook_runs_once(self) -> None:
+        calls: list[str] = []
+
+        def callback() -> None:
+            calls.append("called")
+
+        register_invocation_hook("activate", callback)
+        first = WaitUntilCollector()
+        schedule_invocation_hooks(first.wait_until)
+        await first.drain()
+        second = WaitUntilCollector()
+        schedule_invocation_hooks(second.wait_until)
+        await second.drain()
+
+        self.assertEqual(calls, ["called"])
+
+    async def test_repeated_identical_registration_is_idempotent(self) -> None:
+        def callback() -> None:
+            return
+
+        register_invocation_hook("activate", callback)
+        register_invocation_hook("activate", callback)
+
+    async def test_conflicting_registration_is_rejected(self) -> None:
+        def first() -> None:
+            return
+
+        def second() -> None:
+            return
+
+        register_invocation_hook("activate", first)
+        with self.assertRaisesRegex(ValueError, "differently"):
+            register_invocation_hook("activate", second)
+
+    async def test_interval_hook_only_runs_when_due(self) -> None:
+        calls: list[str] = []
+
+        def callback() -> None:
+            calls.append("called")
+
+        with patch(
+            "vercel_runtime.invocation_hooks.monotonic",
+            side_effect=[100.0, 100.0, 100.0, 159.0, 160.0, 160.0],
+        ):
+            register_invocation_hook(
+                "activity",
+                callback,
+                min_interval_seconds=60,
+            )
+            for _ in range(4):
+                collector = WaitUntilCollector()
+                schedule_invocation_hooks(collector.wait_until)
+                await collector.drain()
+
+        self.assertEqual(calls, ["called", "called"])
+
+    async def test_concurrent_invocations_share_running_hook(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        calls = 0
+
+        def callback() -> None:
+            nonlocal calls
+            calls += 1
+            entered.set()
+            release.wait(timeout=5)
+
+        register_invocation_hook("activate", callback)
+        first = WaitUntilCollector()
+        schedule_invocation_hooks(first.wait_until)
+        first_drain = asyncio.create_task(first.drain())
+        self.assertTrue(await asyncio.to_thread(entered.wait, 1))
+
+        second = WaitUntilCollector()
+        schedule_invocation_hooks(second.wait_until)
+        await second.drain()
+        release.set()
+        await first_drain
+
+        self.assertEqual(calls, 1)
+
+    async def test_failed_hook_retries_after_backoff(self) -> None:
+        attempts = 0
+
+        def callback() -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                msg = "try again"
+                raise RuntimeError(msg)
+
+        with patch(
+            "vercel_runtime.invocation_hooks.monotonic",
+            side_effect=[100.0, 100.0, 101.0],
+        ):
+            register_invocation_hook("retry", callback)
+            first = WaitUntilCollector()
+            schedule_invocation_hooks(first.wait_until)
+            with self.assertLogs(
+                "vercel_runtime.invocation_hooks",
+                level="ERROR",
+            ):
+                await first.drain()
+
+            second = WaitUntilCollector()
+            schedule_invocation_hooks(second.wait_until)
+            await second.drain()
+
+        self.assertEqual(attempts, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds private invocation hooks to the Python runtime: a way for Vercel-owned integrations to declare work at import time that runs once on an upcoming request — after the response is sent, with that request's context. Generic infrastructure, not APScheduler-specific; APScheduler is the first consumer, in two ways:

- **Production auto-activation**: `scheduler.start()` work can't run at import time (no OIDC credentials and messages can't be enqueued during the build either). A hook defers it to the deployment's first real request.
- **Preview idle renewal**: a repeating hook renews the durable activity deadline on request traffic, so an opted-in preview stays scheduled only while it's actually receiving requests:

```toml
[tool.vercel.apscheduler.previews]
enabled = true
idle_timeout = "30m"
```

## API

```python
from vercel_runtime.invocation_hooks import run_on_next_invocation

run_on_next_invocation("vercel-apscheduler:auto-activate", activate)

run_on_next_invocation(
    "vercel-apscheduler:renew-preview-deadline",
    renew,
    repeat_after_seconds=300,
)
```

A hook runs **once**, on an upcoming invocation, and is then done — unless `repeat_after_seconds` is set, in which case it becomes eligible again that long after each success, still only running when a request arrives. Never a timer: a deployment receiving no traffic runs nothing. Failures are logged and retried on later requests with capped backoff (which is what makes recovery automatic after e.g. a Redis outage). Registration is idempotent by name; conflicting re-registration is a loud error. Execution is single-flight across concurrent requests.

## How it works

Hooks are built on `wait_until` (previous PR in the stack): `begin_wait_until()` calls `attach_due_hooks()`, which schedules due hooks into the invocation's collector, so they execute during the post-response drain — zero request latency, and the function stays alive until they finish. The collector's captured `contextvars` (plus `asyncio.to_thread` for the sync callback) give the hook the triggering request's headers/OIDC as ambient context.
