### PR TITLE
[cli] Report default-in-code flag evaluations as a null variant

### DIFF
--- a/.changeset/flags-evaluations-default-in-code.md
+++ b/.changeset/flags-evaluations-default-in-code.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Report `vercel flags evaluations` buckets that used the default in code as `"variant": null` instead of `"variant": ""`. The observability API attributes evaluations without an assigned variant to an empty variant id, which `--json` output surfaced as an empty string that matched no entry under `variants`. Human-readable output continues to label them `Default in Code`.

--- a/packages/cli/src/commands/flags/evaluations.ts
+++ b/packages/cli/src/commands/flags/evaluations.ts
@@ -12,13 +12,14 @@ import { FlagsEvaluationsTelemetryClient } from '../../util/telemetry/commands/f
 import { resolveTimeRange } from '../../util/time-utils';
 import output from '../../output-manager';
 import { getRollupColumnName, handleApiError } from '../metrics/output';
-import { formatText } from '../metrics/text-output';
+import { formatText, NOT_SET_GROUP_VALUE } from '../metrics/text-output';
 import {
   computeGranularity,
   toGranularityMsFromDuration,
 } from '../metrics/time-utils';
 import type {
   Granularity,
+  MetricsApiDataCell,
   MetricsQueryResponse,
   ProjectScope,
 } from '../metrics/types';
