### PR TITLE
[ci] Use native Turborepo affected E2E tests

### DIFF
--- a/.changeset/native-e2e-tests.md
+++ b/.changeset/native-e2e-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Run E2E lane scripts as executable Turborepo tasks with native affected-package selection.

--- a/.changeset/native-unit-tests.md
+++ b/.changeset/native-unit-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Run unit-test lane scripts as executable Turborepo tasks with native affected-package selection.

--- a/.github/AFFECTED_TESTING.md
+++ b/.github/AFFECTED_TESTING.md
@@ -4,7 +4,8 @@ This repository implements an affected testing strategy, which runs tests only o
 
 Unit tests use Turborepo's native `--affected` package selection. The CLI unit
 suite runs in seven Vitest shards on Linux and macOS with Node.js 20 and 22, and
-on Windows with Node.js 22. E2E tests continue to use the legacy planner
+on Windows with Node.js 22. E2E lanes also use native `--affected` selection.
+The legacy planner remains temporarily for transition reporting and is
 described below.
 
 To inspect the affected unit tasks locally, run:
@@ -14,7 +15,7 @@ TURBO_SCM_BASE=<base-sha> TURBO_SCM_HEAD=<head-sha> \
   pnpm turbo run vitest-unit --affected --dry=json
 ```
 
-## How E2E Selection Works
+## Legacy Transition Reporting
 
 1. **Git Change Detection**: Uses turborepos's GraphQL query API to detect which packages have been modified since a base commit
 2. **Affected Package Resolution**: Finds packages that:

--- a/.github/AFFECTED_TESTING.md
+++ b/.github/AFFECTED_TESTING.md
@@ -2,7 +2,19 @@
 
 This repository implements an affected testing strategy, which runs tests only on packages that have been changed or are affected by changes.
 
-## How It Works
+Unit tests use Turborepo's native `--affected` package selection. The CLI unit
+suite runs in seven Vitest shards on Linux and macOS with Node.js 20 and 22, and
+on Windows with Node.js 22. E2E tests continue to use the legacy planner
+described below.
+
+To inspect the affected unit tasks locally, run:
+
+```bash
+TURBO_SCM_BASE=<base-sha> TURBO_SCM_HEAD=<head-sha> \
+  pnpm turbo run vitest-unit --affected --dry=json
+```
+
+## How E2E Selection Works
 
 1. **Git Change Detection**: Uses turborepos's GraphQL query API to detect which packages have been modified since a base commit
 2. **Affected Package Resolution**: Finds packages that:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,7 @@ jobs:
   comment-test-strategy:
     name: Comment Test Strategy
     runs-on: ubuntu-latest
+    if: ${{ false }}
     continue-on-error: true
     needs:
       - setup
@@ -495,72 +496,133 @@ jobs:
           done
 
   e2e-test:
+    name: E2E / ${{ matrix.label }}
+    needs: setup
     timeout-minutes: 120
     runs-on: ${{ matrix.runner }}
-    name: E2E / ${{ matrix.label }}
     permissions:
       contents: read
       deployments: read
       id-token: write
       statuses: read
-    if: ${{ needs.setup.outputs['e2eTests'] != '[]' }}
-    needs:
-      - setup
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
-      max-parallel: 75
       matrix:
-        include: ${{ fromJson(needs.setup.outputs['e2eTests']) }}
+        include:
+          - task: vitest-e2e
+            runner: ubuntu-latest
+            nodeVersion: 22
+            concurrency: 2
+            ruby: true
+            label: primary/linux/node22
+          - task: vitest-e2e-node-20
+            runner: ubuntu-latest
+            nodeVersion: 20
+            concurrency: 1
+            ruby: false
+            label: firewall/linux/node20
+          - task: test-e2e-node-all-versions
+            runner: ubuntu-latest
+            nodeVersion: 20
+            concurrency: 1
+            ruby: true
+            label: CLI-integration/linux/node20
+          - task: test-e2e-node-all-versions
+            runner: ubuntu-latest
+            nodeVersion: 22
+            concurrency: 1
+            ruby: true
+            label: CLI-integration/linux/node22
+          - task: test-e2e-node-all-versions
+            runner: ubuntu-latest
+            nodeVersion: 24
+            concurrency: 1
+            ruby: true
+            label: CLI-integration/linux/node24
+          - task: test-next-local
+            runner: ubuntu-latest
+            nodeVersion: 22
+            concurrency: 1
+            ruby: false
+            label: Next-local/linux/node22
+          - task: test-dev
+            runner: ubuntu-latest
+            nodeVersion: 22
+            concurrency: 1
+            ruby: true
+            label: CLI-dev/linux/node22
+          - task: test-dev
+            runner: macos-14
+            nodeVersion: 22
+            concurrency: 1
+            ruby: true
+            label: CLI-dev/mac/node22
+    env:
+      TURBO_SCM_BASE: ${{ needs.setup.outputs.baseSha }}
+      TURBO_SCM_HEAD: ${{ needs.setup.outputs.headSha }}
+      TURBO_TEST_PLATFORM: ${{ matrix.runner }}-node${{ matrix.nodeVersion }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.headSha }}
-      - name: Setup Turborepo Remote Cache
-        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
-        with:
-          team: ${{ vars.TURBO_TEAM }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
-
+      - name: install turbo@2.10.8
+        run: npm i -g turbo@2.10.8
+      - name: Check for affected E2E tests
+        id: affected
+        run: |
+          set -euo pipefail
+          node utils/gen.js
+          count=$(turbo run ${{ matrix.task }} --affected --dry=json | jq '[.tasks[] | select(.task == "${{ matrix.task }}" and .command != "<NONEXISTENT>")] | length')
+          if [ "$count" -gt 0 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No affected ${{ matrix.task }} tasks."
+          fi
+      - name: Setup Turborepo Remote Cache
+        if: steps.affected.outputs.run == 'true'
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Setup Go toolchain
-        if: ${{ matrix.needsGo == true }}
+        if: steps.affected.outputs.run == 'true'
         uses: actions/setup-go@v6
         with:
           go-version: '1.23.12'
           cache: false
-
       - name: Setup Rust toolchain
-        if: ${{ matrix.needsRust == true }}
+        if: steps.affected.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: '1.96.1'
           targets: wasm32-wasip2
-
-      # yarn 1.22.21 introduced a Corepack bug when running tests.
-      # this can be removed once https://github.com/yarnpkg/yarn/issues/9015 is resolved
       - name: install yarn@1.22.19
+        if: steps.affected.outputs.run == 'true'
         run: npm i -g yarn@1.22.19
-
       - name: install pnpm@10.29.3
+        if: steps.affected.outputs.run == 'true'
         run: npm i -g pnpm@10.29.3
-
       - name: Install uv
+        if: steps.affected.outputs.run == 'true'
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
           version: '0.10.11'
-
       - name: Install Ruby + Bundler
-        if: ${{ matrix.packageName == 'vercel' }}
+        if: steps.affected.outputs.run == 'true' && matrix.ruby
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: '3.3'
-
       - run: pnpm install
-
+        if: steps.affected.outputs.run == 'true'
       - name: Wait for deployment tarballs
-        shell: bash
+        if: steps.affected.outputs.run == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ needs.setup.outputs.headSha }}
@@ -616,7 +678,7 @@ jobs:
           echo "Timed out waiting for deployment tarball."
           exit 1
       - name: Resolve Python wheel URLs
-        shell: bash
+        if: steps.affected.outputs.run == 'true'
         run: |
           DEPLOYMENT_URL="$DPL_URL"
 
@@ -638,17 +700,27 @@ jobs:
             env_var="$(printf '%s' "$package_name" | tr -c '[:alnum:]' '_' | tr '[:lower:]' '[:upper:]')_PYTHON"
             echo "$env_var=$package_name @ $DEPLOYMENT_URL/tarballs/$wheel_name" >> "$GITHUB_ENV"
           done
-      - name: Test ${{matrix.packageName}}
-        timeout-minutes: 35
+      - name: Run affected E2E tests
+        if: steps.affected.outputs.run == 'true'
+        timeout-minutes: 45
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          FORCE_COLOR: '1'
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
+          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_CLI }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_CLI }}
+          DD_ENV: ci
+          DD_SERVICE: vercel-cli
+          DD_PROFILING_ENABLED: 'false'
+          DD_NATIVE_METRICS: 'false'
         run: |
           attempt=1
           max_attempts=2
           export NODE_OPTIONS="--require=${GITHUB_WORKSPACE}/utils/dd-trace-ci-init.js"
 
           while [ "$attempt" -le "$max_attempts" ]; do
-            echo "Running tests (attempt $attempt/$max_attempts): ${{matrix.testScript}} ${{matrix.packageName}}"
-
-            if node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}; then
+            if pnpm turbo run ${{ matrix.task }} --affected --summarize --cache-dir='.turbo' --log-order=stream --continue=always --concurrency=${{ matrix.concurrency }}; then
               exit 0
             fi
 
@@ -657,29 +729,9 @@ jobs:
               exit 1
             fi
 
-            echo "Tests failed; retrying once..."
-            attempt=$((attempt+1))
+            echo "Tests failed; retrying once."
+            attempt=$((attempt + 1))
           done
-        shell: bash
-        env:
-          # Per-package pip install specs (e.g. VERCEL_RUNTIME_PYTHON,
-          # VERCEL_WORKERS_PYTHON) are also available here, injected into
-          # $GITHUB_ENV by the "Resolve Python wheel URLs" step above.
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          TURBO_BASE_SHA: ${{ needs.setup.outputs.baseSha }}
-          FORCE_COLOR: '1'
-          # Datadog Test Optimization: emit per-test spans correlated to the
-          # GitHub Actions job span, replacing the previous post-hoc JUnit
-          # upload. See test/lib/deployment/metrics.js for the legacy
-          # DATADOG_API_KEY consumer (custom transient-error metrics).
-          DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
-          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_CLI }}
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_CLI }}
-          DD_ENV: ci
-          DD_SERVICE: vercel-cli
-          DD_PROFILING_ENABLED: 'false'
-          DD_NATIVE_METRICS: 'false'
 
   summary:
     name: Summary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,114 +255,120 @@ jobs:
             }
 
   unit-test:
+    name: Unit / ${{ matrix.label }}
+    needs: setup
     timeout-minutes: 120
     runs-on: ${{ matrix.runner }}
-    name: Unit / ${{ matrix.label }}
     permissions:
       contents: read
       id-token: write
-    if: ${{ needs.setup.outputs['unitTests'] != '[]' }}
-    needs:
-      - setup
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
-      max-parallel: 75
       matrix:
-        include: ${{ fromJson(needs.setup.outputs['unitTests']) }}
+        include:
+          - runner: ubuntu-latest
+            nodeVersion: 20
+            concurrency: 2
+            label: linux/node20
+          - runner: ubuntu-latest
+            nodeVersion: 22
+            concurrency: 2
+            label: linux/node22
+          - runner: macos-14
+            nodeVersion: 20
+            concurrency: 2
+            label: mac/node20
+          - runner: macos-14
+            nodeVersion: 22
+            concurrency: 2
+            label: mac/node22
+          - runner: windows-latest
+            nodeVersion: 22
+            concurrency: 1
+            label: win/node22
+    env:
+      TURBO_SCM_BASE: ${{ needs.setup.outputs.baseSha }}
+      TURBO_SCM_HEAD: ${{ needs.setup.outputs.headSha }}
+      TURBO_TEST_PLATFORM: ${{ matrix.runner }}-node${{ matrix.nodeVersion }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ needs.setup.outputs.headSha }}
-      - name: Setup Turborepo Remote Cache
-        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
-        with:
-          team: ${{ vars.TURBO_TEAM }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
-
+      - name: install turbo@2.10.8
+        run: npm i -g turbo@2.10.8
+      - name: Check for affected unit tests
+        id: affected
+        run: |
+          set -euo pipefail
+          node utils/gen.js
+          count=$(turbo run vitest-unit --affected --filter=!vercel --dry=json | jq '[.tasks[] | select(.task == "vitest-unit" and .command != "<NONEXISTENT>")] | length')
+          if [ "$count" -gt 0 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No affected unit-test tasks."
+          fi
+      - name: Setup Turborepo Remote Cache
+        if: steps.affected.outputs.run == 'true'
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
       - name: Setup Go toolchain
-        if: ${{ matrix.needsGo == true }}
+        if: steps.affected.outputs.run == 'true'
         uses: actions/setup-go@v6
         with:
           go-version: '1.23.12'
           cache: false
-
       - name: Setup Rust toolchain
-        if: ${{ matrix.needsRust == true }}
+        if: steps.affected.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: '1.96.1'
           targets: wasm32-wasip2
-
       # yarn 1.22.21 introduced a Corepack bug when running tests.
       # this can be removed once https://github.com/yarnpkg/yarn/issues/9015 is resolved
       - name: install yarn@1.22.19
+        if: steps.affected.outputs.run == 'true'
         run: npm i -g yarn@1.22.19
-
       - name: install pnpm@10.29.3
+        if: steps.affected.outputs.run == 'true'
         run: npm i -g pnpm@10.29.3
-
       - name: install uv@0.10.11
+        if: steps.affected.outputs.run == 'true'
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
           version: '0.10.11'
-
       - run: pnpm install
-
-      - name: "Print test manifest (chunk ${{matrix.chunkNumber}}/${{matrix.allChunksLength}})"
-        shell: bash
+        if: steps.affected.outputs.run == 'true'
+      - name: Run affected unit tests
+        if: steps.affected.outputs.run == 'true'
+        timeout-minutes: 65
         env:
-          VITEST_TEST_FILES: ${{ matrix.useEnvPaths == true && join(matrix.testPaths, ' ') || '' }}
-        run: |
-          # Resolve the file list the same way the test step does
-          if [ -n "$VITEST_TEST_FILES" ]; then
-            files="$VITEST_TEST_FILES"
-            source="VITEST_TEST_FILES env var"
-          else
-            files="${{ join(matrix.testPaths, ' ') }}"
-            source="CLI args"
-          fi
-
-          count=$(echo "$files" | tr ' ' '\n' | grep -c .)
-          echo "Chunk ${{matrix.chunkNumber}} of ${{matrix.allChunksLength}} — $count files via $source"
-          echo "$files" | tr ' ' '\n' | grep . | sort | sed 's/^/  /'
-
-          {
-            echo "## Chunk ${{matrix.chunkNumber}}/${{matrix.allChunksLength}} — \`${{matrix.packageName}}\`"
-            echo "| | |"
-            echo "|---|---|"
-            echo "| Runner | \`${{matrix.runner}}\` / Node v\`${{matrix.nodeVersion}}\` |"
-            echo "| Files | $count (via $source) |"
-            echo ""
-            echo "<details><summary>File list</summary>"
-            echo ""
-            echo '```'
-            echo "$files" | tr ' ' '\n' | grep . | sort
-            echo '```'
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Test ${{matrix.packageName}}
-        timeout-minutes: 25
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
+          FORCE_COLOR: '1'
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
+          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_CLI }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_CLI }}
+          DD_ENV: ci
+          DD_SERVICE: vercel-cli
+          DD_PROFILING_ENABLED: 'false'
+          DD_NATIVE_METRICS: 'false'
         run: |
           attempt=1
           max_attempts=2
           export NODE_OPTIONS="--require=${GITHUB_WORKSPACE}/utils/dd-trace-ci-init.js"
 
           while [ "$attempt" -le "$max_attempts" ]; do
