### PR TITLE
fix(cli): reject prompts in non-interactive mode

### DIFF
--- a/.changeset/quiet-phones-sip.md
+++ b/.changeset/quiet-phones-sip.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Prevent Vercel plugin-install prompts after successful non-interactive commands.

--- a/.changeset/shy-files-sleep.md
+++ b/.changeset/shy-files-sleep.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Prevent every Vercel CLI prompt from opening in non-interactive mode, even when stdin is attached to a terminal.

--- a/packages/cli/src/util/agent/auto-install-agentic.ts
+++ b/packages/cli/src/util/agent/auto-install-agentic.ts
@@ -239,7 +239,7 @@ async function isPluginInstalledForTarget(target: string): Promise<boolean> {
 }
 
 async function confirm(client: Client, message: string): Promise<boolean> {
-  if (!client.stdin.isTTY) {
+  if (client.nonInteractive || !client.stdin.isTTY) {
     return false;
   }
   return client.input.confirm(message, true);

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -78,6 +78,16 @@ type CancelablePrompt<T> = Promise<T> & {
   cancel?: () => void;
 };
 
+/** Raised when a command reaches a prompt that is unavailable in this invocation. */
+export class PromptUnavailableError extends Error {
+  constructor() {
+    super(
+      'Cannot prompt in non-interactive mode. Provide the required command options instead.'
+    );
+    this.name = 'PromptUnavailableError';
+  }
+}
+
 export interface FetchOptions extends Omit<RequestInit, 'body'> {
   body?: BodyInit | JSONObject;
   json?: boolean;
@@ -187,43 +197,43 @@ export default class Client extends EventEmitter implements Stdio {
     };
     this.input = {
       text: (opts: Parameters<typeof input>[0]) =>
-        this.runPrompt(
+        this.prompt(() =>
           input({ theme, ...opts }, { input: this.stdin, output: this.stderr })
         ),
       password: (opts: Parameters<typeof password>[0]) =>
-        this.runPrompt(
+        this.prompt(() =>
           password(
             { theme, ...opts },
             { input: this.stdin, output: this.stderr }
           )
         ),
       checkbox: <T>(opts: Parameters<typeof checkbox<T>>[0]) =>
-        this.runPrompt(
+        this.prompt(() =>
           checkbox<T>(
             { theme, ...opts },
             { input: this.stdin, output: this.stderr }
           )
         ),
       expand: (opts: Parameters<typeof expand>[0]) =>
-        this.runPrompt(
+        this.prompt(() =>
           expand({ theme, ...opts }, { input: this.stdin, output: this.stderr })
         ),
       confirm: (message: string, default_value: boolean) =>
-        this.runPrompt(
+        this.prompt(() =>
           confirm(
             { theme, message, default: default_value },
             { input: this.stdin, output: this.stderr }
           )
         ),
       select: <T>(opts: Parameters<typeof select<T>>[0]) =>
-        this.runPrompt(
+        this.prompt(() =>
           select<T>(
             { theme, ...opts },
             { input: this.stdin, output: this.stderr }
           )
         ),
       search: <T>(opts: Parameters<typeof search<T>>[0]) =>
-        this.runPrompt(
+        this.prompt(() =>
           search<T>(
             { theme, ...opts },
             { input: this.stdin, output: this.stderr }
@@ -248,6 +258,13 @@ export default class Client extends EventEmitter implements Stdio {
     } finally {
       this.promptBackNavigationDepth--;
     }
+  }
+
+  private prompt<T>(create: () => CancelablePrompt<T>): Promise<T> {
+    if (this.nonInteractive || !this.stdin.isTTY) {
+      return Promise.reject(new PromptUnavailableError());
+    }
+    return this.runPrompt(create());
   }
 
   private runPrompt<T>(prompt: CancelablePrompt<T>): Promise<T> {

--- a/packages/cli/test/unit/util/auto-install-agentic.test.ts
+++ b/packages/cli/test/unit/util/auto-install-agentic.test.ts
@@ -289,6 +289,23 @@ describe('autoInstallVercelPlugin', () => {
     }
   });
 
+  it('does not prompt when the command is non-interactive', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'vercel-cli-agent-prefs-'));
+
+    try {
+      client.setArgv('--global-config', configDir, '--non-interactive');
+      client.agentName = KNOWN_AGENTS.CLAUDE;
+      client.nonInteractive = true;
+      const confirmSpy = vi.spyOn(client.input, 'confirm');
+
+      await autoInstallVercelPlugin(client);
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
   it('enables automatic plugin updates after accepting the plugin prompt', async () => {
     const configDir = await mkdtemp(join(tmpdir(), 'vercel-cli-agent-prefs-'));
 

--- a/packages/cli/test/unit/util/prompt-availability.test.ts
+++ b/packages/cli/test/unit/util/prompt-availability.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { client } from '../../mocks/client';
+
+describe('Client prompt availability', () => {
+  it('rejects every prompt when explicitly non-interactive despite a TTY', async () => {
+    client.nonInteractive = true;
+    client.stdin.isTTY = true;
+
+    const unavailable = { name: 'PromptUnavailableError' };
+    const choices = [{ name: 'One', value: 'one', key: '1' }];
+
+    await expect(client.input.confirm('Continue?', true)).rejects.toMatchObject(
+      unavailable
+    );
+    await expect(client.input.text({ message: 'Name?' })).rejects.toMatchObject(
+      unavailable
+    );
+    await expect(
+      client.input.password({ message: 'Secret?' })
+    ).rejects.toMatchObject(unavailable);
+    await expect(
+      client.input.checkbox({ message: 'Choices?', choices })
+    ).rejects.toMatchObject(unavailable);
+    await expect(
+      client.input.expand({ message: 'Choice?', choices })
+    ).rejects.toMatchObject(unavailable);
+    await expect(
+      client.input.select({ message: 'Choice?', choices })
+    ).rejects.toMatchObject(unavailable);
+    await expect(
+      client.input.search({ message: 'Choice?', source: () => choices })
+    ).rejects.toMatchObject(unavailable);
+  });
+});


### PR DESCRIPTION
## Summary
- make `Client.input` reject every prompt type when `client.nonInteractive` is true
- retain normal interactive prompting and prompt-cancellation behavior
- cover all seven exposed input helpers with a TTY-backed non-interactive regression test

## Why
Several commands independently guarded prompts with `stdin.isTTY`, which misses explicit `--non-interactive` invocations that retain terminal stdin. This stack's parent fixes the observed Claude Code plugin prompt; this PR makes the Client input boundary enforce the CLI-wide no-prompt invariant so future callers cannot recreate the hang. Commands still own their user-facing non-interactive validation and `action_required` output.

## Validation
- `pnpm --filter vercel exec vitest run --config vitest.config.mts test/unit/util/prompt-availability.test.ts test/unit/util/auto-install-agentic.test.ts`
- `pnpm --filter vercel type-check`
- `pnpm exec changeset status --since=main`

Stacked on #17345.