### PR TITLE
[cli] add AI Gateway request logs commands

### DIFF
--- a/.changeset/quiet-gateways-log.md
+++ b/.changeset/quiet-gateways-log.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel ai-gateway logs` commands for listing requests and inspecting provider fallback attempts.

--- a/.changeset/quiet-gateways-log.md
+++ b/.changeset/quiet-gateways-log.md
@@ -2,4 +2,4 @@
 'vercel': minor
 ---
 
-Add `vercel ai-gateway logs` commands for listing requests and inspecting provider fallback attempts.
+Add agent-ready `vercel ai-gateway logs` commands for searching requests and inspecting provider fallback attempts.

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -517,6 +517,129 @@ export const modelsSubcommand = {
   examples: [],
 } as const;
 
+const logsProjectOption = {
+  name: 'project',
+  shorthand: null,
+  type: String,
+  argument: 'NAME|ID',
+  deprecated: false,
+  description: 'Filter requests by project name or ID',
+} as const;
+
+const logsSinceOption = {
+  name: 'since',
+  shorthand: null,
+  type: String,
+  argument: 'TIME',
+  deprecated: false,
+  description:
+    'Include requests after this time (ISO 8601 or relative: 1h, 30m, 7d; default: 1h)',
+} as const;
+
+const logsUntilOption = {
+  name: 'until',
+  shorthand: null,
+  type: String,
+  argument: 'TIME',
+  deprecated: false,
+  description: 'Include requests before this time (ISO 8601 or relative)',
+} as const;
+
+export const logsListSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List AI Gateway requests',
+  arguments: [],
+  options: [
+    logsProjectOption,
+    logsSinceOption,
+    logsUntilOption,
+    {
+      name: 'provider',
+      shorthand: null,
+      type: String,
+      argument: 'PROVIDER',
+      deprecated: false,
+      description: 'Filter requests by provider',
+    },
+    {
+      name: 'model',
+      shorthand: null,
+      type: String,
+      argument: 'MODEL',
+      deprecated: false,
+      description: 'Filter requests by model',
+    },
+    {
+      name: 'status',
+      shorthand: null,
+      type: String,
+      argument: 'CODE|CLASS',
+      deprecated: false,
+      description: 'Filter requests by HTTP status (for example: 200 or 5xx)',
+    },
+    {
+      name: 'page',
+      shorthand: null,
+      type: Number,
+      argument: 'NUMBER',
+      deprecated: false,
+      description: 'Select the 1-based page (default: 1)',
+    },
+    {
+      name: 'limit',
+      shorthand: 'n',
+      type: Number,
+      argument: 'NUMBER',
+      deprecated: false,
+      description: 'Set requests per page (default: 20, max: 100)',
+    },
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'List recent AI Gateway requests',
+      value: `${packageName} ai-gateway logs list`,
+    },
+    {
+      name: 'List failed requests for a project from the last day',
+      value: `${packageName} ai-gateway logs list --project my-app --status 5xx --since 1d`,
+    },
+    {
+      name: 'Print requests as JSON',
+      value: `${packageName} ai-gateway logs list --format json`,
+    },
+  ],
+} as const;
+
+export const logsInspectSubcommand = {
+  name: 'inspect',
+  aliases: [],
+  description: 'Inspect an AI Gateway request and its provider attempts',
+  arguments: [{ name: 'generationId', required: true }],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'Inspect a request',
+      value: `${packageName} ai-gateway logs inspect gen_01K00000000000000000000000`,
+    },
+    {
+      name: 'Print request details as JSON',
+      value: `${packageName} ai-gateway logs inspect gen_01K00000000000000000000000 --format json`,
+    },
+  ],
+} as const;
+
+export const logsSubcommand = {
+  name: 'logs',
+  aliases: [],
+  description: 'Inspect AI Gateway request logs',
+  arguments: [],
+  subcommands: [logsListSubcommand, logsInspectSubcommand],
+  options: [],
+  examples: [],
+} as const;
+
 export const budgetsSetSubcommand = {
   name: 'set',
   aliases: [],
@@ -846,6 +969,7 @@ export const aiGatewayCommand = {
     rulesSubcommand,
     codingAgentsSubcommand,
     modelsSubcommand,
+    logsSubcommand,
     leaderboardSubcommand,
   ],
   options: [],

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -555,6 +555,22 @@ export const logsListSubcommand = {
     logsSinceOption,
     logsUntilOption,
     {
+      name: 'search',
+      shorthand: null,
+      type: String,
+      argument: 'QUERY',
+      deprecated: false,
+      description: 'Search by Generation ID, provider, or model',
+    },
+    {
+      name: 'environment',
+      shorthand: null,
+      type: String,
+      argument: 'ENVIRONMENT',
+      deprecated: false,
+      description: 'Filter requests by environment',
+    },
+    {
       name: 'provider',
       shorthand: null,
       type: String,
@@ -595,6 +611,7 @@ export const logsListSubcommand = {
       description: 'Set requests per page (default: 20, max: 100)',
     },
     formatOption,
+    jsonOption,
   ],
   examples: [
     {
@@ -607,7 +624,7 @@ export const logsListSubcommand = {
     },
     {
       name: 'Print requests as JSON',
-      value: `${packageName} ai-gateway logs list --format json`,
+      value: `${packageName} ai-gateway logs list --json`,
     },
   ],
 } as const;
@@ -617,7 +634,7 @@ export const logsInspectSubcommand = {
   aliases: [],
   description: 'Inspect an AI Gateway request and its provider attempts',
   arguments: [{ name: 'generationId', required: true }],
-  options: [formatOption],
+  options: [formatOption, jsonOption],
   examples: [
     {
       name: 'Inspect a request',
@@ -625,7 +642,7 @@ export const logsInspectSubcommand = {
     },
     {
       name: 'Print request details as JSON',
-      value: `${packageName} ai-gateway logs inspect gen_01K00000000000000000000000 --format json`,
+      value: `${packageName} ai-gateway logs inspect gen_01K00000000000000000000000 --json`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/ai-gateway/index.ts
+++ b/packages/cli/src/commands/ai-gateway/index.ts
@@ -7,6 +7,7 @@ import budgets from './budgets';
 import rules from './rules';
 import codingAgents from './coding-agents';
 import models from './models';
+import logs from './logs';
 import leaderboard from './leaderboard';
 import {
   aiGatewayCommand,
@@ -15,6 +16,7 @@ import {
   rulesSubcommand,
   codingAgentsSubcommand,
   modelsSubcommand,
+  logsSubcommand,
   leaderboardSubcommand,
 } from './command';
 import { help } from '../help';
@@ -29,6 +31,7 @@ const COMMAND_CONFIG = {
   rules: getCommandAliases(rulesSubcommand),
   'coding-agents': getCommandAliases(codingAgentsSubcommand),
   models: getCommandAliases(modelsSubcommand),
+  logs: getCommandAliases(logsSubcommand),
   leaderboard: getCommandAliases(leaderboardSubcommand),
 };
 
@@ -79,6 +82,9 @@ export default async function main(client: Client) {
     case 'models':
       telemetry.trackCliSubcommandModels(subcommandOriginal);
       return models(client);
+    case 'logs':
+      telemetry.trackCliSubcommandLogs(subcommandOriginal);
+      return logs(client);
     case 'leaderboard':
       telemetry.trackCliSubcommandLeaderboard(subcommandOriginal);
       return leaderboard(client);

--- a/packages/cli/src/commands/ai-gateway/logs-api.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-api.ts
@@ -1,0 +1,326 @@
+import type Client from '../../util/client';
+import { ensureTeam } from '../../util/ai-gateway/ensure-team';
+import getTeamById from '../../util/teams/get-team-by-id';
+
+const REQUESTS_API_URL = 'https://vercel.com/api/ai/gateway-inference-requests';
+const METRICS_API_URL = 'https://vercel.com/api/observability/metrics';
+const COST_SEMANTICS_CUTOVER_MS = Date.UTC(2026, 4, 16, 1, 0, 0);
+const GENERATION_ID_PATTERN = /^gen_[0-9A-HJKMNP-TV-Z]{26}$/i;
+const ULID_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface AiGatewayLog {
+  generationId: string;
+  timestamp: string;
+  status: number | null;
+  model: string | null;
+  provider: string | null;
+  region: string | null;
+  projectId: string | null;
+  environment: string | null;
+  durationMs: number | null;
+  timeToFirstTokenMs: number | null;
+  cost: {
+    total: number | null;
+    inference: number | null;
+    currency: string;
+  };
+  tokens: {
+    input: number;
+    cachedInput: number;
+    cacheCreationInput: number;
+    output: number;
+    reasoning: number;
+    total: number;
+  };
+}
+
+export interface AiGatewayProviderAttempt {
+  modelIndex: number;
+  attempt: number;
+  provider: string | null;
+  model: string | null;
+  credentialType: 'byok' | 'vercel';
+  success: boolean;
+  statusCode: number | null;
+  error: string | null;
+  durationMs: number | null;
+}
+
+export interface LogsContext {
+  teamId: string;
+  teamSlug: string;
+}
+
+export interface LogsListQuery {
+  context: LogsContext;
+  projectId?: string;
+  startTime: Date;
+  endTime: Date;
+  provider?: string;
+  model?: string;
+  status?: string;
+  page: number;
+  limit: number;
+}
+
+export async function resolveLogsContext(
+  client: Client
+): Promise<LogsContext | null> {
+  if (!(await ensureTeam(client))) return null;
+  const teamId = client.config.currentTeam;
+  if (!teamId) return null;
+  const team = await getTeamById(client, teamId);
+  return { teamId: team.id, teamSlug: team.slug };
+}
+
+function getRequestsApiUrl(): string {
+  return process.env.VERCEL_AI_GATEWAY_LOGS_API_URL || REQUESTS_API_URL;
+}
+
+function getMetricsApiUrl(): string {
+  return process.env.VERCEL_AI_GATEWAY_METRICS_API_URL || METRICS_API_URL;
+}
+
+export function isValidGenerationId(value: string): boolean {
+  return GENERATION_ID_PATTERN.test(value);
+}
+
+export function buildLogsListUrl(query: LogsListQuery): string {
+  const url = new URL(getRequestsApiUrl());
+  url.searchParams.set('teamId', query.context.teamId);
+  url.searchParams.set('startTime', query.startTime.toISOString());
+  url.searchParams.set('endTime', query.endTime.toISOString());
+  url.searchParams.set('limit', String(query.limit));
+  url.searchParams.set('offset', String((query.page - 1) * query.limit));
+  url.searchParams.set('sortBy', 'timestamp');
+  url.searchParams.set('sortDir', 'DESC');
+  if (query.projectId) url.searchParams.set('projectId', query.projectId);
+  if (query.provider) url.searchParams.set('aiProvider', query.provider);
+  if (query.model) url.searchParams.set('aiModel', query.model);
+  if (query.status) url.searchParams.set('status', query.status);
+  return url.href;
+}
+
+export async function fetchLogsList(
+  client: Client,
+  query: LogsListQuery
+): Promise<{ logs: AiGatewayLog[]; returned: number }> {
+  const response = await client.fetch<unknown>(buildLogsListUrl(query), {
+    useCurrentTeam: false,
+  });
+  const record = asRecord(response);
+  const rows = Array.isArray(record?.data) ? record.data : [];
+  const logs = rows
+    .map(normalizeLog)
+    .filter((log): log is AiGatewayLog => !!log);
+  const pageInfo = asRecord(record?.pageInfo);
+  return {
+    logs,
+    returned: readNumber(pageInfo, 'returned') ?? logs.length,
+  };
+}
+
+export async function fetchLog(
+  client: Client,
+  context: LogsContext,
+  generationId: string
+): Promise<AiGatewayLog | null> {
+  const { startTime, endTime } = getGenerationWindow(generationId);
+  const url = new URL(getRequestsApiUrl());
+  url.searchParams.set('teamId', context.teamId);
+  url.searchParams.set('generationId', generationId);
+  url.searchParams.set('startTime', startTime.toISOString());
+  url.searchParams.set('endTime', endTime.toISOString());
+  url.searchParams.set('limit', '1');
+  const response = await client.fetch<unknown>(url.href, {
+    useCurrentTeam: false,
+  });
+  const rows = asRecord(response)?.data;
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  return normalizeLog(rows[0]);
+}
+
+export async function fetchProviderAttempts(
+  client: Client,
+  context: LogsContext,
+  generationId: string
+): Promise<AiGatewayProviderAttempt[]> {
+  const { startTime, endTime } = getGenerationWindow(generationId);
+  const url = new URL(getMetricsApiUrl());
+  url.searchParams.set('slug', context.teamSlug);
+  const escapedGenerationId = generationId.replace(/'/g, "''");
+  const response = await client.fetch<unknown>(url.href, {
+    method: 'POST',
+    body: {
+      event: 'aiGatewayProviderAttempt',
+      scope: { type: 'team-with-slug', teamSlug: context.teamSlug },
+      summaryOnly: true,
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      granularity: '1h',
+      reason: 'ai_gateway_chart',
+      groupBy: [
+        'aiProvider',
+        'providerAttemptCanonicalSlug',
+        'providerAttemptCredentialType',
+        'providerAttemptSuccess',
+        'providerAttemptStatusCode',
+        'providerAttemptError',
+        'providerAttemptModelIndex',
+        'providerAttemptNumber',
+      ],
+      rollups: {
+        responseTimeMs: {
+          measure: 'providerAttemptResponseTimeMs',
+          aggregation: 'sum',
+        },
+      },
+      filter: `generationId eq '${escapedGenerationId}'`,
+      limit: 50,
+    },
+    useCurrentTeam: false,
+  });
+  const record = asRecord(response);
+  const nested = asRecord(record?.data);
+  const rows = Array.isArray(record?.summary)
+    ? record.summary
+    : Array.isArray(nested?.summary)
+      ? nested.summary
+      : [];
+  return rows
+    .map(normalizeProviderAttempt)
+    .filter((attempt): attempt is AiGatewayProviderAttempt => !!attempt)
+    .sort((a, b) => {
+      if (a.success !== b.success) return Number(a.success) - Number(b.success);
+      if (a.modelIndex !== b.modelIndex) return a.modelIndex - b.modelIndex;
+      return a.attempt - b.attempt;
+    });
+}
+
+function getGenerationWindow(generationId: string): {
+  startTime: Date;
+  endTime: Date;
+} {
+  const timestamp = decodeGenerationTimestamp(generationId) ?? Date.now();
+  return {
+    startTime: new Date(timestamp - 60 * 60 * 1000),
+    endTime: new Date(timestamp + 60 * 60 * 1000),
+  };
+}
+
+function decodeGenerationTimestamp(generationId: string): number | null {
+  const ulid = generationId.slice(4).toUpperCase();
+  if (ulid.length < 10) return null;
+  let timestamp = 0;
+  for (const char of ulid.slice(0, 10)) {
+    const value = ULID_ALPHABET.indexOf(char);
+    if (value === -1) return null;
+    timestamp = timestamp * 32 + value;
+  }
+  return Number.isSafeInteger(timestamp) ? timestamp : null;
+}
+
+function normalizeLog(value: unknown): AiGatewayLog | null {
+  const row = asRecord(value);
+  if (!row) return null;
+  const generationId = readString(row, 'generationId');
+  const timestamp = readString(row, 'timestamp');
+  if (!generationId || !timestamp) return null;
+  const input = readNumber(row, 'inputTokens') ?? 0;
+  const cachedInput = readNumber(row, 'cachedInputTokens') ?? 0;
+  const cacheCreationInput = readNumber(row, 'cacheCreationInputTokens') ?? 0;
+  const output = readNumber(row, 'outputTokens') ?? 0;
+  const reasoning = readNumber(row, 'reasoningTokens') ?? 0;
+  const costs = resolveCosts(row, timestamp);
+  return {
+    generationId,
+    timestamp: normalizeTimestamp(timestamp),
+    status: readNumber(row, 'httpStatus'),
+    model: readString(row, 'aiModel'),
+    provider: readString(row, 'aiProvider'),
+    region: readString(row, 'inferenceGeoRegion'),
+    projectId: readString(row, 'projectId'),
+    environment: readString(row, 'environment'),
+    durationMs: readNumber(row, 'aiRequestDurationMs'),
+    timeToFirstTokenMs: readNumber(row, 'timeToFirstTokenMs'),
+    cost: {
+      total: costs.total,
+      inference: costs.inference,
+      currency: readString(row, 'costCurrency') || 'USD',
+    },
+    tokens: {
+      input,
+      cachedInput,
+      cacheCreationInput,
+      output,
+      reasoning,
+      total: input + output + reasoning,
+    },
+  };
+}
+
+function normalizeProviderAttempt(
+  value: unknown
+): AiGatewayProviderAttempt | null {
+  const row = asRecord(value);
+  if (!row) return null;
+  return {
+    modelIndex: readNumber(row, 'providerAttemptModelIndex') ?? 0,
+    attempt: readNumber(row, 'providerAttemptNumber') ?? 0,
+    provider: readString(row, 'aiProvider'),
+    model: readString(row, 'providerAttemptCanonicalSlug'),
+    credentialType:
+      readString(row, 'providerAttemptCredentialType') === 'byok'
+        ? 'byok'
+        : 'vercel',
+    success: String(row.providerAttemptSuccess) === '1',
+    statusCode: readNumber(row, 'providerAttemptStatusCode'),
+    error: readString(row, 'providerAttemptError'),
+    durationMs: readNumber(row, 'responseTimeMs'),
+  };
+}
+
+function resolveCosts(
+  row: UnknownRecord,
+  timestamp: string
+): { total: number | null; inference: number | null } {
+  const cost = readNumber(row, 'cost');
+  if (cost === null) return { total: null, inference: null };
+  const surcharges = [
+    'zdrCost',
+    'reportingWriteCost',
+    'providerAllowlistCost',
+    'modelAllowlistCost',
+    'quotaWriteCost',
+  ].reduce((sum, key) => sum + (readNumber(row, key) ?? 0), 0);
+  const rowMs = Date.parse(normalizeTimestamp(timestamp));
+  return rowMs >= COST_SEMANTICS_CUTOVER_MS
+    ? { total: cost + surcharges, inference: cost }
+    : { total: cost, inference: cost - surcharges };
+}
+
+function normalizeTimestamp(value: string): string {
+  const normalized = value.endsWith('Z') ? value : `${value}Z`;
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+}
+
+function readString(record: UnknownRecord, key: string): string | null {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readNumber(record: UnknownRecord | null, key: string): number | null {
+  const value = record?.[key];
+  if (value === null || value === undefined || value === '') return null;
+  const number = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(number) ? number : null;
+}

--- a/packages/cli/src/commands/ai-gateway/logs-api.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-api.ts
@@ -61,6 +61,8 @@ export interface LogsListQuery {
   provider?: string;
   model?: string;
   status?: string;
+  search?: string;
+  environment?: string;
   page: number;
   limit: number;
 }
@@ -97,6 +99,8 @@ export function buildLogsListUrl(query: LogsListQuery): string {
   url.searchParams.set('sortBy', 'timestamp');
   url.searchParams.set('sortDir', 'DESC');
   if (query.projectId) url.searchParams.set('projectId', query.projectId);
+  if (query.search) url.searchParams.set('q', query.search);
+  if (query.environment) url.searchParams.set('environment', query.environment);
   if (query.provider) url.searchParams.set('aiProvider', query.provider);
   if (query.model) url.searchParams.set('aiModel', query.model);
   if (query.status) url.searchParams.set('status', query.status);

--- a/packages/cli/src/commands/ai-gateway/logs-api.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-api.ts
@@ -5,6 +5,7 @@ import getTeamById from '../../util/teams/get-team-by-id';
 const REQUESTS_API_URL = 'https://vercel.com/api/ai/gateway-inference-requests';
 const METRICS_API_URL = 'https://vercel.com/api/observability/metrics';
 const COST_SEMANTICS_CUTOVER_MS = Date.UTC(2026, 4, 16, 1, 0, 0);
+const HOUR_MS = 60 * 60 * 1000;
 const GENERATION_ID_PATTERN = /^gen_[0-9A-HJKMNP-TV-Z]{26}$/i;
 const ULID_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 
@@ -163,7 +164,7 @@ export async function fetchProviderAttempts(
       summaryOnly: true,
       startTime: startTime.toISOString(),
       endTime: endTime.toISOString(),
-      granularity: '1h',
+      granularity: { hours: 1 },
       reason: 'ai_gateway_chart',
       groupBy: [
         'aiProvider',
@@ -209,8 +210,8 @@ function getGenerationWindow(generationId: string): {
 } {
   const timestamp = decodeGenerationTimestamp(generationId) ?? Date.now();
   return {
-    startTime: new Date(timestamp - 60 * 60 * 1000),
-    endTime: new Date(timestamp + 60 * 60 * 1000),
+    startTime: new Date(Math.floor((timestamp - HOUR_MS) / HOUR_MS) * HOUR_MS),
+    endTime: new Date(Math.ceil((timestamp + HOUR_MS) / HOUR_MS) * HOUR_MS),
   };
 }
 

--- a/packages/cli/src/commands/ai-gateway/logs-format.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-format.ts
@@ -1,0 +1,116 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import type { AiGatewayLog, AiGatewayProviderAttempt } from './logs-api';
+
+const dash = () => chalk.gray('–');
+
+export function renderLogsTable(logs: AiGatewayLog[]): string {
+  return `${table(
+    [
+      [
+        'time',
+        'status',
+        'model',
+        'provider',
+        'cost',
+        'tokens',
+        'duration',
+        'region',
+        'generation id',
+      ].map(header => chalk.gray(header)),
+      ...logs.map(log => [
+        formatTimestamp(log.timestamp),
+        log.status === null ? dash() : String(log.status),
+        safeCell(log.model),
+        safeCell(log.provider),
+        formatCost(log.cost.total),
+        formatCount(log.tokens.total),
+        formatDuration(log.durationMs),
+        safeCell(log.region?.toUpperCase() ?? null),
+        log.generationId,
+      ]),
+    ],
+    { align: ['l', 'r', 'l', 'l', 'r', 'r', 'r', 'l', 'l'], hsep: 3 }
+  ).replace(/^/gm, '  ')}\n`;
+}
+
+export function renderLogDetails(log: AiGatewayLog): string {
+  return `${table(
+    [
+      ['Generation ID', log.generationId],
+      ['Timestamp', log.timestamp],
+      ['Status', log.status === null ? dash() : String(log.status)],
+      ['Model', safeCell(log.model)],
+      ['Provider', safeCell(log.provider)],
+      ['Region', safeCell(log.region?.toUpperCase() ?? null)],
+      ['Project ID', safeCell(log.projectId)],
+      ['Environment', safeCell(log.environment)],
+      ['Total cost', formatCost(log.cost.total)],
+      ['Inference cost', formatCost(log.cost.inference)],
+      ['Duration', formatDuration(log.durationMs)],
+      ['Time to first token', formatDuration(log.timeToFirstTokenMs)],
+      ['Input tokens', formatCount(log.tokens.input)],
+      ['Cached input tokens', formatCount(log.tokens.cachedInput)],
+      ['Cache creation tokens', formatCount(log.tokens.cacheCreationInput)],
+      ['Output tokens', formatCount(log.tokens.output)],
+      ['Reasoning tokens', formatCount(log.tokens.reasoning)],
+      ['Total tokens', formatCount(log.tokens.total)],
+    ].map(([label, value]) => [chalk.bold(label), value]),
+    { hsep: 3 }
+  ).replace(/^/gm, '  ')}\n`;
+}
+
+export function renderAttemptsTable(
+  attempts: AiGatewayProviderAttempt[]
+): string {
+  return `${table(
+    [
+      [
+        'result',
+        'model',
+        'provider',
+        'credential',
+        'status',
+        'duration',
+        'error',
+      ].map(header => chalk.gray(header)),
+      ...attempts.map(attempt => [
+        attempt.success ? chalk.green('success') : chalk.red('failed'),
+        safeCell(attempt.model),
+        safeCell(attempt.provider),
+        attempt.credentialType,
+        attempt.statusCode === null ? dash() : String(attempt.statusCode),
+        formatDuration(attempt.durationMs),
+        safeCell(attempt.error, 80),
+      ]),
+    ],
+    { align: ['l', 'l', 'l', 'l', 'r', 'r', 'l'], hsep: 3 }
+  ).replace(/^/gm, '  ')}\n`;
+}
+
+function formatTimestamp(value: string): string {
+  return value.replace('T', ' ').replace('.000Z', 'Z');
+}
+
+function formatCost(value: number | null): string {
+  if (value === null) return dash();
+  return `$${value.toFixed(value < 0.01 ? 6 : 4)}`;
+}
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatDuration(value: number | null): string {
+  if (value === null) return dash();
+  if (value < 1000) return `${Math.round(value)}ms`;
+  return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)}s`;
+}
+
+function safeCell(value: string | null, maxLength = 60): string {
+  if (!value) return dash();
+  const normalized = value.replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ');
+  return normalized.length > maxLength
+    ? `${normalized.slice(0, maxLength - 1)}…`
+    : normalized;
+}