-            echo "Running tests (attempt $attempt/$max_attempts): ${{matrix.testScript}} ${{matrix.packageName}}"
-
-            # When VITEST_TEST_FILES is set, the test script reads paths from that env var
-            # instead of CLI args, avoiding the Windows cmd.exe ~8191 char arg limit.
-            if [ -n "$VITEST_TEST_FILES" ]; then
-              run_cmd="node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir='.turbo' --log-order=stream --filter=${{matrix.packageName}}"
-            else
-              run_cmd="node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir='.turbo' --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}"
-            fi
-
-            if eval "$run_cmd"; then
+            if pnpm turbo run vitest-unit --affected --filter=!vercel --summarize --cache-dir='.turbo' --log-order=stream --continue=always --concurrency=${{ matrix.concurrency }}; then
               exit 0
             fi
 
@@ -371,21 +377,97 @@ jobs:
               exit 1
             fi
 
-            echo "Tests failed; retrying once..."
-            attempt=$((attempt+1))
+            echo "Tests failed; retrying once."
+            attempt=$((attempt + 1))
           done
+
+  cli-unit-test:
+    name: CLI Unit / ${{ matrix.runner }}/node${{ matrix.nodeVersion }} / ${{ matrix.shard }}/7
+    needs: setup
+    timeout-minutes: 120
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
         shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-14, windows-latest]
