### PR TITLE
[ci] Extract the test chunking helper

### DIFF
--- a/.changeset/extract-into-chunks.md
+++ b/.changeset/extract-into-chunks.md
@@ -1,8 +1,4 @@
 ---
-'@vercel/go': patch
-'@vercel/node': patch
-'@vercel/python': patch
-'@vercel/static-build': patch
 ---
 
 Extract the shared integration-test chunking helper from the CI planner.

--- a/.changeset/extract-into-chunks.md
+++ b/.changeset/extract-into-chunks.md
@@ -1,0 +1,8 @@
+---
+'@vercel/go': patch
+'@vercel/node': patch
+'@vercel/python': patch
+'@vercel/static-build': patch
+---
+
+Extract the shared integration-test chunking helper from the CI planner.

--- a/packages/go/test/integration-setup.js
+++ b/packages/go/test/integration-setup.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { intoChunks } = require('../../../utils/chunk-tests');
+const { intoChunks } = require('../../../utils/into-chunks');
 
 const {
   testDeployment,

--- a/packages/node/test/integration/integration-setup.js
+++ b/packages/node/test/integration/integration-setup.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { intoChunks } = require('../../../../utils/chunk-tests');
+const { intoChunks } = require('../../../../utils/into-chunks');
 
 const {
   testDeployment,

--- a/packages/python/test/integration-setup.js
+++ b/packages/python/test/integration-setup.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { intoChunks } = require('../../../utils/chunk-tests');
+const { intoChunks } = require('../../../utils/into-chunks');
 
 const {
   testDeployment,

--- a/packages/static-build/test/integration-setup.js
+++ b/packages/static-build/test/integration-setup.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { intoChunks } = require('../../../utils/chunk-tests');
+const { intoChunks } = require('../../../utils/into-chunks');
 
 const {
   testDeployment,

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -2,6 +2,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const testGlob = require('./test-glob');
+const { intoChunks } = require('./into-chunks');
 const {
   getAffectedPackages,
   getAllPackages,
@@ -551,22 +552,6 @@ async function getChunkedTests() {
   );
 
   return chunkedTests;
-}
-
-/**
- * @template T
- * @param {number} minChunks minimum number of chunks
- * @param {number} maxChunks maximum number of chunks
- * @param {T[]} arr
- * @returns {T[][]}
- */
-function intoChunks(minChunks, maxChunks, arr) {
-  const chunkSize = Math.max(minChunks, Math.ceil(arr.length / maxChunks));
-  const chunks = [];
-  for (let i = 0; i < maxChunks; i++) {
-    chunks.push(arr.slice(i * chunkSize, (i + 1) * chunkSize));
-  }
-  return chunks.filter(x => x.length > 0);
 }
 
 async function main() {

--- a/utils/into-chunks.js
+++ b/utils/into-chunks.js
@@ -1,0 +1,17 @@
+/**
+ * @template T
+ * @param {number} minChunks minimum number of chunks
+ * @param {number} maxChunks maximum number of chunks
+ * @param {T[]} items
+ * @returns {T[][]}
+ */
+function intoChunks(minChunks, maxChunks, items) {
+  const chunkSize = Math.max(minChunks, Math.ceil(items.length / maxChunks));
+  const chunks = [];
+  for (let index = 0; index < maxChunks; index++) {
+    chunks.push(items.slice(index * chunkSize, (index + 1) * chunkSize));
+  }
+  return chunks.filter(chunk => chunk.length > 0);
+}
+
+module.exports = { intoChunks };

--- a/utils/into-chunks.test.js
+++ b/utils/into-chunks.test.js
@@ -1,4 +1,4 @@
-const { intoChunks } = require('./chunk-tests');
+const { intoChunks } = require('./into-chunks');
 
 describe('it should create chunks correctly', () => {
   it('should split chunks correctly less chunks than items', () => {


### PR DESCRIPTION
## Summary

- Extract `intoChunks` from the legacy affected-test planner.
- Keep `chunk-tests.js` importing and re-exporting the helper for backward compatibility.
- Point integration setup files directly at the focused helper module.

## Verification

- Ran `pnpm vitest run --config vitest.config.mts utils/into-chunks.test.js`.
- Verified the legacy `chunk-tests.js` export returns the same chunk layout.
- Passed focused Prettier checks and the repository pre-commit hook.

## Stack

This is PR 2 of 6. It is stacked on #17360.