### PR TITLE
[python] Support APScheduler preview idle scheduling

### DIFF
--- a/.changeset/apscheduler-durable-runtime.md
+++ b/.changeset/apscheduler-durable-runtime.md
@@ -5,4 +5,6 @@
 
 Discover durable APScheduler subscribers, inject their stable runtime
 identities, and activate the integration consistently in web and queue
-Functions. Production schedulers activate on their first request.
+Functions. Production schedulers activate on their first request, and
+opted-in previews use request activity to renew a durable scheduling
+deadline configured in pyproject.toml.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -108,6 +108,7 @@ import { InstalledPythonDistributions } from './installed-distributions';
 import {
   createQueueHandlerModule,
   generatedPythonPathToModule,
+  getApschedulerPreviewConfig,
   getGeneratedQueueHandlerPath,
   getPyprojectSubscribers,
   getSubscriberConsumerName,
@@ -1490,6 +1491,12 @@ export const build: BuildVX = async ({
     lambdaEnv.VERCEL_APSCHEDULER_SUBSCRIBERS = JSON.stringify(
       apschedulerSubscribers
     );
+    const previewConfig = await getApschedulerPreviewConfig(workPath);
+    if (previewConfig) {
+      lambdaEnv.VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS = String(
+        previewConfig.idleTimeoutSeconds
+      );
+    }
   }
 
   const globOptions: GlobOptions = {

--- a/packages/python/src/start-dev-server.ts
+++ b/packages/python/src/start-dev-server.ts
@@ -56,6 +56,7 @@ import {
   type QueueIntegration,
 } from './conditional-vendoring';
 import {
+  getApschedulerPreviewConfig,
   getPyprojectSubscribers,
   introspectDevQueueSubscriptions,
 } from './subscribers';
@@ -1013,8 +1014,17 @@ export const startDevServer: StartDevServer = async opts => {
       env.VERCEL_APSCHEDULER_SUBSCRIBERS = JSON.stringify(
         apschedulerSubscribers
       );
+      const previewConfig = await getApschedulerPreviewConfig(workPath);
+      if (previewConfig) {
+        env.VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS = String(
+          previewConfig.idleTimeoutSeconds
+        );
+      } else {
+        delete env.VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS;
+      }
     } else {
       delete env.VERCEL_APSCHEDULER_SUBSCRIBERS;
+      delete env.VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS;
     }
 
     // Legacy vercel-workers projects run every dev process on the injected

--- a/packages/python/src/subscribers.ts
+++ b/packages/python/src/subscribers.ts
@@ -78,6 +78,19 @@ interface RawQueueSubscription {
   max_attempts?: unknown;
 }
 
+interface RawApschedulerPreviews {
+  enabled?: unknown;
+  idle_timeout?: unknown;
+}
+
+interface RawApschedulerConfig {
+  previews?: unknown;
+}
+
+export interface ApschedulerPreviewConfig {
+  idleTimeoutSeconds: number;
+}
+
 interface TriggerNumberField {
   field: keyof RawQueueSubscription;
   output: keyof SubscriberTriggerDefaults;
@@ -158,9 +171,18 @@ interface Pyproject {
   tool?: {
     vercel?: {
       subscribers?: RawSubscriber[];
+      apscheduler?: RawApschedulerConfig;
     };
   };
 }
+
+const APSCHEDULER_PREVIEW_FIELD_NAMES = new Set(['enabled', 'idle_timeout']);
+const APSCHEDULER_DURATION_UNITS: Record<string, number> = {
+  s: 1,
+  m: 60,
+  h: 60 * 60,
+  d: 24 * 60 * 60,
+};
 
 export function getSubscriberOutputPath(subscriberName: string): string {
   return `${SUBSCRIBER_OUTPUT_DIR}/${safePathSegment(subscriberName)}`;
@@ -222,6 +244,80 @@ export async function getPyprojectSubscribers(
   }
 
   return parsedSubscribers;
+}
+
+export async function getApschedulerPreviewConfig(
+  workPath: string
+): Promise<ApschedulerPreviewConfig | undefined> {
+  const pyprojectPath = join(workPath, 'pyproject.toml');
+  if (!fs.existsSync(pyprojectPath)) {
+    return undefined;
+  }
+
+  const pyproject = await readConfigFile<Pyproject>(pyprojectPath);
+  const apscheduler = pyproject?.tool?.vercel?.apscheduler;
+  if (apscheduler === undefined) {
+    return undefined;
+  }
+  if (
+    !apscheduler ||
+    typeof apscheduler !== 'object' ||
+    Array.isArray(apscheduler)
+  ) {
+    throw apschedulerError('"tool.vercel.apscheduler" must be a table');
+  }
+
+  const previews = apscheduler.previews;
+  if (previews === undefined) {
+    return undefined;
+  }
+  if (!previews || typeof previews !== 'object' || Array.isArray(previews)) {
+    throw apschedulerError(
+      '"tool.vercel.apscheduler.previews" must be a table'
+    );
+  }
+
+  const rawPreviews = previews as RawApschedulerPreviews;
+  for (const key of Object.keys(rawPreviews)) {
+    if (!APSCHEDULER_PREVIEW_FIELD_NAMES.has(key)) {
+      throw apschedulerError(
+        `"tool.vercel.apscheduler.previews" has unrecognized field "${key}"`
+      );
+    }
+  }
+
+  if (
+    rawPreviews.enabled !== undefined &&
+    typeof rawPreviews.enabled !== 'boolean'
+  ) {
+    throw apschedulerError(
+      '"tool.vercel.apscheduler.previews.enabled" must be a boolean'
+    );
+  }
+  if (rawPreviews.enabled !== true) {
+    return undefined;
+  }
+  if (typeof rawPreviews.idle_timeout !== 'string') {
+    throw apschedulerError(
+      '"tool.vercel.apscheduler.previews.idle_timeout" must be a duration such as "30m"'
+    );
+  }
+
+  const match = /^([1-9]\d*)([smhd])$/.exec(rawPreviews.idle_timeout);
+  if (!match) {
+    throw apschedulerError(
+      '"tool.vercel.apscheduler.previews.idle_timeout" must be a positive duration using s, m, h, or d (for example "30m")'
+    );
+  }
+  const idleTimeoutSeconds =
+    Number(match[1]) * APSCHEDULER_DURATION_UNITS[match[2]];
+  if (!Number.isSafeInteger(idleTimeoutSeconds)) {
+    throw apschedulerError(
+      '"tool.vercel.apscheduler.previews.idle_timeout" is too large'
+    );
+  }
+
+  return { idleTimeoutSeconds };
 }
 
 export async function resolveQueueSubscribers({
@@ -785,6 +881,13 @@ function getQueueWildcardPrefix(pattern: string): string | undefined {
 function subscriberError(message: string): NowBuildError {
   return new NowBuildError({
     code: 'PYTHON_INVALID_SUBSCRIBER_CONFIG',
+    message,
+  });
+}
+
+function apschedulerError(message: string): NowBuildError {
+  return new NowBuildError({
+    code: 'PYTHON_INVALID_APSCHEDULER_CONFIG',
     message,
   });
 }

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -86,6 +86,7 @@ import {
   createQueueHandlerModule,
   filterQueueSubscriptions,
   generatedPythonPathToModule,
+  getApschedulerPreviewConfig,
   getGeneratedQueueHandlerPath,
   getSubscriberOutputPath,
   queueTopicPatternsOverlap,
@@ -3063,6 +3064,10 @@ describe('pyproject subscribers', () => {
           'version = "0.0.1"',
           'dependencies = ["APScheduler>=3.10.4,<4", "vercel-apscheduler", "redis>=5,<7"]',
           '',
+          '[tool.vercel.apscheduler.previews]',
+          'enabled = true',
+          'idle_timeout = "30m"',
+          '',
           '[[tool.vercel.subscribers]]',
           'entrypoint = "scheduler:scheduler"',
           '',
@@ -3088,6 +3093,9 @@ describe('pyproject subscribers', () => {
       expect(lambda.environment.VERCEL_QUEUE_INTEGRATIONS).toBe(
         'vercel.integrations.apscheduler:install_vercel_apscheduler_integration'
       );
+      expect(
+        lambda.environment.VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS
+      ).toBe('1800');
     }
     expect(
       output.flask.environment.VERCEL_PYTHON_SUBSCRIBER_ID
@@ -3107,6 +3115,36 @@ describe('pyproject subscribers', () => {
       expect(script).not.toContain('VERCEL_APSCHEDULER_SUBSCRIBERS');
       expect(script).toContain('VERCEL_APSCHEDULER_DISCOVERY');
     }
+  });
+
+  it('does not enable APScheduler previews by default', async () => {
+    fs.writeFileSync(
+      path.join(mockWorkPath, 'pyproject.toml'),
+      [
+        '[tool.vercel.apscheduler.previews]',
+        'enabled = false',
+        'idle_timeout = "30m"',
+      ].join('\n')
+    );
+
+    await expect(
+      getApschedulerPreviewConfig(mockWorkPath)
+    ).resolves.toBeUndefined();
+  });
+
+  it('validates APScheduler preview idle_timeout', async () => {
+    fs.writeFileSync(
+      path.join(mockWorkPath, 'pyproject.toml'),
+      [
+        '[tool.vercel.apscheduler.previews]',
+        'enabled = true',
+        'idle_timeout = "five minutes"',
+      ].join('\n')
+    );
+
+    await expect(getApschedulerPreviewConfig(mockWorkPath)).rejects.toThrow(
+      /positive duration/
+    );
   });
 
   it('injects only discovered APScheduler subscriber identities', async () => {


### PR DESCRIPTION
Build-time config for APScheduler preview scheduling. Top of the stack; pairs with the preview idling runtime behavior in vercel-py #216.

Previews are inactive by default. Projects opt in via pyproject.toml:

```toml
[tool.vercel.apscheduler.previews]
enabled = true
idle_timeout = "30m"
```

## Changes

- `getApschedulerPreviewConfig` parses and validates the table at build time. Bad shapes and bad durations are build errors, not runtime surprises (`idle_timeout` takes `s`/`m`/`h`/`d` suffixes).
- The validated timeout is injected as `VERCEL_APSCHEDULER_PREVIEW_IDLE_TIMEOUT_SECONDS` into every Lambda, and mirrored in `vercel dev`.
- The runtime side (vercel-py) uses it to renew a durable idle deadline on request traffic; a preview that stops receiving requests stops scheduling.

## Notes

- Without the opt-in table, nothing changes: no env var, previews stay inactive.
- Merge ordering: needs https://github.com/vercel/vercel-py/pull/216 released, which implements the idle deadline this env var configures.