+        nodeVersion: [20, 22]
+        shard: [1, 2, 3, 4, 5, 6, 7]
+        exclude:
+          - runner: windows-latest
+            nodeVersion: 20
+    env:
+      TURBO_SCM_BASE: ${{ needs.setup.outputs.baseSha }}
+      TURBO_SCM_HEAD: ${{ needs.setup.outputs.headSha }}
+      TURBO_TEST_PLATFORM: ${{ matrix.runner }}-node${{ matrix.nodeVersion }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.setup.outputs.headSha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.nodeVersion }}
+      - name: install turbo@2.10.8
+        run: npm i -g turbo@2.10.8
+      - name: Check for affected CLI unit tests
+        id: affected
+        run: |
+          set -euo pipefail
+          node utils/gen.js
+          count=$(turbo run vitest-unit --affected --filter=vercel --dry=json | jq '[.tasks[] | select(.task == "vitest-unit" and .command != "<NONEXISTENT>")] | length')
+          if [ "$count" -gt 0 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No affected CLI unit-test task."
+          fi
+      - name: Setup Turborepo Remote Cache
+        if: steps.affected.outputs.run == 'true'
+        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
+        with:
+          team: ${{ vars.TURBO_TEAM }}
+      - name: Setup Go toolchain
+        if: steps.affected.outputs.run == 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.23.12'
+          cache: false
+      - name: Setup Rust toolchain
+        if: steps.affected.outputs.run == 'true'
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: '1.96.1'
+          targets: wasm32-wasip2
+      - name: install yarn@1.22.19
+        if: steps.affected.outputs.run == 'true'
+        run: npm i -g yarn@1.22.19
+      - name: install pnpm@10.29.3
+        if: steps.affected.outputs.run == 'true'
+        run: npm i -g pnpm@10.29.3
+      - name: install uv@0.10.11
+        if: steps.affected.outputs.run == 'true'
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.10.11'
+      - run: pnpm install
+        if: steps.affected.outputs.run == 'true'
+      - name: Build affected CLI
+        if: steps.affected.outputs.run == 'true'
+        run: pnpm turbo run build --affected --filter=vercel --summarize --cache-dir='.turbo' --log-order=stream --continue=always
+      - name: Run affected CLI unit tests
+        if: steps.affected.outputs.run == 'true'
+        timeout-minutes: 65
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          TURBO_BASE_SHA: ${{ needs.setup.outputs.baseSha }}
-          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
           FORCE_COLOR: '1'
-          VITEST_TEST_FILES: ${{ matrix.useEnvPaths == true && join(matrix.testPaths, ' ') || '' }}
-          # Datadog Test Optimization: emit per-test spans correlated to the
-          # GitHub Actions job span, replacing the previous post-hoc JUnit
-          # upload. See test/lib/deployment/metrics.js for the legacy
-          # DATADOG_API_KEY consumer (custom transient-error metrics).
           DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
           DD_API_KEY: ${{ secrets.DATADOG_API_KEY_CLI }}
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_CLI }}
@@ -393,6 +475,24 @@ jobs:
           DD_SERVICE: vercel-cli
           DD_PROFILING_ENABLED: 'false'
           DD_NATIVE_METRICS: 'false'
