### PR TITLE
[cli] Isolate Connex token unit tests

### DIFF
--- a/.changeset/isolate-connex-token-test.md
+++ b/.changeset/isolate-connex-token-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+Isolate the Connex token unit tests from repository-level link state.

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -849,7 +849,8 @@ exports[`help command > connex help output snapshots > connex create subcommand 
        --icon <PATH>             Path to a PNG or JPEG image to use as the connector icon (uploaded to Vercel)               
        --json                    Output as JSON                                                                              
   -n,  --name <NAME>             Name of the connector                                                                       
-       --trigger-event <EVENT>   Webhook event to receive. Repeatable.                                                       
+       --trigger-event <EVENT>   Webhook event to receive. Repeatable. Requires --triggers and replaces the provider's       
+                                 default events.                                                                             
        --triggers                Enable webhook triggers for this connector                                                  
 
 

--- a/packages/cli/test/unit/commands/connex/token.test.ts
+++ b/packages/cli/test/unit/commands/connex/token.test.ts
@@ -2,6 +2,7 @@ import { describe, beforeEach, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useTeam } from '../../../mocks/team';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 import connect from '../../../../src/commands/connex';
 
 vi.mock('open', () => ({ default: vi.fn(() => Promise.resolve()) }));
@@ -11,6 +12,7 @@ describe('connex token', () => {
 
   beforeEach(() => {
     client.reset();
+    client.cwd = setupTmpDir();
     const user = useUser();
     team = useTeam();
     client.config.currentTeam = team.id;


### PR DESCRIPTION
This test was:
1. Hanging because it tries to run from the repo root.
2. Failing because we have a missing cache input to `turbo` on retries. (I'm fixing this in other PRs).

Fixing both of those issues here.