### PR TITLE
fix(rust): drain per-request waitUntil futures before sending the end IPC message

### DIFF
--- a/crates/vercel_runtime/src/awaiter.rs
+++ b/crates/vercel_runtime/src/awaiter.rs
@@ -1,14 +1,17 @@
 //! Background work collector for `waitUntil`-style tasks.
 //!
 //! This mirrors the behavior of the Node.js runtime's `Awaiter`
-//! (`packages/node/src/awaiter.ts`). Crucially, `waitUntil` is implemented
-//! entirely in-process: there is **no** dedicated IPC message. The per-request
-//! `end` IPC message is sent immediately after the handler responds and is
-//! **never** delayed by background work. Registered futures are drained only at
-//! process shutdown (SIGTERM). In production the drain is unbounded (background
-//! work runs until it resolves or the function times out); in `vc dev` it is
-//! bounded by [`WAIT_UNTIL_TIMEOUT`] so a hung task cannot keep the dev process
-//! alive.
+//! (`packages/node/src/awaiter.ts`). `waitUntil` is implemented in-process:
+//! there is no dedicated IPC message for registering work. Instead, each
+//! request owns an `Awaiter` (on `AppState`), and the per-request `end` IPC
+//! message is withheld until that request's registered futures settle. Keeping
+//! the invocation open is what keeps the instance from being suspended, so
+//! background work actually runs to completion after the response is sent
+//! (bounded by the function's `maxDuration`), matching the Node.js runtime's
+//! extended-lifecycle behavior. A global `Awaiter` additionally drains
+//! outstanding work at process shutdown (SIGTERM): unbounded in production, and
+//! bounded by [`WAIT_UNTIL_TIMEOUT`] in `vc dev` so a hung task cannot keep the
+//! dev process alive.
 //!
 //! Like the Node implementation:
 //! - A future registered via [`Awaiter::wait_until`] runs regardless of whether
@@ -40,7 +43,9 @@ impl Awaiter {
         Self::default()
     }
 
-    /// Register a background future to be awaited at shutdown.
+    /// Register a background future to be awaited by this set's owner — the
+    /// per-request drain that precedes the `end` IPC message, or the process
+    /// shutdown drain for the global set.
     ///
     /// The future is spawned onto the current Tokio runtime immediately so it
     /// makes progress between requests. Any panic in the future is caught by the