+        run: |
+          attempt=1
+          max_attempts=2
+          export NODE_OPTIONS="--require=${GITHUB_WORKSPACE}/utils/dd-trace-ci-init.js"
+
+          while [ "$attempt" -le "$max_attempts" ]; do
+            if pnpm turbo run vitest-unit --affected --filter=vercel --only --summarize --cache-dir='.turbo' --log-order=stream --continue=always -- --shard=${{ matrix.shard }}/7; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "Tests failed after $max_attempts attempts."
+              exit 1
+            fi
+
+            echo "Tests failed; retrying once."
+            attempt=$((attempt + 1))
+          done
 
   e2e-test:
     timeout-minutes: 120
@@ -589,6 +689,7 @@ jobs:
     needs:
       - setup
       - unit-test
+      - cli-unit-test
       - e2e-test
     permissions:
       statuses: write

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,7 @@
     "test": "vitest run --config ../vitest.config.mts",
     "vitest-run": "vitest -c ../vitest.config.mts",
     "vitest-unit": "pnpm test __tests__/unit/",
-    "vitest-e2e": "glob --absolute '__tests__/integration/'"
+    "vitest-e2e": "pnpm test __tests__/integration/"
   },
   "devDependencies": {
     "@vercel/build-utils": "workspace:*",

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,7 @@
     "test-e2e": "pnpm test __tests__/integration/",
     "test": "vitest run --config ../vitest.config.mts",
     "vitest-run": "vitest -c ../vitest.config.mts",
-    "vitest-unit": "glob --absolute '__tests__/unit/'",
+    "vitest-unit": "pnpm test __tests__/unit/",
     "vitest-e2e": "glob --absolute '__tests__/integration/'"
   },
   "devDependencies": {

--- a/internals/get-package-json/package.json
+++ b/internals/get-package-json/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run --config ../../vitest.config.mts",
     "test-unit": "pnpm test tests/unit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'tests/unit'"
+    "vitest-unit": "pnpm test tests/unit/"
   },
   "devDependencies": {
     "@types/node": "20.11.0",

--- a/internals/ipc-proxy/package.json
+++ b/internals/ipc-proxy/package.json
@@ -15,7 +15,8 @@
     "test": "pnpm test-go && vitest run --config ../../vitest.config.mts",
     "test-go": "go -C bootstrap test ./...",
     "test-unit": "pnpm test",
-    "vitest-run": "vitest -c ../../vitest.config.mts"
+    "vitest-run": "vitest -c ../../vitest.config.mts",
+    "vitest-unit": "pnpm test"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -24,7 +24,7 @@
     "build": "tsdown",
     "vitest-run": "vitest -c ../../vitest.config.mts",
     "vitest": "tsdown && vitest",
-    "vitest-unit": "glob --absolute 'test/unit.*test.ts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit.",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run --config ../../vitest.config.mts",
     "vitest-run": "vitest -c ../../vitest.config.mts",
     "vitest-unit": "pnpm vitest-run --run test/unit.",
-    "vitest-e2e": "glob --absolute 'test/integration*.test.ts'",
+    "vitest-e2e": "pnpm vitest-run --run test/integration",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -14,7 +14,7 @@
     "build": "node build.mjs",
     "test": "vitest run --config ../../vitest.config.mts",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit.*test.ts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit.",
     "vitest-e2e": "glob --absolute 'test/integration*.test.ts'",
     "type-check": "tsc --noEmit"
   },

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -25,7 +25,7 @@
     "test": "pnpm test-unit",
     "test-unit": "pnpm run vitest-run -- test",
     "vitest-run": "vitest run -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/*.test.ts'",
