### PR TITLE
fix(cli): skip plugin prompts in non-interactive mode

### DIFF
--- a/.changeset/quiet-phones-sip.md
+++ b/.changeset/quiet-phones-sip.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Prevent Vercel plugin-install prompts after successful non-interactive commands.

--- a/packages/cli/src/util/agent/auto-install-agentic.ts
+++ b/packages/cli/src/util/agent/auto-install-agentic.ts
@@ -239,7 +239,7 @@ async function isPluginInstalledForTarget(target: string): Promise<boolean> {
 }
 
 async function confirm(client: Client, message: string): Promise<boolean> {
-  if (!client.stdin.isTTY) {
+  if (client.nonInteractive || !client.stdin.isTTY) {
     return false;
   }
   return client.input.confirm(message, true);

--- a/packages/cli/test/unit/util/auto-install-agentic.test.ts
+++ b/packages/cli/test/unit/util/auto-install-agentic.test.ts
@@ -289,6 +289,23 @@ describe('autoInstallVercelPlugin', () => {
     }
   });
 
+  it('does not prompt when the command is non-interactive', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'vercel-cli-agent-prefs-'));
+
+    try {
+      client.setArgv('--global-config', configDir, '--non-interactive');
+      client.agentName = KNOWN_AGENTS.CLAUDE;
+      client.nonInteractive = true;
+      const confirmSpy = vi.spyOn(client.input, 'confirm');
+
+      await autoInstallVercelPlugin(client);
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
   it('enables automatic plugin updates after accepting the plugin prompt', async () => {
     const configDir = await mkdtemp(join(tmpdir(), 'vercel-cli-agent-prefs-'));
 


### PR DESCRIPTION
## Summary
- skip the optional Claude Code Vercel plugin prompt for every non-interactive CLI command
- retain the prompt for interactive TTY commands
- add regression coverage for `client.nonInteractive` with a TTY stdin

## Why
`vercel env pull --yes --non-interactive` completes the environment pull, then the `env` command invokes `autoInstallVercelPlugin`. The helper only checked `stdin.isTTY`; it therefore opened a Claude Code plugin-install confirmation prompt even when `client.nonInteractive` was true. When invoked by eve, that prompt could keep the native CLI process alive after `.env.local` was written.

## Validation
- `pnpm exec vitest run --config vitest.config.mts test/unit/util/auto-install-agentic.test.ts`
- `pnpm --filter vercel type-check`