### PR TITLE
[config] Add function maxConcurrency type

### DIFF
--- a/.changeset/curvy-wolves-limit.md
+++ b/.changeset/curvy-wolves-limit.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': minor
+---
+
+Add `maxConcurrency` to the per-function configuration type.

--- a/packages/config/src/types.test.ts
+++ b/packages/config/src/types.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import type { FunctionConfig } from './types';
+
+describe('FunctionConfig', () => {
+  it('accepts maxConcurrency', () => {
+    const config: FunctionConfig = { maxConcurrency: 8 };
+
+    expect(config.maxConcurrency).toBe(8);
+  });
+});

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -90,6 +90,10 @@ export interface FunctionConfig {
    */
   maxDuration?: number | 'max';
   /**
+   * The maximum number of requests that one instance of your Serverless Function can process concurrently.
+   */
+  maxConcurrency?: number;
+  /**
    * An integer defining the memory your Serverless Function should be provided with (between 128 and 10240).
    */
   memory?: number;


### PR DESCRIPTION
## Summary

- Add `maxConcurrency` to the public per-function TypeScript configuration type.
- Add a compile-time and runtime type regression test.
- Add a package changeset.

The public configuration schema already accepts this field. This change keeps `@vercel/config` in sync with that schema.

## Tests

- `pnpm --filter @vercel/config exec vitest run -c ../../vitest.config.mts src/types.test.ts`
- `pnpm --filter @vercel/routing-utils build`
- `pnpm --filter @vercel/config type-check`

Docs/knowledge: none needed — this restores type parity with the existing public configuration schema.
