### PR TITLE
[cli] Add --team-level flag to vercel firewall commands

### DIFF
--- a/.changeset/firewall-team-level.md
+++ b/.changeset/firewall-team-level.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `--team-level` flag to `vercel firewall` rules, ip-blocks, diff, publish, and discard commands for managing the team-level firewall configuration, which applies to every project in the team. Requires an Enterprise plan and team owner role; no linked project is needed.

--- a/packages/cli/src/commands/firewall/command.ts
+++ b/packages/cli/src/commands/firewall/command.ts
@@ -1,6 +1,15 @@
 import { packageName } from '../../util/pkg-name';
 import { projectOption, yesOption } from '../../util/arg-common';
 
+export const teamLevelOption = {
+  name: 'team-level',
+  shorthand: null,
+  type: Boolean,
+  deprecated: false,
+  description:
+    'Operate on the team-level firewall configuration, which applies to every project in the team. No linked project required. Cannot be combined with --project',
+} as const;
+
 export const overviewSubcommand = {
   name: 'overview',
   aliases: [],
@@ -33,6 +42,7 @@ export const diffSubcommand = {
   arguments: [],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'json',
       shorthand: null,
@@ -46,6 +56,10 @@ export const diffSubcommand = {
       name: 'Show unpublished changes',
       value: `${packageName} firewall diff`,
     },
+    {
+      name: 'Show unpublished team-level changes',
+      value: `${packageName} firewall diff --team-level`,
+    },
   ],
 } as const;
 
