### PR TITLE
[python] Build durable APScheduler subscribers

### DIFF
--- a/.changeset/apscheduler-durable-runtime.md
+++ b/.changeset/apscheduler-durable-runtime.md
@@ -1,0 +1,8 @@
+---
+'@vercel/python': minor
+'@vercel/python-runtime': minor
+---
+
+Discover durable APScheduler subscribers, inject their stable runtime
+identities, and activate the integration consistently in web and queue
+Functions. Production schedulers activate on their first request.

--- a/packages/python/src/conditional-vendoring.ts
+++ b/packages/python/src/conditional-vendoring.ts
@@ -2,6 +2,8 @@ import { normalizePackageName, parsePep508 } from '@vercel/python-analysis';
 import type { PythonPackage } from '@vercel/python-analysis';
 
 type InjectedPackageName =
+  | 'vercel-apscheduler'
+  | 'vercel-apscheduler-bundle'
   | 'vercel-celery'
   | 'vercel-celery-bundle'
   | 'vercel-dramatiq'
@@ -17,6 +19,22 @@ const UPSTREAM_DEPENDENCY_ADAPTERS = new Map<
     integration: QueueIntegration;
   }
 >([
+  [
+    'apscheduler',
+    {
+      bundled: 'vercel-apscheduler-bundle',
+      unbundled: 'vercel-apscheduler',
+      envOverride: 'VERCEL_PYTHON_APSCHEDULER_DEPENDENCY',
+      preferUnbundledWhenPresent: ['vercel-queue'],
+      integration: {
+        module: 'vercel.integrations.apscheduler',
+        installer: 'install_vercel_apscheduler_integration',
+        // APScheduler jobs are declared while the subscriber module imports.
+        // Install first so the adapter can capture those definitions.
+        installBeforeImport: true,
+      },
+    },
+  ],
   [
     'celery',
     {
@@ -75,8 +93,8 @@ export interface QueueIntegration {
 
 /**
  * Queue adapter integrations required by the project's direct
- * dependencies. Activation is keyed on the upstream dependency (celery,
- * dramatiq, …) being declared by the project — the integration package
+ * dependencies. Activation is keyed on the upstream dependency (APScheduler,
+ * Celery, Dramatiq, …) being declared by the project — the integration package
  * itself may be conditionally injected or declared directly. Failing to
  * import or install a required integration is a hard error for the
  * callers emitting activation code.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -1257,10 +1257,10 @@ export const build: BuildVX = async ({
 
   // Queue adapter integrations the project's dependencies require; both
   // introspection and the generated handler modules activate them right
-  // after importing the subscriber module (each installer retroactively
-  // registers apps the import created) and fail hard when activation
-  // fails. Legacy vercel-workers projects use the legacy integration
-  // instead (see the conditional injection gate above).
+  // around importing the subscriber module (according to whether the adapter
+  // must observe declarations during import) and fail hard when activation
+  // fails. Legacy vercel-workers projects use the legacy integration instead
+  // (see the conditional injection gate above).
   const queueIntegrations = legacyWorkersProject
     ? []
     : await getQueueIntegrations({ pythonPackage });
@@ -1461,9 +1461,9 @@ export const build: BuildVX = async ({
     lambdaEnv.VERCEL_HAS_WORKER_SERVICES = '1';
   }
   if (queueIntegrations.length > 0) {
-    // Every function of the project may publish through the adapter's
-    // transport (not just subscriber lambdas), so the runtime activates
-    // the required integrations at startup in all of them.
+    // Activate every detected adapter through the same runtime path in every
+    // Function. The runtime passes register_queues=False outside queue-serving
+    // processes when an installer supports that distinction.
     lambdaEnv.VERCEL_QUEUE_INTEGRATIONS = queueIntegrations
       .map(
         ({ module, installer, servingActivator }) =>
@@ -1471,6 +1471,25 @@ export const build: BuildVX = async ({
           (servingActivator ? `:${servingActivator}` : '')
       )
       .join(',');
+  }
+  const apschedulerSubscribers = subscribers
+    .filter(subscriber => {
+      const topics = new Set(
+        subscriber.subscriptions.map(subscription => subscription.topic)
+      );
+      return (
+        topics.has(`__aps_${subscriber.name}_start`) &&
+        topics.has(`__aps_${subscriber.name}_wakeup`)
+      );
+    })
+    .map(subscriber => ({
+      id: subscriber.name,
+      entrypoint: `${subscriber.moduleName}:${subscriber.variableName}`,
+    }));
+  if (apschedulerSubscribers.length > 0) {
+    lambdaEnv.VERCEL_APSCHEDULER_SUBSCRIBERS = JSON.stringify(
+      apschedulerSubscribers
+    );
   }
 
   const globOptions: GlobOptions = {
@@ -1853,7 +1872,9 @@ export const build: BuildVX = async ({
       runtime: pythonVersion.runtime,
       ...lambdaOptions,
       architecture: target.architecture,
-      environment: lambdaEnv,
+      environment: {
+        ...lambdaEnv,
+      },
       supportsResponseStreaming: true,
     });
   }
@@ -1898,7 +1919,12 @@ export const build: BuildVX = async ({
       handler: `${handlerPyFilename}.vc_handler`,
       runtime: pythonVersion.runtime,
       architecture: target.architecture,
-      environment: lambdaEnv,
+      environment: {
+        ...lambdaEnv,
+        // The runtime activates publish-side integrations before importing the
+        // generated subscriber module, so the identity must already be present.
+        VERCEL_PYTHON_SUBSCRIBER_ID: subscriber.name,
+      },
       experimentalTriggers,
       supportsResponseStreaming: true,
     });

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -55,14 +55,28 @@ import {
   getQueueIntegrations,
   type QueueIntegration,
 } from './conditional-vendoring';
-import { introspectDevQueueSubscriptions } from './subscribers';
+import {
+  getPyprojectSubscribers,
+  introspectDevQueueSubscriptions,
+} from './subscribers';
 import {
   isLegacyWorkersProject,
   isQueueWorkflowSdkVersion,
   queryPythonVercelSdkVersion,
 } from './sdk-detection';
+import { getModuleEntrypointName } from './module-entrypoint';
 
 const DEV_SERVER_STARTUP_TIMEOUT = 5 * 60_000; // 5 minutes
+
+function serializeQueueIntegrations(integrations: QueueIntegration[]): string {
+  return integrations
+    .map(
+      ({ module, installer, servingActivator }) =>
+        `${module}:${installer}` +
+        (servingActivator ? `:${servingActivator}` : '')
+    )
+    .join(',');
+}
 
 // Silence all Node.js warnings during the dev server lifecycle to avoid noise and only show the python logs.
 // Specifically, this is implemented to silence the [DEP0060] DeprecationWarning warning from the http-proxy library.
@@ -911,9 +925,9 @@ export const startDevServer: StartDevServer = async opts => {
       devOpts
     );
 
-    // Mirror the build-time conditional adapter injection (celery/dramatiq →
-    // vercel-celery(-bundle)/vercel-dramatiq(-bundle)) so modules importing
-    // `vercel.integrations.*` resolve in dev too. Legacy vercel-workers
+    // Mirror build-time conditional adapter injection for APScheduler, Celery,
+    // and Dramatiq so modules importing `vercel.integrations.*` resolve in dev
+    // too. Legacy vercel-workers
     // projects use the legacy integration instead — injecting or activating
     // the vercel-queue adapters there would install competing transports.
     const legacyProject = await isLegacyWorkersProject(workPath);
@@ -926,17 +940,11 @@ export const startDevServer: StartDevServer = async opts => {
       queueIntegrations = legacyProject
         ? []
         : await getQueueIntegrations({ pythonPackage });
-      // Any function of the project may publish through an adapter's
-      // transport, so the runtime activates the required integrations at
-      // startup in every dev process; activation failures are hard errors.
+      // Activate every detected adapter through the same runtime path. Queue
+      // registration remains disabled outside queue-serving sidecars.
       if (queueIntegrations.length > 0) {
-        env.VERCEL_QUEUE_INTEGRATIONS = queueIntegrations
-          .map(
-            ({ module, installer, servingActivator }) =>
-              `${module}:${installer}` +
-              (servingActivator ? `:${servingActivator}` : '')
-          )
-          .join(',');
+        env.VERCEL_QUEUE_INTEGRATIONS =
+          serializeQueueIntegrations(queueIntegrations);
       } else {
         delete env.VERCEL_QUEUE_INTEGRATIONS;
       }
@@ -962,6 +970,51 @@ export const startDevServer: StartDevServer = async opts => {
           err instanceof Error ? err.message : String(err)
         }`
       );
+    }
+
+    const apschedulerSubscribers: {
+      id: string;
+      entrypoint: string;
+    }[] = [];
+    if (!legacyProject) {
+      const runtimeDir = join(workPath, '.vercel', 'python');
+      const declaredSubscribers = await getPyprojectSubscribers(workPath);
+      const introspectionEnv: NodeJS.ProcessEnv = {
+        ...env,
+        PYTHONPATH: [runtimeDir, env.PYTHONPATH]
+          .filter(Boolean)
+          .join(delimiter),
+      };
+      delete introspectionEnv.VERCEL_APSCHEDULER_SUBSCRIBERS;
+      for (const declaration of declaredSubscribers) {
+        const discovered = await introspectDevQueueSubscriptions({
+          moduleName: declaration.moduleName,
+          subscriberName: declaration.name,
+          pythonBin: spawnCommand,
+          cwd: workPath,
+          env: introspectionEnv,
+          integrations: queueIntegrations,
+        });
+        const topics = new Set(
+          (discovered ?? []).map(subscription => subscription.topic)
+        );
+        if (
+          topics.has(`__aps_${declaration.name}_start`) &&
+          topics.has(`__aps_${declaration.name}_wakeup`)
+        ) {
+          apschedulerSubscribers.push({
+            id: declaration.name,
+            entrypoint: `${declaration.moduleName}:${declaration.variableName}`,
+          });
+        }
+      }
+    }
+    if (apschedulerSubscribers.length > 0) {
+      env.VERCEL_APSCHEDULER_SUBSCRIBERS = JSON.stringify(
+        apschedulerSubscribers
+      );
+    } else {
+      delete env.VERCEL_APSCHEDULER_SUBSCRIBERS;
     }
 
     // Legacy vercel-workers projects run every dev process on the injected
@@ -1010,26 +1063,37 @@ export const startDevServer: StartDevServer = async opts => {
 
       if (useQueueServing) {
         env.VERCEL_DEV_QUEUE_SERVING = '1';
+        env.VERCEL_QUEUE_INTEGRATIONS =
+          serializeQueueIntegrations(queueIntegrations);
+        const subscriberName = getModuleEntrypointName({
+          moduleName: modulePath,
+          variableName: variableName || 'app',
+        });
+        env.VERCEL_PYTHON_SUBSCRIBER_ID = subscriberName;
         // The vercel-queue SDK dispatches deliveries by the registered
         // (consumer group, topic) pair, so the dev queue broker must
         // deliver with the SDK-registered consumer groups. Introspect them
         // the same way the build does. Conditional adapters live in
         // .vercel/python, so put it on the interpreter's path.
         const runtimeDir = join(workPath, '.vercel', 'python');
+        const introspectionEnv: NodeJS.ProcessEnv = {
+          ...env,
+          PYTHONPATH: [runtimeDir, env.PYTHONPATH]
+            .filter(Boolean)
+            .join(delimiter),
+        };
+        delete introspectionEnv.VERCEL_APSCHEDULER_SUBSCRIBERS;
         queueSubscriptions = await introspectDevQueueSubscriptions({
           moduleName: modulePath,
+          subscriberName,
           pythonBin: spawnCommand,
           cwd: workPath,
-          env: {
-            ...env,
-            PYTHONPATH: [runtimeDir, env.PYTHONPATH]
-              .filter(Boolean)
-              .join(delimiter),
-          },
+          env: introspectionEnv,
           integrations: queueIntegrations,
         });
       } else {
         delete env.VERCEL_DEV_QUEUE_SERVING;
+        delete env.VERCEL_PYTHON_SUBSCRIBER_ID;
         await installInjectedDevPackage(
           {
             name: 'vercel-workers',

--- a/packages/python/src/subscribers.ts
+++ b/packages/python/src/subscribers.ts
@@ -23,6 +23,7 @@ import type { QueueIntegration } from './conditional-vendoring';
 // producing the same `_py_subscribers/...`-based names to retain their
 // queue consumer-group positions.
 const SUBSCRIBER_OUTPUT_DIR = '_py_subscribers';
+const SUBSCRIBER_ID_ENV = 'VERCEL_PYTHON_SUBSCRIBER_ID';
 
 type SubscriberTriggerDefaults = Omit<
   TriggerEvent,
@@ -364,8 +365,10 @@ export function createQueueHandlerModule(
 ): string {
   return [
     'import importlib',
+    'import os',
     'import vercel.queue',
     '',
+    `os.environ[${JSON.stringify(SUBSCRIBER_ID_ENV)}] = ${JSON.stringify(declaration.name)}`,
     ...createIntegrationInstallLines(integrations, {
       serving: true,
       beforeImport: true,
@@ -543,16 +546,18 @@ function parseTopicPatterns(
  * explicitly. None values are dropped rather than emitted as JSON null.
  */
 function createQueueIntrospectionScript(
-  moduleName: string,
+  declaration: Pick<SubscriberDeclaration, 'moduleName' | 'name'>,
   integrations: QueueIntegration[]
 ): string {
   return [
-    'import importlib, json, sys',
+    'import importlib, json, os, sys',
+    `os.environ[${JSON.stringify(SUBSCRIBER_ID_ENV)}] = ${JSON.stringify(declaration.name)}`,
+    'os.environ["VERCEL_APSCHEDULER_DISCOVERY"] = "1"',
     ...createIntegrationInstallLines(integrations, {
       serving: false,
       beforeImport: true,
     }),
-    `importlib.import_module(${JSON.stringify(moduleName)})`,
+    `importlib.import_module(${JSON.stringify(declaration.moduleName)})`,
     ...createIntegrationInstallLines(integrations, {
       serving: false,
       beforeImport: false,
@@ -588,10 +593,7 @@ async function introspectQueueSubscriptions({
   kind: 'subscriber' | 'workflow';
   integrations: QueueIntegration[];
 }): Promise<SubscriberSubscription[]> {
-  const script = createQueueIntrospectionScript(
-    declaration.moduleName,
-    integrations
-  );
+  const script = createQueueIntrospectionScript(declaration, integrations);
 
   try {
     const { stdout } = await uv.run({
@@ -632,12 +634,14 @@ async function introspectQueueSubscriptions({
  */
 export async function introspectDevQueueSubscriptions({
   moduleName,
+  subscriberName,
   pythonBin,
   cwd,
   env,
   integrations,
 }: {
   moduleName: string;
+  subscriberName: string;
   pythonBin: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
@@ -646,7 +650,13 @@ export async function introspectDevQueueSubscriptions({
   try {
     const { stdout } = await execa(
       pythonBin,
-      ['-c', createQueueIntrospectionScript(moduleName, integrations)],
+      [
+        '-c',
+        createQueueIntrospectionScript(
+          { moduleName, name: subscriberName },
+          integrations
+        ),
+      ],
       // Match the deployed-function environment (see
       // introspectQueueSubscriptions): SDKs may need VERCEL=1,
       // VERCEL_REGION, and VERCEL_DEPLOYMENT_ID to register subscriptions.
@@ -778,3 +788,4 @@ function subscriberError(message: string): NowBuildError {
     message,
   });
 }
+

--- a/packages/python/src/subscribers.ts
+++ b/packages/python/src/subscribers.ts
@@ -788,4 +788,3 @@ function subscriberError(message: string): NowBuildError {
     message,
   });
 }
-

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -235,6 +235,17 @@ describe('queue adapter integration activation', () => {
         pythonPackage: makePackageWithDependencies(['fastapi']),
       })
     ).resolves.toEqual([]);
+    await expect(
+      getQueueIntegrations({
+        pythonPackage: makePackageWithDependencies(['APScheduler>=3.10.4,<4']),
+      })
+    ).resolves.toEqual([
+      {
+        module: 'vercel.integrations.apscheduler',
+        installer: 'install_vercel_apscheduler_integration',
+        installBeforeImport: true,
+      },
+    ]);
   });
 
   it('generated handler modules activate integrations after the import', () => {
@@ -263,10 +274,70 @@ describe('queue adapter integration activation', () => {
 
     const withoutIntegrations = createQueueHandlerModule(declaration, []);
     expect(withoutIntegrations).not.toContain('vercel.integrations');
+
+    const withAPScheduler = createQueueHandlerModule(declaration, [
+      {
+        module: 'vercel.integrations.apscheduler',
+        installer: 'install_vercel_apscheduler_integration',
+        installBeforeImport: true,
+      },
+    ]);
+    expect(withAPScheduler).toContain(
+      'os.environ["VERCEL_PYTHON_SUBSCRIBER_ID"] = "worker_app"'
+    );
+    expect(
+      withAPScheduler.indexOf('install_vercel_apscheduler_integration')
+    ).toBeLessThan(withAPScheduler.indexOf('importlib.import_module'));
   });
 });
 
 describe('conditional Python adapter vendoring', () => {
+  it('selects vercel-apscheduler-bundle when APScheduler is declared', async () => {
+    await expect(
+      getConditionalInjectedPackages({
+        pythonPackage: makePackageWithDependencies(['APScheduler>=3.10.4,<4']),
+        env: {},
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({ name: 'vercel-apscheduler-bundle' }),
+    ]);
+  });
+
+  it('selects vercel-apscheduler when vercel-queue is declared', async () => {
+    await expect(
+      getConditionalInjectedPackages({
+        pythonPackage: makePackageWithDependencies([
+          'APScheduler>=3.10.4,<4',
+          'vercel-queue',
+        ]),
+        env: {},
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({ name: 'vercel-apscheduler' }),
+    ]);
+  });
+
+  it('does not inject when an APScheduler adapter is declared', async () => {
+    await expect(
+      getConditionalInjectedPackages({
+        pythonPackage: makePackageWithDependencies([
+          'APScheduler>=3.10.4,<4',
+          'vercel-apscheduler',
+        ]),
+        env: {},
+      })
+    ).resolves.toEqual([]);
+    await expect(
+      getConditionalInjectedPackages({
+        pythonPackage: makePackageWithDependencies([
+          'APScheduler>=3.10.4,<4',
+          'vercel-apscheduler-bundle',
+        ]),
+        env: {},
+      })
+    ).resolves.toEqual([]);
+  });
+
   it('selects vercel-celery-bundle when celery is declared', async () => {
     await expect(
       getConditionalInjectedPackages({
@@ -465,14 +536,31 @@ describe('conditional Python adapter vendoring', () => {
     await expect(
       getConditionalInjectedPackages({
         pythonPackage: makePackageWithDependencies([
+          'APScheduler>=3.10.4,<4',
           'celery>=5.3',
           'dramatiq>=1.17',
         ]),
         env: {},
       })
     ).resolves.toEqual([
+      expect.objectContaining({ name: 'vercel-apscheduler-bundle' }),
       expect.objectContaining({ name: 'vercel-celery-bundle' }),
       expect.objectContaining({ name: 'vercel-dramatiq-bundle' }),
+    ]);
+  });
+
+  it('only suppresses the adapter that the project already declares', async () => {
+    await expect(
+      getConditionalInjectedPackages({
+        pythonPackage: makePackageWithDependencies([
+          'APScheduler>=3.10.4,<4',
+          'celery>=5.3',
+          'vercel-celery',
+        ]),
+        env: {},
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({ name: 'vercel-apscheduler-bundle' }),
     ]);
   });
 });
@@ -2948,6 +3036,155 @@ describe('pyproject subscribers', () => {
     expect(getGeneratedQueueHandlerPath('_py_workflows/flows_workflows')).toBe(
       '_vc_queue_handlers/_py_workflows_flows_workflows.py'
     );
+  });
+
+  it('injects APScheduler subscriber identities into runtime Lambdas', async () => {
+    mockQueueIntrospection([
+      {
+        topic: '__aps_scheduler_scheduler_start',
+        consumer_group: 'apscheduler-scheduler_scheduler',
+      },
+      {
+        topic: '__aps_scheduler_scheduler_wakeup',
+        consumer_group: 'apscheduler-scheduler_scheduler',
+      },
+    ]);
+    const files = {
+      'app.py': new FileBlob({
+        data: 'def app(environ, start_response): pass\n',
+      }),
+      'scheduler.py': new FileBlob({
+        data: 'scheduler = object()\n',
+      }),
+      'pyproject.toml': new FileBlob({
+        data: [
+          '[project]',
+          'name = "x"',
+          'version = "0.0.1"',
+          'dependencies = ["APScheduler>=3.10.4,<4", "vercel-apscheduler", "redis>=5,<7"]',
+          '',
+          '[[tool.vercel.subscribers]]',
+          'entrypoint = "scheduler:scheduler"',
+          '',
+        ].join('\n'),
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath: mockWorkPath,
+      files,
+      entrypoint: 'app.py',
+      meta: { isDev: false },
+      config: { framework: 'flask' },
+      repoRootPath: mockWorkPath,
+    });
+    const output = getBuildOutputV2(result).output as any;
+    const scheduler = output[getSubscriberOutputPath('scheduler_scheduler')];
+
+    for (const lambda of [output.flask, scheduler]) {
+      expect(lambda.environment.VERCEL_APSCHEDULER_SUBSCRIBERS).toBe(
+        '[{"id":"scheduler_scheduler","entrypoint":"scheduler:scheduler"}]'
+      );
+      expect(lambda.environment.VERCEL_QUEUE_INTEGRATIONS).toBe(
+        'vercel.integrations.apscheduler:install_vercel_apscheduler_integration'
+      );
+    }
+    expect(
+      output.flask.environment.VERCEL_PYTHON_SUBSCRIBER_ID
+    ).toBeUndefined();
+    expect(scheduler.environment.VERCEL_PYTHON_SUBSCRIBER_ID).toBe(
+      'scheduler_scheduler'
+    );
+
+    const introspectionScripts = mockedExeca.mock.calls
+      .map(([, args]) => (Array.isArray(args) ? args[args.length - 1] : ''))
+      .filter(
+        script =>
+          typeof script === 'string' && script.includes('get_subscriptions')
+      );
+    expect(introspectionScripts).not.toEqual([]);
+    for (const script of introspectionScripts) {
+      expect(script).not.toContain('VERCEL_APSCHEDULER_SUBSCRIBERS');
+      expect(script).toContain('VERCEL_APSCHEDULER_DISCOVERY');
+    }
+  });
+
+  it('injects only discovered APScheduler subscriber identities', async () => {
+    mockedExeca.mockImplementation(async (_cmd, args) => {
+      if (
+        Array.isArray(args) &&
+        args[0] === 'run' &&
+        typeof args[args.length - 1] === 'string'
+      ) {
+        const script = args[args.length - 1] as string;
+        if (script.includes('get_subscriptions')) {
+          if (script.includes('importlib.import_module("scheduler")')) {
+            return {
+              stdout: JSON.stringify([
+                {
+                  topic: '__aps_scheduler_scheduler_start',
+                  consumer_group: 'apscheduler-scheduler_scheduler',
+                },
+                {
+                  topic: '__aps_scheduler_scheduler_wakeup',
+                  consumer_group: 'apscheduler-scheduler_scheduler',
+                },
+              ]),
+            } as any;
+          }
+          return {
+            stdout: JSON.stringify([
+              { topic: 'work', consumer_group: 'work-consumer' },
+            ]),
+          } as any;
+        }
+      }
+      return { stdout: '' } as any;
+    });
+    const files = {
+      'app.py': new FileBlob({
+        data: 'def app(environ, start_response): pass\n',
+      }),
+      'scheduler.py': new FileBlob({
+        data: 'scheduler = object()\n',
+      }),
+      'worker.py': new FileBlob({
+        data: 'worker = object()\n',
+      }),
+      'pyproject.toml': new FileBlob({
+        data: [
+          '[project]',
+          'name = "x"',
+          'version = "0.0.1"',
+          'dependencies = ["APScheduler>=3.10.4,<4", "vercel-apscheduler", "redis>=5,<7"]',
+          '',
+          '[[tool.vercel.subscribers]]',
+          'entrypoint = "scheduler:scheduler"',
+          '',
+          '[[tool.vercel.subscribers]]',
+          'entrypoint = "worker:worker"',
+          '',
+        ].join('\n'),
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath: mockWorkPath,
+      files,
+      entrypoint: 'app.py',
+      meta: { isDev: false },
+      config: { framework: 'flask' },
+      repoRootPath: mockWorkPath,
+    });
+    const output = getBuildOutputV2(result).output as any;
+    const worker = output[getSubscriberOutputPath('worker_worker')];
+
+    expect(worker.environment.VERCEL_APSCHEDULER_SUBSCRIBERS).toBe(
+      '[{"id":"scheduler_scheduler","entrypoint":"scheduler:scheduler"}]'
+    );
+    expect(
+      worker.environment.VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS
+    ).toBeUndefined();
   });
 
   it('returns dev sidecars matching build consumer names', async () => {
@@ -5657,12 +5894,14 @@ describe('worker services dependency installation', () => {
   beforeEach(() => {
     vi.resetModules();
     makeMockPython('3.12');
+    delete process.env.VERCEL_PYTHON_APSCHEDULER_DEPENDENCY;
     delete process.env.VERCEL_PYTHON_CELERY_DEPENDENCY;
     delete process.env.VERCEL_PYTHON_DRAMATIQ_DEPENDENCY;
     delete process.env.VERCEL_WORKERS_PYTHON;
   });
 
   afterEach(() => {
+    delete process.env.VERCEL_PYTHON_APSCHEDULER_DEPENDENCY;
     delete process.env.VERCEL_PYTHON_CELERY_DEPENDENCY;
     delete process.env.VERCEL_PYTHON_DRAMATIQ_DEPENDENCY;
     delete process.env.VERCEL_WORKERS_PYTHON;
@@ -5685,6 +5924,36 @@ describe('worker services dependency installation', () => {
     for (const args of pipCalls) {
       expect(args.slice(0, 3)).toEqual(['install', '--link-mode', 'copy']);
     }
+  });
+
+  it('installs vercel-apscheduler-bundle after uv sync when APScheduler is declared', async () => {
+    const { operations, pipCalls } = await buildWithPipSpy({
+      dependencies: ['APScheduler>=3.10.4,<4'],
+    });
+
+    expect(
+      pipCalls.some(args => args.includes('vercel-apscheduler-bundle'))
+    ).toBe(true);
+    expect(operations.indexOf('sync')).toBeGreaterThanOrEqual(0);
+    expect(operations.indexOf('pip:vercel-apscheduler-bundle')).toBeGreaterThan(
+      operations.indexOf('sync')
+    );
+  });
+
+  it('installs vercel-apscheduler when vercel-queue is declared', async () => {
+    const { operations, pipCalls } = await buildWithPipSpy({
+      dependencies: ['APScheduler>=3.10.4,<4', 'vercel-queue'],
+    });
+
+    expect(
+      pipCalls.some(args => args[args.length - 1] === 'vercel-apscheduler')
+    ).toBe(true);
+    expect(
+      pipCalls.some(args => args.includes('vercel-apscheduler-bundle'))
+    ).toBe(false);
+    expect(operations.indexOf('pip:vercel-apscheduler')).toBeGreaterThan(
+      operations.indexOf('sync')
+    );
   });
 
   it('installs vercel-celery-bundle after uv sync when celery is declared', async () => {
@@ -5796,6 +6065,36 @@ describe('worker services dependency installation', () => {
     expect(
       pipCalls.some(args =>
         args.includes('vercel-workers @ file:///tmp/vercel-workers.whl')
+      )
+    ).toBe(true);
+  });
+
+  it('uses VERCEL_PYTHON_APSCHEDULER_DEPENDENCY override for bundled APScheduler', async () => {
+    process.env.VERCEL_PYTHON_APSCHEDULER_DEPENDENCY =
+      'vercel-apscheduler-bundle @ file:///tmp/vercel-apscheduler-bundle.whl';
+
+    const { pipCalls } = await buildWithPipSpy({
+      dependencies: ['APScheduler>=3.10.4,<4'],
+    });
+    expect(
+      pipCalls.some(args =>
+        args.includes(
+          'vercel-apscheduler-bundle @ file:///tmp/vercel-apscheduler-bundle.whl'
+        )
+      )
+    ).toBe(true);
+  });
+
+  it('uses VERCEL_PYTHON_APSCHEDULER_DEPENDENCY override for unbundled APScheduler', async () => {
+    process.env.VERCEL_PYTHON_APSCHEDULER_DEPENDENCY =
+      'vercel-apscheduler @ file:///tmp/vercel-apscheduler.whl';
+
+    const { pipCalls } = await buildWithPipSpy({
+      dependencies: ['APScheduler>=3.10.4,<4', 'vercel-queue'],
+    });
+    expect(
+      pipCalls.some(args =>
+        args.includes('vercel-apscheduler @ file:///tmp/vercel-apscheduler.whl')
       )
     ).toBe(true);
   });


### PR DESCRIPTION
Builder support for durable APScheduler subscribers. Builds on the install-phase mechanics from #17338; the integration itself lives in vercel-py (`vercel-apscheduler`).

The user contract is one declaration, no Vercel imports in scheduler code:

```toml
[[tool.vercel.subscribers]]
entrypoint = "scheduler:scheduler"
```

## What the builder does

- Detects `apscheduler` in the project's dependencies and injects `vercel-apscheduler(-bundle)` as a conditional adapter, installed *before* the subscriber module imports (APScheduler declares its jobs during import).
- Recognizes APScheduler subscribers by their internal `__aps_*` start/wake topic pair and builds their queue Functions like any other subscriber.
- Injects `VERCEL_APSCHEDULER_SUBSCRIBERS` (entrypoint-to-id map) into every Lambda, so `scheduler.start()` called from any web Function can resolve its deployment-scoped identity.
- Pins `VERCEL_PYTHON_SUBSCRIBER_ID` on subscriber Lambdas, so queue-serving processes identify themselves before any import runs.
- Runs build-time introspection in discovery mode: lifecycle calls no-op, builds never enqueue messages.
- Mirrors all of the above in `vercel dev`.

## Notes

- No behavior change for projects that don't depend on APScheduler.
- Merge ordering: needs `vercel-apscheduler` published first (vercel-py #212 to #214), since builds will install the injected package.
