### PR TITLE
[node] Trace Node exports for Bun functions

### DIFF
--- a/.changeset/tidy-buns-trace.md
+++ b/.changeset/tidy-buns-trace.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+Trace Node conditional exports used by the Bun runtime.

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -214,7 +214,7 @@ async function compile(
   const conditions = isEdgeFunction
     ? ['edge-light', 'browser', 'module', 'import', 'require']
     : isBun
-      ? ['bun']
+      ? ['bun', 'node']
       : undefined;
 
   const { fileList, esmFileList, warnings } = await nodeFileTrace(

--- a/packages/node/test/unit/bun-conditions.test.ts
+++ b/packages/node/test/unit/bun-conditions.test.ts
@@ -1,0 +1,44 @@
+import type { NodejsLambda } from '@vercel/build-utils';
+import { describe, expect, it } from 'vitest';
+import { build } from '../../src';
+import { prepareFilesystem } from './test-utils';
+
+describe('Bun export conditions', () => {
+  it('traces Node conditional exports used by the Bun runtime', async () => {
+    const filesystem = await prepareFilesystem(
+      {
+        'api/index.ts': `
+        import { condition } from 'conditional-export';
+        export default { fetch: () => new Response(condition) };
+      `,
+        'node_modules/conditional-export/package.json': JSON.stringify({
+          name: 'conditional-export',
+          type: 'module',
+          exports: {
+            '.': {
+              node: './node.js',
+              default: './default.js',
+            },
+          },
+        }),
+        'node_modules/conditional-export/node.js':
+          "export const condition = 'node';",
+        'node_modules/conditional-export/default.js':
+          "export const condition = 'default';",
+      },
+      'vercel-node-bun-conditions-tests'
+    );
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'api/index.ts',
+      config: { bunVersion: '1.x' },
+      meta: { skipDownload: true },
+    });
+    const lambda = buildResult.output as NodejsLambda;
+
+    expect(
+      lambda.files['node_modules/conditional-export/node.js']
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- trace Bun functions with both the `bun` and `node` export conditions
- add a regression test covering a package with `node` and `default` exports
- add the required `@vercel/node` patch changeset

## Problem

`@vercel/node` currently traces Bun functions with only the `bun` export condition, while Bun also enables the `node` condition at runtime. For packages such as `uuid` that expose a `node` entry before `default`, the deployed function can therefore execute a file that was not included in the trace and fail with a module-not-found error.

Adding `node` makes the traced dependency graph match Bun's runtime resolution.

Related context: #9769, #14098, and the Vercel Community report [Production down — React Router 7 SSR function crashes](https://community.vercel.com/t/production-down-react-router-7-ssr-function-crashes/42108). The Bun-only tracing condition was introduced in #14164.

## Test plan

- [x] Regression test fails without the tracing change and passes with it
- [x] `pnpm test test/unit/bun-conditions.test.ts`
- [x] `pnpm test test/unit --no-file-parallelism` (135 tests)
- [x] `pnpm --filter @vercel/node type-check`
- [x] `pnpm --filter @vercel/node build`
- [x] Biome format and lint on touched TypeScript files
