### PR TITLE
feat(cli): experimental Kilo Code agent in coding-agents setup

### DIFF
--- a/.changeset/kilo-coding-agent.md
+++ b/.changeset/kilo-coding-agent.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add an experimental Kilo Code agent to `vercel ai-gateway coding-agents setup`. Writes an `openai-compatible` provider to `~/.config/kilo/kilo.json` using Kilo's `{env:AI_GATEWAY_API_KEY}` substitution so the key never lands in the file; the model picker auto-populates from the gateway's `/v1/models`. Select it explicitly with `--agent kilo`.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -2,6 +2,7 @@ import type { CodingAgent } from '../types';
 import { claudeCode } from './claude-code';
 import { codex } from './codex';
 import { cursor } from './cursor';
+import { kilo } from './kilo';
 import { opencode } from './opencode';
 import { pi } from './pi';
 
@@ -9,6 +10,7 @@ export const CODING_AGENTS: CodingAgent[] = [
   claudeCode,
   codex,
   cursor,
+  kilo,
   opencode,
   pi,
 ];

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/kilo.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/kilo.ts
@@ -1,0 +1,68 @@
+import { join } from 'node:path';
+import type { CodingAgent } from '../types';
+import { mergeJson, pathExists } from '../config-files';
+
+/**
+ * Kilo Code's CLI reads a global config at `~/.config/kilo/kilo.json[c]`
+ * (an OpenCode fork, but with its own provider registry). We add the
+ * gateway as an `openai-compatible` provider. The `{env:VAR}` reference is
+ * Kilo's own substitution syntax, resolved only for configs in trusted
+ * locations (the global config is one), so the key never lands in the file —
+ * it stays in the shell environment we export.
+ *
+ * Kilo auto-fetches the model list from the base URL's /models endpoint, so
+ * no per-model declarations are needed; users pick with /models in a session.
+ *
+ * Docs: https://kilo.ai/docs/ai-providers/openai-compatible
+ */
+function kiloConfigDir(home: string): string {
+  return join(home, '.config', 'kilo');
+}
+
+export const kilo: CodingAgent = {
+  id: 'kilo',
+  displayName: 'Kilo Code',
+  experimental: true,
+
+  async detect(home) {
+    return pathExists(kiloConfigDir(home));
+  },
+
+  configPath(ctx) {
+    return (
+      ctx.overrides?.['kilo'] ?? join(kiloConfigDir(ctx.home), 'kilo.json')
+    );
+  },
+
+  buildPlan(ctx) {
+    const path = this.configPath(ctx);
+    const baseURL = ctx.baseUrlOverride ?? 'https://ai-gateway.vercel.sh/v1';
+    return {
+      fileChanges: [
+        {
+          path,
+          label: 'Kilo Code config',
+          format: 'json',
+          transform: current =>
+            mergeJson(current, {
+              provider: {
+                'openai-compatible': {
+                  options: {
+                    // Kilo resolves {env:…} itself; the literal key never
+                    // enters the file.
+                    apiKey: '{env:AI_GATEWAY_API_KEY}',
+                    baseURL,
+                  },
+                },
+              },
+            }),
+        },
+      ],
+      envExports: [{ name: 'AI_GATEWAY_API_KEY', value: ctx.apiKey }],
+      notes: [
+        'Kilo Code lists the gateway catalog automatically — pick a model with /models in a session (ids look like openai-compatible/anthropic/claude-fable-5).',
+        'If you keep your Kilo config in kilo.jsonc instead of kilo.json, merge the new provider block into it manually.',
+      ],
+    };
+  },
+};

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -294,6 +294,36 @@ describe('ai-gateway coding-agents setup', () => {
       }
     );
 
+    it('configures Kilo Code with an env-referenced openai-compatible provider', async () => {
+      useUser();
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.config', 'kilo'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0002',
+        '--agent',
+        'kilo'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const raw = readFileSync(
+        join(home, '.config', 'kilo', 'kilo.json'),
+        'utf8'
+      );
+      const config = JSON.parse(raw);
+      expect(config.provider['openai-compatible'].options).toEqual({
+        apiKey: '{env:AI_GATEWAY_API_KEY}',
+        baseURL: 'https://ai-gateway.vercel.sh/v1',
+      });
+      // Kilo substitutes {env:…} itself — the literal key stays out of the file.
+      expect(raw).not.toContain('vck_DummyKey0002');
+    });
+
     it('writes a --base-url override verbatim into the Codex config', async () => {
       useUser();
       client.nonInteractive = true;


### PR DESCRIPTION
Adds Kilo Code (`--agent kilo`) to coding-agents setup — the file-mode agent of the new batch (smrth's ask 8/1), following the opencode/pi pattern.

- Writes an `openai-compatible` provider to `~/.config/kilo/kilo.json` with `apiKey: "{env:AI_GATEWAY_API_KEY}"` — Kilo resolves the env reference itself (trusted global config), so the literal key never lands in the file (test-enforced)
- Models auto-populate from the gateway's `/v1/models` — no per-model declarations
- Experimental: never auto-selected
- Sandbox-verified: config written correctly, key absent from file
- Stacked on #17365 (cursor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)