@@ -79,5 +84,56 @@ impl Awaiter {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[tokio::test]
+    async fn awaiting_completes_registered_futures() {
+        let awaiter = Awaiter::new();
+        let count = Arc::new(AtomicU32::new(0));
+        for _ in 0..3 {
+            let count = count.clone();
+            awaiter.wait_until(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                count.fetch_add(1, Ordering::SeqCst);
+            });
+        }
+        awaiter.awaiting().await;
+        assert_eq!(count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn awaiting_drains_futures_registered_during_the_drain() {
+        let awaiter = Awaiter::new();
+        let count = Arc::new(AtomicU32::new(0));
+        let nested_awaiter = awaiter.clone();
+        let nested_count = count.clone();
+        awaiter.wait_until(async move {
+            let count = nested_count.clone();
+            nested_awaiter.wait_until(async move {
+                count.fetch_add(1, Ordering::SeqCst);
+            });
+            nested_count.fetch_add(1, Ordering::SeqCst);
+        });
+        awaiter.awaiting().await;
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn a_panicking_future_does_not_abort_the_drain() {
+        let awaiter = Awaiter::new();
+        let count = Arc::new(AtomicU32::new(0));
+        awaiter.wait_until(async { panic!("waitUntil task panic") });
+        let survivor = count.clone();
+        awaiter.wait_until(async move {
+            survivor.fetch_add(1, Ordering::SeqCst);
+        });
+        awaiter.awaiting().await;
+        assert_eq!(count.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/vercel_runtime/src/lib.rs
+++ b/crates/vercel_runtime/src/lib.rs
@@ -138,6 +138,12 @@ impl Default for LogContext {
 #[derive(Clone)]
 pub struct AppState {
     pub log_context: LogContext,
+    /// Per-request background-work set. The request's `end` IPC message is
+    /// withheld until every future registered here settles, so the platform
+    /// keeps the invocation active (and the instance unsuspended) while
+    /// `waitUntil` work runs. Without this, Fluid suspends the instance as
+    /// soon as the response completes and background futures only advance
+    /// while later requests happen to wake the process.
     awaiter: Awaiter,
 }
 
@@ -145,13 +151,15 @@ impl AppState {
     pub fn new(log_context: LogContext) -> Self {
         Self {
             log_context,
-            awaiter: AWAITER.clone(),
+            awaiter: Awaiter::new(),
         }
     }
 
     /// Register a background future to keep running after the response has been
-    /// sent. The future is spawned immediately and awaited at process shutdown
-    /// (bounded by [`awaiter::WAIT_UNTIL_TIMEOUT`]).
+    /// sent. The future is spawned immediately; the request's `end` IPC message
+    /// (which lets the platform consider the invocation finished) is delayed
+    /// until all futures registered during the request settle, bounded by the
+    /// function's `maxDuration`.
     ///
     /// This future runs regardless of whether the handler succeeded or errored.
     /// A panic in the future is isolated from the rest of the runtime.
@@ -160,6 +168,12 @@ impl AppState {
         F: std::future::Future<Output = ()> + Send + 'static,
     {
         self.awaiter.wait_until(future);
+    }
+
+    /// Handle to this request's background-work set, used by [`run`] to drain
+    /// it before emitting the per-request `end` IPC message.
+    pub(crate) fn awaiter(&self) -> Awaiter {
+        self.awaiter.clone()
     }
 }
 
@@ -426,6 +440,8 @@ where
                         async move {
                             #[cfg(unix)]
                             let ipc_stream_for_end = app_state.log_context.ipc_stream.clone();
+                            #[cfg(unix)]
+                            let request_awaiter = app_state.awaiter();
 
                             if req.uri().path() == "/_vercel/ping" {
                                 let response = hyper::Response::builder()
@@ -462,15 +478,30 @@ where
                                 }
                             };
 
-                            // Send end message via IPC
+                            // Send end message via IPC once this request's
+                            // `waitUntil` work settles. The response is
+                            // returned to hyper immediately below, so client
+                            // latency is unaffected; only the platform's
+                            // "invocation finished" signal is delayed, which
+                            // keeps the instance from suspending while
+                            // background futures run (mirroring the Node.js
+                            // runtime's extended-lifecycle behavior). With no
+                            // registered work the drain resolves immediately
+                            // and the end message is sent right away. The
+                            // drain task is registered in the global AWAITER
+                            // so the SIGTERM drain also waits for in-flight
+                            // end messages.
                             #[cfg(unix)]
                             if let (Some(ipc_stream), Some(inv_id), Some(req_id)) =
-                                (&ipc_stream_for_end, &invocation_id, &request_id)
+                                (ipc_stream_for_end, invocation_id, request_id)
                             {
-                                let end_message = EndMessage::new(inv_id.clone(), *req_id, None);
-                                if let Err(_e) = send_message(ipc_stream, end_message) {
-                                    // Failed to send end message
-                                }
+                                AWAITER.wait_until(async move {
+                                    request_awaiter.awaiting().await;
+                                    let end_message = EndMessage::new(inv_id, req_id, None);
+                                    if let Err(_e) = send_message(&ipc_stream, end_message) {
+                                        // Failed to send end message
+                                    }
+                                });
                             }
 
                             Ok::<_, Infallible>(response)


### PR DESCRIPTION
### What

Fixes `waitUntil` on the Rust runtime: background futures registered via `AppState::wait_until` currently stop executing as soon as the response is sent, because the per-request `end` IPC message is emitted unconditionally right after the handler returns. Once the platform sees `end`, the instance is eligible for suspension, so the spawned future loses CPU and only advances in slices while later, unrelated requests happen to wake the same instance. With sparse traffic it never completes at all. This contradicts the documented contract — the crate's own doc comments promise the future "makes progress between requests" and "keep[s] running after the response has been sent", and the Rust runtime docs list `waitUntil` as supported.

The SIGTERM drain does not cover this case: suspension is not shutdown, so no signal arrives until the instance is eventually reaped, long after any in-task deadline has expired.

### How

- `AppState` now owns a **per-request** `Awaiter` instead of a clone of the global one.
- The per-request `end` IPC message is sent from a task that first drains that request's registered futures, instead of inline. The response is still returned to hyper immediately, so client latency is unchanged; only the platform's "invocation finished" signal waits, which keeps the instance active while background work runs — the same extended-lifecycle semantics as the Node.js runtime, bounded by `maxDuration`.
- Requests that register no background work behave exactly as before (the drain resolves immediately).
- The drain task is registered in the global `AWAITER`, so the existing SIGTERM drain also waits for in-flight `end` messages.
- Updated the `awaiter` module docs to describe the actual lifecycle, and added unit tests for drain semantics (completion, nested registration during drain, panic isolation).

### Evidence (measured on deployed functions)

Probe: a handler registers a 30-tick, once-per-second logger via `wait_until` (each tick logs monotonic `elapsed_ms`), responds in ~1.4 ms. I send one trigger request, then nothing for 75 s, then a single `GET /health`, 40 more silent seconds, then one more `GET /health`.

**Before (unpatched 2.4.0), region `pdx1`:**

```
03:35:42.835  probe scheduled (response 1.4 ms)
03:36:58.243  tick=1  elapsed_ms=75408   <- ran 75.4 s late, inside the /health invocation's log group
03:37:38.470  tick=2  elapsed_ms=115634  <- inside the second /health invocation
(ticks 3-30 and completion: never executed)
```

Exactly one tick per wake-up: the expired 1 s timer fires instantly on thaw, the future parks on its next `sleep`, and the instance suspends when the carrying invocation ends. Note `elapsed_ms=75408` across a 1-second `tokio::time::sleep` — every timeout/deadline inside a parked future expires without the code executing, which surfaces as misleading phantom errors (dead DB connections, "timeouts" with no elapsed execution) far from the actual cause.

**After (this patch, same experiment):**

```
03:49:22.140  probe scheduled (response 1.4 ms)
03:49:23.143  tick=1   elapsed_ms=1003
03:49:24.143  tick=2   elapsed_ms=2003
...           (every tick present, ~1.001 s apart, all attached to the registering invocation)
03:49:52.173  tick=30  elapsed_ms=30033
03:49:52.173  DONE     elapsed_ms=30033
```

All 30 ticks at exact 1-second cadence with no follow-up traffic required. The dashboard shows the invocation duration extending to ~30 s while the response completed in ~146 ms, i.e. Fluid extended lifecycle with Active CPU billing only for actual execution.

This also empirically confirms that suspension is gated on the per-request `end` message, so the fix is entirely crate-side.

### Impact

Any Rust function using `wait_until` as documented (cache refresh, provider sync, webhook fan-out, analytics) currently loses that work silently in production while working fine locally. I hit this in production as multi-day sync failures with phantom "database unavailable" / deadline errors before tracing it to instance suspension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