+    "vitest-unit": "pnpm vitest-run --run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -28,7 +28,7 @@
     "build": "node ../../utils/build.mjs",
     "test": "vitest run -c ../../vitest.config.mts",
     "vitest-run": "vitest run -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'tests/*.test.ts'",
+    "vitest-unit": "pnpm vitest-run --run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run --config ./vitest.config.mts",
     "vitest-run": "node scripts/vitest-run.mjs",
     "vitest-unit": "pnpm vitest-run --run test/unit/",
-    "vitest-e2e": "glob --absolute 'test/e2e-*.test.ts'",
+    "vitest-e2e": "pnpm vitest-run --run test/e2e-",
     "test-e2e-node-all-versions": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts test/integration-link-env-pull.test.ts",
     "test-dev": "pnpm test test/dev/",
     "coverage": "codecov",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "vitest run --config ./vitest.config.mts",
     "vitest-run": "node scripts/vitest-run.mjs",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit/",
     "vitest-e2e": "glob --absolute 'test/e2e-*.test.ts'",
     "test-e2e-node-all-versions": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts test/integration-link-env-pull.test.ts",
     "test-dev": "pnpm test test/dev/",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run --config ../../vitest.config.mts",
     "vitest-run": "vitest -c ./vitest.config.mts",
     "vitest-unit": "pnpm vitest-run --run tests/unit.",
