### PR TITLE
fix(cli): build linux native on manylinux_2_28, fall back on glibc mismatch

### DIFF
--- a/.changeset/native-binary-glibc-compat.md
+++ b/.changeset/native-binary-glibc-compat.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Build the linux native CLI Node runtime on manylinux_2_28 so the published binary stays at glibc ≤ 2.28 (runs on Amazon Linux 2023 / Vercel Sandboxes). Also fall back to the JS CLI when the native binary fails to load (e.g. GLIBC version mismatch).

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -54,6 +54,10 @@ jobs:
             custom_node_path: ''
             custom_node_platform: ''
             custom_node_arch: ''
+          # Linux Node is compiled inside manylinux_2_28 so the published ELF
+          # stays at glibc <= 2.28 (matches official Node; runs on AL2023 /
+          # Vercel Sandboxes with glibc 2.34). Building on ubuntu-latest
+          # previously produced GLIBC_2.38 and broke those hosts.
           - runs-on: ubuntu-latest-32-core-arm-oss
             target: node24.14.1-linux-arm64
             asset: vercel-linux-arm64
@@ -63,6 +67,7 @@ jobs:
             custom_node_path: .node-runtime/node-v24.14.1-linux-arm64-small-icu/bin/node
             custom_node_platform: linux
             custom_node_arch: arm64
+            manylinux_image: quay.io/pypa/manylinux_2_28_aarch64
           - runs-on: ubuntu-latest-32-core-oss
             target: node24.14.1-linux-x64
             asset: vercel-linux-x64
@@ -72,6 +77,7 @@ jobs:
             custom_node_path: .node-runtime/node-v24.14.1-linux-x64-small-icu/bin/node
             custom_node_platform: linux
             custom_node_arch: x64
+            manylinux_image: quay.io/pypa/manylinux_2_28_x86_64
           # Node 24.14.1 does not build with Clang 22 on the VS 2026 image.
           # windows-latest migrated to VS 2026 in June 2026, so use the
           # stable VS 2022/LLVM 20 toolchain until the embedded Node source
@@ -135,24 +141,57 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Linux build tools
-        if: ${{ matrix.custom_node_platform == 'linux' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
-
       - name: Build workspace packages
         run: pnpm build
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Build custom Node runtime
-        if: ${{ matrix.custom_node_path != '' }}
+        if: ${{ matrix.custom_node_path != '' && matrix.custom_node_platform != 'linux' }}
         env:
           VERCEL_CLI_NODE_VERSION: 24.14.1
           VERCEL_CLI_NODE_PLATFORM: ${{ matrix.custom_node_platform }}
           VERCEL_CLI_NODE_ARCH: ${{ matrix.custom_node_arch }}
         run: pnpm turbo --no-update-notifier --root-turbo-json turbo.node-runtime.json run //#build-binary-node --output-logs=new-only
+
+      # Compile the pruned Node on manylinux_2_28 so the final vercel ELF's
+      # glibc floor stays at 2.28 (ubuntu-latest hosts produce 2.38+).
+      - name: Build custom Node runtime (manylinux)
+        if: ${{ matrix.custom_node_platform == 'linux' }}
+        env:
+          VERCEL_CLI_NODE_VERSION: 24.14.1
+          VERCEL_CLI_NODE_PLATFORM: linux
+          VERCEL_CLI_NODE_ARCH: ${{ matrix.custom_node_arch }}
+          MANYLINUX_IMAGE: ${{ matrix.manylinux_image }}
+        run: |
+          set -euo pipefail
+          case "${VERCEL_CLI_NODE_ARCH}" in
+            x64) NODE_DIST_ARCH=x64 ;;
+            arm64) NODE_DIST_ARCH=arm64 ;;
+            *)
+              echo "::error::Unsupported VERCEL_CLI_NODE_ARCH=${VERCEL_CLI_NODE_ARCH}"
+              exit 1
+              ;;
+          esac
+
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
+            -e VERCEL_CLI_NODE_VERSION \
+            -e VERCEL_CLI_NODE_PLATFORM \
+            -e VERCEL_CLI_NODE_ARCH \
+            -e TMPDIR=/tmp \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -w /work \
+            "$MANYLINUX_IMAGE" \
+            bash -lc "
+              set -euo pipefail
+              curl -fsSL \"https://nodejs.org/dist/v\${VERCEL_CLI_NODE_VERSION}/node-v\${VERCEL_CLI_NODE_VERSION}-linux-${NODE_DIST_ARCH}.tar.gz\" \
+                | tar -xz -C /tmp
+              export PATH=\"/tmp/node-v\${VERCEL_CLI_NODE_VERSION}-linux-${NODE_DIST_ARCH}/bin:\$PATH\"
+              node --version
+              node packages/cli/scripts/build-binary-node.mjs
+            "
 
       - name: Build binary
         working-directory: packages/cli
