### PR TITLE
[connect] Add Resend API key helper for eve

### DIFF
--- a/.changeset/tiny-pears-email.md
+++ b/.changeset/tiny-pears-email.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add `connectResendApiKey` to the eve integration helpers for lazily resolving an app-scoped Resend API key from Vercel Connect.

--- a/packages/connect/src/eve/index.ts
+++ b/packages/connect/src/eve/index.ts
@@ -43,6 +43,11 @@ export {
   type ConnectPhotonCredentialsParams,
 } from './photon-credentials.js';
 export {
+  connectResendApiKey,
+  type ConnectResendApiKeyParams,
+  type ConnectResendApiKeyProvider,
+} from './resend-api-key.js';
+export {
   connectSlackCredentials,
   type ConnectSlackCredentialsParams,
 } from './slack-credentials.js';

--- a/packages/connect/src/eve/resend-api-key.ts
+++ b/packages/connect/src/eve/resend-api-key.ts
@@ -1,0 +1,43 @@
+import {
+  getToken,
+  type ConnectOptions,
+  type ConnectTokenParams,
+} from '../index.js';
+
+/** Lazy Resend API-key provider returned by {@link connectResendApiKey}. */
+export type ConnectResendApiKeyProvider = () => Promise<string>;
+
+/**
+ * Token parameters accepted by {@link connectResendApiKey}.
+ *
+ * Mirrors {@link ConnectTokenParams} from `@vercel/connect`, minus `subject` —
+ * Resend API keys are app-scoped, so this helper pins the subject to
+ * `{ type: "app" }`.
+ */
+export type ConnectResendApiKeyParams = Omit<ConnectTokenParams, 'subject'>;
+
+/**
+ * Build a lazy Resend API-key provider backed by a Vercel Connect connector.
+ *
+ * The helper is compatible with the `apiKey` callback accepted by
+ * `@resend/chat-sdk-adapter`. The connector may be a generic API-key connector
+ * for `api.resend.com`; callers do not need a native Resend connector type.
+ *
+ * ```ts
+ * import { connectResendApiKey } from '@vercel/connect/eve';
+ * import { createResendAdapter } from '@resend/chat-sdk-adapter';
+ *
+ * const resend = createResendAdapter({
+ *   apiKey: connectResendApiKey('api-key/resend-my-agent'),
+ *   fromAddress: 'agent@example.com',
+ * });
+ * ```
+ */
+export function connectResendApiKey(
+  connector: string,
+  params: ConnectResendApiKeyParams = {},
+  options?: ConnectOptions
+): ConnectResendApiKeyProvider {
+  return () =>
+    getToken(connector, { ...params, subject: { type: 'app' } }, options);
+}

--- a/packages/connect/test/eve/channel-credentials.test.ts
+++ b/packages/connect/test/eve/channel-credentials.test.ts
@@ -4,6 +4,7 @@ import {
   connectGitHubCredentials,
   connectLinearCredentials,
   connectPhotonCredentials,
+  connectResendApiKey,
   connectSlackCredentials,
 } from '../../src/eve/index.js';
 
@@ -166,6 +167,54 @@ describe('Eve channel credential helpers', () => {
     await expect(credentials()).rejects.toThrow(
       'Photon connector returned invalid credentials.'
     );
+  });
+
+  it('resolves a Resend API key from an app-scoped Connect token', async () => {
+    fetchMock.mockResolvedValue(jsonTokenResponse('re_secret'));
+
+    const apiKey = connectResendApiKey(
+      'api-key/resend-my-agent',
+      {},
+      { vercelToken: 'vercel_token' }
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(apiKey()).resolves.toBe('re_secret');
+    expectTokenRequest('api-key/resend-my-agent', {
+      subject: { type: 'app' },
+    });
+  });
+
+  it('forwards Resend token refinements while keeping the subject app-scoped', async () => {
+    fetchMock.mockResolvedValue(jsonTokenResponse('re_secret'));
+
+    const apiKey = connectResendApiKey(
+      'api-key/resend-my-agent',
+      { installationId: 'resend-installation' },
+      { vercelToken: 'vercel_token' }
+    );
+
+    await expect(apiKey()).resolves.toBe('re_secret');
+    expectTokenRequest('api-key/resend-my-agent', {
+      installationId: 'resend-installation',
+      subject: { type: 'app' },
+    });
+  });
+
+  it('keeps failed Resend API-key resolution retryable', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(jsonTokenResponse('re_secret'));
+
+    const apiKey = connectResendApiKey(
+      'api-key/resend-retry',
+      {},
+      { vercelToken: 'vercel_token', forceRefresh: true }
+    );
+
+    await expect(apiKey()).rejects.toThrow('temporary failure');
+    await expect(apiKey()).resolves.toBe('re_secret');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('keeps Slack credentials backed by an app-scoped Connect token', async () => {


### PR DESCRIPTION
## Summary

Adds `connectResendApiKey` to `@vercel/connect/eve` for generated eve Resend channels.

The helper:

- resolves credentials lazily so setup does not fetch a token at module load;
- pins Connect token requests to the app subject;
- works with the `apiKey` callback accepted by `@resend/chat-sdk-adapter`;
- supports the generic `api-key` connector for `api.resend.com`, without requiring a native Resend connector type.

This is intended for the follow-up eve guided setup generated by `eve add channel/resend`.

## Example

```ts
import { createResendAdapter } from '@resend/chat-sdk-adapter';
import { connectResendApiKey } from '@vercel/connect/eve';

const resend = createResendAdapter({
  apiKey: connectResendApiKey('api-key/resend-my-agent'),
  fromAddress: 'agent@example.com',
});
```

## Testing

- `pnpm --dir packages/connect test`
- `pnpm --dir packages/connect typecheck`
- `pnpm --dir packages/connect build`
