### PR TITLE
[cli] Improve error when unknown command falls back to deploy

### DIFF
--- a/.changeset/tidy-donkeys-repeat.md
+++ b/.changeset/tidy-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve the error shown when the first argument is neither a known command nor an existing directory. Instead of falling back to `vercel deploy` and failing with a confusing path error like "Could not find" or "Can't deploy more than one path", the CLI now explains that the token is not a vercel command, that no matching directory exists to deploy, and points to `vercel help`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,7 +40,10 @@ import { URL } from 'url';
 import { getSentry } from './util/get-sentry';
 import hp from './util/humanize-path';
 import { commands, commandNames } from './commands';
-import { handleCommandTypo } from './util/handle-command-typo';
+import {
+  handleCommandTypo,
+  handleUnknownCommand,
+} from './util/handle-command-typo';
 import { matchesCliApiTag } from './util/openapi/matches-cli-api-tag';
 import { tryOpenApiFallback } from './util/openapi';
 import pkg from './util/pkg';
@@ -884,9 +887,10 @@ const main = async () => {
         if (isErrnoException(err) && err.code === 'ENOENT') {
           // Check if the user made a typo before falling back to deploy
           if (
-            handleCommandTypo({
+            handleUnknownCommand({
               command: targetCommand,
               availableCommands: commandNames,
+              cwd,
             })
           ) {
             return 1;

--- a/packages/cli/src/util/handle-command-typo.ts
+++ b/packages/cli/src/util/handle-command-typo.ts
@@ -1,6 +1,9 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
 import didYouMean from './did-you-mean';
 import param from './output/param';
 import output from '../output-manager';
+import { getCommandName } from './pkg-name';
 
 /**
  * Handles typo detection for invalid commands and provides helpful error messages.
@@ -30,6 +33,35 @@ export function handleCommandTypo({
   if (suggestion) {
     output.error(
       `${param(command)} is not a valid target directory or subcommand. Did you mean ${param(suggestion)}?`
+    );
+    return true;
+  }
+
+  return false;
+}
+
+export function handleUnknownCommand({
+  command,
+  availableCommands,
+  cwd,
+  threshold,
+}: {
+  command: string | undefined;
+  availableCommands: string[];
+  cwd: string;
+  threshold?: number;
+}): boolean {
+  if (!command || command.startsWith('-')) {
+    return false;
+  }
+
+  if (handleCommandTypo({ command, availableCommands, threshold })) {
+    return true;
+  }
+
+  if (!existsSync(join(cwd, command))) {
+    output.error(
+      `${param(command)} is not a vercel command, and no directory named ${param(command)} exists to deploy. Run ${getCommandName('help')} to see all commands.`
     );
     return true;
   }

--- a/packages/cli/test/unit/util/handle-command-typo.test.ts
+++ b/packages/cli/test/unit/util/handle-command-typo.test.ts
@@ -1,0 +1,119 @@
+import { join } from 'node:path';
+import { mkdtempSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  handleCommandTypo,
+  handleUnknownCommand,
+} from '../../../src/util/handle-command-typo';
+import output from '../../../src/output-manager';
+
+describe('handleCommandTypo', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(output, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns false for flags', () => {
+    expect(
+      handleCommandTypo({
+        command: '--prod',
+        availableCommands: ['deploy'],
+      })
+    ).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('suggests the closest command for a typo', () => {
+    expect(
+      handleCommandTypo({
+        command: 'deplyo',
+        availableCommands: ['deploy', 'env', 'ls'],
+      })
+    ).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Did you mean')
+    );
+  });
+
+  it('returns false when nothing is close', () => {
+    expect(
+      handleCommandTypo({
+        command: 'instant-demo',
+        availableCommands: ['deploy', 'env', 'ls'],
+      })
+    ).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleUnknownCommand', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let cwd: string;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(output, 'error').mockImplementation(() => {});
+    cwd = mkdtempSync(join(tmpdir(), 'vc-unknown-command-'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns false for flags without printing', () => {
+    expect(
+      handleUnknownCommand({
+        command: '--prod',
+        availableCommands: ['deploy'],
+        cwd,
+      })
+    ).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('prints a typo suggestion when a close command exists', () => {
+    expect(
+      handleUnknownCommand({
+        command: 'deplyo',
+        availableCommands: ['deploy', 'env', 'ls'],
+        cwd,
+      })
+    ).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Did you mean')
+    );
+  });
+
+  it('prints an unknown command error when no directory exists', () => {
+    expect(
+      handleUnknownCommand({
+        command: 'instant-demo',
+        availableCommands: ['deploy', 'env', 'ls'],
+        cwd,
+      })
+    ).toBe(true);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const message = errorSpy.mock.calls[0][0] as string;
+    expect(message).toContain('is not a vercel command');
+    expect(message).toContain('instant-demo');
+    expect(message).toContain('exists to deploy');
+    expect(message).toContain('help');
+  });
+
+  it('returns false when a matching directory exists', () => {
+    mkdirSync(join(cwd, 'my-app'));
+    expect(
+      handleUnknownCommand({
+        command: 'my-app',
+        availableCommands: ['deploy', 'env', 'ls'],
+        cwd,
+      })
+    ).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Description

When the first argument to `vercel` is not a known command, not an installed CLI extension, and has no close typo match, the CLI silently rewrites the invocation to `vercel deploy <args>`. If no matching directory exists either, deploy then fails with a path error that never mentions the real problem:

```
$ vercel instant-demo vc deploy --prod
Error: Can't deploy more than one path.

$ vercel instant-demo
Error: Could not find "instant-demo"
```

These messages are dead ends — especially for agents driving the CLI, which have no way to learn that the command name itself was wrong.

This PR adds a check at the fallback site: if the token also does not exist as a directory, the CLI prints one complete error instead of invoking deploy:

```
$ vercel instant-demo vc deploy --prod
Error: "instant-demo" is not a vercel command, and no directory named "instant-demo" exists to deploy. Run `vercel help` to see all commands.
```

Behavior is unchanged when the directory exists (deploy fallback proceeds as before), when a typo suggestion is available ("Did you mean deploy?"), and for CLI extensions. Exit code remains 1.

### Changes

- `src/util/handle-command-typo.ts`: new `handleUnknownCommand` helper that runs the existing typo check, then validates the deploy-fallback directory and prints the complete unknown-command error when it is missing
- `src/index.ts`: the extension-ENOENT fallback now calls `handleUnknownCommand` (with `client.cwd`, so `--cwd` is respected) instead of `handleCommandTypo`
- `test/unit/util/handle-command-typo.test.ts`: unit tests for both helpers covering flags, typo suggestions, missing directory, and existing directory

### Tests

```
pnpm test test/unit/util/handle-command-typo.test.ts
Test Files  1 passed (1)
     Tests  7 passed (7)
```