### PR TITLE
test(next): use adapter-vercel PR #90 artifact

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -29,7 +29,7 @@
     "@vercel/nft": "1.10.0"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.24",
+    "@next-community/adapter-vercel": "https://adapter-vercel-pr90-artifact.vercel.app/adapter.tgz",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1760,8 +1760,8 @@ importers:
         version: 1.10.0(rollup@4.60.4)
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.24
-        version: 0.0.1-beta.24
+        specifier: https://adapter-vercel-pr90-artifact.vercel.app/adapter.tgz
+        version: https://adapter-vercel-pr90-artifact.vercel.app/adapter.tgz
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -4580,8 +4580,9 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next-community/adapter-vercel@0.0.1-beta.24':
-    resolution: {integrity: sha512-6c3DfRgVcDocIB2CTpp+7txplXMdrK69/CwyLJMDmcB2mvdjpXjKBOOJwjwa13E8zBPzhvRKnmkBxj+U40UUvw==}
+  '@next-community/adapter-vercel@https://adapter-vercel-pr90-artifact.vercel.app/adapter.tgz':
+    resolution: {integrity: sha512-MQZ1LQlUkzL4yxZzZTrrj1u0UBsJChe/soZvAznAsv9ZmzkLq5iTS9H9Bc/Wot+cXARa+N+2Tu4nf7ez18ugUQ==, tarball: https://adapter-vercel-pr90-artifact.vercel.app/adapter.tgz}
+    version: 0.0.1-beta.24
     engines: {node: '>= 20.6.0'}
 
   '@next/env@11.1.2':
@@ -15134,7 +15135,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@next-community/adapter-vercel@0.0.1-beta.24': {}
+  '@next-community/adapter-vercel@https://adapter-vercel-pr90-artifact.vercel.app/adapter.tgz': {}
 
   '@next/env@11.1.2': {}
 


### PR DESCRIPTION
Uses the build artifact from https://github.com/nextjs/adapter-vercel/pull/90 so the Vercel CLI can be built with those adapter changes.