### PR TITLE
[python] adapter install phases

### DIFF
--- a/.changeset/python-adapter-install-phases.md
+++ b/.changeset/python-adapter-install-phases.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python': patch
+---
+
+Generalize queue adapter injection to per-adapter dependency checks and
+support installing an integration before the subscriber module imports.

--- a/packages/python/src/conditional-vendoring.ts
+++ b/packages/python/src/conditional-vendoring.ts
@@ -59,6 +59,12 @@ export interface QueueIntegration {
   /** Name of the integration's install function within {@link module}. */
   installer: string;
   /**
+   * Install before importing the subscriber module. Frameworks whose
+   * declarations are created during import use this to observe construction
+   * rather than trying to reconstruct it afterward.
+   */
+  installBeforeImport?: boolean;
+  /**
    * Optional function within {@link module} that queue-serving processes
    * call after {@link installer} to activate consumption (register push
    * callbacks, start the adapter's embedded worker). Never called from
@@ -91,13 +97,6 @@ export async function getQueueIntegrations({
   return integrations;
 }
 
-const INJECTED_PACKAGE_NAMES = new Set<InjectedPackageName>([
-  'vercel-celery',
-  'vercel-celery-bundle',
-  'vercel-dramatiq',
-  'vercel-dramatiq-bundle',
-]);
-
 export interface ConditionalInjectedPackage {
   name: InjectedPackageName;
   requirement: string;
@@ -118,7 +117,10 @@ export async function getConditionalInjectedPackages({
   const injectedPackages: ConditionalInjectedPackage[] = [];
   for (const [upstream, adapter] of UPSTREAM_DEPENDENCY_ADAPTERS) {
     if (!dependencies.has(upstream)) continue;
-    if (hasDirectInjectedPackage(dependencies)) {
+    if (
+      dependencies.has(adapter.bundled) ||
+      dependencies.has(adapter.unbundled)
+    ) {
       continue;
     }
 
@@ -153,11 +155,4 @@ async function getDirectDependencyNames(
       .map(dependency => normalizePackageName(dependency.name))
   );
   return dependencyNames;
-}
-
-function hasDirectInjectedPackage(dependencies: Set<string>): boolean {
-  for (const packageName of INJECTED_PACKAGE_NAMES) {
-    if (dependencies.has(packageName)) return true;
-  }
-  return false;
 }

--- a/packages/python/src/subscribers.ts
+++ b/packages/python/src/subscribers.ts
@@ -332,26 +332,30 @@ export function queueTopicPatternsOverlap(
 /**
  * Python lines that activate the queue adapter integrations required by
  * the project's dependencies. The adapter packages have no import-time
- * side effects, so nothing else activates them. Activation runs after
- * the subscriber module is imported: each installer retroactively
- * registers subscriptions for apps the import created. And because the
- * project demonstrably depends on the upstream package, a failed import
- * or install is a hard error rather than something to skip.
+ * side effects, so nothing else activates them. Most adapters install after
+ * import and retroactively register framework objects; adapters that must
+ * observe declarations during import opt into the earlier phase. Because the
+ * project demonstrably depends on the upstream package, a failed import or
+ * install is a hard error rather than something to skip.
  */
 function createIntegrationInstallLines(
   integrations: QueueIntegration[],
-  { serving }: { serving: boolean }
+  { serving, beforeImport }: { serving: boolean; beforeImport: boolean }
 ): string[] {
-  return integrations.flatMap(({ module, installer, servingActivator }) => [
-    `from ${module} import ${installer}`,
-    `${installer}()`,
-    // Queue-serving processes must also activate consumption (register
-    // push callbacks, start the adapter's embedded worker); introspection
-    // and publish-only processes must not.
-    ...(serving && servingActivator
-      ? [`from ${module} import ${servingActivator}`, `${servingActivator}()`]
-      : []),
-  ]);
+  return integrations
+    .filter(
+      integration => Boolean(integration.installBeforeImport) === beforeImport
+    )
+    .flatMap(({ module, installer, servingActivator }) => [
+      `from ${module} import ${installer}`,
+      `${installer}()`,
+      // Queue-serving processes must also activate consumption (register
+      // push callbacks, start the adapter's embedded worker); introspection
+      // and publish-only processes must not.
+      ...(serving && servingActivator
+        ? [`from ${module} import ${servingActivator}`, `${servingActivator}()`]
+        : []),
+    ]);
 }
 
 export function createQueueHandlerModule(
@@ -362,8 +366,15 @@ export function createQueueHandlerModule(
     'import importlib',
     'import vercel.queue',
     '',
+    ...createIntegrationInstallLines(integrations, {
+      serving: true,
+      beforeImport: true,
+    }),
     `importlib.import_module(${JSON.stringify(declaration.moduleName)})`,
-    ...createIntegrationInstallLines(integrations, { serving: true }),
+    ...createIntegrationInstallLines(integrations, {
+      serving: true,
+      beforeImport: false,
+    }),
     'app = vercel.queue.asgi_app()',
     '',
   ].join('\n');
@@ -537,8 +548,15 @@ function createQueueIntrospectionScript(
 ): string {
   return [
     'import importlib, json, sys',
+    ...createIntegrationInstallLines(integrations, {
+      serving: false,
+      beforeImport: true,
+    }),
     `importlib.import_module(${JSON.stringify(moduleName)})`,
-    ...createIntegrationInstallLines(integrations, { serving: false }),
+    ...createIntegrationInstallLines(integrations, {
+      serving: false,
+      beforeImport: false,
+    }),
     'from vercel.queue import get_subscriptions',
     'subs = [',
     '    {k: v for k, v in {',

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -319,6 +319,21 @@ describe('conditional Python adapter vendoring', () => {
     ).resolves.toEqual([]);
   });
 
+  it('keeps injecting other adapters when one is declared directly', async () => {
+    await expect(
+      getConditionalInjectedPackages({
+        pythonPackage: makePackageWithDependencies([
+          'celery>=5.3',
+          'dramatiq>=1.17',
+          'vercel-celery',
+        ]),
+        env: {},
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({ name: 'vercel-dramatiq-bundle' }),
+    ]);
+  });
+
   it('does not inject when vercel-celery is declared', async () => {
     await expect(
       getConditionalInjectedPackages({

--- a/python/vercel-runtime/src/vercel_runtime/workers.py
+++ b/python/vercel-runtime/src/vercel_runtime/workers.py
@@ -40,8 +40,8 @@ def install_queue_integrations(*, queue_serving: bool) -> None:
     "module:installer:serving_activator" entries (comma separated), set by
     the builder from the project's declared dependencies. Because the
     project demonstrably depends on the adapter's upstream package, any
-    activation failure is a hard error. Each install also retroactively
-    registers subscriptions for apps created before it ran.
+    activation failure is a hard error. Installers may hook future framework
+    objects or retroactively register objects created before activation.
 
     With ``queue_serving=False`` only publish capability is activated
     (transport registration and broker defaults): consuming-side queue


### PR DESCRIPTION
Prep for the APScheduler builder PR (next in the stack). No new adapters. Generated output for celery/dramatiq is unchanged, except one bug fix below.

## 1. Integrations can install before the subscriber module imports

Celery and Dramatiq install after import. Their frameworks keep global registries (the broker's actors, the app's tasks), so the adapter can walk them retroactively.

APScheduler can't be adopted after the fact. Some facts only exist at call time:

```python
scheduler.add_job(cleanup, "cron", hour=4, id="cleanup")   # explicit id: durable-safe
scheduler.add_job(cleanup, "cron", hour=4)                 # generated id: must be rejected
```

After import, both are just jobs with an id string. Only an explicit id is safe to persist durably, and there is no way to tell a user-chosen id from a generated UUID later. The integration has to be patched in before the module runs. It also needs to intercept a module-level `scheduler.start()` during build-time imports, which would otherwise hang the build.

Mechanically:

- `QueueIntegration` gains an `installBeforeImport` flag.
- The generated queue-handler module and introspection script emit install lines in two phases, around `importlib.import_module(...)`.
- No current adapter opts in, so output is identical today.

## 2. Conditional injection is per-adapter now

Declaring any `vercel-celery(-bundle)` / `vercel-dramatiq(-bundle)` directly used to disable injection for all adapters. A celery+dramatiq project that declared only `vercel-celery` silently lost its dramatiq injection and failed at activation.

Each upstream dependency now checks only its own adapter pair (new test). Adding an adapter later is a single map entry instead of edits in three places.
