### PR TITLE
[vercel/connex] Configure trigger destinations on connector create

### DIFF
--- a/.changeset/calm-connectors-create.md
+++ b/.changeset/calm-connectors-create.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `--trigger-project`, `--trigger-path`, `--trigger-branch`, and `--trigger-environment` to `vercel connect create` so trigger-enabled connectors can atomically register full destination routing, defaulting to the linked project.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -42,6 +42,42 @@ export const createSubcommand = {
         "Webhook event to receive. Repeatable. Requires --triggers and replaces the provider's default events.",
     },
     {
+      name: 'trigger-project',
+      shorthand: null,
+      type: String,
+      argument: 'PROJECT',
+      deprecated: false,
+      description:
+        'Target a project by name or ID instead of the linked project. Requires --triggers.',
+    },
+    {
+      name: 'trigger-path',
+      shorthand: null,
+      type: String,
+      argument: 'PATH',
+      deprecated: false,
+      description:
+        'Set the path on the destination project that receives forwarded webhooks. Requires --triggers.',
+    },
+    {
+      name: 'trigger-branch',
+      shorthand: null,
+      type: String,
+      argument: 'BRANCH',
+      deprecated: false,
+      description:
+        'Target a specific git branch for the trigger destination. Requires --triggers.',
+    },
+    {
+      name: 'trigger-environment',
+      shorthand: null,
+      type: String,
+      argument: 'ENV',
+      deprecated: false,
+      description:
+        'Target a custom environment by slug or stable ID. Mutually exclusive with --trigger-branch and requires --triggers.',
+    },
+    {
       name: 'data',
       shorthand: null,
       type: String,
@@ -103,6 +139,18 @@ export const createSubcommand = {
     {
       name: 'Create with selected webhook events',
       value: `${packageName} connect create linear --name linear --triggers --trigger-event Issue --trigger-event Comment --trigger-event Project`,
+    },
+    {
+      name: 'Create with a custom trigger path',
+      value: `${packageName} connect create github --name github --triggers --trigger-path /eve/v1/github`,
+    },
+    {
+      name: 'Create with branch-specific trigger routing',
+      value: `${packageName} connect create github --name github --triggers --trigger-path /api/webhooks --trigger-branch main`,
+    },
+    {
+      name: 'Create with trigger routing on another project',
+      value: `${packageName} connect create github --name github --triggers --trigger-project my-api --trigger-path /api/webhooks`,
     },
     {
       name: 'Create with branding (icon and colors)',

--- a/packages/cli/src/commands/connex/create.ts
+++ b/packages/cli/src/commands/connex/create.ts
@@ -8,6 +8,8 @@ import type { JSONObject } from '@vercel-internals/types';
 import { validateJsonOutput } from '../../util/output-format';
 import { printError } from '../../util/error';
 import { getProjectLink } from '../../util/projects/link';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
 import { selectConnexTeam } from '../../util/connex/select-team';
 import {
   generateRequestCode,
@@ -20,6 +22,10 @@ import {
   type PreparedIcon,
 } from '../../util/connex/upload-icon';
 import type { ConnexClient } from './types';
+import {
+  getCustomEnvironments,
+  pickCustomEnvironment,
+} from '../../util/target/get-custom-environments';
 
 interface ConnexServiceInfo {
   types?: Array<{
@@ -37,6 +43,10 @@ export async function create(
     '--json'?: boolean;
     '--triggers'?: boolean;
     '--trigger-event'?: string[];
+    '--trigger-path'?: string;
+    '--trigger-project'?: string;
+    '--trigger-branch'?: string;
+    '--trigger-environment'?: string;
     '--icon'?: string;
     '--background-color'?: string;
     '--accent-color'?: string;
@@ -59,6 +69,50 @@ export async function create(
 
   if (flags['--trigger-event'] && !flags['--triggers']) {
     output.error('The --trigger-event flag requires --triggers.');
+    return 1;
+  }
+
+  const triggerPath = flags['--trigger-path'];
+  const triggerProject = flags['--trigger-project'];
+  const triggerBranch = flags['--trigger-branch'];
+  const triggerEnvironment = flags['--trigger-environment'];
+  if (
+    !flags['--triggers'] &&
+    (triggerPath !== undefined ||
+      triggerProject !== undefined ||
+      triggerBranch !== undefined ||
+      triggerEnvironment !== undefined)
+  ) {
+    output.error(
+      'The --trigger-project, --trigger-path, --trigger-branch, and --trigger-environment flags require --triggers.'
+    );
+    return 1;
+  }
+  if (triggerBranch !== undefined && triggerEnvironment !== undefined) {
+    output.error(
+      'The --trigger-branch and --trigger-environment flags are mutually exclusive.'
+    );
+    return 1;
+  }
+  if (triggerProject !== undefined && triggerProject.trim() === '') {
+    output.error('The --trigger-project value must not be empty.');
+    return 1;
+  }
+  if (
+    triggerPath !== undefined &&
+    (triggerPath.length === 0 || triggerPath.length > 2048)
+  ) {
+    output.error(
+      'The --trigger-path value must be between 1 and 2048 characters.'
+    );
+    return 1;
+  }
+  if (triggerBranch !== undefined && triggerBranch.trim() === '') {
+    output.error('The --trigger-branch value must not be empty.');
+    return 1;
+  }
+  if (triggerEnvironment !== undefined && triggerEnvironment.trim() === '') {
+    output.error('The --trigger-environment value must not be empty.');
     return 1;
   }
 
@@ -132,6 +186,68 @@ export async function create(
     'Select the team where you want to create this connector'
   );
 
+  const link = await getProjectLink(client, client.cwd);
+  let triggerProjectId: string | undefined;
+  if (triggerProject !== undefined) {
+    output.spinner('Looking up trigger destination project…');
+    try {
+      const resolvedProject = await getProjectByNameOrId(
+        client,
+        triggerProject,
+        client.config.currentTeam
+      );
+      output.stopSpinner();
+      if (resolvedProject instanceof ProjectNotFound) {
+        output.error(
+          `Trigger destination project ${triggerProject} was not found. Check the name/ID and try again.`
+        );
+        return 1;
+      }
+      triggerProjectId = resolvedProject.id;
+    } catch (err: unknown) {
+      output.stopSpinner();
+      printError(err);
+      return 1;
+    }
+  }
+  const destinationProjectId = triggerProjectId ?? link?.projectId;
+  if (
+    (triggerPath !== undefined ||
+      triggerProject !== undefined ||
+      triggerBranch !== undefined ||
+      triggerEnvironment !== undefined) &&
+    !destinationProjectId
+  ) {
+    output.error(
+      'Trigger destination flags require a linked project. Run `vercel link` first.'
+    );
+    return 1;
+  }
+
+  let customEnvironmentId: string | undefined;
+  if (triggerEnvironment !== undefined && destinationProjectId) {
+    try {
+      const customEnvironments = await getCustomEnvironments(
+        client,
+        destinationProjectId
+      );
+      const customEnvironment = pickCustomEnvironment(
+        customEnvironments,
+        triggerEnvironment
+      );
+      if (!customEnvironment) {
+        output.error(
+          `Unknown trigger environment ${triggerEnvironment} for project ${destinationProjectId}. Use a custom environment slug or stable ID from that project.`
+        );
+        return 1;
+      }
+      customEnvironmentId = customEnvironment.id;
+    } catch (err: unknown) {
+      printError(err);
+      return 1;
+    }
+  }
+
   if (isDataFlagEmpty) {
     return await outputMissingDataError(client, serviceType, connectorType);
   }
@@ -167,8 +283,6 @@ export async function create(
     output.stopSpinner();
   }
 
-  const link = await getProjectLink(client, client.cwd);
-
   const body: JSONObject = {
     service: serviceType,
     name,
@@ -179,6 +293,21 @@ export async function create(
   body.triggers = { enabled: flags['--triggers'] === true };
   if (flags['--trigger-event'] !== undefined) {
     body.events = flags['--trigger-event'];
+  }
+  if (
+    triggerPath !== undefined ||
+    triggerProject !== undefined ||
+    triggerBranch !== undefined ||
+    triggerEnvironment !== undefined
+  ) {
+    body.triggerDestination = {
+      ...(triggerProjectId !== undefined
+        ? { projectId: triggerProjectId }
+        : {}),
+      ...(triggerPath !== undefined ? { path: triggerPath } : {}),
+      ...(triggerBranch !== undefined ? { branch: triggerBranch } : {}),
+      ...(customEnvironmentId !== undefined ? { customEnvironmentId } : {}),
+    };
   }
   if (iconSha) {
     body.icon = iconSha;

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -116,6 +116,19 @@ export default async function connex(client: Client): Promise<number> {
         telemetry.trackCliOptionTriggerEvent(
           createParsedArgs.flags['--trigger-event']
         );
+        telemetry.trackCliFlagTriggers(createParsedArgs.flags['--triggers']);
+        telemetry.trackCliOptionTriggerPath(
+          createParsedArgs.flags['--trigger-path']
+        );
+        telemetry.trackCliOptionTriggerProject(
+          createParsedArgs.flags['--trigger-project']
+        );
+        telemetry.trackCliOptionTriggerBranch(
+          createParsedArgs.flags['--trigger-branch']
+        );
+        telemetry.trackCliOptionTriggerEnvironment(
+          createParsedArgs.flags['--trigger-environment']
+        );
         return await create(
           client,
           createParsedArgs.args,

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -191,6 +191,15 @@ export class ConnexTelemetryClient
     }
   }
 
+  trackCliOptionTriggerProject(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'trigger-project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagMyTokens(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('my-tokens');

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -849,8 +849,14 @@ exports[`help command > connex help output snapshots > connex create subcommand 
        --icon <PATH>             Path to a PNG or JPEG image to use as the connector icon (uploaded to Vercel)               
        --json                    Output as JSON                                                                              
   -n,  --name <NAME>             Name of the connector                                                                       
-       --trigger-event <EVENT>   Webhook event to receive. Repeatable.                                                       
-       --triggers                Enable webhook triggers for this connector                                                  
+       --trigger-branch <BRANCH>    Target a specific git branch for the trigger destination. Requires --triggers.            
+       --trigger-environment <ENV>  Target a custom environment by slug or stable ID. Mutually exclusive with                
+                                    --trigger-branch and requires --triggers.                                                 
+       --trigger-event <EVENT>      Webhook event to receive. Repeatable.                                                     
+       --trigger-path <PATH>        Set the path on the destination project that receives forwarded webhooks. Requires        
+                                    --triggers.                                                                              
+       --trigger-project <PROJECT>  Target a project by name or ID instead of the linked project. Requires --triggers.        
+       --triggers                   Enable webhook triggers for this connector                                                
 
 
   Global Options:
@@ -884,6 +890,18 @@ exports[`help command > connex help output snapshots > connex create subcommand 
   - Create with selected webhook events
 
     $ vercel connect create linear --name linear --triggers --trigger-event Issue --trigger-event Comment --trigger-event Project
+
+  - Create with a custom trigger path
+
+    $ vercel connect create github --name github --triggers --trigger-path /eve/v1/github
+
+  - Create with branch-specific trigger routing
+
+    $ vercel connect create github --name github --triggers --trigger-path /api/webhooks --trigger-branch main
+
+  - Create with trigger routing on another project
+
+    $ vercel connect create github --name github --triggers --trigger-project my-api --trigger-path /api/webhooks
 
   - Create with branding (icon and colors)
 

--- a/packages/cli/test/unit/commands/connex/create.test.ts
+++ b/packages/cli/test/unit/commands/connex/create.test.ts
@@ -6,6 +6,7 @@ import open from 'open';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useTeam } from '../../../mocks/team';
+import { defaultProject, useProject } from '../../../mocks/project';
 import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 import connect from '../../../../src/commands/connex';
 import * as configFilesUtil from '../../../../src/util/config/files';
@@ -139,6 +140,161 @@ describe('connex create', () => {
     expect(requestMade).toBe(false);
     await expect(client.stderr).toOutput(
       'The --trigger-event flag requires --triggers.'
+    );
+  });
+
+  it('requires --triggers when setting a trigger path', async () => {
+    client.setArgv(
+      'connect',
+      'create',
+      'github',
+      '--name',
+      'github',
+      '--trigger-path',
+      '/eve/v1/github'
+    );
+
+    expect(await connect(client)).toBe(1);
+    await expect(client.stderr).toOutput(
+      'The --trigger-project, --trigger-path, --trigger-branch, and --trigger-environment flags require --triggers.'
+    );
+  });
+
+  it('requires a linked project when setting a trigger path', async () => {
+    client.setArgv(
+      'connect',
+      'create',
+      'github',
+      '--name',
+      'github',
+      '--triggers',
+      '--trigger-path',
+      '/eve/v1/github'
+    );
+
+    expect(await connect(client)).toBe(1);
+    await expect(client.stderr).toOutput(
+      'Trigger destination flags require a linked project. Run `vercel link` first.'
+    );
+  });
+
+  it('forwards a custom trigger path and branch during connector creation', async () => {
+    const cwd = setupTmpDir();
+    await mkdirp(join(cwd, '.vercel'));
+    await writeJSON(join(cwd, '.vercel', 'project.json'), {
+      orgId: team.id,
+      projectId: 'proj_linked',
+    });
+    client.cwd = cwd;
+
+    let postBody: any;
+    client.scenario.post('/v1/connect/connectors/managed', (req, res) => {
+      postBody = req.body;
+      res.json(fakeConnexClient({ type: 'github', name: 'github' }));
+    });
+    client.setArgv(
+      'connect',
+      'create',
+      'github',
+      '--name',
+      'github',
+      '--triggers',
+      '--trigger-path',
+      '/eve/v1/github',
+      '--trigger-branch',
+      'main'
+    );
+
+    expect(await connect(client)).toBe(0);
+    expect(postBody).toMatchObject({
+      projectId: 'proj_linked',
+      triggers: { enabled: true },
+      triggerDestination: {
+        path: '/eve/v1/github',
+        branch: 'main',
+      },
+    });
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:create', value: 'create' },
+      { key: 'flag:triggers', value: 'true' },
+      { key: 'option:trigger-path', value: '[REDACTED]' },
+      { key: 'option:trigger-branch', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('resolves a custom trigger environment slug to its stable ID', async () => {
+    const cwd = setupTmpDir();
+    await mkdirp(join(cwd, '.vercel'));
+    await writeJSON(join(cwd, '.vercel', 'project.json'), {
+      orgId: team.id,
+      projectId: 'proj_linked',
+    });
+    client.cwd = cwd;
+    useProject({
+      ...defaultProject,
+      id: 'proj_destination',
+      customEnvironments: [
+        {
+          id: 'env_qa123',
+          slug: 'qa',
+          type: 'preview',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+
+    let postBody: any;
+    client.scenario.post('/v1/connect/connectors/managed', (req, res) => {
+      postBody = req.body;
+      res.json(fakeConnexClient({ type: 'github', name: 'github' }));
+    });
+    client.setArgv(
+      'connect',
+      'create',
+      'github',
+      '--name',
+      'github',
+      '--triggers',
+      '--trigger-project',
+      'proj_destination',
+      '--trigger-environment',
+      'qa'
+    );
+
+    expect(await connect(client)).toBe(0);
+    expect(postBody).toMatchObject({
+      projectId: 'proj_linked',
+      triggerDestination: {
+        projectId: 'proj_destination',
+        customEnvironmentId: 'env_qa123',
+      },
+    });
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:create', value: 'create' },
+      { key: 'flag:triggers', value: 'true' },
+      { key: 'option:trigger-project', value: '[REDACTED]' },
+      { key: 'option:trigger-environment', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('rejects branch and custom environment routing together', async () => {
+    client.setArgv(
+      'connect',
+      'create',
+      'github',
+      '--name',
+      'github',
+      '--triggers',
+      '--trigger-branch',
+      'main',
+      '--trigger-environment',
+      'qa'
+    );
+
+    expect(await connect(client)).toBe(1);
+    await expect(client.stderr).toOutput(
+      'The --trigger-branch and --trigger-environment flags are mutually exclusive.'
     );
   });
 


### PR DESCRIPTION
### Summary

Adds full create-time trigger destination routing to `vercel connect create`:

- `--trigger-project <name-or-id>`
- `--trigger-path <path>`
- `--trigger-branch <branch>`
- `--trigger-environment <slug-or-id>`

All destination flags require `--triggers`. The destination defaults to the linked project; `--trigger-project` can select another project and also enables use without a local project link. Branch and custom-environment routing are mutually exclusive. Custom-environment slugs are resolved against the destination project, and destination values are redacted in telemetry.

This removes the create → detach → attach workaround for routes such as `/eve/v1/github`. Browser-assisted creation is supported through vercel/api#84014 and vercel/front#79935.

### Examples

```bash
vercel connect create github --triggers --trigger-path /eve/v1/github
vercel connect create github --triggers --trigger-project my-api --trigger-path /api/webhooks --trigger-branch main
vercel connect create github --triggers --trigger-project my-api --trigger-environment qa
```

### Validation

- Biome check passes on changed TypeScript files
- Pre-commit formatting and lint hooks pass
- Unit coverage includes destination-project resolution, custom-environment resolution against that project, mutual exclusion, fallback validation, and telemetry redaction
- Help snapshot updated
- Local Vitest startup requires prebuilt workspace packages unavailable in this worktree; CI runs it in the native environment

### Related

- vercel/api#84014
- vercel/front#79935
- vercel/eve#1672

_Written by GPT-5_