### PR TITLE
feat(cli): experimental Cursor agent in coding-agents setup

### DIFF
--- a/.changeset/cursor-coding-agent-setup.md
+++ b/.changeset/cursor-coding-agent-setup.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add experimental Cursor support to `vercel ai-gateway coding-agents setup`. Cursor stores its BYOK settings in its own account-synced store, so setup provisions the AI Gateway key into the shell environment and walks through the manual steps in Cursor's Models settings (base URL override, adding gateway model ids), instead of writing config files. Select it explicitly with `--agent cursor`.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/cursor.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/cursor.ts
@@ -1,0 +1,53 @@
+import { join } from 'node:path';
+import type { CodingAgent } from '../types';
+import { pathExists } from '../config-files';
+
+/**
+ * Cursor stores its BYOK credential and base-URL override in its own
+ * account-synced store (not a local config file the CLI can safely write),
+ * so this agent provisions the key and walks the user through Cursor's
+ * Models settings instead of editing files. The key lands in the shell
+ * environment (Keychain-backed where available) so the user can copy it
+ * without it ever being printed.
+ *
+ * The base URL below targets the gateway's Cursor compatibility surface
+ * (`/v1/cursor/chat/completions`), which normalizes the Responses-shaped
+ * payloads and Anthropic-style tool definitions Cursor sends.
+ *
+ * Known Cursor limitations (theirs, not ours): BYOK requests route through
+ * Cursor's backend, Tab completions never use BYOK, and Agent/Auto modes may
+ * bypass the override.
+ */
+const CURSOR_BASE_URL = 'https://ai-gateway.vercel.sh/v1/cursor';
+
+export const cursor: CodingAgent = {
+  id: 'cursor',
+  displayName: 'Cursor',
+  experimental: true,
+
+  async detect(home) {
+    return pathExists(join(home, '.cursor'));
+  },
+
+  configPath(ctx) {
+    // Cursor has no CLI-writable config; this anchors detection/overrides.
+    return ctx.overrides?.['cursor'] ?? join(ctx.home, '.cursor');
+  },
+
+  buildPlan(ctx) {
+    return {
+      fileChanges: [],
+      envExports: [{ name: 'AI_GATEWAY_API_KEY', value: ctx.apiKey }],
+      notes: [
+        'Cursor keeps its API-key settings in the app itself, so finish the setup there:',
+        '1. Open Cursor → Settings (Cmd+Shift+J) → Models.',
+        `2. Under OpenAI API Key: paste your gateway key, then enable "Override OpenAI Base URL" and set it to ${ctx.baseUrlOverride ?? CURSOR_BASE_URL}`,
+        '3. Copy the key from a new terminal without echoing it: printf %s "$AI_GATEWAY_API_KEY" | pbcopy',
+        '4. Use "Add model" to add gateway model ids you want in the picker (e.g. anthropic/claude-fable-5, openai/gpt-5.6-sol).',
+        "While the override is on, Cursor's built-in non-OpenAI models stop working — use gateway model ids for everything, or toggle the override off to go back.",
+        'Cursor chats are stored by its backend, so there are no local sessions to migrate.',
+        'Cursor limitations: Tab completions never use custom keys, and Agent/Auto modes may bypass the override.',
+      ],
+    };
+  },
+};

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -1,10 +1,17 @@
 import type { CodingAgent } from '../types';
 import { claudeCode } from './claude-code';
 import { codex } from './codex';
+import { cursor } from './cursor';
 import { opencode } from './opencode';
 import { pi } from './pi';
 
-export const CODING_AGENTS: CodingAgent[] = [claudeCode, codex, opencode, pi];
+export const CODING_AGENTS: CodingAgent[] = [
+  claudeCode,
+  codex,
+  cursor,
+  opencode,
+  pi,
+];
 
 export const DEFAULT_AGENTS = CODING_AGENTS.filter(a => !a.experimental);
 
@@ -12,7 +19,6 @@ export function getAgentById(id: string): CodingAgent | undefined {
   return CODING_AGENTS.find(a => a.id === id);
 }
 
-export const UNSUPPORTED_AGENTS: Record<string, string> = {
-  cursor:
-    'Cursor stores model settings in a SQLite database with no safely writable config, and its "Override OpenAI Base URL" GUI option is known to break other models. Set the base URL to https://ai-gateway.vercel.sh/v1 manually in Settings → Models if you want to try it.',
-};
+// Agents we deliberately do not support, with the reason shown to users.
+// (Cursor graduated to an experimental guided setup — see agents/cursor.ts.)
+export const UNSUPPORTED_AGENTS: Record<string, string> = {};

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -252,6 +252,48 @@ describe('ai-gateway coding-agents setup', () => {
       }
     );
 
+    // Cursor keeps BYOK settings in its own store, so setup is guidance-only:
+    // provision the key into the shell environment and emit manual steps.
+    it.skipIf(process.platform === 'win32')(
+      'configures Cursor with a shell export and manual-steps notes only',
+      async () => {
+        useUser();
+        client.nonInteractive = true;
+        mkdirSync(join(home, '.cursor'), { recursive: true });
+        client.setArgv(
+          'ai-gateway',
+          'coding-agents',
+          'setup',
+          '--key',
+          'vck_DummyKey0002',
+          '--agent',
+          'cursor'
+        );
+
+        const exitCode = await aiGateway(client);
+        expect(exitCode).toBe(0);
+
+        const bashrc = readFileSync(bashrcPath(), 'utf8');
+        expect(bashrc).toContain(
+          "export AI_GATEWAY_API_KEY='vck_DummyKey0002'"
+        );
+        // Guidance-only: nothing is written into Cursor's own directory.
+        expect(readdirSync(join(home, '.cursor'))).toEqual([]);
+
+        const out = JSON.parse(client.stdout.getFullOutput());
+        expect(out.status).toBe('ok');
+        const notes: string[] = out.notes ?? [];
+        expect(notes.some(n => n.includes('Override OpenAI Base URL'))).toBe(
+          true
+        );
+        expect(
+          notes.some(n => n.includes('ai-gateway.vercel.sh/v1/cursor'))
+        ).toBe(true);
+        // The key itself must never appear in notes.
+        expect(notes.every(n => !n.includes('vck_DummyKey0002'))).toBe(true);
+      }
+    );
+
     it('writes a --base-url override verbatim into the Codex config', async () => {
       useUser();
       client.nonInteractive = true;


### PR DESCRIPTION
Graduates Cursor off the UNSUPPORTED_AGENTS list into an experimental guidance-mode agent (smrth's ask 7/31: cursor integration in the CLI for coding-agents setup).

**Why guidance-mode:** Cursor keeps BYOK settings in its account-synced store — no local config the CLI can safely write (the reason it was unsupported). Setup provisions the key (Keychain-backed shell export, never printed) and emits exact steps for Cursor's Models UI: override base URL → `https://ai-gateway.vercel.sh/v1/cursor`, add gateway model ids, plus the known Cursor caveats (Tab never uses BYOK; the override disables built-in non-OpenAI models).

**Pairs with** vercel/ai-gateway#2382 (the `/v1/cursor` endpoint — rebased + tool-calling/streaming fixes landed, all checks green). Until that merges the notes point at a surface that 404s in prod, hence **draft**.

- `experimental: true` — excluded from auto-detection; explicit `--agent cursor` only
- No sessionMigration (chats live in Cursor's backend)
- Tests: guidance-only invariants (shell export present, Cursor dir untouched, key never in notes)
- Stacked on #17303 · **Stack continues:** #17370 (kilo) → #17371 (cline) → #17372 (command-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)