-    "vitest-e2e": "glob --absolute 'tests/integration-*.test.ts'",
+    "vitest-e2e": "pnpm vitest-run --run tests/integration-",
     "type-check": "tsc --noEmit"
   },
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../utils/build.mjs",
     "test": "vitest run --config ../../vitest.config.mts",
     "vitest-run": "vitest -c ./vitest.config.mts",
-    "vitest-unit": "glob --absolute 'tests/unit.*.test.ts'",
+    "vitest-unit": "pnpm vitest-run --run tests/unit.",
     "vitest-e2e": "glob --absolute 'tests/integration-*.test.ts'",
     "type-check": "tsc --noEmit"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,7 +37,7 @@
     "build": "tsc",
     "generate-types": "tsx scripts/generate-types.ts",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'src/**/*.test.ts'",
+    "vitest-unit": "pnpm vitest-run --run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -13,7 +13,7 @@
     "build": "node ../../utils/build-builder.mjs",
     "type-check": "tsc --noEmit",
     "test-unit": "vitest run --config ../../vitest.config.mts test/unit.test.ts test/diagnostics.test.ts",
-    "vitest-unit": "glob --absolute 'test/*.test.ts'"
+    "vitest-unit": "pnpm test-unit"
   },
   "files": [
     "dist"

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -21,7 +21,7 @@
     "test-unit": "pnpm test",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/**/*.test.js' 'test/**/*.test.ts' 'test/**/*.test.mjs' 'test/**/*.test.mts' 'tests/**/*.test.js' 'tests/**/*.test.ts'"
+    "vitest-unit": "pnpm test"
   },
   "devDependencies": {
     "@vercel/functions": "workspace:*",

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts' 'test/unit/**/*.test.mts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit/",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/error-utils/package.json
+++ b/packages/error-utils/package.json
@@ -16,7 +16,7 @@
     "build": "node ../../utils/build.mjs",
     "test": "vitest run --config ../../vitest.config.mts --coverage",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/*.test.ts'",
+    "vitest-unit": "pnpm vitest-run --run",
     "type-check": "tsc --noEmit"
   },
   "license": "Apache-2.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts' 'test/unit/**/*.test.mts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit/",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts' 'test/unit/**/*.test.mts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit/",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/firewall/package.json
+++ b/packages/firewall/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "pretest": "pnpm run build:code",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-e2e-node-20": "glob --absolute 'test/e2e/*.test.ts'",
+    "vitest-e2e-node-20": "pnpm vitest-run --run test/e2e/",
     "build": "pnpm run build:code && pnpm run build:docs",
     "build:code": "node ../../utils/build.mjs",
     "build:docs": "typedoc && prettier --write docs/**/*.md docs/*.md"

--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -18,7 +18,7 @@
     "test-unit": "pnpm test",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/**/*.test.js' 'test/**/*.test.ts' 'test/**/*.test.mjs' 'test/**/*.test.mts' 'tests/**/*.test.js' 'tests/**/*.test.ts'"
+    "vitest-unit": "pnpm test"
   },
   "dependencies": {
     "smol-toml": "1.5.2",

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -21,7 +21,7 @@
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
     "vitest-unit": "pnpm test test/unit.",
-    "vitest-e2e": "glob --absolute 'test/integration.test.ts'"
+    "vitest-e2e": "pnpm test test/integration.test.ts"
   },
   "dependencies": {
     "@vercel/build-utils": "workspace:*",

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -20,7 +20,7 @@
     "test-e2e": "pnpm test test/integration.test.ts",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit.*test.*'",
+    "vitest-unit": "pnpm test test/unit.",
     "vitest-e2e": "glob --absolute 'test/integration.test.ts'"
   },
   "dependencies": {

--- a/packages/gatsby-plugin-vercel-builder/package.json
+++ b/packages/gatsby-plugin-vercel-builder/package.json
@@ -18,7 +18,7 @@
     "test-unit": "pnpm test test/unit.*test.*",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit.*test.*'"
+    "vitest-unit": "pnpm test test/unit."
   },
   "dependencies": {
     "@sinclair/typebox": "0.25.24",

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -15,7 +15,7 @@
     "test-e2e": "pnpm test test/integration-*",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-e2e": "glob --absolute 'test/integration-*'"
+    "vitest-e2e": "pnpm test test/integration-"
   },
   "files": [
     "dist",

--- a/packages/h3/package.json
+++ b/packages/h3/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts' 'test/unit/**/*.test.mts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit/",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts' 'test/unit/**/*.test.mts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit/",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run --config ../../vitest.config.mts",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-e2e": "glob --absolute 'test/test.js'"
+    "vitest-e2e": "pnpm test test/test.js"
   },
   "files": [
     "dist",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts' 'test/unit/**/*.test.mts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit/",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts' 'test/unit/**/*.test.mts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit/",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -15,7 +15,7 @@
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
     "vitest-unit": "pnpm test test/unit/",
-    "vitest-e2e": "glob --absolute 'test/fixtures/**/*.test.js'"
+    "vitest-e2e": "pnpm test-e2e"
   },
   "repository": {
     "type": "git",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -14,7 +14,7 @@
     "test-e2e": "rm -f test/builder-info.json; pnpm test test/fixtures/**/*.test.js",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/'",
+    "vitest-unit": "pnpm test test/unit/",
     "vitest-e2e": "glob --absolute 'test/fixtures/**/*.test.js'"
   },
   "repository": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -15,7 +15,7 @@
     "test-e2e": "pnpm test test/integration",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit/**/*.test.ts' 'test/unit/**/*.test.mts'",
