### PR TITLE
[cli] Resolve --scope for teams without a direct membership

### DIFF
--- a/.changeset/scope-direct-team-lookup.md
+++ b/.changeset/scope-direct-team-lookup.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Resolve `--scope` for teams that the user can access without a direct membership.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,6 +54,7 @@ import highlight from './util/output/highlight';
 import { parseArguments } from './util/get-args';
 import getUser from './util/get-user';
 import getTeams from './util/teams/get-teams';
+import getTeamByIdOrSlug from './util/teams/get-team-by-id-or-slug';
 import Client from './util/client';
 import { setFetchDispatcher } from './util/fetch';
 import { printError } from './util/error';
@@ -869,8 +870,22 @@ const main = async () => {
     // name, since the personal-account check below would reject it. So resolve
     // teams first and only fall back to personal-account handling when no team
     // matches the scope.
-    const related =
+    let related =
       teams && teams.find(team => team.id === scope || team.slug === scope);
+
+    // The `/teams` list only contains teams where the user is a direct
+    // member. The user can also hold a "virtual membership" to a team. In
+    // that case the list does not contain the team, but `GET /teams/:id`
+    // still returns it. Look up the scope directly before we reject it.
+    if (!related && !scopeMatchesUserIdentity) {
+      try {
+        related = await getTeamByIdOrSlug(client, scope);
+      } catch (err: unknown) {
+        output.debug(
+          `Direct team lookup for scope "${scope}" failed: ${errorToString(err)}`
+        );
+      }
+    }
 
     if (related) {
       client.config.currentTeam = related.id;

--- a/packages/cli/src/util/teams/get-team-by-id-or-slug.ts
+++ b/packages/cli/src/util/teams/get-team-by-id-or-slug.ts
@@ -1,0 +1,23 @@
+import type Client from '../client';
+import type { Team } from '@vercel-internals/types';
+import { teamCache } from './get-team-by-id';
+
+/**
+ * Fetches a single team by ID or slug.
+ *
+ * The `/teams` list endpoint only returns teams where the user is a direct
+ * member. A user can also hold a "virtual membership" to a team. In that
+ * case the list does not contain the team, but `GET /teams/:id` still
+ * returns it, so this lookup resolves it.
+ */
+export default async function getTeamByIdOrSlug(
+  client: Client,
+  teamIdOrSlug: string
+): Promise<Team> {
+  const team = await client.fetch<Team>(
+    `/teams/${encodeURIComponent(teamIdOrSlug)}`,
+    { useCurrentTeam: false }
+  );
+  teamCache.set(team.id, team);
+  return team;
+}

--- a/packages/cli/test/unit/util/teams/get-team-by-id-or-slug.test.ts
+++ b/packages/cli/test/unit/util/teams/get-team-by-id-or-slug.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import getTeamById from '../../../../src/util/teams/get-team-by-id';
+import getTeamByIdOrSlug from '../../../../src/util/teams/get-team-by-id-or-slug';
+import { client } from '../../../mocks/client';
+import { createTeam } from '../../../mocks/team';
+
+describe('getTeamByIdOrSlug', () => {
+  it('fetches a team by ID', async () => {
+    const team = createTeam('team_example', 'example-team', 'Example Team');
+    client.scenario.get('/teams/team_example', (_req, res) => {
+      res.json(team);
+    });
+
+    const fetchedTeam = await getTeamByIdOrSlug(client, team.id);
+
+    expect(fetchedTeam).toEqual(team);
+  });
+
+  it('fetches a team by slug', async () => {
+    const team = createTeam('team_example', 'example-team', 'Example Team');
+    client.scenario.get('/teams/example-team', (_req, res) => {
+      res.json(team);
+    });
+
+    const fetchedTeam = await getTeamByIdOrSlug(client, team.slug);
+
+    expect(fetchedTeam).toEqual(team);
+  });
+
+  it('does not send the current team as a query parameter', async () => {
+    const team = createTeam('team_example', 'example-team', 'Example Team');
+    client.config.currentTeam = 'team_other';
+    let teamIdParam: string | null = null;
+    client.scenario.get('/teams/team_example', (req, res) => {
+      teamIdParam = req.query.teamId ? String(req.query.teamId) : null;
+      res.json(team);
+    });
+
+    await getTeamByIdOrSlug(client, team.id);
+
+    expect(teamIdParam).toBeNull();
+  });
+
+  it('hydrates the team-by-id cache', async () => {
+    const team = createTeam('team_example', 'example-team', 'Example Team');
+    let teamFetchCount = 0;
+    client.scenario.get('/teams/example-team', (_req, res) => {
+      teamFetchCount++;
+      res.json(team);
+    });
+
+    await getTeamByIdOrSlug(client, team.slug);
+    const cachedTeam = await getTeamById(client, team.id);
+
+    expect(cachedTeam).toEqual(team);
+    expect(teamFetchCount).toBe(1);
+  });
+
+  it('throws when the team is not found', async () => {
+    client.scenario.get('/teams/missing-team', (_req, res) => {
+      res.statusCode = 404;
+      res.json({
+        error: {
+          code: 'not_found',
+          message: 'Team not found by the given slug/id',
+        },
+      });
+    });
+
+    await expect(getTeamByIdOrSlug(client, 'missing-team')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
### Why

- The CLI resolves `--scope` from the `/teams` list endpoint, which only returns teams where the user is a direct member.
- A user can also hold a "virtual membership" to a team. The `/teams` list does not contain such a team, but `GET /teams/:id` still returns it. For these teams, `--scope` failed with "The specified scope does not exist".
- This change adds a fallback: when the teams list has no match, the CLI looks up the scope directly by ID or slug before it rejects the scope.

### Validation

- New unit tests cover the lookup by ID, the lookup by slug, the omission of the `teamId` query parameter, cache hydration, and the 404 path.
- Verified manually with the local CLI against a team that only resolves through the direct lookup: `--scope <slug>` and `--scope <team id>` both list the team's projects. A scope that does not exist still shows the old error.