### PR TITLE
[vercel/connex] Configure GitHub webhook events on create

### DIFF
--- a/.changeset/github-trigger-events.md
+++ b/.changeset/github-trigger-events.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Document GitHub webhook event selection when creating managed connectors.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -42,6 +42,15 @@ export const createSubcommand = {
         "Webhook event to receive. Repeatable. Requires --triggers and replaces the provider's default events.",
     },
     {
+      name: 'events',
+      shorthand: null,
+      type: String,
+      argument: 'EVENTS',
+      deprecated: false,
+      description:
+        'Comma-separated GitHub webhook events to receive. Requires --triggers and replaces GitHub defaults.',
+    },
+    {
       name: 'data',
       shorthand: null,
       type: String,
@@ -106,7 +115,7 @@ export const createSubcommand = {
     },
     {
       name: 'Create a GitHub connector with selected webhook events',
-      value: `${packageName} connect create github --name github --triggers --trigger-event issue_comment --trigger-event pull_request_review_comment`,
+      value: `${packageName} connect create github --name github --triggers --events issue_comment,pull_request_review_comment`,
     },
     {
       name: 'Create with branding (icon and colors)',

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -105,6 +105,10 @@ export const createSubcommand = {
       value: `${packageName} connect create linear --name linear --triggers --trigger-event Issue --trigger-event Comment --trigger-event Project`,
     },
     {
+      name: 'Create a GitHub connector with selected webhook events',
+      value: `${packageName} connect create github --name github --triggers --trigger-event issue_comment --trigger-event pull_request_review_comment`,
+    },
+    {
       name: 'Create with branding (icon and colors)',
       value: `${packageName} connect create slack --name my-bot --icon ./logo.png --background-color '#1A2B3C' --accent-color '#FF0066'`,
     },

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -37,6 +37,7 @@ export async function create(
     '--json'?: boolean;
     '--triggers'?: boolean;
     '--trigger-event'?: string[];
+    '--events'?: string;
     '--icon'?: string;
     '--background-color'?: string;
     '--accent-color'?: string;
@@ -57,8 +58,21 @@ export async function create(
     return 1;
   }
 
-  if (flags['--trigger-event'] && !flags['--triggers']) {
-    output.error('The --trigger-event flag requires --triggers.');
+  if (flags['--trigger-event'] && flags['--events']) {
+    output.error('Use either --trigger-event or --events, not both.');
+    return 1;
+  }
+  if (flags['--events'] && serviceType !== 'github') {
+    output.error('The --events flag is only supported for GitHub connectors.');
+    return 1;
+  }
+  if ((flags['--trigger-event'] || flags['--events']) && !flags['--triggers']) {
+    output.error('The --trigger-event and --events flags require --triggers.');
+    return 1;
+  }
+  const events = flags['--events']?.trim();
+  if (flags['--events'] !== undefined && !events) {
+    output.error('The --events flag requires at least one event.');
     return 1;
   }
 
@@ -179,6 +193,8 @@ export async function create(
   body.triggers = { enabled: flags['--triggers'] === true };
   if (flags['--trigger-event'] !== undefined) {
     body.events = flags['--trigger-event'];
+  } else if (events !== undefined) {
+    body.events = events;
   }
   if (iconSha) {
     body.icon = iconSha;

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -173,6 +173,36 @@ describe('connex create', () => {
     });
   });
 
+  it('forwards GitHub webhook events to managed connector creation', async () => {
+    let postBody: any;
+    client.scenario.post('/v1/connect/connectors/managed', (req, res) => {
+      postBody = req.body;
+      res.json(fakeConnexClient({ type: 'github', name: 'github' }));
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'github',
+      '--name',
+      'github',
+      '--triggers',
+      '--trigger-event',
+      'issue_comment',
+      '--trigger-event',
+      'pull_request_review_comment'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(postBody).toMatchObject({
+      service: 'github',
+      triggers: { enabled: true },
+      events: ['issue_comment', 'pull_request_review_comment'],
+    });
+  });
+
   it('should pass any type to the server without validation', async () => {
     let postBody: any;
     client.scenario.post('/v1/connect/connectors/managed', (req, res) => {

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -187,10 +187,8 @@ describe('connex create', () => {
       '--name',
       'github',
       '--triggers',
-      '--trigger-event',
-      'issue_comment',
-      '--trigger-event',
-      'pull_request_review_comment'
+      '--events',
+      'issue_comment,pull_request_review_comment'
     );
 
     const exitCode = await connect(client);
@@ -199,8 +197,35 @@ describe('connex create', () => {
     expect(postBody).toMatchObject({
       service: 'github',
       triggers: { enabled: true },
-      events: ['issue_comment', 'pull_request_review_comment'],
+      events: 'issue_comment,pull_request_review_comment',
     });
+  });
+
+  it('rejects --events for non-GitHub connectors', async () => {
+    let requestMade = false;
+    client.scenario.post('/v1/connect/connectors/managed', (_req, res) => {
+      requestMade = true;
+      res.json(fakeConnexClient());
+    });
+
+    client.setArgv(
+      'connect',
+      'create',
+      'linear',
+      '--name',
+      'linear',
+      '--triggers',
+      '--events',
+      'Issue'
+    );
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(requestMade).toBe(false);
+    await expect(client.stderr).toOutput(
+      'The --events flag is only supported for GitHub connectors.'
+    );
   });
 
   it('should pass any type to the server without validation', async () => {


### PR DESCRIPTION
## Summary

- Add a GitHub-only `--events <comma-separated-events>` flag to `vercel connect create`.
- Forward the supplied comma-separated value as the managed-create API’s `events` field.
- Reject `--events` for non-GitHub connectors, empty values, and combinations with generic `--trigger-event`.
- Update the GitHub example and cover the managed-create payload.

The CLI deliberately does not hardcode GitHub’s supported event catalog; Connect validates event names server-side.

## Dependency

Stacks on #17343, which introduces generic `--trigger-event`. Retarget to `main` after that PR merges.

## Validation

- `pnpm exec prettier --check packages/cli/src/commands/connex/command.ts packages/cli/src/commands/connex/create.ts packages/cli/test/unit/commands/connex/create.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/github/connect.test.ts src/setup/integrations/github/setup.test.ts --reporter=dot`