@@ -39,6 +40,34 @@ const FLAG_EVALUATIONS_ROLLUP = getRollupColumnName(
 const DISPLAY_GROUP_BY = 'Variants';
 const QUERY_ENGINE_GROUP_BY = 'flagVariant';
 const MAX_VARIANTS = 100;
+const DEFAULT_IN_CODE_LABEL = 'Default in Code';
+
+/**
+ * Evaluations that fell back to the default value in code are not tied to a
+ * variant, so the API reports them with an empty variant id. Missing cells and
+ * the text renderer's `(not set)` placeholder mean the same thing.
+ */
+function isDefaultInCodeVariant(
+  variantId: MetricsApiDataCell | undefined
+): variantId is '' | typeof NOT_SET_GROUP_VALUE | null | undefined {
+  return (
+    variantId === undefined ||
+    variantId === null ||
+    variantId === '' ||
+    variantId === NOT_SET_GROUP_VALUE
+  );
+}
+
+/**
+ * Canonicalizes a variant id so the default-in-code bucket is represented as
+ * `null` everywhere instead of leaking an empty variant into output, and so a
+ * single grouping key covers every spelling the API may use for it.
+ */
+function toVariantId(
+  variantId: MetricsApiDataCell | undefined
+): MetricsApiDataCell {
+  return isDefaultInCodeVariant(variantId) ? null : variantId;
+}
 
 function getFlagEvaluationsApiUrl(ownerId: string): string {
   const url = new URL(
@@ -69,8 +98,8 @@ function alignTimeRange(
 }
 
 function getVariantDisplayName(flag: Flag, variantId: string): string {
-  if (!variantId || variantId === '(not set)') {
-    return 'Default in Code';
+  if (isDefaultInCodeVariant(variantId)) {
+    return DEFAULT_IN_CODE_LABEL;
   }
 
   const variant = flag.variants.find(item => item.id === variantId);
@@ -120,14 +149,14 @@ function limitEvaluationVariants(response: MetricsQueryResponse): {
 
   const summary = response.summary.slice(0, MAX_VARIANTS);
   const visibleVariants = new Set(
-    summary.map(row => row[QUERY_ENGINE_GROUP_BY])
+    summary.map(row => toVariantId(row[QUERY_ENGINE_GROUP_BY]))
   );
   return {
     response: {
       ...response,
       summary,
       data: response.data?.filter(row =>
-        visibleVariants.has(row[QUERY_ENGINE_GROUP_BY])
+        visibleVariants.has(toVariantId(row[QUERY_ENGINE_GROUP_BY]))
       ),
     },
     truncated: true,
@@ -152,9 +181,11 @@ function formatEvaluationsJson(
       endTime: endTime.toISOString(),
       granularity,
       truncated,
+      // A `null` variant marks evaluations that used the default in code, which
+      // the API reports without a variant id.
       buckets: (response.data ?? []).map(row => ({
         timestamp: row.timestamp,
-        variant: row[QUERY_ENGINE_GROUP_BY] ?? null,
+        variant: toVariantId(row[QUERY_ENGINE_GROUP_BY]),
         evaluations: row[FLAG_EVALUATIONS_ROLLUP] ?? null,
       })),
     },
@@ -361,7 +392,7 @@ export default async function evaluations(
           ...limited.response,
           data: limited.response.data?.map(row => ({
             ...row,
-            [DISPLAY_GROUP_BY]: row[QUERY_ENGINE_GROUP_BY] ?? null,
+            [DISPLAY_GROUP_BY]: toVariantId(row[QUERY_ENGINE_GROUP_BY]),
           })),
         },
         {

--- a/packages/cli/src/commands/metrics/text-output.ts
+++ b/packages/cli/src/commands/metrics/text-output.ts
@@ -100,6 +100,9 @@ export interface FormatTextOptions {
 const GROUP_KEY_DELIMITER = '\u001f';
 const MAX_SPARKLINE_LENGTH = 120;
 
+/** Placeholder shown for group values the API reports as missing or empty. */
+export const NOT_SET_GROUP_VALUE = '(not set)';
+
 type TableAlignment = 'l' | 'c' | 'r';
 type StatColumn = 'total' | 'avg' | 'min' | 'max';
 
@@ -282,7 +285,7 @@ function getOrCreate<K, V>(map: Map<K, V>, key: K, make: () => V): V {
 
 function getGroupFieldValue(row: MetricsDataRow, field: string): string {
   const value = row[field];
-  return value == null || value === '' ? '(not set)' : String(value);
+  return value == null || value === '' ? NOT_SET_GROUP_VALUE : String(value);
 }
 
 /**

--- a/packages/cli/test/unit/commands/flags/evaluations.test.ts
+++ b/packages/cli/test/unit/commands/flags/evaluations.test.ts
@@ -289,7 +289,7 @@ describe('flags evaluations', () => {
         },
         {
           timestamp: '2026-07-10T10:01:00.000Z',
-          variant: '',
+          variant: null,
           evaluations: 1,
         },
       ],
@@ -303,6 +303,145 @@ describe('flags evaluations', () => {
       { key: 'option:since', value: '[REDACTED]' },
       { key: 'option:until', value: '[REDACTED]' },
       { key: 'flag:json', value: 'TRUE' },
+    ]);
+  });
+
+  it('reports default-in-code evaluations as a null variant in JSON', async () => {
+    // The API attributes evaluations that fell back to the default in code to
+    // an empty variant id, because no variant was assigned.
+    useEvaluationsResponse({
+      data: [
+        {
+          timestamp: '2026-07-10T10:00:00.000Z',
+          flagVariant: '',
+          [ROLLUP]: 13,
+        },
+        {
+          timestamp: '2026-07-10T10:01:00.000Z',
+          flagVariant: '',
+          [ROLLUP]: 46,
+        },
+        {
+          timestamp: '2026-07-10T10:01:00.000Z',
+          flagVariant: 'on',
+          [ROLLUP]: 107,
+        },
+      ],
+      summary: [
+        { flagVariant: '', [ROLLUP]: 59 },
+        { flagVariant: 'on', [ROLLUP]: 107 },
+      ],
+    });
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--since',
+      '2026-07-10T10:00:00.000Z',
+      '--until',
+      '2026-07-10T11:00:00.000Z',
+      '--json'
+    );
+
+    expect(await flags(client)).toBe(0);
+
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).not.toContain('"variant": ""');
+    expect(JSON.parse(stdout).buckets).toEqual([
+      {
+        timestamp: '2026-07-10T10:00:00.000Z',
+        variant: null,
+        evaluations: 13,
+      },
+      {
+        timestamp: '2026-07-10T10:01:00.000Z',
+        variant: null,
+        evaluations: 46,
+      },
+      {
+        timestamp: '2026-07-10T10:01:00.000Z',
+        variant: 'on',
+        evaluations: 107,
+      },
+    ]);
+  });
+
+  it('labels default-in-code evaluations in human-readable output', async () => {
+    useEvaluationsResponse({
+      data: [
+        {
+          timestamp: '2026-07-10T10:00:00.000Z',
+          flagVariant: '',
+          [ROLLUP]: 13,
+        },
+        {
+          timestamp: '2026-07-10T10:01:00.000Z',
+          flagVariant: 'on',
+          [ROLLUP]: 107,
+        },
+      ],
+      summary: [
+        { flagVariant: '', [ROLLUP]: 13 },
+        { flagVariant: 'on', [ROLLUP]: 107 },
+      ],
+    });
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--since',
+      '2026-07-10T10:00:00.000Z',
+      '--until',
+      '2026-07-10T11:00:00.000Z'
+    );
+
+    expect(await flags(client)).toBe(0);
+
+    const stdout = stripAnsi(client.stdout.getFullOutput());
+    expect(stdout).toContain('Default in Code');
+    expect(stdout).toContain('true: On');
+    expect(stdout).not.toContain('(not set)');
+  });
+
+  it('keeps default-in-code buckets when the API omits the variant id', async () => {
+    // The summary and the buckets may spell the missing variant differently.
+    useEvaluationsResponse({
+      summary: [
+        { flagVariant: '', [ROLLUP]: 59 },
+        ...Array.from({ length: 100 }, (_, index) => ({
+          flagVariant: `variant-${index}`,
+          [ROLLUP]: 100 - index,
+        })),
+      ],
+      data: [
+        {
+          timestamp: '2026-07-10T10:00:00.000Z',
+          flagVariant: null,
+          [ROLLUP]: 59,
+        },
+      ],
+    });
+    client.setArgv(
+      'flags',
+      'evaluations',
+      'my-feature',
+      '--since',
+      '2026-07-10T10:00:00.000Z',
+      '--until',
+      '2026-07-10T11:00:00.000Z',
+      '--json'
+    );
+
+    expect(await flags(client)).toBe(0);
+
+    const json = JSON.parse(client.stdout.getFullOutput());
+    expect(json.truncated).toBe(true);
+    expect(json.buckets).toEqual([
+      {
+        timestamp: '2026-07-10T10:00:00.000Z',
+        variant: null,
+        evaluations: 59,
+      },
     ]);
   });
 


### PR DESCRIPTION
## Problem

`vercel flags evaluations <flag> --json` reports evaluations that used the **default in code** with an empty-string variant:

```
vercel flags evaluations async-datafile-sync --scope vercel --project api --since 72h --granularity 1h --json
```

```json
{
  "buckets": [
    { "timestamp": "2026-08-05T12:00:00.000Z", "variant": "", "evaluations": 13 },
    { "timestamp": "2026-08-05T13:00:00.000Z", "variant": "", "evaluations": 46 }
  ]
}
```

The observability API attributes evaluations that fell back to the code default to an empty variant id, because no variant was assigned. The CLI passed that through verbatim, so JSON consumers get a `variant` that matches no entry in the `variants` map the same payload emits — for the flag above that was 59 of 798 evaluations presented as an empty variant.

## Change

Canonicalize the empty variant to `null`, in one place, and apply it wherever a variant id is read:

- **JSON buckets** now emit `"variant": null` for default-in-code evaluations.
- **Truncation** keys the visible-variant set through the same canonicalization, so a bucket survives even if the summary and the data rows spell the missing variant differently (`""` vs. omitted).
- **Human-readable output** is unchanged and still labels these `Default in Code`; it now routes through the same predicate instead of matching the text renderer's `(not set)` placeholder by hand. That placeholder is exported as `NOT_SET_GROUP_VALUE` so the two stay in sync.

`null` was chosen over a sentinel string so the value can never collide with a real variant id, and so consumers can tell "no variant" apart from the ids listed under `variants`.

## Tests

`packages/cli/test/unit/commands/flags/evaluations.test.ts`:

- new: default-in-code buckets are reported as `variant: null` and the payload contains no `"variant": ""`
- new: human-readable output labels them `Default in Code` and renders no `(not set)`
- new: a default-in-code bucket survives variant truncation when the summary uses `""` and the bucket omits the id
- updated: the existing exact-bucket JSON expectation

All three new JSON assertions fail on `main`. `packages/cli` flags + metrics unit tests pass (528).