### PR TITLE
feat(cli): guided unsupported entry for command-code

### DIFF
--- a/.changeset/command-code-unsupported.md
+++ b/.changeset/command-code-unsupported.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vercel ai-gateway coding-agents setup --agent command-code` now explains why Command Code can't be configured (no external-provider mechanism; custom providers require a ProviderModule mod) instead of failing with a bare error. Unsupported-agent reasons also surface when they're the only agents selected.

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/index.ts
@@ -25,4 +25,7 @@ export function getAgentById(id: string): CodingAgent | undefined {
 
 // Agents we deliberately do not support, with the reason shown to users.
 // (Cursor graduated to an experimental guided setup — see agents/cursor.ts.)
-export const UNSUPPORTED_AGENTS: Record<string, string> = {};
+export const UNSUPPORTED_AGENTS: Record<string, string> = {
+  'command-code':
+    "Command Code routes inference through its own subscription API and has no external-provider override (no base-URL env vars and no declarative provider config — verified against the shipped CLI bundle). Custom providers require a ProviderModule mod through its plugin seam; until there's a vercel-ai-gateway mod, it can't use the AI Gateway.",
+};

--- a/packages/cli/src/util/ai-gateway/coding-agents/resolve.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/resolve.ts
@@ -44,8 +44,11 @@ export async function resolveAgents(args: {
       };
     }
     if (selected.length === 0) {
+      // When everything the user named is unsupported, the reasons are the
+      // only actionable output — surface them instead of a bare error.
+      const why = guidance.length > 0 ? ` ${guidance.join(' ')}` : '';
       return {
-        error: 'No configurable agents selected.',
+        error: `No configurable agents selected.${why}`,
         reason: AGENT_REASON.INVALID_ARGUMENTS,
       };
     }

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -402,6 +402,39 @@ describe('ai-gateway coding-agents setup', () => {
       expect(config.lastUsedProvider).toBe('vercel-ai-gateway');
     });
 
+    it('explains why command-code is unsupported instead of erroring as unknown', async () => {
+      useUser();
+      client.nonInteractive = true;
+      // The mock throws to simulate process.exit terminating; assert on the
+      // spy and the emitted payload rather than the return value.
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+        _code?: number
+      ) => {
+        throw new Error('exit');
+      }) as () => never);
+      try {
+        client.setArgv(
+          'ai-gateway',
+          'coding-agents',
+          'setup',
+          '--key',
+          'vck_DummyKey0002',
+          '--agent',
+          'command-code'
+        );
+        await aiGateway(client).catch(() => {});
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        const out = JSON.parse(client.stdout.getFullOutput());
+        expect(out.status).toBe('error');
+        // Unsupported (with the why) — not treated as a typo of a known agent.
+        expect(out.message).toContain('ProviderModule mod');
+        expect(out.message).not.toContain('Unknown agent');
+      } finally {
+        exitSpy.mockRestore();
+      }
+    });
+
     it('writes a --base-url override verbatim into the Codex config', async () => {
       useUser();
       client.nonInteractive = true;


### PR DESCRIPTION
Answers the third of smrth's three agents (8/1): **Command Code can't use the AI Gateway today**, and now the CLI says so precisely.

Findings (verified against the shipped `command-code@1.9.0` npm bundle, not just docs):
- No base-URL environment overrides (no `OPENAI_BASE_URL`-style escape hatch)
- No declarative custom-provider config — the `providers` settings key only tunes built-ins
- Custom model providers go through its **ProviderModule mod seam** (`cmd.addProvider`), same interface as its first-party providers, publicly undocumented

Changes:
- `UNSUPPORTED_AGENTS['command-code']` with the reason
- resolve.ts fix: unsupported reasons now surface even when they're the only agents selected (was a bare "No configurable agents selected.")

Follow-up (separate): ship a `vercel-ai-gateway` ProviderModule mod to close the gap.

Stacked on #17371 (cline) → #17370 (kilo) → #17365 (cursor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)