+    "vitest-unit": "pnpm test test/unit/",
     "vitest-e2e": "glob --absolute 'test/integration'"
   },
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,7 +16,7 @@
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
     "vitest-unit": "pnpm test test/unit/",
-    "vitest-e2e": "glob --absolute 'test/integration'"
+    "vitest-e2e": "pnpm test test/integration"
   },
   "files": [
     "dist"

--- a/packages/python-analysis/package.json
+++ b/packages/python-analysis/package.json
@@ -34,7 +34,7 @@
     "generate:schemas": "ts-to-zod --all",
     "test": "vitest run --config ../../vitest.config.mts",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/*.test.ts'",
+    "vitest-unit": "pnpm vitest-run --run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -20,7 +20,7 @@
     "test-unit": "vitest run --config ../../vitest.config.mts test/unit",
     "test-e2e": "pnpm test test/integration-*",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit.*test.ts'",
+    "vitest-unit": "pnpm test test/unit",
     "vitest-e2e": "glob --absolute 'test/integration-*'"
   },
   "dependencies": {

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -21,7 +21,7 @@
     "test-e2e": "pnpm test test/integration-*",
     "vitest-run": "vitest -c ../../vitest.config.mts",
     "vitest-unit": "pnpm test test/unit",
-    "vitest-e2e": "glob --absolute 'test/integration-*'"
+    "vitest-e2e": "pnpm test test/integration-"
   },
   "dependencies": {
     "@vercel/python-analysis": "workspace:*"

--- a/packages/python/turbo.json
+++ b/packages/python/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turborepo.org/schema.json",
   "extends": ["//"],
   "tasks": {
+    "vitest-e2e": {
+      "env": ["VERCEL_RUNTIME_PYTHON", "VERCEL_WORKERS_PYTHON"]
+    },
     "test-e2e": {
       "env": ["VERCEL_RUNTIME_PYTHON", "VERCEL_WORKERS_PYTHON"]
     }

--- a/packages/related-projects/package.json
+++ b/packages/related-projects/package.json
@@ -18,7 +18,7 @@
     "test-unit": "pnpm test",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/**/*.test.js' 'test/**/*.test.ts' 'test/**/*.test.mjs' 'test/**/*.test.mts' 'tests/**/*.test.js' 'tests/**/*.test.ts'"
+    "vitest-unit": "pnpm test"
   },
   "devDependencies": {
     "@types/node": "20.11.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run --config ../../vitest.config.mts",
     "vitest-run": "vitest -c ../../vitest.config.mts",
     "vitest-unit": "pnpm vitest-run --run test/unit.",
-    "vitest-e2e": "glob --absolute 'test/integration-*.test.ts'",
+    "vitest-e2e": "pnpm vitest-run --run test/integration-",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -14,7 +14,7 @@
     "build": "node ../../utils/build-builder.mjs",
     "test": "vitest run --config ../../vitest.config.mts",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/unit.*.test.ts'",
+    "vitest-unit": "pnpm vitest-run --run test/unit.",
     "vitest-e2e": "glob --absolute 'test/integration-*.test.ts'",
     "type-check": "tsc --noEmit"
   },

--- a/packages/routing-utils/package.json
+++ b/packages/routing-utils/package.json
@@ -19,7 +19,7 @@
     "test-unit": "pnpm test",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/**/*.test.js' 'test/**/*.test.ts' 'test/**/*.test.mjs' 'test/**/*.test.mts' 'tests/**/*.test.js' 'tests/**/*.test.ts'"