--- a/packages/cli/src/commands/ai-gateway/logs-inspect.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-inspect.ts
@@ -4,7 +4,6 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { validateJsonOutput } from '../../util/output-format';
-import { isAPIError } from '../../util/errors-ts';
 import { logsInspectSubcommand } from './command';
 import {
   fetchLog,
@@ -13,7 +12,15 @@ import {
   resolveLogsContext,
 } from './logs-api';
 import { renderAttemptsTable, renderLogDetails } from './logs-format';
+import {
+  argvRequestsLogsJson,
+  outputLogsApiError,
+  outputLogsError,
+  outputMissingLogsTeam,
+  shouldUseLogsJson,
+} from './logs-output';
 import { AiGatewayLogsInspectTelemetryClient } from '../../util/telemetry/commands/ai-gateway/logs-inspect';
+import { AGENT_REASON } from '../../util/agent-output-constants';
 
 export default async function inspect(client: Client, argv: string[]) {
   const telemetry = new AiGatewayLogsInspectTelemetryClient({
@@ -26,6 +33,16 @@ export default async function inspect(client: Client, argv: string[]) {
   try {
     parsedArgs = parseArguments(argv, flagsSpecification);
   } catch (error) {
+    if (shouldUseLogsJson(client, argvRequestsLogsJson(argv))) {
+      return outputLogsError(
+        client,
+        {
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: error instanceof Error ? error.message : String(error),
+        },
+        true
+      );
+    }
     printError(error);
     return 1;
   }
@@ -33,36 +50,69 @@ export default async function inspect(client: Client, argv: string[]) {
   const generationId = args[0];
   telemetry.trackCliArgumentGenerationId(generationId);
   telemetry.trackCliOptionFormat(opts['--format']);
+  telemetry.trackCliFlagJson(opts['--json']);
+
+  const requestedJson =
+    opts['--json'] === true || opts['--format']?.toLowerCase() === 'json';
+  const jsonOutput = shouldUseLogsJson(client, requestedJson);
 
   if (!generationId) {
-    output.error('Specify a Generation ID.');
-    return 1;
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.MISSING_ARGUMENTS,
+        message: 'Specify a Generation ID.',
+        next: [
+          {
+            command:
+              'vercel ai-gateway logs inspect <generationId> --scope <team-slug> --json',
+          },
+        ],
+      },
+      jsonOutput
+    );
   }
   if (!isValidGenerationId(generationId)) {
-    output.error(
-      'Generation ID must be `gen_` followed by a 26-character ULID.'
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message:
+          'Generation ID must be `gen_` followed by a 26-character ULID.',
+      },
+      jsonOutput
     );
-    return 1;
   }
   const formatResult = validateJsonOutput(opts);
   if (!formatResult.valid) {
-    output.error(formatResult.error);
-    return 1;
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: formatResult.error,
+      },
+      jsonOutput
+    );
+  }
+
+  if (!client.config.currentTeam && jsonOutput) {
+    return outputMissingLogsTeam(client, 'inspect');
   }
 
   let context;
   try {
     context = await resolveLogsContext(client);
   } catch (error) {
-    if (isAPIError(error)) {
-      output.error(error.message);
-      return 1;
-    }
-    throw error;
+    return outputLogsApiError(
+      client,
+      error,
+      jsonOutput,
+      `vercel ai-gateway logs inspect ${generationId} --scope <team-slug> --json`
+    );
   }
   if (!context) return 1;
 
-  output.spinner('Fetching AI Gateway request…');
+  if (!jsonOutput) output.spinner('Fetching AI Gateway request…');
   let request;
   let attempts;
   try {
@@ -71,24 +121,51 @@ export default async function inspect(client: Client, argv: string[]) {
       fetchProviderAttempts(client, context, generationId),
     ]);
   } catch (error) {
-    output.stopSpinner();
-    if (isAPIError(error)) {
-      output.error(error.message);
-      return 1;
-    }
-    throw error;
+    if (!jsonOutput) output.stopSpinner();
+    return outputLogsApiError(
+      client,
+      error,
+      jsonOutput,
+      `vercel ai-gateway logs inspect ${generationId} --scope <team-slug> --json`
+    );
   }