@@ -55,7 +69,7 @@ export const publishSubcommand = {
   description:
     'Publish all draft firewall changes to production, making them live immediately',
   arguments: [],
-  options: [projectOption, yesOption],
+  options: [projectOption, teamLevelOption, yesOption],
   examples: [
     {
       name: 'Publish draft changes',
@@ -64,6 +78,10 @@ export const publishSubcommand = {
     {
       name: 'Publish without confirmation',
       value: `${packageName} firewall publish --yes`,
+    },
+    {
+      name: 'Publish team-level draft changes',
+      value: `${packageName} firewall publish --team-level`,
     },
   ],
 } as const;
@@ -74,7 +92,7 @@ export const discardSubcommand = {
   description:
     'Permanently discard all unpublished draft changes, reverting to the current production configuration',
   arguments: [],
-  options: [projectOption, yesOption],
+  options: [projectOption, teamLevelOption, yesOption],
   examples: [
     {
       name: 'Discard draft changes',
@@ -210,6 +228,7 @@ export const ipBlocksListSubcommand = {
   arguments: [],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'json',
       shorthand: null,
@@ -234,6 +253,7 @@ export const ipBlocksBlockSubcommand = {
   arguments: [{ name: 'ip', required: true }],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'hostname',
       shorthand: null,
@@ -275,6 +295,7 @@ export const ipBlocksUnblockSubcommand = {
   arguments: [{ name: 'id-or-ip', required: true }],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'hostname',
       shorthand: null,
@@ -340,6 +361,7 @@ export const rulesListSubcommand = {
   arguments: [],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'expand',
       shorthand: 'e',
@@ -364,6 +386,10 @@ export const rulesListSubcommand = {
       name: 'List rules with full condition details',
       value: `${packageName} firewall rules list --expand`,
     },
+    {
+      name: 'List team-level rules',
+      value: `${packageName} firewall rules list --team-level`,
+    },
   ],
 } as const;
 
@@ -375,6 +401,7 @@ export const rulesInspectSubcommand = {
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'json',
       shorthand: null,
@@ -403,6 +430,7 @@ export const rulesAddSubcommand = {
   arguments: [{ name: 'name', required: false }],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'ai',
       shorthand: null,
@@ -549,6 +577,7 @@ export const rulesEditSubcommand = {
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'ai',
       shorthand: null,
@@ -703,7 +732,7 @@ export const rulesEnableSubcommand = {
   description:
     'Enable a disabled custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [projectOption, yesOption],
+  options: [projectOption, teamLevelOption, yesOption],
   examples: [
     {
       name: 'Enable a rule',
@@ -718,7 +747,7 @@ export const rulesDisableSubcommand = {
   description:
     'Disable a custom firewall rule without removing it. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [projectOption, yesOption],
+  options: [projectOption, teamLevelOption, yesOption],
   examples: [
     {
       name: 'Disable a rule',
@@ -733,7 +762,7 @@ export const rulesRemoveSubcommand = {
   description:
     'Remove a custom firewall rule. Stages a draft change — run `publish` to make it live',
   arguments: [{ name: 'name-or-id', required: true }],
-  options: [projectOption, yesOption],
+  options: [projectOption, teamLevelOption, yesOption],
   examples: [
     {
       name: 'Remove a rule',
@@ -750,6 +779,7 @@ export const rulesReorderSubcommand = {
   arguments: [{ name: 'name-or-id', required: true }],
   options: [
     projectOption,
+    teamLevelOption,
     {
       name: 'position',
       shorthand: null,

--- a/packages/cli/src/commands/firewall/diff.ts
+++ b/packages/cli/src/commands/firewall/diff.ts
@@ -1,9 +1,14 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { diffSubcommand } from './command';
-import { parseSubcommandArgs, outputJson, withGlobalFlags } from './shared';
+import {
+  parseSubcommandArgs,
+  outputJson,
+  withGlobalFlags,
+  resolveFirewallScope,
+  mapFirewallApiError,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import { formatDiffOutput } from '../../util/firewall/format';
 import { outputAgentError } from '../../util/agent-output';
@@ -12,22 +17,13 @@ export default async function diff(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, diffSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
-
-  output.spinner(`Fetching draft changes for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching draft changes for ${chalk.bold(scope.displayName)}`);
 
   try {
-    const { active, draft } = await listFirewallConfigs(client, project.id, {
-      teamId,
-    });
+    const { active, draft } = await listFirewallConfigs(client, scope);
 
     if (!draft || draft.changes.length === 0) {
       if (parsed.flags['--json']) {
@@ -52,19 +48,18 @@ export default async function diff(client: Client, argv: string[]) {
     output.print(formatDiffOutput(draft.changes, activeRulesMap));
     output.print('\n\n');
     output.print(
-      `  Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard'))} to discard.\n\n`
+      `  Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish', scope))} to publish, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard', scope))} to discard.\n\n`
     );
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to fetch draft changes';
+    const msg = mapFirewallApiError(e, scope, 'Failed to fetch draft changes');
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
         reason: 'api_error',
         message: msg,
-        next: [{ command: withGlobalFlags(client, 'firewall diff') }],
+        next: [{ command: withGlobalFlags(client, 'firewall diff', scope) }],
       });
       process.exit(1);
       return 1;

--- a/packages/cli/src/commands/firewall/discard.ts
+++ b/packages/cli/src/commands/firewall/discard.ts
@@ -1,9 +1,14 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { discardSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction, withGlobalFlags } from './shared';
+import {
+  parseSubcommandArgs,
+  confirmAction,
+  withGlobalFlags,
+  resolveFirewallScope,
+  mapFirewallApiError,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import deleteFirewallDraft from '../../util/firewall/delete-firewall-draft';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -14,22 +19,13 @@ export default async function discard(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, discardSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
-
-  output.spinner(`Fetching draft changes for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching draft changes for ${chalk.bold(scope.displayName)}`);
 
   try {
-    const { active, draft } = await listFirewallConfigs(client, project.id, {
-      teamId,
-    });
+    const { active, draft } = await listFirewallConfigs(client, scope);
 
     if (!draft || draft.changes.length === 0) {
       output.warn('No draft changes to discard.');
@@ -59,7 +55,7 @@ export default async function discard(client: Client, argv: string[]) {
     const updateStamp = stamp();
     output.spinner('Discarding draft changes');
 
-    await deleteFirewallDraft(client, project.id, { teamId });
+    await deleteFirewallDraft(client, scope);
 
     output.log(
       `${chalk.cyan('Success!')} Draft changes discarded ${chalk.gray(updateStamp())}`
@@ -67,14 +63,19 @@ export default async function discard(client: Client, argv: string[]) {
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to discard draft changes';
+    const msg = mapFirewallApiError(
+      e,
+      scope,
+      'Failed to discard draft changes'
+    );
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
         reason: 'api_error',
         message: msg,
-        next: [{ command: withGlobalFlags(client, 'firewall discard --yes') }],
+        next: [
+          { command: withGlobalFlags(client, 'firewall discard --yes', scope) },
+        ],
       });
       process.exit(1);
       return 1;

--- a/packages/cli/src/commands/firewall/index.ts
+++ b/packages/cli/src/commands/firewall/index.ts
@@ -86,6 +86,7 @@ export default async function main(client: Client) {
 
   if (subcommand && !needHelp) {
     telemetry.trackCliOptionProject(getProjectOptionFromArgs(args));
+    telemetry.trackCliFlagTeamLevel(args.includes('--team-level'));
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/firewall/ip-blocks/block.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/block.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { ipBlocksBlockSubcommand } from '../command';
 import {
@@ -9,6 +8,8 @@ import {
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import {
@@ -63,15 +64,8 @@ export default async function block(client: Client, argv: string[]) {
     }
   }
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
-
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
   const hostnameLabel =
     hostname === '*' || hostname === '' ? 'all hosts' : hostname;
@@ -90,41 +84,30 @@ export default async function block(client: Client, argv: string[]) {
   output.spinner('Staging IP block rule');
 
   try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+    const hadExistingDraft = await detectExistingDraft(client, scope);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'ip.insert',
-        id: null,
-        value: {
-          ip,
-          hostname,
-          action: 'deny',
-          ...(notes ? { notes } : {}),
-        },
+    await patchFirewallDraft(client, scope, {
+      action: 'ip.insert',
+      id: null,
+      value: {
+        ip,
+        hostname,
+        action: 'deny',
+        ...(notes ? { notes } : {}),
       },
-      { teamId }
-    );
+    });
 
     output.log(
       `${chalk.cyan('Success!')} IP block for ${chalk.bold(ip)} on ${chalk.bold(hostnameLabel)} staged ${chalk.gray(blockStamp())}`
     );
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: parsed.flags['--yes'],
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to stage IP block rule';
+    const msg = mapFirewallApiError(e, scope, 'Failed to stage IP block rule');
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -134,7 +117,8 @@ export default async function block(client: Client, argv: string[]) {
           {
             command: withGlobalFlags(
               client,
-              `firewall ip-blocks block ${ip}${hostname !== '*' ? ` --hostname ${hostname}` : ''} --yes`
+              `firewall ip-blocks block ${ip}${hostname !== '*' ? ` --hostname ${hostname}` : ''} --yes`,
+              scope
             ),
           },
         ],

--- a/packages/cli/src/commands/firewall/ip-blocks/list.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/list.ts
@@ -1,9 +1,14 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { ipBlocksListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson, withGlobalFlags } from '../shared';
+import {
+  parseSubcommandArgs,
+  outputJson,
+  withGlobalFlags,
+  resolveFirewallScope,
+  mapFirewallApiError,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateIpRules,
@@ -20,22 +25,15 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
+
+  output.spinner(
+    `Fetching IP blocking rules for ${chalk.bold(scope.displayName)}`
   );
-  if (typeof link === 'number') return link;
-
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
-
-  output.spinner(`Fetching IP blocking rules for ${chalk.bold(project.name)}`);
 
   try {
-    const { active, draft } = await listFirewallConfigs(client, project.id, {
-      teamId,
-    });
+    const { active, draft } = await listFirewallConfigs(client, scope);
 
     const activeIps = active?.ips || [];
     const draftIps = draft?.ips || null;
@@ -66,7 +64,7 @@ export default async function list(client: Client, argv: string[]) {
     const ipChanges = changes.filter(c => c.action.startsWith('ip.')).length;
     if (ipChanges > 0) {
       output.print(
-        `\n  ${chalk.yellow(`${ipChanges} unpublished IP block change${ipChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish.\n`
+        `\n  ${chalk.yellow(`${ipChanges} unpublished IP block change${ipChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish', scope))} to publish.\n`
       );
     } else {
       output.print(`\n  ${chalk.dim('Showing live configuration.')}\n`);
@@ -75,8 +73,11 @@ export default async function list(client: Client, argv: string[]) {
     output.print('\n');
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to fetch IP blocking rules';
+    const msg = mapFirewallApiError(
+      e,
+      scope,
+      'Failed to fetch IP blocking rules'
+    );
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -84,7 +85,7 @@ export default async function list(client: Client, argv: string[]) {
         message: msg,
         next: [
           {
-            command: withGlobalFlags(client, 'firewall ip-blocks list'),
+            command: withGlobalFlags(client, 'firewall ip-blocks list', scope),
           },
         ],
       });

--- a/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
+++ b/packages/cli/src/commands/firewall/ip-blocks/unblock.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { ipBlocksUnblockSubcommand } from '../command';
 import {
@@ -9,6 +8,8 @@ import {
   confirmAction,
   offerAutoPublish,
   resolveIpRule,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
@@ -30,22 +31,15 @@ export default async function unblock(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
+
+  output.spinner(
+    `Fetching IP blocking rules for ${chalk.bold(scope.displayName)}`
   );
-  if (typeof link === 'number') return link;
-
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
-
-  output.spinner(`Fetching IP blocking rules for ${chalk.bold(project.name)}`);
 
   try {
-    const { active, draft } = await listFirewallConfigs(client, project.id, {
-      teamId,
-    });
+    const { active, draft } = await listFirewallConfigs(client, scope);
 
     // Resolve against draft (if exists) or active — draft includes draft-added rules
     const currentIps = draft?.ips || active?.ips || [];
@@ -64,7 +58,7 @@ export default async function unblock(client: Client, argv: string[]) {
 
     if (matches.length === 0) {
       output.error(
-        `No IP block found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall ip-blocks list'))} to view all rules.`
+        `No IP block found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall ip-blocks list', scope))} to view all rules.`
       );
       return 1;
     }
@@ -85,7 +79,8 @@ export default async function unblock(client: Client, argv: string[]) {
               next: matches.map(r => ({
                 command: withGlobalFlags(
                   client,
-                  `firewall ip-blocks unblock "${identifier}" --hostname "${r.hostname}" --yes`
+                  `firewall ip-blocks unblock "${identifier}" --hostname "${r.hostname}" --yes`,
+                  scope
                 ),
                 when: `unblock on ${r.hostname === '*' ? 'all hosts' : r.hostname}`,
               })),
@@ -139,30 +134,27 @@ export default async function unblock(client: Client, argv: string[]) {
     // Use the draft data we already fetched (avoid a second API call)
     const hadExistingDraft = draft !== null && draft.changes.length > 0;
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'ip.remove',
-        id: rule.id,
-        value: null,
-      },
-      { teamId }
-    );
+    await patchFirewallDraft(client, scope, {
+      action: 'ip.remove',
+      id: rule.id,
+      value: null,
+    });
 
     output.log(
       `${chalk.cyan('Success!')} IP block removal for ${chalk.bold(rule.ip)} staged ${chalk.gray(unblockStamp())}`
     );
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: parsed.flags['--yes'],
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to stage IP block removal';
+    const msg = mapFirewallApiError(
+      e,
+      scope,
+      'Failed to stage IP block removal'
+    );
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -172,7 +164,8 @@ export default async function unblock(client: Client, argv: string[]) {
           {
             command: withGlobalFlags(
               client,
-              `firewall ip-blocks unblock ${identifier} --yes`
+              `firewall ip-blocks unblock ${identifier} --yes`,
+              scope
             ),
           },
         ],

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -5,6 +5,7 @@ import output from '../../output-manager';
 import { overviewSubcommand } from './command';
 import { parseSubcommandArgs, outputJson, withGlobalFlags } from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
+import { projectScope } from '../../util/firewall/scope';
 import getBypass from '../../util/firewall/get-bypass';
 import {
   formatStatusOutput,
@@ -31,7 +32,7 @@ export default async function overview(client: Client, argv: string[]) {
 
   try {
     const [configList, bypassList, freshProject] = await Promise.all([
-      listFirewallConfigs(client, project.id, { teamId }),
+      listFirewallConfigs(client, projectScope(project, teamId)),
       getBypass(client, project.id, { teamId }),
       client.fetch<ProjectSecurityResponse>(
         `/v9/projects/${encodeURIComponent(project.id)}`,

--- a/packages/cli/src/commands/firewall/publish.ts
+++ b/packages/cli/src/commands/firewall/publish.ts
@@ -1,9 +1,14 @@
 import chalk from 'chalk';
 import type Client from '../../util/client';
-import { requireProjectContext } from '../../util/projects/require-project-context';
 import output from '../../output-manager';
 import { publishSubcommand } from './command';
-import { parseSubcommandArgs, confirmAction, withGlobalFlags } from './shared';
+import {
+  parseSubcommandArgs,
+  confirmAction,
+  withGlobalFlags,
+  resolveFirewallScope,
+  mapFirewallApiError,
+} from './shared';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
 import { formatDiffOutput } from '../../util/firewall/format';
@@ -14,22 +19,13 @@ export default async function publish(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, publishSubcommand, client);
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
-
-  output.spinner(`Fetching draft changes for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching draft changes for ${chalk.bold(scope.displayName)}`);
 
   try {
-    const { active, draft } = await listFirewallConfigs(client, project.id, {
-      teamId,
-    });
+    const { active, draft } = await listFirewallConfigs(client, scope);
 
     if (!draft || draft.changes.length === 0) {
       output.warn('No draft changes to publish.');
@@ -48,7 +44,9 @@ export default async function publish(client: Client, argv: string[]) {
       client,
       parsed.flags['--yes'],
       'Publish these changes to production?',
-      `This will make them live for ${chalk.bold(project.name)}.`
+      scope.type === 'team'
+        ? `This will make them live team-wide for ${chalk.bold(scope.displayName)}.`
+        : `This will make them live for ${chalk.bold(scope.displayName)}.`
     );
 
     if (!confirmed) {
@@ -59,7 +57,7 @@ export default async function publish(client: Client, argv: string[]) {
     const updateStamp = stamp();
     output.spinner('Publishing to production');
 
-    await activateFirewallConfig(client, project.id, 'draft', { teamId });
+    await activateFirewallConfig(client, scope, 'draft');
 
     output.log(
       `${chalk.cyan('Success!')} Firewall config published to production ${chalk.gray(updateStamp())}`
@@ -67,14 +65,19 @@ export default async function publish(client: Client, argv: string[]) {
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to publish firewall config';
+    const msg = mapFirewallApiError(
+      e,
+      scope,
+      'Failed to publish firewall config'
+    );
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
         reason: 'api_error',
         message: msg,
-        next: [{ command: withGlobalFlags(client, 'firewall publish --yes') }],
+        next: [
+          { command: withGlobalFlags(client, 'firewall publish --yes', scope) },
+        ],
       });
       process.exit(1);
       return 1;

--- a/packages/cli/src/commands/firewall/rules/add-ai.ts
+++ b/packages/cli/src/commands/firewall/rules/add-ai.ts
@@ -9,6 +9,7 @@ import {
 } from '../shared';
 import { outputAgentError } from '../../../util/agent-output';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
+import { projectScope } from '../../../util/firewall/scope';
 import generateFirewallRule from '../../../util/firewall/generate-firewall-rule';
 import { formatRuleExpanded } from '../../../util/firewall/format';
 import type { FirewallRule } from '../../../util/firewall/types';
@@ -339,37 +340,29 @@ async function createFromGenerated(
   const createStamp = stamp();
   output.spinner('Staging rule');
 
-  try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+  const scope = projectScope(project, teamId);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'rules.insert',
-        id: null,
-        value: {
-          name: rule.name,
-          description: rule.description,
-          active: rule.active !== false,
-          conditionGroup: rule.conditionGroup,
-          action: rule.action,
-        },
+  try {
+    const hadExistingDraft = await detectExistingDraft(client, scope);
+
+    await patchFirewallDraft(client, scope, {
+      action: 'rules.insert',
+      id: null,
+      value: {
+        name: rule.name,
+        description: rule.description,
+        active: rule.active !== false,
+        conditionGroup: rule.conditionGroup,
+        action: rule.action,
       },
-      { teamId }
-    );
+    });
 
     output.log(
       `${chalk.cyan('Success!')} Rule "${chalk.bold(rule.name)}" staged ${chalk.gray(createStamp())}`
     );
     printActionImpactWarning(rule.action);
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: opts.skipPrompts,
     });
 

--- a/packages/cli/src/commands/firewall/rules/add-interactive.ts
+++ b/packages/cli/src/commands/firewall/rules/add-interactive.ts
@@ -6,7 +6,9 @@ import {
   detectExistingDraft,
   offerAutoPublish,
   printActionImpactWarning,
+  mapFirewallApiError,
 } from '../shared';
+import type { FirewallScope } from '../../../util/firewall/scope';
 import {
   fetchPlanInfo,
   getAvailableConditionTypes,
@@ -42,8 +44,7 @@ interface AddInteractiveOptions {
 
 export async function addInteractive(
   client: Client,
-  project: { id: string; name: string },
-  teamId: string | undefined,
+  scope: FirewallScope,
   opts: AddInteractiveOptions = {}
 ): Promise<number> {
   const pre = opts.prePopulated;
@@ -109,43 +110,32 @@ export async function addInteractive(
   output.spinner('Staging rule');
 
   try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+    const hadExistingDraft = await detectExistingDraft(client, scope);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'rules.insert',
-        id: null,
-        value: {
-          name,
-          description: description || undefined,
-          active,
-          conditionGroup: conditionGroups,
-          action,
-        },
+    await patchFirewallDraft(client, scope, {
+      action: 'rules.insert',
+      id: null,
+      value: {
+        name,
+        description: description || undefined,
+        active,
+        conditionGroup: conditionGroups,
+        action,
       },
-      { teamId }
-    );
+    });
 
     output.log(
       `${chalk.cyan('Success!')} Rule "${chalk.bold(name)}" staged ${chalk.gray(createStamp())}`
     );
     printActionImpactWarning(action);
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: opts.skipPrompts,
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    output.error(error.message || 'Failed to stage rule');
+    output.error(mapFirewallApiError(e, scope, 'Failed to stage rule'));
     return 1;
   }
 }

--- a/packages/cli/src/commands/firewall/rules/add.ts
+++ b/packages/cli/src/commands/firewall/rules/add.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesAddSubcommand } from '../command';
 import {
@@ -10,6 +9,8 @@ import {
   detectExistingDraft,
   offerAutoPublish,
   printActionImpactWarning,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
 import { parseConditionFlags } from '../../../util/firewall/parse-conditions';
@@ -54,6 +55,14 @@ export default async function add(client: Client, argv: string[]) {
 
   // Mode dispatch
   if (aiPrompt) {
+    // AI generation is project-only (its endpoint requires a project)
+    if (parsed.flags['--team-level']) {
+      output.error(
+        'AI mode is not available with --team-level. Use --json or --condition flags instead.'
+      );
+      return 1;
+    }
+
     // AI mode — blocked for agents/non-interactive (AI output requires human review)
     if (client.nonInteractive || !client.stdin.isTTY) {
       if (client.nonInteractive) {
@@ -87,19 +96,24 @@ export default async function add(client: Client, argv: string[]) {
     }
 
     // AI mode
-    const link = await requireProjectContext(
+    const scope = await resolveFirewallScope(client, parsed.flags);
+    if (typeof scope === 'number') return scope;
+    if (scope.type === 'team') {
+      output.error(
+        'AI mode is not available with --team-level. Use --json or --condition flags instead.'
+      );
+      return 1;
+    }
+    return handleAIAdd(
       client,
-      'firewall',
-      parsed.flags['--project']
+      { id: scope.projectId, name: scope.displayName },
+      scope.teamId,
+      {
+        prompt: aiPrompt,
+        name: parsed.args[0],
+        skipPrompts: !!parsed.flags['--yes'],
+      }
     );
-    if (typeof link === 'number') return link;
-    const { project, org } = link;
-    const teamId = org.type === 'team' ? org.id : undefined;
-    return handleAIAdd(client, project, teamId, {
-      prompt: aiPrompt,
-      name: parsed.args[0],
-      skipPrompts: !!parsed.flags['--yes'],
-    });
   }
 
   if (jsonInput) {
@@ -114,14 +128,21 @@ export default async function add(client: Client, argv: string[]) {
 
   // No mode specified — interactive or error
   if (client.stdin.isTTY && !client.nonInteractive) {
-    // Interactive mode: offer AI vs manual choice
+    const scope = await resolveFirewallScope(client, parsed.flags);
+    if (typeof scope === 'number') return scope;
+
+    // Interactive mode: offer AI vs manual choice (AI is project-only)
     const mode = await client.input.select({
       message: 'How would you like to create the rule?',
       choices: [
-        {
-          value: 'ai',
-          name: 'Describe what you want (AI-powered)',
-        },
+        ...(scope.type === 'project'
+          ? [
+              {
+                value: 'ai',
+                name: 'Describe what you want (AI-powered)',
+              },
+            ]
+          : []),
         {
           value: 'manual',
           name: 'Build manually (step by step)',
@@ -133,19 +154,15 @@ export default async function add(client: Client, argv: string[]) {
       ],
     });
 
-    const link = await requireProjectContext(
-      client,
-      'firewall',
-      parsed.flags['--project']
-    );
-    if (typeof link === 'number') return link;
-    const { project, org } = link;
-    const teamId = org.type === 'team' ? org.id : undefined;
-
-    if (mode === 'ai') {
-      return handleAIAdd(client, project, teamId, {
-        skipPrompts: false,
-      });
+    if (mode === 'ai' && scope.type === 'project') {
+      return handleAIAdd(
+        client,
+        { id: scope.projectId, name: scope.displayName },
+        scope.teamId,
+        {
+          skipPrompts: false,
+        }
+      );
     }
 
     if (mode === 'json') {
@@ -156,7 +173,7 @@ export default async function add(client: Client, argv: string[]) {
     }
 
     // Manual interactive mode
-    return addInteractive(client, project, teamId, {
+    return addInteractive(client, scope, {
       skipPrompts: !!parsed.flags['--yes'],
     });
   }
@@ -406,16 +423,11 @@ async function createRule(
   parsed: { args: string[]; flags: Record<string, unknown> },
   rule: Omit<FirewallRule, 'id'>
 ): Promise<number> {
-  const projectName = parsed.flags['--project'];
-  const link = await requireProjectContext(
+  const scope = await resolveFirewallScope(
     client,
-    'firewall',
-    typeof projectName === 'string' ? projectName : undefined
+    parsed.flags as { '--project'?: string; '--team-level'?: boolean }
   );
-  if (typeof link === 'number') return link;
-
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
+  if (typeof scope === 'number') return scope;
 
   // Show preview and confirm
   const previewRule = { ...rule, id: '(new)' } as FirewallRule;
@@ -436,37 +448,26 @@ async function createRule(
   output.spinner('Staging rule');
 
   try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+    const hadExistingDraft = await detectExistingDraft(client, scope);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'rules.insert',
-        id: null,
-        value: rule,
-      },
-      { teamId }
-    );
+    await patchFirewallDraft(client, scope, {
+      action: 'rules.insert',
+      id: null,
+      value: rule,
+    });
 
     output.log(
       `${chalk.cyan('Success!')} Rule "${chalk.bold(rule.name)}" staged ${chalk.gray(createStamp())}`
     );
     printActionImpactWarning(rule.action);
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: parsed.flags['--yes'] as boolean,
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to stage rule';
+    const msg = mapFirewallApiError(e, scope, 'Failed to stage rule');
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -474,7 +475,7 @@ async function createRule(
         message: msg,
         next: [
           {
-            command: withGlobalFlags(client, 'firewall rules add --yes'),
+            command: withGlobalFlags(client, 'firewall rules add --yes', scope),
           },
         ],
       });

--- a/packages/cli/src/commands/firewall/rules/disable.ts
+++ b/packages/cli/src/commands/firewall/rules/disable.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesDisableSubcommand } from '../command';
 import {
@@ -9,6 +8,8 @@ import {
   resolveRule,
   detectExistingDraft,
   offerAutoPublish,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import { formatActionDisplay } from '../../../util/firewall/format';
 import { outputAgentError } from '../../../util/agent-output';
@@ -25,22 +26,14 @@ export default async function disable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
   let identifier = parsed.args[0] as string | undefined;
 
-  output.spinner(`Fetching rules for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching rules for ${chalk.bold(scope.displayName)}`);
 
-  const { active, draft } = await listFirewallConfigs(client, project.id, {
-    teamId,
-  });
+  const { active, draft } = await listFirewallConfigs(client, scope);
   const currentRules = draft?.rules || active?.rules || [];
 
   if (currentRules.length === 0) {
@@ -71,7 +64,7 @@ export default async function disable(client: Client, argv: string[]) {
                 when: 'replace <name-or-id>',
               },
               {
-                command: withGlobalFlags(client, 'firewall rules list'),
+                command: withGlobalFlags(client, 'firewall rules list', scope),
                 when: 'list rules',
               },
             ],
@@ -80,7 +73,7 @@ export default async function disable(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules disable <name-or-id>')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules disable <name-or-id>', scope)}`
       );
       return 1;
     }
@@ -112,7 +105,7 @@ export default async function disable(client: Client, argv: string[]) {
   if (allMatches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list', scope))} to view all rules.`
     );
     return 1;
   }
@@ -143,7 +136,8 @@ export default async function disable(client: Client, argv: string[]) {
           next: matches.map(r => ({
             command: withGlobalFlags(
               client,
-              `firewall rules disable "${r.id}" --yes`
+              `firewall rules disable "${r.id}" --yes`,
+              scope
             ),
             when: `disable "${r.name}"`,
           })),
@@ -177,42 +171,31 @@ export default async function disable(client: Client, argv: string[]) {
   output.spinner('Staging changes');
 
   try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+    const hadExistingDraft = await detectExistingDraft(client, scope);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'rules.update',
-        id: rule.id,
-        value: {
-          name: rule.name,
-          description: rule.description,
-          active: false,
-          conditionGroup: rule.conditionGroup,
-          action: rule.action,
-        },
+    await patchFirewallDraft(client, scope, {
+      action: 'rules.update',
+      id: rule.id,
+      value: {
+        name: rule.name,
+        description: rule.description,
+        active: false,
+        conditionGroup: rule.conditionGroup,
+        action: rule.action,
       },
-      { teamId }
-    );
+    });
 
     output.log(
       `${chalk.cyan('Disabled')} rule "${chalk.bold(rule.name)}" ${chalk.gray(disableStamp())}`
     );
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: parsed.flags['--yes'] as boolean,
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    output.error(error.message || 'Failed to disable rule');
+    output.error(mapFirewallApiError(e, scope, 'Failed to disable rule'));
     return 1;
   }
 }

--- a/packages/cli/src/commands/firewall/rules/edit.ts
+++ b/packages/cli/src/commands/firewall/rules/edit.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesEditSubcommand } from '../command';
 import {
@@ -11,9 +10,13 @@ import {
   offerAutoPublish,
   resolveRule,
   printActionImpactWarning,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import patchFirewallDraft from '../../../util/firewall/patch-firewall-draft';
+import type { FirewallScope } from '../../../util/firewall/scope';
+import { projectScope } from '../../../util/firewall/scope';
 import generateFirewallRule from '../../../util/firewall/generate-firewall-rule';
 import { parseConditionFlags } from '../../../util/firewall/parse-conditions';
 import {
@@ -42,22 +45,13 @@ export default async function edit(client: Client, argv: string[]) {
 
   let identifier = parsed.args[0] as string | undefined;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
-
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
   // Resolve the rule
-  output.spinner(`Fetching rules for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching rules for ${chalk.bold(scope.displayName)}`);
 
-  const { active, draft } = await listFirewallConfigs(client, project.id, {
-    teamId,
-  });
+  const { active, draft } = await listFirewallConfigs(client, scope);
 
   const currentRules = draft?.rules || active?.rules || [];
 
@@ -67,7 +61,7 @@ export default async function edit(client: Client, argv: string[]) {
 
     if (client.nonInteractive || !client.stdin.isTTY) {
       output.error(
-        `Missing required argument: <name-or-id>. Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to see all rules.`
+        `Missing required argument: <name-or-id>. Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list', scope))} to see all rules.`
       );
       return 1;
     }
@@ -99,7 +93,7 @@ export default async function edit(client: Client, argv: string[]) {
 
   if (matches.length === 0) {
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list', scope))} to view all rules.`
     );
     return 1;
   }
@@ -151,6 +145,14 @@ export default async function edit(client: Client, argv: string[]) {
 
   // AI mode — blocked for agents/non-interactive (AI output requires human review)
   if (aiPrompt) {
+    // AI generation is project-only (its endpoint requires a project)
+    if (scope.type === 'team') {
+      output.error(
+        'AI mode is not available with --team-level. Use --json or flag-based editing instead.'
+      );
+      return 1;
+    }
+
     if (client.nonInteractive || !client.stdin.isTTY) {
       if (client.nonInteractive) {
         outputAgentError(client, {
@@ -182,22 +184,21 @@ export default async function edit(client: Client, argv: string[]) {
       return 1;
     }
 
-    return handleAIEdit(client, project, teamId, originalRule, {
-      prompt: aiPrompt,
-      skipPrompts: !!parsed.flags['--yes'],
-    });
+    return handleAIEdit(
+      client,
+      { id: scope.projectId, name: scope.displayName },
+      scope.teamId,
+      originalRule,
+      {
+        prompt: aiPrompt,
+        skipPrompts: !!parsed.flags['--yes'],
+      }
+    );
   }
 
   // JSON mode
   if (jsonInput) {
-    return handleJsonEdit(
-      client,
-      parsed,
-      originalRule,
-      jsonInput,
-      project,
-      teamId
-    );
+    return handleJsonEdit(client, parsed, originalRule, jsonInput, scope);
   }
 
   // Flag overrides
@@ -218,7 +219,7 @@ export default async function edit(client: Client, argv: string[]) {
     parsed.flags['--redirect-permanent'];
 
   if (hasEditFlags) {
-    return handleFlagEdit(client, parsed, originalRule, argv, project, teamId);
+    return handleFlagEdit(client, parsed, originalRule, argv, scope);
   }
 
   // Interactive mode
@@ -230,15 +231,24 @@ export default async function edit(client: Client, argv: string[]) {
     const mode = await client.input.select({
       message: 'How would you like to edit this rule?',
       choices: [
-        { value: 'ai', name: 'Describe changes (AI-powered)' },
+        // AI generation is project-only (its endpoint requires a project)
+        ...(scope.type === 'project'
+          ? [{ value: 'ai', name: 'Describe changes (AI-powered)' }]
+          : []),
         { value: 'manual', name: 'Edit manually (field by field)' },
       ],
     });
 
-    if (mode === 'ai') {
-      return handleAIEdit(client, project, teamId, originalRule, {
-        skipPrompts: false,
-      });
+    if (mode === 'ai' && scope.type === 'project') {
+      return handleAIEdit(
+        client,
+        { id: scope.projectId, name: scope.displayName },
+        scope.teamId,
+        originalRule,
+        {
+          skipPrompts: false,
+        }
+      );
     }
 
     // Manual edit
@@ -254,7 +264,7 @@ export default async function edit(client: Client, argv: string[]) {
       return 0;
     }
 
-    return saveEdit(client, project, teamId, originalRule, modified, parsed, {
+    return saveEdit(client, scope, originalRule, modified, parsed, {
       skipConfirm: true,
     });
   }
@@ -410,9 +420,15 @@ async function handleAIEdit(
 
   // Auto-save with --yes
   if (opts.skipPrompts) {
-    return saveEdit(client, project, teamId, originalRule, currentRule, {
-      flags: { '--yes': true },
-    });
+    return saveEdit(
+      client,
+      projectScope(project, teamId),
+      originalRule,
+      currentRule,
+      {
+        flags: { '--yes': true },
+      }
+    );
   }
 
   // Review menu
@@ -435,8 +451,7 @@ async function handleAIEdit(
     if (choice === 'save') {
       return saveEdit(
         client,
-        project,
-        teamId,
+        projectScope(project, teamId),
         originalRule,
         currentRule,
         {
@@ -507,8 +522,7 @@ async function handleJsonEdit(
   parsed: { args: string[]; flags: Record<string, unknown> },
   originalRule: FirewallRule,
   jsonStr: string,
-  project: { id: string; name: string },
-  teamId: string | undefined
+  scope: FirewallScope
 ): Promise<number> {
   let ruleData: Record<string, unknown>;
   try {
@@ -573,7 +587,7 @@ async function handleJsonEdit(
     action: ruleData.action as FirewallRule['action'],
   };
 
-  return saveEdit(client, project, teamId, originalRule, modified, parsed);
+  return saveEdit(client, scope, originalRule, modified, parsed);
 }
 
 // --- Flag Edit ---
@@ -603,8 +617,7 @@ async function handleFlagEdit(
   parsed: { args: string[]; flags: Record<string, unknown> },
   originalRule: FirewallRule,
   rawArgv: string[],
-  project: { id: string; name: string },
-  teamId: string | undefined
+  scope: FirewallScope
 ): Promise<number> {
   // Clone the original rule
   const modified: FirewallRule = JSON.parse(JSON.stringify(originalRule));
@@ -694,15 +707,14 @@ async function handleFlagEdit(
     return 0;
   }
 
-  return saveEdit(client, project, teamId, originalRule, modified, parsed);
+  return saveEdit(client, scope, originalRule, modified, parsed);
 }
 
 // --- Shared save logic ---
 
 async function saveEdit(
   client: Client,
-  project: { id: string; name: string },
-  teamId: string | undefined,
+  scope: FirewallScope,
   originalRule: FirewallRule,
   modified: FirewallRule,
   parsed: { flags: Record<string, unknown> },
@@ -728,43 +740,32 @@ async function saveEdit(
   output.spinner('Staging changes');
 
   try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+    const hadExistingDraft = await detectExistingDraft(client, scope);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'rules.update',
-        id: originalRule.id,
-        value: {
-          name: modified.name,
-          description: modified.description,
-          active: modified.active,
-          conditionGroup: modified.conditionGroup,
-          action: modified.action,
-        },
+    await patchFirewallDraft(client, scope, {
+      action: 'rules.update',
+      id: originalRule.id,
+      value: {
+        name: modified.name,
+        description: modified.description,
+        active: modified.active,
+        conditionGroup: modified.conditionGroup,
+        action: modified.action,
       },
-      { teamId }
-    );
+    });
 
     output.log(
       `${chalk.cyan('Success!')} Rule "${chalk.bold(modified.name)}" updated and staged ${chalk.gray(editStamp())}`
     );
     printActionImpactWarning(modified.action);
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: parsed.flags['--yes'] as boolean,
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to stage rule changes';
+    const msg = mapFirewallApiError(e, scope, 'Failed to stage rule changes');
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -774,7 +775,8 @@ async function saveEdit(
           {
             command: withGlobalFlags(
               client,
-              `firewall rules edit "${originalRule.name}" --yes`
+              `firewall rules edit "${originalRule.name}" --yes`,
+              scope
             ),
           },
         ],

--- a/packages/cli/src/commands/firewall/rules/enable.ts
+++ b/packages/cli/src/commands/firewall/rules/enable.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesEnableSubcommand } from '../command';
 import {
@@ -10,6 +9,8 @@ import {
   detectExistingDraft,
   offerAutoPublish,
   printActionImpactWarning,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import { formatActionDisplay } from '../../../util/firewall/format';
 import { outputAgentError } from '../../../util/agent-output';
@@ -26,22 +27,14 @@ export default async function enable(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
   let identifier = parsed.args[0] as string | undefined;
 
-  output.spinner(`Fetching rules for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching rules for ${chalk.bold(scope.displayName)}`);
 
-  const { active, draft } = await listFirewallConfigs(client, project.id, {
-    teamId,
-  });
+  const { active, draft } = await listFirewallConfigs(client, scope);
   const currentRules = draft?.rules || active?.rules || [];
 
   if (currentRules.length === 0) {
@@ -72,7 +65,7 @@ export default async function enable(client: Client, argv: string[]) {
                 when: 'replace <name-or-id>',
               },
               {
-                command: withGlobalFlags(client, 'firewall rules list'),
+                command: withGlobalFlags(client, 'firewall rules list', scope),
                 when: 'list rules',
               },
             ],
@@ -81,7 +74,7 @@ export default async function enable(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules enable <name-or-id>')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules enable <name-or-id>', scope)}`
       );
       return 1;
     }
@@ -113,7 +106,7 @@ export default async function enable(client: Client, argv: string[]) {
   if (allMatches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list', scope))} to view all rules.`
     );
     return 1;
   }
@@ -144,7 +137,8 @@ export default async function enable(client: Client, argv: string[]) {
           next: matches.map(r => ({
             command: withGlobalFlags(
               client,
-              `firewall rules enable "${r.id}" --yes`
+              `firewall rules enable "${r.id}" --yes`,
+              scope
             ),
             when: `enable "${r.name}"`,
           })),
@@ -178,43 +172,32 @@ export default async function enable(client: Client, argv: string[]) {
   output.spinner('Staging changes');
 
   try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+    const hadExistingDraft = await detectExistingDraft(client, scope);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'rules.update',
-        id: rule.id,
-        value: {
-          name: rule.name,
-          description: rule.description,
-          active: true,
-          conditionGroup: rule.conditionGroup,
-          action: rule.action,
-        },
+    await patchFirewallDraft(client, scope, {
+      action: 'rules.update',
+      id: rule.id,
+      value: {
+        name: rule.name,
+        description: rule.description,
+        active: true,
+        conditionGroup: rule.conditionGroup,
+        action: rule.action,
       },
-      { teamId }
-    );
+    });
 
     output.log(
       `${chalk.cyan('Enabled')} rule "${chalk.bold(rule.name)}" ${chalk.gray(enableStamp())}`
     );
     printActionImpactWarning(rule.action);
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: parsed.flags['--yes'] as boolean,
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    output.error(error.message || 'Failed to enable rule');
+    output.error(mapFirewallApiError(e, scope, 'Failed to enable rule'));
     return 1;
   }
 }

--- a/packages/cli/src/commands/firewall/rules/inspect.ts
+++ b/packages/cli/src/commands/firewall/rules/inspect.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesInspectSubcommand } from '../command';
 import {
@@ -8,6 +7,8 @@ import {
   resolveRule,
   outputJson,
   withGlobalFlags,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import { formatRuleDetail } from '../../../util/firewall/format';
@@ -54,22 +55,13 @@ export default async function inspect(client: Client, argv: string[]) {
     return 1;
   }
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
-
-  output.spinner(`Fetching rules for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching rules for ${chalk.bold(scope.displayName)}`);
 
   try {
-    const { active, draft } = await listFirewallConfigs(client, project.id, {
-      teamId,
-    });
+    const { active, draft } = await listFirewallConfigs(client, scope);
 
     // Resolve against draft (if exists) or active
     const currentRules = draft?.rules || active?.rules || [];
@@ -86,7 +78,7 @@ export default async function inspect(client: Client, argv: string[]) {
             message: `No rule found for "${identifier}".`,
             next: [
               {
-                command: withGlobalFlags(client, 'firewall rules list'),
+                command: withGlobalFlags(client, 'firewall rules list', scope),
                 when: 'list rules',
               },
             ],
@@ -95,7 +87,7 @@ export default async function inspect(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
+        `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list', scope))} to view all rules.`
       );
       return 1;
     }
@@ -116,7 +108,8 @@ export default async function inspect(client: Client, argv: string[]) {
               next: matches.map(r => ({
                 command: withGlobalFlags(
                   client,
-                  `firewall rules inspect "${r.id}"`
+                  `firewall rules inspect "${r.id}"`,
+                  scope
                 ),
                 when: `inspect "${r.name}"`,
               })),
@@ -154,8 +147,7 @@ export default async function inspect(client: Client, argv: string[]) {
     output.print(`\n${formatRuleDetail(rule)}\n\n`);
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to fetch rules';
+    const msg = mapFirewallApiError(e, scope, 'Failed to fetch rules');
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
@@ -165,7 +157,8 @@ export default async function inspect(client: Client, argv: string[]) {
           {
             command: withGlobalFlags(
               client,
-              `firewall rules inspect ${identifier}`
+              `firewall rules inspect ${identifier}`,
+              scope
             ),
           },
         ],

--- a/packages/cli/src/commands/firewall/rules/list.ts
+++ b/packages/cli/src/commands/firewall/rules/list.ts
@@ -1,9 +1,14 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesListSubcommand } from '../command';
-import { parseSubcommandArgs, outputJson, withGlobalFlags } from '../shared';
+import {
+  parseSubcommandArgs,
+  outputJson,
+  withGlobalFlags,
+  resolveFirewallScope,
+  mapFirewallApiError,
+} from '../shared';
 import listFirewallConfigs from '../../../util/firewall/list-firewall-configs';
 import {
   annotateRules,
@@ -21,22 +26,13 @@ export default async function list(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
-
-  output.spinner(`Fetching custom rules for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching custom rules for ${chalk.bold(scope.displayName)}`);
 
   try {
-    const { active, draft } = await listFirewallConfigs(client, project.id, {
-      teamId,
-    });
+    const { active, draft } = await listFirewallConfigs(client, scope);
 
     const activeRules = active?.rules || [];
     const draftRules = draft?.rules || null;
@@ -106,7 +102,7 @@ export default async function list(client: Client, argv: string[]) {
     ).length;
     if (ruleChanges > 0) {
       output.print(
-        `\n  ${chalk.yellow(`${ruleChanges} unpublished rule change${ruleChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to publish.\n`
+        `\n  ${chalk.yellow(`${ruleChanges} unpublished rule change${ruleChanges !== 1 ? 's' : ''}.`)} Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish', scope))} to publish.\n`
       );
     } else {
       output.print(`\n  ${chalk.dim('Showing live configuration.')}\n`);
@@ -115,14 +111,15 @@ export default async function list(client: Client, argv: string[]) {
     output.print('\n');
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    const msg = error.message || 'Failed to fetch custom rules';
+    const msg = mapFirewallApiError(e, scope, 'Failed to fetch custom rules');
     if (client.nonInteractive) {
       outputAgentError(client, {
         status: 'error',
         reason: 'api_error',
         message: msg,
-        next: [{ command: withGlobalFlags(client, 'firewall rules list') }],
+        next: [
+          { command: withGlobalFlags(client, 'firewall rules list', scope) },
+        ],
       });
       process.exit(1);
       return 1;

--- a/packages/cli/src/commands/firewall/rules/remove.ts
+++ b/packages/cli/src/commands/firewall/rules/remove.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesRemoveSubcommand } from '../command';
 import {
@@ -10,6 +9,8 @@ import {
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import { formatActionDisplay } from '../../../util/firewall/format';
 import { outputAgentError } from '../../../util/agent-output';
@@ -26,22 +27,14 @@ export default async function remove(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
   let identifier = parsed.args[0] as string | undefined;
 
-  output.spinner(`Fetching rules for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching rules for ${chalk.bold(scope.displayName)}`);
 
-  const { active, draft } = await listFirewallConfigs(client, project.id, {
-    teamId,
-  });
+  const { active, draft } = await listFirewallConfigs(client, scope);
   const currentRules = draft?.rules || active?.rules || [];
 
   if (currentRules.length === 0) {
@@ -72,7 +65,7 @@ export default async function remove(client: Client, argv: string[]) {
                 when: 'replace <name-or-id>',
               },
               {
-                command: withGlobalFlags(client, 'firewall rules list'),
+                command: withGlobalFlags(client, 'firewall rules list', scope),
                 when: 'list rules',
               },
             ],
@@ -81,7 +74,7 @@ export default async function remove(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules remove <name-or-id> --yes')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules remove <name-or-id> --yes', scope)}`
       );
       return 1;
     }
@@ -107,7 +100,7 @@ export default async function remove(client: Client, argv: string[]) {
   if (matches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list', scope))} to view all rules.`
     );
     return 1;
   }
@@ -125,7 +118,8 @@ export default async function remove(client: Client, argv: string[]) {
           next: matches.map(r => ({
             command: withGlobalFlags(
               client,
-              `firewall rules remove "${r.id}" --yes`
+              `firewall rules remove "${r.id}" --yes`,
+              scope
             ),
             when: `remove "${r.name}"`,
           })),
@@ -180,36 +174,25 @@ export default async function remove(client: Client, argv: string[]) {
   output.spinner('Staging removal');
 
   try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+    const hadExistingDraft = await detectExistingDraft(client, scope);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'rules.remove',
-        id: rule.id,
-        value: null,
-      },
-      { teamId }
-    );
+    await patchFirewallDraft(client, scope, {
+      action: 'rules.remove',
+      id: rule.id,
+      value: null,
+    });
 
     output.log(
       `${chalk.cyan('Removed')} rule "${chalk.bold(rule.name)}" ${chalk.gray(removeStamp())}`
     );
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: parsed.flags['--yes'] as boolean,
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    output.error(error.message || 'Failed to remove rule');
+    output.error(mapFirewallApiError(e, scope, 'Failed to remove rule'));
     return 1;
   }
 }

--- a/packages/cli/src/commands/firewall/rules/reorder.ts
+++ b/packages/cli/src/commands/firewall/rules/reorder.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type Client from '../../../util/client';
-import { requireProjectContext } from '../../../util/projects/require-project-context';
 import output from '../../../output-manager';
 import { rulesReorderSubcommand } from '../command';
 import {
@@ -10,6 +9,8 @@ import {
   confirmAction,
   detectExistingDraft,
   offerAutoPublish,
+  resolveFirewallScope,
+  mapFirewallApiError,
 } from '../shared';
 import { formatActionDisplay } from '../../../util/firewall/format';
 import { outputAgentError } from '../../../util/agent-output';
@@ -26,22 +27,14 @@ export default async function reorder(client: Client, argv: string[]) {
   );
   if (typeof parsed === 'number') return parsed;
 
-  const link = await requireProjectContext(
-    client,
-    'firewall',
-    parsed.flags['--project']
-  );
-  if (typeof link === 'number') return link;
+  const scope = await resolveFirewallScope(client, parsed.flags);
+  if (typeof scope === 'number') return scope;
 
-  const { project, org } = link;
-  const teamId = org.type === 'team' ? org.id : undefined;
   let identifier = parsed.args[0] as string | undefined;
 
-  output.spinner(`Fetching rules for ${chalk.bold(project.name)}`);
+  output.spinner(`Fetching rules for ${chalk.bold(scope.displayName)}`);
 
-  const { active, draft } = await listFirewallConfigs(client, project.id, {
-    teamId,
-  });
+  const { active, draft } = await listFirewallConfigs(client, scope);
   const currentRules = draft?.rules || active?.rules || [];
 
   if (currentRules.length < 2) {
@@ -70,7 +63,7 @@ export default async function reorder(client: Client, argv: string[]) {
                 when: 'replace <name-or-id>',
               },
               {
-                command: withGlobalFlags(client, 'firewall rules list'),
+                command: withGlobalFlags(client, 'firewall rules list', scope),
                 when: 'list rules',
               },
             ],
@@ -79,7 +72,7 @@ export default async function reorder(client: Client, argv: string[]) {
         );
       }
       output.error(
-        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules reorder <name-or-id> --position N --yes')}`
+        `Rule name or ID is required. Usage: ${withGlobalFlags(client, 'firewall rules reorder <name-or-id> --position N --yes', scope)}`
       );
       return 1;
     }
@@ -105,7 +98,7 @@ export default async function reorder(client: Client, argv: string[]) {
   if (matches.length === 0) {
     output.stopSpinner();
     output.error(
-      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list'))} to view all rules.`
+      `No rule found for "${identifier}". Run ${chalk.cyan(withGlobalFlags(client, 'firewall rules list', scope))} to view all rules.`
     );
     return 1;
   }
@@ -123,7 +116,8 @@ export default async function reorder(client: Client, argv: string[]) {
           next: matches.map(r => ({
             command: withGlobalFlags(
               client,
-              `firewall rules reorder "${r.id}" --first --yes`
+              `firewall rules reorder "${r.id}" --first --yes`,
+              scope
             ),
             when: `reorder "${r.name}"`,
           })),
@@ -204,14 +198,16 @@ export default async function reorder(client: Client, argv: string[]) {
               {
                 command: withGlobalFlags(
                   client,
-                  `firewall rules reorder "${rule.name}" --first --yes`
+                  `firewall rules reorder "${rule.name}" --first --yes`,
+                  scope
                 ),
                 when: 'move to first position',
               },
               {
                 command: withGlobalFlags(
                   client,
-                  `firewall rules reorder "${rule.name}" --last --yes`
+                  `firewall rules reorder "${rule.name}" --last --yes`,
+                  scope
                 ),
                 when: 'move to last position',
               },
@@ -277,36 +273,25 @@ export default async function reorder(client: Client, argv: string[]) {
   output.spinner('Staging reorder');
 
   try {
-    const hadExistingDraft = await detectExistingDraft(
-      client,
-      project.id,
-      teamId
-    );
+    const hadExistingDraft = await detectExistingDraft(client, scope);
 
-    await patchFirewallDraft(
-      client,
-      project.id,
-      {
-        action: 'rules.priority',
-        id: rule.id,
-        value: targetIndex,
-      },
-      { teamId }
-    );
+    await patchFirewallDraft(client, scope, {
+      action: 'rules.priority',
+      id: rule.id,
+      value: targetIndex,
+    });
 
     output.log(
       `${chalk.cyan('Moved')} rule "${chalk.bold(rule.name)}" to position ${targetIndex + 1} ${chalk.gray(reorderStamp())}`
     );
 
-    await offerAutoPublish(client, project.id, hadExistingDraft, {
-      teamId,
+    await offerAutoPublish(client, scope, hadExistingDraft, {
       skipPrompts: parsed.flags['--yes'] as boolean,
     });
 
     return 0;
   } catch (e: unknown) {
-    const error = e as { message?: string };
-    output.error(error.message || 'Failed to reorder rule');
+    output.error(mapFirewallApiError(e, scope, 'Failed to reorder rule'));
     return 1;
   }
 }

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -121,9 +121,9 @@ export function mapFirewallApiError(
   const err = e as { status?: number; code?: string; message?: string };
   if (scope.type === 'team' && err.status === 403) {
     if (err.code === 'plan_not_supported') {
-      return 'Team-level firewall requires an Enterprise plan.';
+      return `Team-level firewall requires an Enterprise plan (current team: "${scope.displayName}"). Pass --scope <team> or run \`vercel switch\` to target a different team.`;
     }
-    return `You need to be a team owner to manage the team-level firewall.${err.message ? ` (${err.message})` : ''}`;
+    return `You need to be a team owner to manage the team-level firewall for "${scope.displayName}".${err.message ? ` (${err.message})` : ''}`;
   }
   return err.message || fallback;
 }

--- a/packages/cli/src/commands/firewall/shared.ts
+++ b/packages/cli/src/commands/firewall/shared.ts
@@ -16,20 +16,116 @@ import {
   type ParsedSubcommandArguments,
 } from '../../util/command-arguments';
 import type { FirewallIpRule, FirewallRule } from '../../util/firewall/types';
+import type { FirewallScope } from '../../util/firewall/scope';
 import listFirewallConfigs from '../../util/firewall/list-firewall-configs';
 import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
+import getScope from '../../util/get-scope';
+import { requireProjectContext } from '../../util/projects/require-project-context';
 import stamp from '../../util/output/stamp';
 
 /**
  * Plain suggested command with global flags from argv (--cwd, --non-interactive, etc.).
+ * Suggested follow-ups must keep targeting the team config, so team scope appends --team-level.
  */
 export function withGlobalFlags(
   client: Client,
-  commandTemplate: string
+  commandTemplate: string,
+  scope?: FirewallScope
 ): string {
-  return withClientGlobalFlags(client, commandTemplate, {
+  const template =
+    scope?.type === 'team'
+      ? `${commandTemplate} --team-level`
+      : commandTemplate;
+  return withClientGlobalFlags(client, template, {
     preserveProject: true,
   });
+}
+
+/**
+ * Resolves the firewall config to operate on: the team-level config when
+ * --team-level is passed (no linked project required), else the linked or
+ * --project project. Returns an exit code on failure.
+ */
+export async function resolveFirewallScope(
+  client: Client,
+  flags: { '--project'?: string; '--team-level'?: boolean }
+): Promise<FirewallScope | number> {
+  if (flags['--team-level'] && flags['--project']) {
+    const message =
+      'Cannot specify both --team-level and --project. Use one or the other.';
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message,
+        },
+        1
+      );
+      return 1;
+    }
+    output.error(message);
+    return 1;
+  }
+
+  if (flags['--team-level']) {
+    const { team } = await getScope(client);
+    if (!team) {
+      const message =
+        'Team-level firewall requires a team scope. Personal accounts are not supported. Run `vercel switch` to select a team or pass --scope <team>.';
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: AGENT_STATUS.ERROR,
+            reason: AGENT_REASON.MISSING_SCOPE,
+            message,
+          },
+          1
+        );
+        return 1;
+      }
+      output.error(message);
+      return 1;
+    }
+    return { type: 'team', teamId: team.id, displayName: team.slug };
+  }
+
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    flags['--project']
+  );
+  if (typeof link === 'number') return link;
+  const { project, org } = link;
+  return {
+    type: 'project',
+    projectId: project.id,
+    teamId: org.type === 'team' ? org.id : undefined,
+    displayName: project.name,
+  };
+}
+
+/**
+ * User-facing message for firewall API errors. Team scope maps the two 403
+ * causes (plan gate, owner-only ACL) to actionable messages; everything else
+ * surfaces the server message so gated-feature errors (e.g. 401 Security Plus)
+ * stay verbatim.
+ */
+export function mapFirewallApiError(
+  e: unknown,
+  scope: FirewallScope,
+  fallback: string
+): string {
+  const err = e as { status?: number; code?: string; message?: string };
+  if (scope.type === 'team' && err.status === 403) {
+    if (err.code === 'plan_not_supported') {
+      return 'Team-level firewall requires an Enterprise plan.';
+    }
+    return `You need to be a team owner to manage the team-level firewall.${err.message ? ` (${err.message})` : ''}`;
+  }
+  return err.message || fallback;
 }
 
 export async function parseSubcommandArgs(
@@ -117,10 +213,9 @@ export function outputJson(client: Client, data: unknown): void {
  */
 export async function detectExistingDraft(
   client: Client,
-  projectId: string,
-  teamId?: string
+  scope: FirewallScope
 ): Promise<boolean> {
-  const { draft } = await listFirewallConfigs(client, projectId, { teamId });
+  const { draft } = await listFirewallConfigs(client, scope);
   return draft !== null && draft.changes.length > 0;
 }
 
@@ -130,12 +225,12 @@ export async function detectExistingDraft(
  */
 export async function offerAutoPublish(
   client: Client,
-  projectId: string,
+  scope: FirewallScope,
   hadExistingDraft: boolean,
-  opts: { teamId?: string; skipPrompts?: boolean }
+  opts: { skipPrompts?: boolean }
 ): Promise<void> {
   output.print(
-    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish'))} to make it live, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard'))} to undo.`)}\n`
+    `\n  ${chalk.gray(`This change is staged. Run ${chalk.cyan(withGlobalFlags(client, 'firewall publish', scope))} to make it live, or ${chalk.cyan(withGlobalFlags(client, 'firewall discard', scope))} to undo.`)}\n`
   );
 
   if (
@@ -155,22 +250,19 @@ export async function offerAutoPublish(
       output.spinner('Publishing to production');
 
       try {
-        await activateFirewallConfig(client, projectId, 'draft', {
-          teamId: opts.teamId,
-        });
+        await activateFirewallConfig(client, scope, 'draft');
         output.log(
           `${chalk.cyan('Published')} to production ${chalk.gray(publishStamp())}`
         );
       } catch (e: unknown) {
-        const err = e as { message?: string };
         output.error(
-          `Failed to publish to production: ${err.message || 'Unknown error'}`
+          `Failed to publish to production: ${mapFirewallApiError(e, scope, 'Unknown error')}`
         );
       }
     }
   } else if (hadExistingDraft) {
     output.warn(
-      `There are other draft changes. Review with ${chalk.cyan(withGlobalFlags(client, 'firewall diff'))} before publishing.`
+      `There are other draft changes. Review with ${chalk.cyan(withGlobalFlags(client, 'firewall diff', scope))} before publishing.`
     );
   }
 }

--- a/packages/cli/src/util/firewall/activate-firewall-config.ts
+++ b/packages/cli/src/util/firewall/activate-firewall-config.ts
@@ -1,26 +1,19 @@
 import type Client from '../client';
+import type { FirewallScope } from './scope';
+import { firewallConfigUrl } from './scope';
 import type { FirewallConfigResponse } from './types';
-
-interface ActivateOptions {
-  teamId?: string;
-}
 
 export default async function activateFirewallConfig(
   client: Client,
-  projectId: string,
-  configVersion: string,
-  options: ActivateOptions = {}
+  scope: FirewallScope,
+  configVersion: string
 ): Promise<FirewallConfigResponse> {
-  const { teamId } = options;
-
-  const query = new URLSearchParams();
-  query.set('projectId', projectId);
-  if (teamId) query.set('teamId', teamId);
-
-  const url = `/v1/security/firewall/config/${configVersion}/activate?${query.toString()}`;
-  return client.fetch<FirewallConfigResponse>(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
-  });
+  return client.fetch<FirewallConfigResponse>(
+    firewallConfigUrl(scope, `/${configVersion}/activate`),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    }
+  );
 }

--- a/packages/cli/src/util/firewall/delete-firewall-draft.ts
+++ b/packages/cli/src/util/firewall/delete-firewall-draft.ts
@@ -1,22 +1,12 @@
 import type Client from '../client';
-
-interface DeleteDraftOptions {
-  teamId?: string;
-}
+import type { FirewallScope } from './scope';
+import { firewallConfigUrl } from './scope';
 
 export default async function deleteFirewallDraft(
   client: Client,
-  projectId: string,
-  options: DeleteDraftOptions = {}
+  scope: FirewallScope
 ): Promise<void> {
-  const { teamId } = options;
-
-  const query = new URLSearchParams();
-  query.set('projectId', projectId);
-  if (teamId) query.set('teamId', teamId);
-
-  const url = `/v1/security/firewall/config/draft?${query.toString()}`;
-  await client.fetch(url, {
+  await client.fetch(firewallConfigUrl(scope, '/draft'), {
     method: 'DELETE',
   });
 }

--- a/packages/cli/src/util/firewall/list-firewall-configs.ts
+++ b/packages/cli/src/util/firewall/list-firewall-configs.ts
@@ -1,21 +1,11 @@
 import type Client from '../client';
+import type { FirewallScope } from './scope';
+import { firewallConfigUrl } from './scope';
 import type { FirewallConfigListResponse } from './types';
-
-interface ListFirewallConfigsOptions {
-  teamId?: string;
-}
 
 export default async function listFirewallConfigs(
   client: Client,
-  projectId: string,
-  options: ListFirewallConfigsOptions = {}
+  scope: FirewallScope
 ): Promise<FirewallConfigListResponse> {
-  const { teamId } = options;
-
-  const query = new URLSearchParams();
-  query.set('projectId', projectId);
-  if (teamId) query.set('teamId', teamId);
-
-  const url = `/v1/security/firewall/config?${query.toString()}`;
-  return client.fetch<FirewallConfigListResponse>(url);
+  return client.fetch<FirewallConfigListResponse>(firewallConfigUrl(scope));
 }

--- a/packages/cli/src/util/firewall/patch-firewall-draft.ts
+++ b/packages/cli/src/util/firewall/patch-firewall-draft.ts
@@ -1,26 +1,19 @@
 import type Client from '../client';
+import type { FirewallScope } from './scope';
+import { firewallConfigUrl } from './scope';
 import type { FirewallConfigPatch, FirewallConfigResponse } from './types';
-
-interface PatchDraftOptions {
-  teamId?: string;
-}
 
 export default async function patchFirewallDraft(
   client: Client,
-  projectId: string,
-  patch: FirewallConfigPatch,
-  options: PatchDraftOptions = {}
+  scope: FirewallScope,
+  patch: FirewallConfigPatch
 ): Promise<FirewallConfigResponse> {
-  const { teamId } = options;
-
-  const query = new URLSearchParams();
-  query.set('projectId', projectId);
-  if (teamId) query.set('teamId', teamId);
-
-  const url = `/v1/security/firewall/config/draft?${query.toString()}`;
-  return client.fetch<FirewallConfigResponse>(url, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(patch),
-  });
+  return client.fetch<FirewallConfigResponse>(
+    firewallConfigUrl(scope, '/draft'),
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    }
+  );
 }

--- a/packages/cli/src/util/firewall/scope.ts
+++ b/packages/cli/src/util/firewall/scope.ts
@@ -1,0 +1,34 @@
+/**
+ * The firewall config a command operates on: a project's config, or the
+ * team-level config that applies to every project in the team (`--team-level`).
+ */
+export type FirewallScope =
+  | { type: 'project'; projectId: string; teamId?: string; displayName: string }
+  | { type: 'team'; teamId: string; displayName: string };
+
+export function projectScope(
+  project: { id: string; name: string },
+  teamId: string | undefined
+): FirewallScope {
+  return {
+    type: 'project',
+    projectId: project.id,
+    teamId,
+    displayName: project.name,
+  };
+}
+
+/**
+ * Builds the firewall config endpoint URL for the scope. `path` is appended to
+ * the config base, e.g. `/draft` or `/draft/activate`.
+ */
+export function firewallConfigUrl(scope: FirewallScope, path = ''): string {
+  const query = new URLSearchParams();
+  if (scope.type === 'project') {
+    query.set('projectId', scope.projectId);
+    if (scope.teamId) query.set('teamId', scope.teamId);
+    return `/v1/security/firewall/config${path}?${query.toString()}`;
+  }
+  query.set('teamId', scope.teamId);
+  return `/v1/security/firewall/team-config${path}?${query.toString()}`;
+}

--- a/packages/cli/src/util/telemetry/commands/firewall/index.ts
+++ b/packages/cli/src/util/telemetry/commands/firewall/index.ts
@@ -6,6 +6,12 @@ export class FirewallTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof firewallCommand>
 {
+  trackCliFlagTeamLevel(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('team-level');
+    }
+  }
+
   trackCliSubcommandOverview(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'overview',

--- a/packages/cli/test/mocks/firewall.ts
+++ b/packages/cli/test/mocks/firewall.ts
@@ -210,6 +210,15 @@ export const capturedRequests: {
   activate?: { version: string };
   deleteDraft?: boolean;
   patchDraft?: { action: string; id?: string; value?: unknown };
+  teamConfigQuery?: Record<string, string>;
+  teamActivate?: { version: string; query: Record<string, string> };
+  teamDeleteDraft?: { query: Record<string, string> };
+  teamPatchDraft?: {
+    action: string;
+    id?: string;
+    value?: unknown;
+    query: Record<string, string>;
+  };
   addBypass?: {
     sourceIp?: string;
     allSources?: boolean;
@@ -336,6 +345,101 @@ export function usePatchDraft(
           ...responseOverrides,
         })
       );
+    }
+  );
+}
+
+export function useListTeamFirewallConfigs(
+  active: FirewallConfigResponse | null = null,
+  draft: FirewallConfigResponse | null = null
+) {
+  delete capturedRequests.teamConfigQuery;
+  client.scenario.get(
+    '/v1/security/firewall/team-config',
+    (req: any, res: any) => {
+      capturedRequests.teamConfigQuery = { ...req.query };
+      const response: FirewallConfigListResponse = {
+        active,
+        draft,
+        versions: [],
+      };
+      res.json(response);
+    }
+  );
+}
+
+export function usePatchTeamDraft(
+  responseOverrides: Partial<FirewallConfigResponse> = {}
+) {
+  delete capturedRequests.teamPatchDraft;
+  client.scenario.patch(
+    '/v1/security/firewall/team-config/draft',
+    (req: any, res: any) => {
+      const patch = req.body;
+      capturedRequests.teamPatchDraft = {
+        action: patch.action,
+        id: patch.id,
+        value: patch.value,
+        query: { ...req.query },
+      };
+      res.json(
+        createConfig({
+          id: 'team_config_draft',
+          projectKey: 'v1_sc#draft',
+          changes: [
+            {
+              action: patch.action,
+              id: patch.id || `generated_${Date.now()}`,
+              value: patch.value,
+            },
+          ],
+          ...responseOverrides,
+        })
+      );
+    }
+  );
+}
+
+export function useActivateTeamConfig() {
+  delete capturedRequests.teamActivate;
+  client.scenario.post(
+    '/v1/security/firewall/team-config/:version/activate',
+    (req: any, res: any) => {
+      capturedRequests.teamActivate = {
+        version: req.params.version,
+        query: { ...req.query },
+      };
+      res.json(
+        createConfig({
+          id: 'team_config_new_active',
+          projectKey: 'v1_sc#active',
+          version: 2,
+        })
+      );
+    }
+  );
+}
+
+export function useDeleteTeamDraft() {
+  delete capturedRequests.teamDeleteDraft;
+  client.scenario.delete(
+    '/v1/security/firewall/team-config/draft',
+    (req: any, res: any) => {
+      capturedRequests.teamDeleteDraft = { query: { ...req.query } };
+      res.status(204).end();
+    }
+  );
+}
+
+export function useTeamConfigError(
+  statusCode: number,
+  code: string,
+  message: string
+) {
+  client.scenario.get(
+    '/v1/security/firewall/team-config',
+    (_req: any, res: any) => {
+      res.status(statusCode).json({ error: { code, message } });
     }
   );
 }

--- a/packages/cli/test/unit/commands/firewall/team-level.test.ts
+++ b/packages/cli/test/unit/commands/firewall/team-level.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import firewall from '../../../../src/commands/firewall';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+import {
+  useListTeamFirewallConfigs,
+  usePatchTeamDraft,
+  useActivateTeamConfig,
+  useDeleteTeamDraft,
+  useTeamConfigError,
+  capturedRequests,
+  createConfig,
+  createChange,
+  createRule,
+  createIpRule,
+} from '../../../mocks/firewall';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+
+function teamConfig(overrides = {}) {
+  return createConfig({ projectKey: 'v1_sc#active', ...overrides });
+}
+
+function teamDraft(overrides = {}) {
+  return createConfig({
+    projectKey: 'v1_sc#draft',
+    id: 'team_config_draft',
+    version: 2,
+    changes: [createChange('rules.insert', { id: 'rule_001' })],
+    ...overrides,
+  });
+}
+
+describe('firewall --team-level', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    client.config.currentTeam = 'team_dummy';
+    // Unlinked directory — team-level commands must not require `vercel link`
+    client.cwd = setupTmpDir();
+    for (const key of Object.keys(capturedRequests)) {
+      delete (capturedRequests as Record<string, unknown>)[key];
+    }
+  });
+
+  it('rejects --team-level combined with --project', async () => {
+    client.setArgv('firewall', 'diff', '--team-level', '--project', 'foo');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Cannot specify both --team-level and --project'
+    );
+  });
+
+  it('diff works from an unlinked directory and targets the team config', async () => {
+    useListTeamFirewallConfigs(teamConfig(), null);
+
+    client.setArgv('firewall', 'diff', '--team-level');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('No pending changes.');
+    expect(capturedRequests.teamConfigQuery?.teamId).toBe('team_dummy');
+    expect(capturedRequests.teamConfigQuery?.projectId).toBeUndefined();
+  });
+
+  it('diff suggests publish/discard commands with --team-level', async () => {
+    useListTeamFirewallConfigs(teamConfig(), teamDraft());
+
+    client.setArgv('firewall', 'diff', '--team-level');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('firewall publish --team-level');
+  });
+
+  it('publish activates the team draft', async () => {
+    useListTeamFirewallConfigs(teamConfig(), teamDraft());
+    useActivateTeamConfig();
+
+    client.setArgv('firewall', 'publish', '--team-level', '--yes');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    expect(capturedRequests.teamActivate?.version).toBe('draft');
+    expect(capturedRequests.teamActivate?.query.teamId).toBe('team_dummy');
+  });
+
+  it('discard deletes the team draft (204 response)', async () => {
+    useListTeamFirewallConfigs(teamConfig(), teamDraft());
+    useDeleteTeamDraft();
+
+    client.setArgv('firewall', 'discard', '--team-level', '--yes');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    expect(capturedRequests.teamDeleteDraft?.query.teamId).toBe('team_dummy');
+  });
+
+  it('rules list reads the team config', async () => {
+    useListTeamFirewallConfigs(teamConfig({ rules: [createRule(1)] }), null);
+
+    client.setArgv('firewall', 'rules', 'list', '--team-level');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Test Rule 1');
+    expect(capturedRequests.teamConfigQuery?.teamId).toBe('team_dummy');
+  });
+
+  it('rules add stages a rules.insert patch on the team draft', async () => {
+    useListTeamFirewallConfigs(teamConfig(), null);
+    usePatchTeamDraft();
+    useActivateTeamConfig();
+
+    client.setArgv(
+      'firewall',
+      'rules',
+      'add',
+      'Block bad IP',
+      '--condition',
+      '{"type":"ip_address","op":"eq","value":"1.1.1.1"}',
+      '--action',
+      'deny',
+      '--team-level',
+      '--yes'
+    );
+    const exitCode = await firewall(client);
+    await expect(client.stderr).toOutput('Rule "Block bad IP" staged');
+    expect(exitCode).toEqual(0);
+    expect(capturedRequests.teamPatchDraft?.action).toBe('rules.insert');
+    expect(capturedRequests.teamPatchDraft?.query.teamId).toBe('team_dummy');
+    expect(capturedRequests.teamPatchDraft?.query.projectId).toBeUndefined();
+  });
+
+  it('rules remove stages a rules.remove patch on the team draft', async () => {
+    useListTeamFirewallConfigs(teamConfig({ rules: [createRule(1)] }), null);
+    usePatchTeamDraft();
+    useActivateTeamConfig();
+
+    client.setArgv(
+      'firewall',
+      'rules',
+      'remove',
+      'rule_001',
+      '--team-level',
+      '--yes'
+    );
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    expect(capturedRequests.teamPatchDraft?.action).toBe('rules.remove');
+    expect(capturedRequests.teamPatchDraft?.id).toBe('rule_001');
+  });
+
+  it('rules disable stages a rules.update patch on the team draft', async () => {
+    // createRule(1) is active (index % 3 !== 0)
+    useListTeamFirewallConfigs(teamConfig({ rules: [createRule(1)] }), null);
+    usePatchTeamDraft();
+    useActivateTeamConfig();
+
+    client.setArgv(
+      'firewall',
+      'rules',
+      'disable',
+      'rule_001',
+      '--team-level',
+      '--yes'
+    );
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    expect(capturedRequests.teamPatchDraft?.action).toBe('rules.update');
+    expect((capturedRequests.teamPatchDraft?.value as any)?.active).toBe(false);
+  });
+
+  it('rules add rejects --ai with --team-level', async () => {
+    client.setArgv(
+      'firewall',
+      'rules',
+      'add',
+      '--ai',
+      'block everything',
+      '--team-level'
+    );
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'AI mode is not available with --team-level'
+    );
+  });
+
+  it('ip-blocks block stages an ip.insert patch on the team draft', async () => {
+    useListTeamFirewallConfigs(teamConfig(), null);
+    usePatchTeamDraft();
+    useActivateTeamConfig();
+
+    client.setArgv(
+      'firewall',
+      'ip-blocks',
+      'block',
+      '1.1.1.1',
+      '--team-level',
+      '--yes'
+    );
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    expect(capturedRequests.teamPatchDraft?.action).toBe('ip.insert');
+    expect((capturedRequests.teamPatchDraft?.value as any)?.ip).toBe('1.1.1.1');
+    expect(capturedRequests.teamPatchDraft?.query.teamId).toBe('team_dummy');
+  });
+
+  it('ip-blocks unblock stages an ip.remove patch on the team draft', async () => {
+    useListTeamFirewallConfigs(teamConfig({ ips: [createIpRule(1)] }), null);
+    usePatchTeamDraft();
+    useActivateTeamConfig();
+
+    client.setArgv(
+      'firewall',
+      'ip-blocks',
+      'unblock',
+      '10.0.0.1',
+      '--team-level',
+      '--yes'
+    );
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    expect(capturedRequests.teamPatchDraft?.action).toBe('ip.remove');
+    expect(capturedRequests.teamPatchDraft?.id).toBe('ip_001');
+  });
+
+  it('maps 403 plan_not_supported to an Enterprise plan message', async () => {
+    useTeamConfigError(
+      403,
+      'plan_not_supported',
+      'Team plan does not support this feature'
+    );
+
+    client.setArgv('firewall', 'rules', 'list', '--team-level');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Team-level firewall requires an Enterprise plan.'
+    );
+  });
+
+  it('maps plain 403 to a team owner message', async () => {
+    useTeamConfigError(403, 'forbidden', 'Not authorized');
+
+    client.setArgv('firewall', 'rules', 'list', '--team-level');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'You need to be a team owner to manage the team-level firewall.'
+    );
+  });
+
+  it('surfaces gated-feature errors verbatim (401 Security Plus)', async () => {
+    useTeamConfigError(
+      401,
+      'unauthorized',
+      'This feature requires Security Plus to be enabled'
+    );
+
+    client.setArgv('firewall', 'rules', 'list', '--team-level');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'This feature requires Security Plus to be enabled'
+    );
+  });
+
+  it('tracks the team-level flag in telemetry', async () => {
+    useListTeamFirewallConfigs(teamConfig(), null);
+
+    client.setArgv('firewall', 'diff', '--team-level');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'flag:team-level',
+        value: 'TRUE',
+      },
+      {
+        key: 'subcommand:diff',
+        value: 'diff',
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/firewall/team-level.test.ts
+++ b/packages/cli/test/unit/commands/firewall/team-level.test.ts
@@ -233,7 +233,7 @@ describe('firewall --team-level', () => {
     const exitCode = await firewall(client);
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput(
-      'Team-level firewall requires an Enterprise plan.'
+      'Team-level firewall requires an Enterprise plan (current team:'
     );
   });
 
@@ -244,7 +244,7 @@ describe('firewall --team-level', () => {
     const exitCode = await firewall(client);
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput(
-      'You need to be a team owner to manage the team-level firewall.'
+      'You need to be a team owner to manage the team-level firewall for'
     );
   });
 


### PR DESCRIPTION
# Problem

Team-level firewall custom rules (rules that apply to every project in a team) can only be managed from the dashboard today. The `vercel firewall` command tree only calls the project-scoped config endpoints and requires a linked project, so team-level rules are unreachable from the CLI — and by extension from any agent tooling built on top of it.

# Solution

Add a `--team-level` flag to the 14 firewall subcommands that operate on firewall config. When the flag is passed, commands target `/v1/security/firewall/team-config` (same `FirewallConfigPatch` draft → publish flow as project configs), resolved from the team scope — no linked project required. Mutually exclusive with `--project`.

## Commands supporting `--team-level`

**Custom rules**

```
vercel firewall rules list --team-level                          # list team rules (incl. draft changes)
vercel firewall rules inspect <name-or-id> --team-level          # full rule detail
vercel firewall rules add <name> --condition ... --action ... --team-level   # stage a new rule (flags, JSON, or interactive)
vercel firewall rules edit <name-or-id> ... --team-level         # stage changes to a rule
vercel firewall rules enable <name-or-id> --team-level           # stage enabling a disabled rule
vercel firewall rules disable <name-or-id> --team-level          # stage disabling a rule
vercel firewall rules remove <name-or-id> --team-level           # stage removing a rule
vercel firewall rules reorder <name-or-id> --position N --team-level   # stage a priority change
```

**IP blocks**

```
vercel firewall ip-blocks list --team-level                      # list team-level IP blocks
vercel firewall ip-blocks block <ip> --team-level                # stage blocking an IP/CIDR team-wide
vercel firewall ip-blocks unblock <ip-or-id> --team-level        # stage removing an IP block
```

**Draft lifecycle**

```
vercel firewall diff --team-level                                # show unpublished team draft changes
vercel firewall publish --team-level                             # publish the team draft to production
vercel firewall discard --team-level                             # throw away the team draft
```

Not supported at team level: `overview`, `attack-mode`, `system-bypass`, `system-mitigations` (their APIs are project-bound), and AI rule generation (`--ai`), whose endpoint requires a project — `--ai` is rejected under `--team-level` and the interactive mode selectors omit the AI choice.

## Implementation notes

- A new `FirewallScope` discriminated union (`src/util/firewall/scope.ts`) threads through the shared API utils, so project and team scope share one code path.
- Suggested follow-up commands (`firewall publish/discard/diff` hints) preserve `--team-level` so drafts are published against the right config.
- 403s map to actionable messages naming the resolved team (Enterprise plan gate, owner-only ACL); other API errors (e.g. Security Plus 401s) surface verbatim.

Tested with 16 new unit tests (`test/unit/commands/firewall/team-level.test.ts`) covering scope resolution from an unlinked directory, mutual exclusivity, all patch actions, error mapping, and telemetry; all 264 existing firewall tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)