+    "vitest-unit": "pnpm test"
   },
   "dependencies": {
     "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -22,7 +22,7 @@
     "test-e2e": "pnpm test",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-e2e": "glob --absolute 'test/**/*.test.js' 'test/**/*.test.ts' 'tests/**/*.test.js' 'tests/**/*.test.ts'"
+    "vitest-e2e": "pnpm test"
   },
   "devDependencies": {
     "@types/fs-extra": "8.0.0",

--- a/packages/rust/package.json
+++ b/packages/rust/package.json
@@ -15,7 +15,7 @@
     "test-e2e": "pnpm test",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-e2e": "glob --absolute 'test/**/*.test.js' 'test/**/*.test.ts' 'tests/**/*.test.js' 'tests/**/*.test.ts'"
+    "vitest-e2e": "pnpm test"
   },
   "files": [
     "dist"

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -19,7 +19,7 @@
     "test-e2e": "pnpm test test/integration-*.test.js",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/build.test.ts' 'test/hugo.test.ts' 'test/gatsby.test.ts' 'test/prepare-cache.test.ts'",
+    "vitest-unit": "pnpm test test/build.test.ts test/hugo.test.ts test/gatsby.test.ts test/prepare-cache.test.ts",
     "vitest-e2e": "glob --absolute 'test/integration-*.test.js'"
   },
   "dependencies": {

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -20,7 +20,7 @@
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
     "vitest-unit": "pnpm test test/build.test.ts test/hugo.test.ts test/gatsby.test.ts test/prepare-cache.test.ts",
-    "vitest-e2e": "glob --absolute 'test/integration-*.test.js'"
+    "vitest-e2e": "pnpm test test/integration-"
   },
   "dependencies": {
     "@vercel/gatsby-plugin-vercel-analytics": "workspace:*",

--- a/packages/static-config/package.json
+++ b/packages/static-config/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run --config ../../vitest.config.mts",
     "type-check": "tsc --noEmit",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/**/*.test.js' 'test/**/*.test.ts' 'test/**/*.test.mjs' 'test/**/*.test.mts' 'tests/**/*.test.js' 'tests/**/*.test.ts'"
+    "vitest-unit": "pnpm test"
   },
   "files": [
     "dist"

--- a/packages/vc-native/package.json
+++ b/packages/vc-native/package.json
@@ -13,7 +13,7 @@
     "build": "node scripts/stage-packages.mjs --check-sources",
     "test": "vitest run --config ../../vitest.config.mts test/*.test.mjs",
     "vitest-run": "vitest run --config ../../vitest.config.mts",
-    "vitest-unit": "glob --absolute 'test/*.test.mjs'",
+    "vitest-unit": "pnpm vitest-run --run",
     "type-check": "echo 'No type-check needed for vc-native staging package'"
   },
   "files": [

--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,7 @@
     },
     "test-e2e-node-all-versions": {
       "dependsOn": ["build"],
+      "env": ["TURBO_TEST_PLATFORM"],
       "outputLogs": "new-only"
     },
     "test-unit": {
@@ -50,6 +51,7 @@
     },
     "test-dev": {
       "dependsOn": ["build"],
+      "env": ["TURBO_TEST_PLATFORM"],
       "outputLogs": "new-only"
     },
     "test-cli": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,16 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "globalDependencies": [
+    ".github/workflows/**",
+    "packages/build-utils/src/**",
+    "packages/cli/scripts/start.js",
+    "pnpm-lock.yaml",
     "turbo-cache-key.json",
     "package.json",
     "test/lib/**",
-    "utils/build.mjs"
+    "utils/**/*.js",
+    "utils/**/*.mjs",
+    "vitest.config.mts"
   ],
   "envMode": "loose",
   "tasks": {
@@ -15,6 +21,7 @@
     },
     "vitest-unit": {
       "dependsOn": ["build"],
+      "env": ["TURBO_TEST_PLATFORM"],
       "outputLogs": "new-only"
     },
     "vitest-unit-node-24": {


### PR DESCRIPTION
## Summary

- Make package E2E lane scripts executable Turborepo tasks.
- Run E2E lanes with native `--affected` package selection.
- Restore the Next.js fixture suite through `vitest-e2e`.
- Preserve CLI integration coverage on Node.js 20, 22, and 24 and CLI development coverage on Linux and macOS.
- Hash multi-runtime E2E lanes by OS and Node.js version.
- Keep legacy E2E execution and transition reporting disabled until the cleanup layer removes them.

## Verification

- Confirmed 14 primary E2E tasks and one task in each specialized lane.
- Confirmed the Next.js E2E task resolves to `pnpm test-e2e`.
- Confirmed multi-runtime task hashes differ across Node.js and platform lanes.
- Confirmed the transitional planner still completes in unit and E2E modes.
- Passed workflow YAML parsing, focused formatting checks, and the repository pre-commit hook.

## Stack

This is PR 3 of 5. It is stacked on #17368.