### PR TITLE
feat(cli): experimental Cline agent in coding-agents setup

### DIFF
--- a/.changeset/cline-coding-agent.md
+++ b/.changeset/cline-coding-agent.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add an experimental Cline agent to `vercel ai-gateway coding-agents setup`. Writes Cline's first-party `vercel-ai-gateway` provider entry in `~/.cline/data/settings/providers.json` (the same 0600 file `cline auth` manages), preserving any existing schema version and provider entries. Select it explicitly with `--agent cline`.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/cline.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/cline.ts
@@ -1,0 +1,71 @@
+import { join } from 'node:path';
+import type { CodingAgent } from '../types';
+import { mergeJson, pathExists } from '../config-files';
+
+/**
+ * Cline's CLI keeps provider settings in `~/.cline/data/settings/providers.json`
+ * (versioned JSON, mode 0600 — the same file its own `cline auth` command
+ * writes; the settings dir nests inside the data dir). Cline ships a
+ * first-party `vercel-ai-gateway` provider, so we write that entry (no base
+ * URL needed — the provider knows the endpoint; `--base-url` overrides don't
+ * apply here) and make it the last-used provider, matching what Cline's own
+ * interactive picker saves.
+ *
+ * `version` is only stamped on newly created files so an existing store's
+ * schema version is never downgraded.
+ */
+const DEFAULT_MODEL = 'anthropic/claude-fable-5';
+
+export const cline: CodingAgent = {
+  id: 'cline',
+  displayName: 'Cline',
+  experimental: true,
+
+  async detect(home) {
+    return pathExists(join(home, '.cline'));
+  },
+
+  configPath(ctx) {
+    return (
+      ctx.overrides?.['cline'] ??
+      join(ctx.home, '.cline', 'data', 'settings', 'providers.json')
+    );
+  },
+
+  buildPlan(ctx) {
+    const path = this.configPath(ctx);
+    return {
+      fileChanges: [
+        {
+          path,
+          label: 'Cline providers',
+          format: 'json',
+          mode: 0o600,
+          transform: current => {
+            const isNew = !current || !current.trim();
+            return mergeJson(current, {
+              ...(isNew ? { version: 1 } : {}),
+              lastUsedProvider: 'vercel-ai-gateway',
+              providers: {
+                'vercel-ai-gateway': {
+                  settings: {
+                    provider: 'vercel-ai-gateway',
+                    apiKey: ctx.apiKey,
+                    model: DEFAULT_MODEL,
+                  },
+                  updatedAt: new Date().toISOString(),
+                  tokenSource: 'manual',
+                },
+              },
+            });
+          },
+        },
+      ],
+      envExports: [],
+      notes: [
+        `Cline will use its native Vercel AI Gateway provider with ${DEFAULT_MODEL}; switch models in-session or with \`cline auth -p vercel-ai-gateway -m <gateway-model-id>\`.`,
+        'In the VS Code extension, pick the Vercel AI Gateway provider under Settings → API Provider.',
+      ],
+    };
+  },
+};

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -1,5 +1,6 @@
 import type { CodingAgent } from '../types';
 import { claudeCode } from './claude-code';
+import { cline } from './cline';
 import { codex } from './codex';
 import { cursor } from './cursor';
 import { kilo } from './kilo';
@@ -8,6 +9,7 @@ import { pi } from './pi';
 
 export const CODING_AGENTS: CodingAgent[] = [
   claudeCode,
+  cline,
   codex,
   cursor,
   kilo,

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -324,6 +324,84 @@ describe('ai-gateway coding-agents setup', () => {
       expect(raw).not.toContain('vck_DummyKey0002');
     });
 
+    it('configures Cline via its providers.json (0600), version only when new', async () => {
+      useUser();
+      client.nonInteractive = true;
+      mkdirSync(join(home, '.cline'), { recursive: true });
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0002',
+        '--agent',
+        'cline'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const providersPath = join(
+        home,
+        '.cline',
+        'data',
+        'settings',
+        'providers.json'
+      );
+      const config = JSON.parse(readFileSync(providersPath, 'utf8'));
+      expect(config.version).toBe(1);
+      expect(config.lastUsedProvider).toBe('vercel-ai-gateway');
+      expect(config.providers['vercel-ai-gateway'].settings).toMatchObject({
+        provider: 'vercel-ai-gateway',
+        apiKey: 'vck_DummyKey0002',
+      });
+      expect(config.providers['vercel-ai-gateway'].tokenSource).toBe('manual');
+      if (process.platform !== 'win32') {
+        expect(statSync(providersPath).mode & 0o777).toBe(0o600);
+      }
+    });
+
+    it('preserves an existing providers.json schema version for Cline', async () => {
+      useUser();
+      client.nonInteractive = true;
+      const settingsDir = join(home, '.cline', 'data', 'settings');
+      mkdirSync(settingsDir, { recursive: true });
+      writeFileSync(
+        join(settingsDir, 'providers.json'),
+        JSON.stringify({
+          version: 2,
+          lastUsedProvider: 'anthropic',
+          providers: {
+            anthropic: { settings: { provider: 'anthropic' } },
+          },
+        })
+      );
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0002',
+        '--agent',
+        'cline'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const config = JSON.parse(
+        readFileSync(join(settingsDir, 'providers.json'), 'utf8')
+      );
+      // Never downgrade another tool's schema version.
+      expect(config.version).toBe(2);
+      // Existing provider entries survive alongside the new one.
+      expect(config.providers.anthropic).toBeDefined();
+      expect(config.providers['vercel-ai-gateway'].settings.apiKey).toBe(
+        'vck_DummyKey0002'
+      );
+      expect(config.lastUsedProvider).toBe('vercel-ai-gateway');
+    });
+
     it('writes a --base-url override verbatim into the Codex config', async () => {
       useUser();
       client.nonInteractive = true;


### PR DESCRIPTION
Adds Cline (`--agent cline`) to coding-agents setup — file-mode via **Cline's first-party `vercel-ai-gateway` provider** (discovered during live testing: Cline ships native gateway support in its provider picker).

- Writes the `vercel-ai-gateway` entry in `~/.cline/data/settings/providers.json` (0600) — shape verified against a live cline 3.0.48 configuration created through Cline's own interactive picker; the settings dir nests inside Cline's data dir
- No base URL — the native provider knows the endpoint
- Never downgrades the store's schema `version` (only stamped on new files) and preserves existing provider entries — test-enforced
- Defaults to `anthropic/claude-fable-5`; switch in-session or `cline auth -p vercel-ai-gateway -m <id>`
- **Live-verified end-to-end**: Cline (native gateway provider) billed `google/gemini-3.6-flash` through the gateway with the full catalog visible in its model browser
- Experimental: never auto-selected
- Stacked on #17370 (kilo) → #17365 (cursor)

Side intel from testing: Cline's own first-party "Cline Usage-Billing" backend appears to run on Vercel AI Gateway (its error bodies are the gateway's exact 404 format), and its free-tier default slug `qwen/qwen3.8-max` 404s against the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)