### PR TITLE
[vercel] Document Connector Manager access

### DIFF
--- a/.changeset/wise-connectors-manage.md
+++ b/.changeset/wise-connectors-manage.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update Connect permission guidance for Connector Manager access.

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -441,7 +441,7 @@ export async function attach(
       const status = (err as { status?: number }).status;
       if (status === 403) {
         output.error(
-          `You don't have permission to attach projects on this team. Ask a team owner to grant Connector Manager access.`
+          `You don't have permission to attach projects on this team. Owner or Member role, or Connector Manager permission required.`
         );
         return 1;
       }
@@ -471,7 +471,7 @@ export async function attach(
       const status = (err as { status?: number }).status;
       if (status === 403) {
         output.error(
-          `You don't have permission to update trigger destinations on this team. Ask a team owner to grant Connector Manager access.`
+          `You don't have permission to update trigger destinations on this team. Owner or Member role, or Connector Manager permission required.`
         );
         return 1;
       }

--- a/packages/cli/src/commands/connex/attach.ts
+++ b/packages/cli/src/commands/connex/attach.ts
@@ -441,7 +441,7 @@ export async function attach(
       const status = (err as { status?: number }).status;
       if (status === 403) {
         output.error(
-          `You don't have permission to attach projects on this team. Owner or Member role required.`
+          `You don't have permission to attach projects on this team. Ask a team owner to grant Connector Manager access.`
         );
         return 1;
       }
@@ -471,7 +471,7 @@ export async function attach(
       const status = (err as { status?: number }).status;
       if (status === 403) {
         output.error(
-          `You don't have permission to update trigger destinations on this team. Owner or Member role required.`
+          `You don't have permission to update trigger destinations on this team. Ask a team owner to grant Connector Manager access.`
         );
         return 1;
       }

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -420,7 +420,7 @@ export const revokeTokensSubcommand = {
       type: Boolean,
       deprecated: false,
       description:
-        'Revoke every token for all users and installations. Requires team owner or member permissions.',
+        'Revoke every token for all users and installations. Requires the team Owner or Member role, or Connector Manager permission',
     },
     {
       ...yesOption,

--- a/packages/cli/src/commands/connex/detach.ts
+++ b/packages/cli/src/commands/connex/detach.ts
@@ -188,7 +188,7 @@ export async function detach(
     const status = (err as { status?: number }).status;
     if (status === 403) {
       output.error(
-        `You don't have permission to detach projects on this team. Owner or Member role required.`
+        `You don't have permission to detach projects on this team. Ask a team owner to grant Connector Manager access.`
       );
       return 1;
     }

--- a/packages/cli/src/commands/connex/detach.ts
+++ b/packages/cli/src/commands/connex/detach.ts
@@ -188,7 +188,7 @@ export async function detach(
     const status = (err as { status?: number }).status;
     if (status === 403) {
       output.error(
-        `You don't have permission to detach projects on this team. Ask a team owner to grant Connector Manager access.`
+        `You don't have permission to detach projects on this team. Owner or Member role, or Connector Manager permission required.`
       );
       return 1;
     }

--- a/packages/cli/test/unit/commands/connex/attach.test.ts
+++ b/packages/cli/test/unit/commands/connex/attach.test.ts
@@ -633,7 +633,7 @@ describe('connex attach', () => {
     expect(exitCode).toBe(1);
     const stderr = client.stderr.getFullOutput();
     expect(stderr).toContain(
-      "You don't have permission to attach projects on this team. Ask a team owner to grant Connector Manager access."
+      "You don't have permission to attach projects on this team. Owner or Member role, or Connector Manager permission required."
     );
     expect(stderr).not.toContain('Owner or Member role required');
   });
@@ -1124,7 +1124,7 @@ describe('connex attach', () => {
       expect(exitCode).toBe(1);
       const stderr = client.stderr.getFullOutput();
       expect(stderr).toContain(
-        "You don't have permission to update trigger destinations on this team. Ask a team owner to grant Connector Manager access."
+        "You don't have permission to update trigger destinations on this team. Owner or Member role, or Connector Manager permission required."
       );
       expect(stderr).not.toContain('Owner or Member role required');
     });

--- a/packages/cli/test/unit/commands/connex/attach.test.ts
+++ b/packages/cli/test/unit/commands/connex/attach.test.ts
@@ -1109,6 +1109,12 @@ describe('connex attach', () => {
           });
         }
       );
+      client.scenario.post(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({});
+        }
+      );
       client.scenario.patch(
         '/v1/connect/connectors/:clientId/trigger-destinations',
         (_req, res) => {

--- a/packages/cli/test/unit/commands/connex/attach.test.ts
+++ b/packages/cli/test/unit/commands/connex/attach.test.ts
@@ -631,9 +631,11 @@ describe('connex attach', () => {
     const exitCode = await connect(client);
 
     expect(exitCode).toBe(1);
-    expect(client.stderr.getFullOutput()).toContain(
-      "don't have permission to attach"
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain(
+      "You don't have permission to attach projects on this team. Ask a team owner to grant Connector Manager access."
     );
+    expect(stderr).not.toContain('Owner or Member role required');
   });
 
   describe('--triggers', () => {
@@ -1083,6 +1085,48 @@ describe('connex attach', () => {
         { projectId: 'prj_existing' },
         { projectId: PROJECT_ID },
       ]);
+    });
+
+    it('explains how to get access when updating trigger destinations is forbidden', async () => {
+      await setupLinkedProject(team);
+
+      client.scenario.get('/v1/connect/connectors/:clientId', (_req, res) => {
+        res.json({
+          id: 'scl_abc123',
+          uid: 'slack/my-bot',
+          supportsTriggers: true,
+          triggers: { enabled: true },
+          triggerDestinations: [],
+        });
+      });
+      client.scenario.get(
+        '/v1/connect/connectors/:clientId/projects/:projectId',
+        (_req, res) => {
+          res.json({
+            clientId: 'scl_abc123',
+            projectId: PROJECT_ID,
+            environments: ['production'],
+          });
+        }
+      );
+      client.scenario.patch(
+        '/v1/connect/connectors/:clientId/trigger-destinations',
+        (_req, res) => {
+          res.statusCode = 403;
+          res.json({ error: { code: 'forbidden', message: 'Forbidden' } });
+        }
+      );
+
+      client.setArgv('connect', 'attach', 'scl_abc123', '--triggers', '--yes');
+
+      const exitCode = await connect(client);
+
+      expect(exitCode).toBe(1);
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain(
+        "You don't have permission to update trigger destinations on this team. Ask a team owner to grant Connector Manager access."
+      );
+      expect(stderr).not.toContain('Owner or Member role required');
     });
 
     it('warns but proceeds when triggers.enabled is false on the connector', async () => {

--- a/packages/cli/test/unit/commands/connex/detach.test.ts
+++ b/packages/cli/test/unit/commands/connex/detach.test.ts
@@ -358,8 +358,10 @@ describe('connex detach', () => {
     const exitCode = await connect(client);
 
     expect(exitCode).toBe(1);
-    expect(client.stderr.getFullOutput()).toContain(
-      "don't have permission to detach"
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain(
+      "You don't have permission to detach projects on this team. Ask a team owner to grant Connector Manager access."
     );
+    expect(stderr).not.toContain('Owner or Member role required');
   });
 });

--- a/packages/cli/test/unit/commands/connex/detach.test.ts
+++ b/packages/cli/test/unit/commands/connex/detach.test.ts
@@ -360,7 +360,7 @@ describe('connex detach', () => {
     expect(exitCode).toBe(1);
     const stderr = client.stderr.getFullOutput();
     expect(stderr).toContain(
-      "You don't have permission to detach projects on this team. Ask a team owner to grant Connector Manager access."
+      "You don't have permission to detach projects on this team. Owner or Member role, or Connector Manager permission required."
     );
     expect(stderr).not.toContain('Owner or Member role required');
   });


### PR DESCRIPTION
## Why / Summary

- Connect permission errors currently imply that only Owners and Members can manage project connections and trigger destinations.
- Directs users to request Connector Manager access and updates token-revocation help accordingly.

## Validation

- Added coverage for attach, trigger-destination, and detach permission guidance, including stale-copy assertions.