### PR TITLE
ci: name test setup helper steps for readability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,8 @@ jobs:
           node-version: 22
       - name: install turbo@2.5.0
         run: npm i -g turbo@2.5.0
-      - id: affected-packages
+      - name: Detect affected packages and test strategy
+        id: affected-packages
         run: |
           # Set base SHA for affected package detection
           export TURBO_BASE_SHA="${{ steps.pr-context.outputs.baseSha }}"
@@ -122,7 +123,8 @@ jobs:
           echo "count=$PACKAGE_COUNT" >> $GITHUB_OUTPUT
           echo "total=$TOTAL_COUNT" >> $GITHUB_OUTPUT
           echo "allPackages=$ALL_PACKAGES" >> $GITHUB_OUTPUT
-      - id: set-tests
+      - name: Chunk unit and e2e test matrices
+        id: set-tests
         run: |
           UNIT_TESTS_ARRAY=$(TEST_TYPE=unit node utils/chunk-tests.js)
           E2E_TESTS_ARRAY=$(TEST_TYPE=e2e node utils/chunk-tests.js)


### PR DESCRIPTION
## Problem

In `.github/workflows/test.yml`, the `affected-packages` and `set-tests` helper `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when affected-package detection or test matrix chunking fails.

(`test-e2e.yml` from the analyzer list is already gone on the latest default branch.)

## Changes

Semantics are unchanged: same step `id`s, same `GITHUB_OUTPUT` keys, and the same job output wiring.

- Add `name: Detect affected packages and test strategy` to `id: affected-packages`
- Add `name: Chunk unit and e2e test matrices` to `id: set-tests`

## Test plan
- [ ] Confirm setup outputs still come from `steps.affected-packages` / `steps.set-tests`
- [ ] Confirm the steps show the new names in the Actions UI
