### PR TITLE
[vercel/connex] Configure webhook events on connector create

### DIFF
--- a/.changeset/linear-trigger-events.md
+++ b/.changeset/linear-trigger-events.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow selecting webhook events when creating Linear connectors.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -38,7 +38,8 @@ export const createSubcommand = {
       type: [String],
       argument: 'EVENT',
       deprecated: false,
-      description: 'Webhook event to receive. Repeatable.',
+      description:
+        "Webhook event to receive. Repeatable. Requires --triggers and replaces the provider's default events.",
     },
     {
       name: 'data',

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -101,7 +101,7 @@ export const createSubcommand = {
       value: `${packageName} connect create slack --name my-bot --triggers`,
     },
     {
-      name: 'Create a Linear connector with selected webhook events',
+      name: 'Create with selected webhook events',
       value: `${packageName} connect create linear --name linear --triggers --trigger-event Issue --trigger-event Comment --trigger-event Project`,
     },
     {

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -33,6 +33,14 @@ export const createSubcommand = {
       description: 'Enable webhook triggers for this connector',
     },
     {
+      name: 'trigger-event',
+      shorthand: null,
+      type: [String],
+      argument: 'EVENT',
+      deprecated: false,
+      description: 'Webhook event to receive. Repeatable.',
+    },
+    {
       name: 'data',
       shorthand: null,
       type: String,
@@ -90,6 +98,10 @@ export const createSubcommand = {
     {
       name: 'Create with webhook triggers enabled',
       value: `${packageName} connect create slack --name my-bot --triggers`,
+    },
+    {
+      name: 'Create a Linear connector with selected webhook events',
+      value: `${packageName} connect create linear --name linear --triggers --trigger-event Issue --trigger-event Comment --trigger-event Project`,
     },
     {
       name: 'Create with branding (icon and colors)',

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -36,6 +36,7 @@ export async function create(
     '--format'?: string;
     '--json'?: boolean;
     '--triggers'?: boolean;
+    '--trigger-event'?: string[];
     '--icon'?: string;
     '--background-color'?: string;
     '--accent-color'?: string;
@@ -171,6 +172,9 @@ export async function create(
     body.projectId = link.projectId;
   }
   body.triggers = { enabled: flags['--triggers'] === true };
+  if (flags['--trigger-event'] !== undefined) {
+    body.events = flags['--trigger-event'];
+  }
   if (iconSha) {
     body.icon = iconSha;
   }

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -57,6 +57,11 @@ export async function create(
     return 1;
   }
 
+  if (flags['--trigger-event'] && !flags['--triggers']) {
+    output.error('The --trigger-event flag requires --triggers.');
+    return 1;
+  }
+
   const dataFlag = flags['--data'];
   const connectorType = flags['--connector-type'];
   if (connectorType && dataFlag === undefined) {

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -113,6 +113,9 @@ export default async function connex(client: Client): Promise<number> {
         telemetry.trackCliOptionConnectorType(
           createParsedArgs.flags['--connector-type']
         );
+        telemetry.trackCliOptionTriggerEvent(
+          createParsedArgs.flags['--trigger-event']
+        );
         return await create(
           client,
           createParsedArgs.args,

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -155,6 +155,15 @@ export class ConnexTelemetryClient
     }
   }
 
+  trackCliOptionTriggerEvent(v: string[] | undefined) {
+    if (v && v.length > 0) {
+      this.trackCliOption({
+        option: 'trigger-event',
+        value: String(v.length),
+      });
+    }
+  }
+
   trackCliOptionTriggerBranch(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -849,6 +849,7 @@ exports[`help command > connex help output snapshots > connex create subcommand 
        --icon <PATH>             Path to a PNG or JPEG image to use as the connector icon (uploaded to Vercel)               
        --json                    Output as JSON                                                                              
   -n,  --name <NAME>             Name of the connector                                                                       
+       --trigger-event <EVENT>   Webhook event to receive. Repeatable.                                                       
        --triggers                Enable webhook triggers for this connector                                                  
 
 
@@ -879,6 +880,10 @@ exports[`help command > connex help output snapshots > connex create subcommand 
   - Create with webhook triggers enabled
 
     $ vercel connect create slack --name my-bot --triggers
+
+  - Create a Linear connector with selected webhook events
+
+    $ vercel connect create linear --name linear --triggers --trigger-event Issue --trigger-event Comment --trigger-event Project
 
   - Create with branding (icon and colors)
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -881,7 +881,7 @@ exports[`help command > connex help output snapshots > connex create subcommand 
 
     $ vercel connect create slack --name my-bot --triggers
 
-  - Create a Linear connector with selected webhook events
+  - Create with selected webhook events
 
     $ vercel connect create linear --name linear --triggers --trigger-event Issue --trigger-event Comment --trigger-event Project
 

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -116,6 +116,37 @@ describe('connex create', () => {
     await expect(client.stderr).toOutput('scl_direct1 (UID uid_direct1)');
   });
 
+  it('forwards selected trigger events to managed connector creation', async () => {
+    let postBody: any;
+    client.scenario.post('/v1/connect/connectors/managed', (req, res) => {
+      postBody = req.body;
+      res.json(fakeConnexClient({ type: 'linear', name: 'linear' }));
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'linear',
+      '--name',
+      'linear',
+      '--triggers',
+      '--trigger-event',
+      'Issue',
+      '--trigger-event',
+      'Comment',
+      '--trigger-event',
+      'Project'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(postBody).toMatchObject({
+      triggers: { enabled: true },
+      events: ['Issue', 'Comment', 'Project'],
+    });
+  });
+
   it('should pass any type to the server without validation', async () => {
     let postBody: any;
     client.scenario.post('/v1/connect/connectors/managed', (req, res) => {

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -116,6 +116,32 @@ describe('connex create', () => {
     await expect(client.stderr).toOutput('scl_direct1 (UID uid_direct1)');
   });
 
+  it('requires --triggers when selecting trigger events', async () => {
+    let requestMade = false;
+    client.scenario.post('/v1/connect/connectors/managed', (_req, res) => {
+      requestMade = true;
+      res.json(fakeConnexClient());
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'linear',
+      '--name',
+      'linear',
+      '--trigger-event',
+      'Issue'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(requestMade).toBe(false);
+    await expect(client.stderr).toOutput(
+      'The --trigger-event flag requires --triggers.'
+    );
+  });
+
   it('forwards selected trigger events to managed connector creation', async () => {
     let postBody: any;
     client.scenario.post('/v1/connect/connectors/managed', (req, res) => {


### PR DESCRIPTION
## Why/Summary

- Let managed connector creators choose webhook events with repeatable `--trigger-event` flags.
- Forward selected events through the existing generic managed-create API contract.
- No provider event catalog is duplicated in the CLI; Connect remains responsible for validation.

## Validation

- Focused command tests cover generic event forwarding and trigger validation.

## Follow-up

The eve guided GitHub setup uses the repeatable flag to select event subscriptions before creating the GitHub App.