### PR TITLE
Adds support for multi-document pnpm yaml configs

### DIFF
--- a/.changeset/clean-lockfiles-rest.md
+++ b/.changeset/clean-lockfiles-rest.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Support pnpm lockfiles containing multiple YAML documents.

--- a/packages/backends/test/diagnostics.test.ts
+++ b/packages/backends/test/diagnostics.test.ts
@@ -637,6 +637,46 @@ packages:
     expect(accepts.resolved).toBe('1.3.8');
   });
 
+  it('uses the final document from multi-document lockfiles', async () => {
+    writePackageJson(tempDir, { dependencies: { express: '^4.18.0' } });
+    const lockPath = writePnpmLock(
+      tempDir,
+      `\
+---
+lockfileVersion: '9.0'
+
+packages:
+  pnpm@11.10.0:
+    resolution: {integrity: sha512-env}
+---
+lockfileVersion: '9.0'
+
+packages:
+  express@4.18.2:
+    resolution: {integrity: sha512-workspace}
+`
+    );
+
+    await generateProjectManifest({
+      workPath: tempDir,
+      nodeVersion,
+      cliType: 'pnpm',
+      lockfilePath: lockPath,
+      lockfileVersion: 9,
+    });
+
+    const { dependencies } = readManifest(tempDir);
+    expect(dependencies).toEqual([
+      {
+        name: 'express',
+        type: 'direct',
+        scopes: ['prod'],
+        requested: '^4.18.0',
+        resolved: '4.18.2',
+      },
+    ]);
+  });
+
   it('handles @org/pkg namespaced packages', async () => {
     writePackageJson(tempDir, { dependencies: { '@vercel/node': '^3.0.0' } });
     const lockPath = writePnpmLock(

--- a/packages/build-utils/src/fs/read-config-file.ts
+++ b/packages/build-utils/src/fs/read-config-file.ts
@@ -37,7 +37,12 @@ export async function readConfigFile<T>(
         } else if (name.endsWith('.toml')) {
           return tomlParse(str) as unknown as T;
         } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
-          return yaml.safeLoad(str, { filename: name }) as T;
+          const docs: Array<T | null> = [];
+          yaml.safeLoadAll(str, doc => docs.push(doc as T | null), {
+            filename: name,
+          });
+          const parsedYaml = docs.at(-1);
+          return parsedYaml ?? null;
         }
       } catch (_error: unknown) {
         console.log(`Error while parsing config file: "${name}"`);

--- a/packages/build-utils/src/node-diagnostics.ts
+++ b/packages/build-utils/src/node-diagnostics.ts
@@ -230,12 +230,13 @@ function parsePnpmLock(
   lockfileVersion: number | undefined
 ): Map<string, LockEntry> {
   const lockMap = new Map<string, LockEntry>();
-  // pnpm lockfiles may have multiple YAML documents (starts with '---')
+  // pnpm lockfiles may have multiple YAML documents (starts with '---'),
+  // with the workspace lockfile in the final document.
   const docs: Array<Record<string, unknown> | null> = [];
   yaml.safeLoadAll(content, doc =>
     docs.push(doc as Record<string, unknown> | null)
   );
-  const parsedYaml = docs[0];
+  const parsedYaml = docs.at(-1);
   if (!parsedYaml) return lockMap;
 
   const lv =

--- a/packages/build-utils/test/unit.read-config-file.test.ts
+++ b/packages/build-utils/test/unit.read-config-file.test.ts
@@ -21,6 +21,7 @@ describe('Test `readConfigFile()`', () => {
   const doesnotexist = join(__dirname, 'does-not-exist.json');
   const tsconfig = join(__dirname, '../tsconfig.json');
   const invalid = join(__dirname, 'invalid.json');
+  const multiDocumentYaml = join(__dirname, 'multi-document.yaml');
 
   it('should return null when file does not exist', async () => {
     expect(await readConfigFile(doesnotexist)).toBeNull();
@@ -43,6 +44,28 @@ describe('Test `readConfigFile()`', () => {
         outDir: './dist',
       },
     });
+    expect(logMessages).toEqual([]);
+  });
+
+  it('should return the final document from multi-document YAML', async () => {
+    try {
+      await writeFile(
+        multiDocumentYaml,
+        `---
+lockfileVersion: '9.0'
+source: config-dependency
+---
+lockfileVersion: '9.0'
+source: workspace
+`
+      );
+      expect(await readConfigFile(multiDocumentYaml)).toEqual({
+        lockfileVersion: '9.0',
+        source: 'workspace',
+      });
+    } finally {
+      await rm(multiDocumentYaml);
+    }
     expect(logMessages).toEqual([]);
   });
 


### PR DESCRIPTION
This PR is intended to suppress a warning we're seeing during our `vercel deploy` process where the `stdout` coming from deploy is prefixed with:

```
Error while parsing config file: "/home/buildkite-agent/repo/pnpm-lock.yaml"
```

It seems that this is the result of `readConfigFile` in `packages/build-utils/src/fs/read-config-file.ts` not supporting multiple YAML documents within a config. This has otherwise been checked for in `parsePnpmLock` in `packages/build-utils/src/node-diagnostics.ts`.

The proposed fix is to match the two implementations so that multiple documents are accepted in both. I have chosen to use the last document in the file rather than the first document in the file, which is a change to the existing implementation in `node-diagnostics.ts`. This is because I believe we want the application's lockfile as opposed to the environment's lockfile.