@@ -160,6 +199,14 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           VERCEL_CLI_BINARY_NODE_PATH: ${{ matrix.custom_node_path }}
         run: node scripts/build-binary.mjs --target ${{ matrix.target }} --compress Brotli --output ./dist-bin/${{ matrix.asset }}${{ matrix.ext }}
+
+      - name: Verify linux binary glibc ceiling
+        if: ${{ matrix.custom_node_platform == 'linux' }}
+        working-directory: packages/cli
+        run: |
+          set -euo pipefail
+          bin="dist-bin/${{ matrix.asset }}${{ matrix.ext }}"
+          node scripts/check-binary-glibc.mjs "$bin" 2.28
 
       - name: Smoke test binary before signing
         shell: bash

--- a/packages/cli/scripts/check-binary-glibc.mjs
+++ b/packages/cli/scripts/check-binary-glibc.mjs
@@ -1,0 +1,73 @@
+// Fail if a linux ELF requires a newer glibc than the supported ceiling.
+// Used in release-binary.yml so we never publish a native CLI that cannot run
+// on Vercel Sandboxes (Amazon Linux 2023 / glibc 2.34) or other older hosts.
+//
+// Usage: node scripts/check-binary-glibc.mjs <binary> [maxGlibc]
+// Default maxGlibc is 2.28 (manylinux_2_28 / official Node linux builds).
+
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const binPath = resolve(process.argv[2] ?? '');
+const maxGlibc = process.argv[3] ?? '2.28';
+
+if (!binPath) {
+  console.error('Usage: node scripts/check-binary-glibc.mjs <binary> [maxGlibc]');
+  process.exit(2);
+}
+
+const result = spawnSync('strings', [binPath], {
+  encoding: 'utf8',
+  maxBuffer: 128 * 1024 * 1024,
+});
+
+if (result.error) {
+  console.error(`Failed to scan ${binPath}: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  console.error(
+    `strings exited ${result.status} for ${binPath}:\n${result.stderr || ''}`
+  );
+  process.exit(1);
+}
+
+const versions = new Set();
+for (const match of result.stdout.matchAll(/GLIBC_(\d+\.\d+)/g)) {
+  versions.add(match[1]);
+}
+
+if (versions.size === 0) {
+  console.error(`No GLIBC_* version symbols found in ${binPath}`);
+  process.exit(1);
+}
+
+const sorted = [...versions].sort(compareGlibc);
+const highest = sorted[sorted.length - 1];
+
+console.log(
+  `${binPath}: glibc symbols ${sorted.join(', ')} (highest ${highest})`
+);
+
+if (compareGlibc(highest, maxGlibc) > 0) {
+  console.error(
+    `::error::${binPath} requires GLIBC_${highest}, which exceeds the ` +
+      `supported ceiling GLIBC_${maxGlibc}. Rebuild the embedded Node runtime ` +
+      `on an older glibc baseline (e.g. manylinux_2_28).`
+  );
+  process.exit(1);
+}
+
+console.log(`OK: highest GLIBC_${highest} <= ceiling GLIBC_${maxGlibc}`);
+
+function compareGlibc(left, right) {
+  const a = left.split('.').map(Number);
+  const b = right.split('.').map(Number);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -87,7 +87,7 @@ function isNativeLoaderFailure(result) {
       result.error.code === 'ENOEXEC'
     );
   }
-  const text = `${result.stderr || ''}`;
+  const text = `${result.stderr || ''}${result.stdout || ''}`;
   return (
     /version [`']GLIBC_[\d.]+[`'] not found/i.test(text) ||
     /GLIBC_[\d.]+[`'] not found/i.test(text) ||
@@ -95,35 +95,51 @@ function isNativeLoaderFailure(result) {
   );
 }
 
+// Probe with a short --version spawn (piped, bounded output) so we can detect
+// glibc/loader failures without piping stderr for the real command — that
+// would hit Node's default 1 MiB maxBuffer on verbose/long-running CLIs.
+function canRunNativeBinary(binPath) {
+  const probe = spawnSync(binPath, ['--version'], {
+    encoding: 'utf8',
+    timeout: 30_000,
+    maxBuffer: 1024 * 1024,
+    windowsHide: true,
+  });
+  return !isNativeLoaderFailure(probe);
+}
+
 const bin = resolveNative();
 
 if (bin && (await isNativeBinaryOptedIn())) {
   process.env.VERCEL_VC_NATIVE = '1';
-  // Pipe stderr so we can detect loader/glibc failures and fall back to JS
-  // without surfacing the dynamic-linker noise. Stdin/stdout stay inherited
-  // so interactive and long-running commands still stream.
-  const r = spawnSync(bin, process.argv.slice(2), {
-    encoding: 'utf8',
-    stdio: ['inherit', 'inherit', 'pipe'],
-    windowsHide: true,
-  });
-  if (isNativeLoaderFailure(r)) {
+  if (!canRunNativeBinary(bin)) {
     delete process.env.VERCEL_VC_NATIVE;
     // fall through to JS
   } else {
-    if (r.stderr) {
-      process.stderr.write(r.stderr);
+    const r = spawnSync(bin, process.argv.slice(2), {
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+    if (
+      r.error &&
+      (r.error.code === 'ENOENT' ||
+        r.error.code === 'EACCES' ||
+        r.error.code === 'ENOEXEC')
+    ) {
+      delete process.env.VERCEL_VC_NATIVE;
+      // fall through to JS
+    } else {
+      if (r.error) {
+        console.error(r.error.message);
+        process.exit(1);
+      }
+      if (r.signal) {
+        try {
+          process.kill(process.pid, r.signal);
+        } catch {}
+      }
+      process.exit(r.status ?? 1);
     }
-    if (r.error) {
-      console.error(r.error.message);
-      process.exit(1);
-    }
-    if (r.signal) {
-      try {
-        process.kill(process.pid, r.signal);
-      } catch {}
-    }
-    process.exit(r.status ?? 1);
   }
 }
 

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -77,18 +77,43 @@ async function isNativeBinaryOptedIn() {
   }
 }
 
+// Dynamic-linker / missing-binary failures should fall through to JS instead of
+// hard-failing (e.g. a linux binary built against a newer glibc than the host).
+function isNativeLoaderFailure(result) {
+  if (result.error) {
+    return (
+      result.error.code === 'ENOENT' ||
+      result.error.code === 'EACCES' ||
+      result.error.code === 'ENOEXEC'
+    );
+  }
+  const text = `${result.stderr || ''}`;
+  return (
+    /version [`']GLIBC_[\d.]+[`'] not found/i.test(text) ||
+    /GLIBC_[\d.]+[`'] not found/i.test(text) ||
+    /error while loading shared libraries/i.test(text)
+  );
+}
+
 const bin = resolveNative();
 
 if (bin && (await isNativeBinaryOptedIn())) {
   process.env.VERCEL_VC_NATIVE = '1';
+  // Pipe stderr so we can detect loader/glibc failures and fall back to JS
+  // without surfacing the dynamic-linker noise. Stdin/stdout stay inherited
+  // so interactive and long-running commands still stream.
   const r = spawnSync(bin, process.argv.slice(2), {
-    stdio: 'inherit',
+    encoding: 'utf8',
+    stdio: ['inherit', 'inherit', 'pipe'],
     windowsHide: true,
   });
-  if (r.error && (r.error.code === 'ENOENT' || r.error.code === 'EACCES')) {
+  if (isNativeLoaderFailure(r)) {
     delete process.env.VERCEL_VC_NATIVE;
     // fall through to JS
   } else {
+    if (r.stderr) {
+      process.stderr.write(r.stderr);
+    }
     if (r.error) {
       console.error(r.error.message);
       process.exit(1);

--- a/packages/cli/test/unit/esm/native-trampoline.test.ts
+++ b/packages/cli/test/unit/esm/native-trampoline.test.ts
@@ -222,6 +222,7 @@ describe('dist/vc.js native resolution', () => {
       const { vcJs } = buildInstall({
         platform: process.platform,
         arch: process.arch,
+        // Probe runs `native --version`; linker-style stderr must trigger fallback.
         body:
           '#!/bin/sh\n' +
           'echo "version \'GLIBC_2.38\' not found (required by native)" >&2\n' +

--- a/packages/cli/test/unit/esm/native-trampoline.test.ts
+++ b/packages/cli/test/unit/esm/native-trampoline.test.ts
@@ -215,4 +215,26 @@ describe('dist/vc.js native resolution', () => {
       expect(r.stderr).not.toContain('(native)');
     }
   );
+
+  it.runIf(process.platform !== 'win32')(
+    'falls through to JS when the native binary fails with a glibc loader error',
+    () => {
+      const { vcJs } = buildInstall({
+        platform: process.platform,
+        arch: process.arch,
+        body:
+          '#!/bin/sh\n' +
+          'echo "version \'GLIBC_2.38\' not found (required by native)" >&2\n' +
+          'exit 127\n',
+      });
+      const r = spawnSync(process.execPath, [vcJs, '--version'], {
+        encoding: 'utf8',
+        env: optInEnv(),
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe(cliVersion);
+      expect(r.stderr).not.toContain('(native)');
+      expect(r.stderr).not.toContain('GLIBC_2.38');
+    }
+  );
 });

--- a/turbo.node-runtime.json
+++ b/turbo.node-runtime.json
@@ -7,6 +7,7 @@
         ".github/workflows/release-binary.yml",
         "turbo.node-runtime.json",
         "packages/cli/scripts/build-binary-node.mjs",
+        "packages/cli/scripts/check-binary-glibc.mjs",
         "packages/cli/scripts/patch-node-source.mjs"
       ],
       "outputs": ["packages/cli/.node-runtime/**"],


### PR DESCRIPTION
Compile the embedded Node runtime for linux binaries inside manylinux_2_28 so the published ELF stays at glibc <= 2.28 (Vercel Sandboxes / AL2023 are 2.34). Also fall through to the JS CLI when the native binary fails to load due to a dynamic-linker / glibc error instead of hard-failing.