-  output.stopSpinner();
+  if (!jsonOutput) output.stopSpinner();
 
   if (!request) {
-    output.error(
-      `Request not found: ${generationId}. It may be outside retention or belong to another team.`
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.NOT_FOUND,
+        message: `Request not found: ${generationId}. It may be outside retention or belong to another team.`,
+        next: [
+          {
+            command:
+              'vercel ai-gateway logs list --scope <team-slug> --search <generationId> --json',
+            when: 'Search for the request under another team or time range',
+          },
+        ],
+      },
+      jsonOutput
     );
-    return 1;
   }
 
-  if (formatResult.jsonOutput) {
-    client.stdout.write(`${JSON.stringify({ request, attempts }, null, 2)}\n`);
+  if (jsonOutput) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: 'success',
+          reason: 'ai_gateway_log_inspected',
+          message: 'Loaded AI Gateway request details.',
+          data: {
+            team: { id: context.teamId, slug: context.teamSlug },
+            request,
+            attempts,
+          },
+        },
+        null,
+        2
+      )}\n`
+    );
     return 0;
   }
 

--- a/packages/cli/src/commands/ai-gateway/logs-inspect.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-inspect.ts
@@ -1,0 +1,104 @@
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { validateJsonOutput } from '../../util/output-format';
+import { isAPIError } from '../../util/errors-ts';
+import { logsInspectSubcommand } from './command';
+import {
+  fetchLog,
+  fetchProviderAttempts,
+  isValidGenerationId,
+  resolveLogsContext,
+} from './logs-api';
+import { renderAttemptsTable, renderLogDetails } from './logs-format';
+import { AiGatewayLogsInspectTelemetryClient } from '../../util/telemetry/commands/ai-gateway/logs-inspect';
+
+export default async function inspect(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLogsInspectTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+  const flagsSpecification = getFlagsSpecification(
+    logsInspectSubcommand.options
+  );
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { flags: opts, args } = parsedArgs;
+  const generationId = args[0];
+  telemetry.trackCliArgumentGenerationId(generationId);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!generationId) {
+    output.error('Specify a Generation ID.');
+    return 1;
+  }
+  if (!isValidGenerationId(generationId)) {
+    output.error(
+      'Generation ID must be `gen_` followed by a 26-character ULID.'
+    );
+    return 1;
+  }
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+
+  let context;
+  try {
+    context = await resolveLogsContext(client);
+  } catch (error) {
+    if (isAPIError(error)) {
+      output.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
+  if (!context) return 1;
+
+  output.spinner('Fetching AI Gateway request…');
+  let request;
+  let attempts;
+  try {
+    [request, attempts] = await Promise.all([
+      fetchLog(client, context, generationId),
+      fetchProviderAttempts(client, context, generationId),
+    ]);
+  } catch (error) {
+    output.stopSpinner();
+    if (isAPIError(error)) {
+      output.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
+  output.stopSpinner();
+
+  if (!request) {
+    output.error(
+      `Request not found: ${generationId}. It may be outside retention or belong to another team.`
+    );
+    return 1;
+  }
+
+  if (formatResult.jsonOutput) {
+    client.stdout.write(`${JSON.stringify({ request, attempts }, null, 2)}\n`);
+    return 0;
+  }
+
+  output.log('Request');
+  client.stdout.write(renderLogDetails(request));
+  if (attempts.length === 0) {
+    output.log('No provider attempts found.');
+    return 0;
+  }
+  output.log('Provider attempts · failures first');
+  client.stdout.write(renderAttemptsTable(attempts));
+  return 0;
+}

--- a/packages/cli/src/commands/ai-gateway/logs-list.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-list.ts
@@ -1,0 +1,167 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { validateJsonOutput } from '../../util/output-format';
+import { resolveTimeRange } from '../../util/time-utils';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { isAPIError, ProjectNotFound } from '../../util/errors-ts';
+import { logsListSubcommand } from './command';
+import { fetchLogsList, resolveLogsContext } from './logs-api';
+import { renderLogsTable } from './logs-format';
+import { AiGatewayLogsListTelemetryClient } from '../../util/telemetry/commands/ai-gateway/logs-list';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export default async function list(client: Client, argv: string[]) {
+  const telemetry = new AiGatewayLogsListTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+  const flagsSpecification = getFlagsSpecification(logsListSubcommand.options);
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { flags: opts } = parsedArgs;
+  const project = opts['--project'];
+  const since = opts['--since'];
+  const until = opts['--until'];
+  const provider = opts['--provider'];
+  const model = opts['--model'];
+  const status = opts['--status'];
+  const page = opts['--page'] ?? 1;
+  const limit = opts['--limit'] ?? DEFAULT_LIMIT;
+
+  telemetry.trackCliOptionProject(project);
+  telemetry.trackCliOptionSince(since);
+  telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliOptionProvider(provider);
+  telemetry.trackCliOptionModel(model);
+  telemetry.trackCliOptionStatus(status);
+  telemetry.trackCliOptionPage(opts['--page']);
+  telemetry.trackCliOptionLimit(opts['--limit']);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  if (!Number.isInteger(page) || page < 1) {
+    output.error('Page must be an integer greater than 0.');
+    return 1;
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    output.error(`Limit must be an integer from 1 to ${MAX_LIMIT}.`);
+    return 1;
+  }
+  if (status && !/^(?:[1-5]xx|\d{3})$/.test(status)) {
+    output.error('Status must be an HTTP code or class, such as 200 or 5xx.');
+    return 1;
+  }
+
+  let timeRange;
+  try {
+    timeRange = resolveTimeRange(since || '1h', until);
+  } catch (error) {
+    output.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+  if (timeRange.startTime >= timeRange.endTime) {
+    output.error('The --since time must be before --until.');
+    return 1;
+  }
+
+  let context;
+  try {
+    context = await resolveLogsContext(client);
+  } catch (error) {
+    if (isAPIError(error)) {
+      output.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
+  if (!context) return 1;
+
+  // Resolve the project after the team so lookup uses the same scope as the
+  // request-log query.
+  let projectId: string | undefined;
+  if (project) {
+    try {
+      const resolved = await getProjectByNameOrId(client, project);
+      if (resolved instanceof ProjectNotFound) {
+        output.error(`Project not found: ${project}`);
+        return 1;
+      }
+      projectId = resolved.id;
+    } catch (error) {
+      if (isAPIError(error)) {
+        output.error(error.message);
+        return 1;
+      }
+      throw error;
+    }
+  }
+
+  output.spinner('Fetching AI Gateway logs…');
+  let result;
+  try {
+    result = await fetchLogsList(client, {
+      context,
+      projectId,
+      startTime: timeRange.startTime,
+      endTime: timeRange.endTime,
+      provider,
+      model,
+      status,
+      page,
+      limit,
+    });
+  } catch (error) {
+    output.stopSpinner();
+    if (isAPIError(error)) {
+      output.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
+  output.stopSpinner();
+
+  const hasMore = result.returned === limit;
+  const response = {
+    requests: result.logs,
+    pagination: { page, limit, returned: result.returned, hasMore },
+  };
+  if (formatResult.jsonOutput) {
+    client.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+    return 0;
+  }
+
+  if (result.logs.length === 0) {
+    const filtered = Boolean(
+      project || provider || model || status || since || until
+    );
+    output.log(
+      filtered
+        ? 'No AI Gateway requests match the current filters.'
+        : 'No AI Gateway requests found.'
+    );
+    return 0;
+  }
+
+  output.log(
+    `AI Gateway logs · ${chalk.bold(context.teamSlug)} · page ${page}`
+  );
+  client.stdout.write(renderLogsTable(result.logs));
+  if (hasMore) {
+    output.log(`Use --page ${page + 1} with the same filters for more.`);
+  }
+  return 0;
+}

--- a/packages/cli/src/commands/ai-gateway/logs-list.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-list.ts
@@ -7,11 +7,19 @@ import { printError } from '../../util/error';
 import { validateJsonOutput } from '../../util/output-format';
 import { resolveTimeRange } from '../../util/time-utils';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
-import { isAPIError, ProjectNotFound } from '../../util/errors-ts';
+import { ProjectNotFound } from '../../util/errors-ts';
 import { logsListSubcommand } from './command';
 import { fetchLogsList, resolveLogsContext } from './logs-api';
 import { renderLogsTable } from './logs-format';
+import {
+  argvRequestsLogsJson,
+  outputLogsApiError,
+  outputLogsError,
+  outputMissingLogsTeam,
+  shouldUseLogsJson,
+} from './logs-output';
 import { AiGatewayLogsListTelemetryClient } from '../../util/telemetry/commands/ai-gateway/logs-list';
+import { AGENT_REASON } from '../../util/agent-output-constants';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -25,6 +33,16 @@ export default async function list(client: Client, argv: string[]) {
   try {
     parsedArgs = parseArguments(argv, flagsSpecification);
   } catch (error) {
+    if (shouldUseLogsJson(client, argvRequestsLogsJson(argv))) {
+      return outputLogsError(
+        client,
+        {
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: error instanceof Error ? error.message : String(error),
+        },
+        true
+      );
+    }
     printError(error);
     return 1;
   }
@@ -32,6 +50,8 @@ export default async function list(client: Client, argv: string[]) {
   const project = opts['--project'];
   const since = opts['--since'];
   const until = opts['--until'];
+  const search = opts['--search'];
+  const environment = opts['--environment'];
   const provider = opts['--provider'];
   const model = opts['--model'];
   const status = opts['--status'];
@@ -41,52 +61,99 @@ export default async function list(client: Client, argv: string[]) {
   telemetry.trackCliOptionProject(project);
   telemetry.trackCliOptionSince(since);
   telemetry.trackCliOptionUntil(until);
+  telemetry.trackCliOptionSearch(search);
+  telemetry.trackCliOptionEnvironment(environment);
   telemetry.trackCliOptionProvider(provider);
   telemetry.trackCliOptionModel(model);
   telemetry.trackCliOptionStatus(status);
   telemetry.trackCliOptionPage(opts['--page']);
   telemetry.trackCliOptionLimit(opts['--limit']);
   telemetry.trackCliOptionFormat(opts['--format']);
+  telemetry.trackCliFlagJson(opts['--json']);
 
   const formatResult = validateJsonOutput(opts);
+  const requestedJson =
+    opts['--json'] === true || opts['--format']?.toLowerCase() === 'json';
+  const jsonOutput = shouldUseLogsJson(client, requestedJson);
   if (!formatResult.valid) {
-    output.error(formatResult.error);
-    return 1;
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: formatResult.error,
+      },
+      jsonOutput
+    );
   }
   if (!Number.isInteger(page) || page < 1) {
-    output.error('Page must be an integer greater than 0.');
-    return 1;
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: 'Page must be an integer greater than 0.',
+      },
+      jsonOutput
+    );
   }
   if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
-    output.error(`Limit must be an integer from 1 to ${MAX_LIMIT}.`);
-    return 1;
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: `Limit must be an integer from 1 to ${MAX_LIMIT}.`,
+      },
+      jsonOutput
+    );
   }
   if (status && !/^(?:[1-5]xx|\d{3})$/.test(status)) {
-    output.error('Status must be an HTTP code or class, such as 200 or 5xx.');
-    return 1;
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: 'Status must be an HTTP code or class, such as 200 or 5xx.',
+      },
+      jsonOutput
+    );
   }
 
   let timeRange;
   try {
     timeRange = resolveTimeRange(since || '1h', until);
   } catch (error) {
-    output.error(error instanceof Error ? error.message : String(error));
-    return 1;
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: error instanceof Error ? error.message : String(error),
+      },
+      jsonOutput
+    );
   }
   if (timeRange.startTime >= timeRange.endTime) {
-    output.error('The --since time must be before --until.');
-    return 1;
+    return outputLogsError(
+      client,
+      {
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: 'The --since time must be before --until.',
+      },
+      jsonOutput
+    );
+  }
+
+  if (!client.config.currentTeam && jsonOutput) {
+    return outputMissingLogsTeam(client, 'list');
   }
 
   let context;
   try {
     context = await resolveLogsContext(client);
   } catch (error) {
-    if (isAPIError(error)) {
-      output.error(error.message);
-      return 1;
-    }
-    throw error;
+    return outputLogsApiError(
+      client,
+      error,
+      jsonOutput,
+      'vercel ai-gateway logs list --scope <team-slug> --json'
+    );
   }
   if (!context) return 1;
 
@@ -97,20 +164,27 @@ export default async function list(client: Client, argv: string[]) {
     try {
       const resolved = await getProjectByNameOrId(client, project);
       if (resolved instanceof ProjectNotFound) {
-        output.error(`Project not found: ${project}`);
-        return 1;
+        return outputLogsError(
+          client,
+          {
+            reason: AGENT_REASON.PROJECT_NOT_FOUND,
+            message: 'The project was not found in the selected team.',
+          },
+          jsonOutput
+        );
       }
       projectId = resolved.id;
     } catch (error) {
-      if (isAPIError(error)) {
-        output.error(error.message);
-        return 1;
-      }
-      throw error;
+      return outputLogsApiError(
+        client,
+        error,
+        jsonOutput,
+        'vercel ai-gateway logs list --scope <team-slug> --json'
+      );
     }
   }
 
-  output.spinner('Fetching AI Gateway logs…');
+  if (!jsonOutput) output.spinner('Fetching AI Gateway logs…');
   let result;
   try {
     result = await fetchLogsList(client, {
@@ -121,32 +195,83 @@ export default async function list(client: Client, argv: string[]) {
       provider,
       model,
       status,
+      search,
+      environment,
       page,
       limit,
     });
   } catch (error) {
-    output.stopSpinner();
-    if (isAPIError(error)) {
-      output.error(error.message);
-      return 1;
-    }
-    throw error;
+    if (!jsonOutput) output.stopSpinner();
+    return outputLogsApiError(
+      client,
+      error,
+      jsonOutput,
+      'vercel ai-gateway logs list --scope <team-slug> --json'
+    );
   }
-  output.stopSpinner();
+  if (!jsonOutput) output.stopSpinner();
 
   const hasMore = result.returned === limit;
   const response = {
-    requests: result.logs,
-    pagination: { page, limit, returned: result.returned, hasMore },
+    status: 'success',
+    reason: 'ai_gateway_logs_listed',
+    message:
+      result.logs.length === 0
+        ? 'No AI Gateway requests matched the query.'
+        : `Found ${result.logs.length} AI Gateway ${result.logs.length === 1 ? 'request' : 'requests'}.`,
+    data: {
+      team: { id: context.teamId, slug: context.teamSlug },
+      filters: {
+        projectId: projectId ?? null,
+        startTime: timeRange.startTime.toISOString(),
+        endTime: timeRange.endTime.toISOString(),
+        search: search ?? null,
+        environment: environment ?? null,
+        provider: provider ?? null,
+        model: model ?? null,
+        status: status ?? null,
+      },
+      requests: result.logs,
+      pagination: {
+        page,
+        limit,
+        returned: result.returned,
+        hasMore,
+        nextPage: hasMore ? page + 1 : null,
+      },
+    },
+    next:
+      result.logs.length === 0
+        ? [
+            {
+              command:
+                'vercel ai-gateway logs list --scope <team-slug> --since 24h --json',
+              when: 'Search a broader time range',
+            },
+          ]
+        : [
+            {
+              command:
+                'vercel ai-gateway logs inspect <generationId> --scope <team-slug> --json',
+              when: 'Inspect a request from data.requests',
+            },
+          ],
   };
-  if (formatResult.jsonOutput) {
+  if (jsonOutput) {
     client.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
     return 0;
   }
 
   if (result.logs.length === 0) {
     const filtered = Boolean(
-      project || provider || model || status || since || until
+      project ||
+        provider ||
+        model ||
+        status ||
+        since ||
+        until ||
+        search ||
+        environment
     );
     output.log(
       filtered

--- a/packages/cli/src/commands/ai-gateway/logs-output.ts
+++ b/packages/cli/src/commands/ai-gateway/logs-output.ts
@@ -1,0 +1,152 @@
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { isAPIError } from '../../util/errors-ts';
+import { shouldEmitNonInteractiveCommandError } from '../../util/agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+
+interface LogsErrorOptions {
+  message: string;
+  reason: string;
+  next?: Array<{ command: string; when?: string }>;
+}
+
+export function shouldUseLogsJson(
+  client: Client,
+  explicitJson: boolean
+): boolean {
+  return explicitJson || shouldEmitNonInteractiveCommandError(client);
+}
+
+export function argvRequestsLogsJson(argv: string[]): boolean {
+  return argv.some(
+    (arg, index) =>
+      arg === '--json' ||
+      arg === '--format=json' ||
+      (arg === '--format' && argv[index + 1]?.toLowerCase() === 'json')
+  );
+}
+
+export function outputLogsError(
+  client: Client,
+  options: LogsErrorOptions,
+  jsonOutput: boolean
+): number {
+  if (jsonOutput) {
+    client.stdout.write(
+      `${JSON.stringify({ status: AGENT_STATUS.ERROR, ...options }, null, 2)}\n`
+    );
+  } else {
+    output.error(options.message);
+  }
+  return 1;
+}
+
+export function outputMissingLogsTeam(
+  client: Client,
+  subcommand: 'inspect' | 'list'
+): number {
+  const command =
+    subcommand === 'inspect'
+      ? 'vercel ai-gateway logs inspect <generationId> --scope <team-slug> --json'
+      : 'vercel ai-gateway logs list --scope <team-slug> --json';
+  client.stdout.write(
+    `${JSON.stringify(
+      {
+        status: AGENT_STATUS.ACTION_REQUIRED,
+        reason: AGENT_REASON.MISSING_SCOPE,
+        message:
+          'Provide --scope <team-slug>. No team is selected in non-interactive mode.',
+        next: [{ command }],
+      },
+      null,
+      2
+    )}\n`
+  );
+  return 1;
+}
+
+export function outputMissingLogsSubcommand(client: Client): number {
+  client.stdout.write(
+    `${JSON.stringify(
+      {
+        status: AGENT_STATUS.ACTION_REQUIRED,
+        reason: AGENT_REASON.MISSING_ARGUMENTS,
+        message: 'Choose an AI Gateway logs subcommand.',
+        next: [
+          {
+            command: 'vercel ai-gateway logs list --scope <team-slug> --json',
+            when: 'Search and filter AI Gateway requests',
+          },
+          {
+            command:
+              'vercel ai-gateway logs inspect <generationId> --scope <team-slug> --json',
+            when: 'Inspect one request and its provider attempts',
+          },
+        ],
+      },
+      null,
+      2
+    )}\n`
+  );
+  return 1;
+}
+
+export function outputLogsApiError(
+  client: Client,
+  error: unknown,
+  jsonOutput: boolean,
+  retryCommand: string
+): number {
+  if (!jsonOutput && isAPIError(error)) {
+    output.error(error.serverMessage || error.message);
+    return 1;
+  }
+  if (!isAPIError(error)) {
+    return outputLogsError(
+      client,
+      {
+        reason: 'unexpected_error',
+        message: 'Failed to fetch AI Gateway logs.',
+      },
+      jsonOutput
+    );
+  }
+
+  const reason =
+    error.status === 401
+      ? AGENT_REASON.LOGIN_REQUIRED
+      : error.status === 403
+        ? AGENT_REASON.PERMISSION_DENIED
+        : error.status === 404
+          ? AGENT_REASON.NOT_FOUND
+          : error.status === 429
+            ? 'rate_limited'
+            : AGENT_REASON.API_ERROR;
+  const message =
+    error.status === 401
+      ? 'Authentication failed. Pass --token <TOKEN> or set VERCEL_TOKEN.'
+      : error.status === 403
+        ? 'You do not have permission to read AI Gateway logs for the selected team.'
+        : error.status === 404
+          ? 'The AI Gateway logs endpoint was not found.'
+          : error.status === 429
+            ? 'AI Gateway log requests are rate limited. Retry after the limit resets.'
+            : error.status >= 500
+              ? `The AI Gateway logs endpoint failed (${error.status}). Re-run with --debug and share the Request ID from the failed request.`
+              : `Failed to fetch AI Gateway logs (${error.status}).`;
+  const next =
+    error.status === 401 || error.status === 403
+      ? [
+          {
+            command: 'vercel whoami --scope <team-slug>',
+            when: 'Verify the current user and team',
+          },
+          {
+            command: retryCommand,
+            when: 'Retry after fixing authentication, team, or permissions',
+          },
+        ]
+      : undefined;
+
+  return outputLogsError(client, { reason, message, next }, jsonOutput);
+}

--- a/packages/cli/src/commands/ai-gateway/logs.ts
+++ b/packages/cli/src/commands/ai-gateway/logs.ts
@@ -15,6 +15,12 @@ import output from '../../output-manager';
 import { getCommandAliases } from '..';
 import { AiGatewayLogsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/logs';
 import { printError } from '../../util/error';
+import {
+  outputLogsError,
+  outputMissingLogsSubcommand,
+  shouldUseLogsJson,
+} from './logs-output';
+import { AGENT_REASON } from '../../util/agent-output-constants';
 
 const COMMAND_CONFIG = {
   inspect: getCommandAliases(logsInspectSubcommand),
@@ -32,6 +38,16 @@ export default async function logs(client: Client) {
       permissive: true,
     });
   } catch (error) {
+    if (shouldUseLogsJson(client, false)) {
+      return outputLogsError(
+        client,
+        {
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: error instanceof Error ? error.message : String(error),
+        },
+        true
+      );
+    }
     printError(error);
     return 1;
   }
@@ -42,7 +58,10 @@ export default async function logs(client: Client) {
   );
   const needHelp = parsedArgs.flags['--help'];
 
-  if (!subcommand && needHelp) {
+  if (!subcommand && (needHelp || parsedArgs.args.slice(2).length === 0)) {
+    if (!needHelp && shouldUseLogsJson(client, false)) {
+      return outputMissingLogsSubcommand(client);
+    }
     telemetry.trackCliFlagHelp('ai-gateway logs', subcommandOriginal);
     output.print(help(logsSubcommand, { columns: client.stderr.columns }));
     return 2;
@@ -72,6 +91,22 @@ export default async function logs(client: Client) {
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return list(client, args);
     default:
+      if (shouldUseLogsJson(client, false)) {
+        return outputLogsError(
+          client,
+          {
+            reason: AGENT_REASON.INVALID_ARGUMENTS,
+            message: 'Unknown AI Gateway logs subcommand.',
+            next: [
+              {
+                command: 'vercel ai-gateway logs --help',
+                when: 'List available logs subcommands',
+              },
+            ],
+          },
+          true
+        );
+      }
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(logsSubcommand, { columns: client.stderr.columns }));
       return 2;

--- a/packages/cli/src/commands/ai-gateway/logs.ts
+++ b/packages/cli/src/commands/ai-gateway/logs.ts
@@ -1,0 +1,79 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import getSubcommand from '../../util/get-subcommand';
+import { type Command, help } from '../help';
+import list from './logs-list';
+import inspect from './logs-inspect';
+import {
+  logsInspectSubcommand,
+  logsListSubcommand,
+  logsSubcommand,
+} from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { getCommandAliases } from '..';
+import { AiGatewayLogsTelemetryClient } from '../../util/telemetry/commands/ai-gateway/logs';
+import { printError } from '../../util/error';
+
+const COMMAND_CONFIG = {
+  inspect: getCommandAliases(logsInspectSubcommand),
+  list: getCommandAliases(logsListSubcommand),
+};
+
+export default async function logs(client: Client) {
+  const telemetry = new AiGatewayLogsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+  const flagsSpecification = getFlagsSpecification(logsSubcommand.options);
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    parsedArgs.args.slice(2),
+    COMMAND_CONFIG
+  );
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('ai-gateway logs', subcommandOriginal);
+    output.print(help(logsSubcommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, { parent: logsSubcommand, columns: client.stderr.columns })
+    );
+  }
+
+  switch (subcommand) {
+    case 'inspect':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('ai-gateway logs', subcommandOriginal);
+        printHelp(logsInspectSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandInspect(subcommandOriginal);
+      return inspect(client, args);
+    case 'list':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('ai-gateway logs', subcommandOriginal);
+        printHelp(logsListSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return list(client, args);
+    default:
+      output.error(getInvalidSubcommand(COMMAND_CONFIG));
+      output.print(help(logsSubcommand, { columns: client.stderr.columns }));
+      return 2;
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/index.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/index.ts
@@ -41,6 +41,13 @@ export class AiGatewayTelemetryClient
     });
   }
 
+  trackCliSubcommandLogs(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'logs',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandLeaderboard(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'leaderboard',

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/logs-inspect.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/logs-inspect.ts
@@ -15,4 +15,8 @@ export class AiGatewayLogsInspectTelemetryClient
   trackCliOptionFormat(value?: string) {
     if (value) this.trackCliOption({ option: 'format', value });
   }
+
+  trackCliFlagJson(value?: boolean) {
+    if (value) this.trackCliFlag('json');
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/logs-inspect.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/logs-inspect.ts
@@ -1,0 +1,18 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { logsInspectSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLogsInspectTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof logsInspectSubcommand>
+{
+  trackCliArgumentGenerationId(value?: string) {
+    if (value) {
+      this.trackCliArgument({ arg: 'generationId', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionFormat(value?: string) {
+    if (value) this.trackCliOption({ option: 'format', value });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/logs-list.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/logs-list.ts
@@ -1,0 +1,43 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { logsListSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLogsListTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof logsListSubcommand>
+{
+  trackCliOptionProject(value?: string) {
+    if (value)
+      this.trackCliOption({ option: 'project', value: this.redactedValue });
+  }
+  trackCliOptionSince(value?: string) {
+    if (value)
+      this.trackCliOption({ option: 'since', value: this.redactedValue });
+  }
+  trackCliOptionUntil(value?: string) {
+    if (value)
+      this.trackCliOption({ option: 'until', value: this.redactedValue });
+  }
+  trackCliOptionProvider(value?: string) {
+    if (value)
+      this.trackCliOption({ option: 'provider', value: this.redactedValue });
+  }
+  trackCliOptionModel(value?: string) {
+    if (value)
+      this.trackCliOption({ option: 'model', value: this.redactedValue });
+  }
+  trackCliOptionStatus(value?: string) {
+    if (value) this.trackCliOption({ option: 'status', value });
+  }
+  trackCliOptionPage(value?: number) {
+    if (value !== undefined)
+      this.trackCliOption({ option: 'page', value: this.redactedValue });
+  }
+  trackCliOptionLimit(value?: number) {
+    if (value !== undefined)
+      this.trackCliOption({ option: 'limit', value: this.redactedValue });
+  }
+  trackCliOptionFormat(value?: string) {
+    if (value) this.trackCliOption({ option: 'format', value });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/logs-list.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/logs-list.ts
@@ -18,6 +18,14 @@ export class AiGatewayLogsListTelemetryClient
     if (value)
       this.trackCliOption({ option: 'until', value: this.redactedValue });
   }
+  trackCliOptionSearch(value?: string) {
+    if (value)
+      this.trackCliOption({ option: 'search', value: this.redactedValue });
+  }
+  trackCliOptionEnvironment(value?: string) {
+    if (value)
+      this.trackCliOption({ option: 'environment', value: this.redactedValue });
+  }
   trackCliOptionProvider(value?: string) {
     if (value)
       this.trackCliOption({ option: 'provider', value: this.redactedValue });
@@ -39,5 +47,8 @@ export class AiGatewayLogsListTelemetryClient
   }
   trackCliOptionFormat(value?: string) {
     if (value) this.trackCliOption({ option: 'format', value });
+  }
+  trackCliFlagJson(value?: boolean) {
+    if (value) this.trackCliFlag('json');
   }
 }

--- a/packages/cli/src/util/telemetry/commands/ai-gateway/logs.ts
+++ b/packages/cli/src/util/telemetry/commands/ai-gateway/logs.ts
@@ -1,0 +1,16 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { logsSubcommand } from '../../../../commands/ai-gateway/command';
+
+export class AiGatewayLogsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof logsSubcommand>
+{
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'inspect', value: actual });
+  }
+
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'list', value: actual });
+  }
+}

--- a/packages/cli/test/unit/commands/ai-gateway/logs-inspect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/logs-inspect.test.ts
@@ -65,9 +65,12 @@ function useAttempts(rows: unknown[] = attempts) {
     expect(req.body).toMatchObject({
       event: 'aiGatewayProviderAttempt',
       scope: { type: 'team-with-slug', teamSlug: 'acme' },
+      granularity: { hours: 1 },
       filter: `generationId eq '${generationId}'`,
       limit: 50,
     });
+    expect(Date.parse(String(req.body.startTime)) % (60 * 60 * 1000)).toBe(0);
+    expect(Date.parse(String(req.body.endTime)) % (60 * 60 * 1000)).toBe(0);
     res.json({ summary: rows });
   });
 }

--- a/packages/cli/test/unit/commands/ai-gateway/logs-inspect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/logs-inspect.test.ts
@@ -91,6 +91,7 @@ describe('ai-gateway logs inspect', () => {
     const help = client.stderr.getFullOutput();
     expect(help).toContain('generationId');
     expect(help).toContain('--format');
+    expect(help).toContain('--json');
   });
 
   it('shows the request and failures before successful attempts', async () => {
@@ -109,29 +110,51 @@ describe('ai-gateway logs inspect', () => {
   it('outputs normalized JSON with the ordered fallback path', async () => {
     useRequest();
     useAttempts();
-    client.setArgv(
-      'ai-gateway',
-      'logs',
-      'inspect',
-      generationId,
-      '--format',
-      'json'
-    );
+    client.setArgv('ai-gateway', 'logs', 'inspect', generationId, '--json');
 
     expect(await logs(client)).toBe(0);
     const result = JSON.parse(client.stdout.getFullOutput());
-    expect(result.request).toMatchObject({ generationId, region: 'sfo1' });
-    expect(result.attempts).toHaveLength(2);
-    expect(result.attempts[0]).toMatchObject({
+    expect(result).toMatchObject({
+      status: 'success',
+      reason: 'ai_gateway_log_inspected',
+    });
+    expect(result.data.request).toMatchObject({
+      generationId,
+      region: 'sfo1',
+    });
+    expect(result.data.attempts).toHaveLength(2);
+    expect(result.data.attempts[0]).toMatchObject({
       provider: 'bedrock',
       success: false,
       statusCode: 429,
     });
-    expect(result.attempts[1]).toMatchObject({
+    expect(result.data.attempts[1]).toMatchObject({
       provider: 'anthropic',
       success: true,
       statusCode: 200,
     });
+    expect(client.stderr.getFullOutput()).toBe('');
+  });
+
+  it('defaults to structured JSON when an agent is detected', async () => {
+    useRequest();
+    useAttempts();
+    client.nonInteractive = true;
+    client.isAgent = true;
+    client.setArgv('ai-gateway', 'logs', 'inspect', generationId);
+
+    expect(await logs(client)).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput())).toMatchObject({
+      status: 'success',
+      data: {
+        request: { generationId },
+        attempts: [
+          { success: false, statusCode: 429 },
+          { success: true, statusCode: 200 },
+        ],
+      },
+    });
+    expect(client.stderr.getFullOutput()).toBe('');
   });
 
   it('rejects malformed Generation IDs before fetching', async () => {
@@ -152,5 +175,20 @@ describe('ai-gateway logs inspect', () => {
     expect(client.stderr.getFullOutput()).toContain(
       'It may be outside retention or belong to another team.'
     );
+  });
+
+  it('returns structured not-found errors for agents', async () => {
+    useRequest(null);
+    useAttempts([]);
+    client.nonInteractive = true;
+    client.setArgv('ai-gateway', 'logs', 'inspect', generationId);
+
+    expect(await logs(client)).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toMatchObject({
+      status: 'error',
+      reason: 'not_found',
+      next: [{ command: expect.stringContaining('logs list') }],
+    });
+    expect(client.stderr.getFullOutput()).toBe('');
   });
 });

--- a/packages/cli/test/unit/commands/ai-gateway/logs-inspect.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/logs-inspect.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import logs from '../../../../src/commands/ai-gateway/logs';
+import { client } from '../../../mocks/client';
+
+const generationId = 'gen_01K00000000000000000000000';
+const request = {
+  aiModel: 'anthropic/claude-sonnet-4.5',
+  aiProvider: 'anthropic',
+  aiRequestDurationMs: 900,
+  cost: 0.002,
+  costCurrency: 'USD',
+  environment: 'production',
+  generationId,
+  httpStatus: 200,
+  inferenceGeoRegion: 'sfo1',
+  inputTokens: 500,
+  outputTokens: 100,
+  projectId: 'prj_123',
+  reasoningTokens: 25,
+  timestamp: '2026-08-03 20:00:00',
+};
+
+const attempts = [
+  {
+    aiProvider: 'anthropic',
+    providerAttemptCanonicalSlug: 'anthropic/claude-sonnet-4.5',
+    providerAttemptCredentialType: 'vercel',
+    providerAttemptError: '',
+    providerAttemptModelIndex: 1,
+    providerAttemptNumber: 2,
+    providerAttemptStatusCode: 200,
+    providerAttemptSuccess: '1',
+    responseTimeMs: 600,
+  },
+  {
+    aiProvider: 'bedrock',
+    providerAttemptCanonicalSlug: 'anthropic/claude-sonnet-4.5',
+    providerAttemptCredentialType: 'byok',
+    providerAttemptError: 'rate limited',
+    providerAttemptModelIndex: 0,
+    providerAttemptNumber: 1,
+    providerAttemptStatusCode: 429,
+    providerAttemptSuccess: '0',
+    responseTimeMs: 300,
+  },
+];
+
+function useTeam() {
+  client.config.currentTeam = 'team_123';
+  client.scenario.get('/teams/team_123', (_req, res) => {
+    res.json({ id: 'team_123', slug: 'acme', name: 'Acme' });
+  });
+}
+
+function useRequest(row: unknown = request) {
+  client.scenario.get('/api/ai/gateway-inference-requests', (req, res) => {
+    expect(req.query.generationId).toBe(generationId);
+    res.json({ data: row ? [row] : [], pageInfo: { returned: row ? 1 : 0 } });
+  });
+}
+
+function useAttempts(rows: unknown[] = attempts) {
+  client.scenario.post('/api/observability/metrics', (req, res) => {
+    expect(req.query.slug).toBe('acme');
+    expect(req.body).toMatchObject({
+      event: 'aiGatewayProviderAttempt',
+      scope: { type: 'team-with-slug', teamSlug: 'acme' },
+      filter: `generationId eq '${generationId}'`,
+      limit: 50,
+    });
+    res.json({ summary: rows });
+  });
+}
+
+describe('ai-gateway logs inspect', () => {
+  beforeEach(() => {
+    process.env.VERCEL_AI_GATEWAY_LOGS_API_URL = `${client.apiUrl}/api/ai/gateway-inference-requests`;
+    process.env.VERCEL_AI_GATEWAY_METRICS_API_URL = `${client.apiUrl}/api/observability/metrics`;
+    useTeam();
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_AI_GATEWAY_LOGS_API_URL;
+    delete process.env.VERCEL_AI_GATEWAY_METRICS_API_URL;
+  });
+
+  it('shows inspect help with the generation ID and JSON output', async () => {
+    client.setArgv('ai-gateway', 'logs', 'inspect', '--help');
+
+    expect(await logs(client)).toBe(2);
+    const help = client.stderr.getFullOutput();
+    expect(help).toContain('generationId');
+    expect(help).toContain('--format');
+  });
+
+  it('shows the request and failures before successful attempts', async () => {
+    useRequest();
+    useAttempts();
+    client.setArgv('ai-gateway', 'logs', 'inspect', generationId);
+
+    expect(await logs(client)).toBe(0);
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).toContain('Input tokens');
+    expect(stdout).toContain('SFO1');
+    expect(stdout.indexOf('failed')).toBeLessThan(stdout.indexOf('success'));
+    expect(stdout).toContain('rate limited');
+  });
+
+  it('outputs normalized JSON with the ordered fallback path', async () => {
+    useRequest();
+    useAttempts();
+    client.setArgv(
+      'ai-gateway',
+      'logs',
+      'inspect',
+      generationId,
+      '--format',
+      'json'
+    );
+
+    expect(await logs(client)).toBe(0);
+    const result = JSON.parse(client.stdout.getFullOutput());
+    expect(result.request).toMatchObject({ generationId, region: 'sfo1' });
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[0]).toMatchObject({
+      provider: 'bedrock',
+      success: false,
+      statusCode: 429,
+    });
+    expect(result.attempts[1]).toMatchObject({
+      provider: 'anthropic',
+      success: true,
+      statusCode: 200,
+    });
+  });
+
+  it('rejects malformed Generation IDs before fetching', async () => {
+    client.setArgv('ai-gateway', 'logs', 'inspect', 'gen_bad?query=1');
+
+    expect(await logs(client)).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Generation ID must be `gen_` followed by a 26-character ULID.'
+    );
+  });
+
+  it('returns a clear error when the request is not retained', async () => {
+    useRequest(null);
+    useAttempts([]);
+    client.setArgv('ai-gateway', 'logs', 'inspect', generationId);
+
+    expect(await logs(client)).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'It may be outside retention or belong to another team.'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/logs-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/logs-list.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import aiGateway from '../../../../src/commands/ai-gateway';
+import logs from '../../../../src/commands/ai-gateway/logs';
+import { client } from '../../../mocks/client';
+
+const generationId = 'gen_01K00000000000000000000000';
+
+const sampleRow = {
+  aiModel: 'anthropic/claude-sonnet-4.5',
+  aiProvider: 'anthropic',
+  aiRequestDurationMs: 1250,
+  cachedInputTokens: 100,
+  cacheCreationInputTokens: 20,
+  contentCaptureInputs: 'private prompt data',
+  cost: 0.0012,
+  costCurrency: 'USD',
+  environment: 'production',
+  generationId,
+  httpStatus: 200,
+  inferenceGeoRegion: 'iad1',
+  inputTokens: 1000,
+  outputTokens: 200,
+  projectId: 'prj_123',
+  reasoningTokens: 50,
+  reportingWriteCost: 0.0001,
+  timeToFirstTokenMs: 300,
+  timestamp: '2026-08-03 20:00:00',
+};
+
+function useTeam() {
+  client.config.currentTeam = 'team_123';
+  client.scenario.get('/teams/team_123', (_req, res) => {
+    res.json({ id: 'team_123', slug: 'acme', name: 'Acme' });
+  });
+}
+
+function useLogs(rows: unknown[] = [sampleRow]) {
+  client.scenario.get('/api/ai/gateway-inference-requests', (req, res) => {
+    expect(req.query.teamId).toBe('team_123');
+    res.json({
+      data: rows,
+      pageInfo: { limit: 20, offset: 0, returned: rows.length },
+    });
+  });
+}
+
+describe('ai-gateway logs list', () => {
+  beforeEach(() => {
+    process.env.VERCEL_AI_GATEWAY_LOGS_API_URL = `${client.apiUrl}/api/ai/gateway-inference-requests`;
+    useTeam();
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_AI_GATEWAY_LOGS_API_URL;
+  });
+
+  it('shows logs subcommand help', async () => {
+    client.setArgv('ai-gateway', 'logs', '--help');
+
+    expect(await aiGateway(client)).toBe(2);
+    const help = client.stderr.getFullOutput();
+    expect(help).toContain('list');
+    expect(help).toContain('inspect');
+  });
+
+  it('shows list help with filters and JSON output', async () => {
+    client.setArgv('ai-gateway', 'logs', 'list', '--help');
+
+    expect(await logs(client)).toBe(2);
+    const help = client.stderr.getFullOutput();
+    expect(help).toContain('--provider');
+    expect(help).toContain('--status');
+    expect(help).toContain('--format');
+  });
+
+  it('lists request fields in a table', async () => {
+    useLogs();
+    client.setArgv('ai-gateway', 'logs', 'list');
+
+    expect(await logs(client)).toBe(0);
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).toContain(generationId);
+    expect(stdout).toContain('anthropic/claude-sonnet-4.5');
+    expect(stdout).toContain('IAD1');
+    expect(stdout).toContain('1,250');
+  });
+
+  it('outputs a normalized, bounded JSON contract', async () => {
+    useLogs();
+    client.setArgv(
+      'ai-gateway',
+      'logs',
+      'list',
+      '--limit',
+      '1',
+      '--format',
+      'json'
+    );
+
+    expect(await logs(client)).toBe(0);
+    const result = JSON.parse(client.stdout.getFullOutput());
+    expect(result).toMatchObject({
+      requests: [
+        {
+          generationId,
+          cost: { total: 0.0013, inference: 0.0012, currency: 'USD' },
+          tokens: {
+            input: 1000,
+            cachedInput: 100,
+            cacheCreationInput: 20,
+            output: 200,
+            reasoning: 50,
+            total: 1250,
+          },
+        },
+      ],
+      pagination: { page: 1, limit: 1, returned: 1, hasMore: true },
+    });
+    expect(client.stdout.getFullOutput()).not.toContain('private prompt data');
+  });
+
+  it('resolves a project and sends filters', async () => {
+    client.scenario.get('/v9/projects/my-app', (_req, res) => {
+      res.json({ id: 'prj_123', name: 'my-app' });
+    });
+    client.scenario.get('/api/ai/gateway-inference-requests', (req, res) => {
+      expect(req.query).toMatchObject({
+        projectId: 'prj_123',
+        aiProvider: 'anthropic',
+        aiModel: 'anthropic/claude-sonnet-4.5',
+        status: '5xx',
+        limit: '10',
+        offset: '10',
+      });
+      res.json({ data: [], pageInfo: { returned: 0 } });
+    });
+    client.setArgv(
+      'ai-gateway',
+      'logs',
+      'list',
+      '--project',
+      'my-app',
+      '--provider',
+      'anthropic',
+      '--model',
+      'anthropic/claude-sonnet-4.5',
+      '--status',
+      '5xx',
+      '--page',
+      '2',
+      '--limit',
+      '10'
+    );
+
+    expect(await logs(client)).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'No AI Gateway requests match the current filters.'
+    );
+  });
+
+  it('rejects invalid status filters before fetching logs', async () => {
+    client.setArgv('ai-gateway', 'logs', 'list', '--status', 'failed');
+
+    expect(await logs(client)).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Status must be an HTTP code or class'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/ai-gateway/logs-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/logs-list.test.ts
@@ -63,14 +63,43 @@ describe('ai-gateway logs list', () => {
     expect(help).toContain('inspect');
   });
 
+  it('shows logs help without treating no arguments as an error', async () => {
+    client.setArgv('ai-gateway', 'logs');
+
+    expect(await aiGateway(client)).toBe(2);
+    const help = client.stderr.getFullOutput();
+    expect(help).toContain('list');
+    expect(help).toContain('inspect');
+    expect(help).not.toContain('Invalid subcommand');
+  });
+
+  it('returns agent-traversable subcommands when no action is provided', async () => {
+    client.nonInteractive = true;
+    client.isAgent = true;
+    client.setArgv('ai-gateway', 'logs');
+
+    expect(await aiGateway(client)).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toMatchObject({
+      status: 'action_required',
+      reason: 'missing_arguments',
+      next: [
+        { command: expect.stringContaining('logs list') },
+        { command: expect.stringContaining('logs inspect') },
+      ],
+    });
+    expect(client.stderr.getFullOutput()).toBe('');
+  });
+
   it('shows list help with filters and JSON output', async () => {
     client.setArgv('ai-gateway', 'logs', 'list', '--help');
 
     expect(await logs(client)).toBe(2);
     const help = client.stderr.getFullOutput();
     expect(help).toContain('--provider');
+    expect(help).toContain('--search');
     expect(help).toContain('--status');
     expect(help).toContain('--format');
+    expect(help).toContain('--json');
   });
 
   it('lists request fields in a table', async () => {
@@ -87,36 +116,70 @@ describe('ai-gateway logs list', () => {
 
   it('outputs a normalized, bounded JSON contract', async () => {
     useLogs();
-    client.setArgv(
-      'ai-gateway',
-      'logs',
-      'list',
-      '--limit',
-      '1',
-      '--format',
-      'json'
-    );
+    client.setArgv('ai-gateway', 'logs', 'list', '--limit', '1', '--json');
 
     expect(await logs(client)).toBe(0);
     const result = JSON.parse(client.stdout.getFullOutput());
     expect(result).toMatchObject({
-      requests: [
-        {
-          generationId,
-          cost: { total: 0.0013, inference: 0.0012, currency: 'USD' },
-          tokens: {
-            input: 1000,
-            cachedInput: 100,
-            cacheCreationInput: 20,
-            output: 200,
-            reasoning: 50,
-            total: 1250,
+      status: 'success',
+      reason: 'ai_gateway_logs_listed',
+      data: {
+        requests: [
+          {
+            generationId,
+            cost: { total: 0.0013, inference: 0.0012, currency: 'USD' },
+            tokens: {
+              input: 1000,
+              cachedInput: 100,
+              cacheCreationInput: 20,
+              output: 200,
+              reasoning: 50,
+              total: 1250,
+            },
           },
+        ],
+        pagination: {
+          page: 1,
+          limit: 1,
+          returned: 1,
+          hasMore: true,
+          nextPage: 2,
         },
-      ],
-      pagination: { page: 1, limit: 1, returned: 1, hasMore: true },
+      },
     });
     expect(client.stdout.getFullOutput()).not.toContain('private prompt data');
+    expect(client.stderr.getFullOutput()).toBe('');
+  });
+
+  it('defaults to structured JSON when an agent is detected', async () => {
+    useLogs();
+    client.nonInteractive = true;
+    client.isAgent = true;
+    client.setArgv('ai-gateway', 'logs', 'list');
+
+    expect(await logs(client)).toBe(0);
+    const result = JSON.parse(client.stdout.getFullOutput());
+    expect(result).toMatchObject({
+      status: 'success',
+      reason: 'ai_gateway_logs_listed',
+      data: { team: { id: 'team_123', slug: 'acme' } },
+    });
+    expect(client.stderr.getFullOutput()).toBe('');
+  });
+
+  it('returns a structured empty result in JSON mode', async () => {
+    useLogs([]);
+    client.setArgv('ai-gateway', 'logs', 'list', '--json');
+
+    expect(await logs(client)).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput())).toMatchObject({
+      status: 'success',
+      data: {
+        requests: [],
+        pagination: { returned: 0, hasMore: false, nextPage: null },
+      },
+    });
+    expect(client.stderr.getFullOutput()).toBe('');
   });
 
   it('resolves a project and sends filters', async () => {
@@ -126,6 +189,8 @@ describe('ai-gateway logs list', () => {
     client.scenario.get('/api/ai/gateway-inference-requests', (req, res) => {
       expect(req.query).toMatchObject({
         projectId: 'prj_123',
+        q: generationId,
+        environment: 'production',
         aiProvider: 'anthropic',
         aiModel: 'anthropic/claude-sonnet-4.5',
         status: '5xx',
@@ -140,6 +205,10 @@ describe('ai-gateway logs list', () => {
       'list',
       '--project',
       'my-app',
+      '--search',
+      generationId,
+      '--environment',
+      'production',
       '--provider',
       'anthropic',
       '--model',
@@ -165,5 +234,35 @@ describe('ai-gateway logs list', () => {
     expect(client.stderr.getFullOutput()).toContain(
       'Status must be an HTTP code or class'
     );
+  });
+
+  it('returns action-required JSON when an agent has no team', async () => {
+    client.config.currentTeam = undefined;
+    client.nonInteractive = true;
+    client.setArgv('ai-gateway', 'logs', 'list');
+
+    expect(await logs(client)).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toMatchObject({
+      status: 'action_required',
+      reason: 'missing_scope',
+      next: [{ command: expect.stringContaining('--scope <team-slug>') }],
+    });
+    expect(client.stderr.getFullOutput()).toBe('');
+  });
+
+  it('returns structured API errors for agents', async () => {
+    client.nonInteractive = true;
+    client.scenario.get('/api/ai/gateway-inference-requests', (_req, res) => {
+      res.status(403).json({ error: { message: 'forbidden' } });
+    });
+    client.setArgv('ai-gateway', 'logs', 'list');
+
+    expect(await logs(client)).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toMatchObject({
+      status: 'error',
+      reason: 'permission_denied',
+      next: expect.any(Array),
+    });
+    expect(client.stderr.getFullOutput()).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

- add `vercel ai-gateway logs list` and `ls` for searching recent team or project requests
- add `vercel ai-gateway logs inspect <generationId>` for request details and the complete provider fallback path, with failures first
- make the command family agent-ready with automatic structured output, stable status and reason fields, actionable traversal, bounded pagination, and a `--json` alias
- add telemetry, help metadata, focused tests, and a CLI changeset

## Agent UX

This follows the agent-facing Vercel CLI direction established by #16904, #17061, #17239, and #17243.

- detected non-interactive agents receive JSON automatically without needing to discover an output flag
- `vercel ai-gateway logs` with no subcommand returns `action_required` JSON with runnable list and inspect paths
- success, empty, invalid-input, missing-team, not-found, permission, authentication, rate-limit, and API failure states have stable machine-readable contracts
- `--json` and `--format json` are equivalent for explicit scripting
- list results include exact filters, team context, `hasMore`, and `nextPage`
- next actions use safe placeholders and remote log fields remain under `data`
- machine mode emits no spinner or human prose to stderr

## UX and scope

The list defaults to the current team, the last hour, 20 rows, and newest-first ordering. It supports project, free-text search across Generation ID/provider/model, environment, time, provider, model, HTTP status, page, and limit filters. The inspect view includes cost, token breakdown, duration, time to first token, model, provider, region, and provider attempts.

This deliberately does not include prompt or response content, live tailing, or raw dashboard response passthrough. Remote strings are sanitized for terminal output and every content-capture field is excluded from JSON.

## API choice

This initial draft follows the existing Agent Runs CLI precedent and uses the authenticated read-only `vercel.com` surfaces already backing AI Gateway logs. It normalizes those responses into a narrow CLI-owned contract.

The main review question is whether v1 should keep this thin-client approach or first promote the data into a dedicated stable public API. The command boundary is isolated in `logs-api.ts` so that backend can change without changing the CLI UX.

## Validation

- 19 focused Vitest tests pass, covering root routing, help, agent traversal, automatic JSON, JSON aliases, search and filters, structured empty/error states, privacy, request details, and failure-first fallback ordering
- targeted Prettier and Biome checks pass
- `git diff --check` and copy/privacy sweeps pass
- the CLI package builds and packs successfully; the tested artifact is `vercel-58.4.4.tgz`
- authenticated production smoke tests passed for list requests against Vercel AI Gateway, AI Gateway Early Access Models, Internal Playground, and Vercel scopes
- real `--status 5xx` and `--provider vertex` filters returned matching production data
- production inspect returned normalized request details and a failed provider attempt after aligning the metrics granularity and time window with the Sonar API contract
- no multi-attempt production request appeared in the bounded recent sample; fixture tests cover stable failure-first ordering across multiple attempts
