### PR TITLE
[react-router] Set Skew Protection cookie at the routing layer

### DIFF
--- a/.changeset/react-router-skew-protection-routing-layer.md
+++ b/.changeset/react-router-skew-protection-routing-layer.md
@@ -1,0 +1,6 @@
+---
+'@vercel/remix-builder': patch
+'@vercel/react-router': patch
+---
+
+Set the `__vdpl` Skew Protection cookie for React Router via a routing-layer header rule instead of `Set-Cookie` on the SSR response, so document responses stay cacheable by the CDN.

--- a/packages/react-router/edge/entry.server.ts
+++ b/packages/react-router/edge/entry.server.ts
@@ -13,10 +13,6 @@ export type RenderOptions = {
     keyof RenderToPipeableStreamOptions]?: RenderToReadableStreamOptions[K];
 };
 
-const vercelDeploymentId = process.env.VERCEL_DEPLOYMENT_ID;
-const vercelSkewProtectionEnabled =
-  process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1';
-
 export async function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -46,13 +42,6 @@ export async function handleRequest(
   }
 
   responseHeaders.set('Content-Type', 'text/html');
-
-  if (vercelSkewProtectionEnabled && vercelDeploymentId) {
-    responseHeaders.append(
-      'Set-Cookie',
-      `__vdpl=${vercelDeploymentId}; HttpOnly`
-    );
-  }
 
   return new Response(body as any, {
     headers: responseHeaders,

--- a/packages/react-router/entry.server.ts
+++ b/packages/react-router/entry.server.ts
@@ -18,10 +18,6 @@ export type RenderOptions = {
     keyof RenderToPipeableStreamOptions]?: RenderToReadableStreamOptions[K];
 };
 
-const vercelDeploymentId = process.env.VERCEL_DEPLOYMENT_ID;
-const vercelSkewProtectionEnabled =
-  process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1';
-
 export function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -56,13 +52,6 @@ export function handleRequest(
           const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set('Content-Type', 'text/html');
-
-          if (vercelSkewProtectionEnabled && vercelDeploymentId) {
-            responseHeaders.append(
-              'Set-Cookie',
-              `__vdpl=${vercelDeploymentId}; HttpOnly`
-            );
-          }
 
           resolve(
             new Response(stream, {

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -26,6 +26,7 @@ import {
   getReactRouterDataPaths,
   getRegExpFromPath,
   getPackageVersion,
+  getSkewProtectionRoute,
   hasScript,
   logNftWarnings,
   shouldRegisterSsrForPrerenderedRoute,
@@ -635,6 +636,19 @@ export const build: BuildV2 = async ({
   // handle so the rewritten path (e.g. `/about.html`) gets resolved by
   // the static lookup.
   routes.unshift(...prerenderRewrites, { handle: 'filesystem' });
+
+  // When Skew Protection is enabled, the routing layer stamps the `__vdpl`
+  // deployment ID cookie onto document responses instead of the rendering
+  // function, so the origin response stays free of `Set-Cookie` and remains
+  // cacheable by the CDN. This must be the first route (before the
+  // filesystem handle) so the cookie is applied to cache HITs and
+  // prerendered static files as well.
+  if (isReactRouter) {
+    const skewProtectionRoute = getSkewProtectionRoute();
+    if (skewProtectionRoute) {
+      routes.unshift(skewProtectionRoute);
+    }
+  }
 
   // For the 404 case, invoke the Function (or serve the static file
   // for `ssr: false` mode) at the `/` path. Remix will serve its 404 route.

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -362,6 +362,42 @@ export function getReactRouterCatchAllDest(): 'index' {
 }
 
 /**
+ * When Skew Protection is enabled for the project, returns a route that
+ * makes Vercel's routing layer stamp the `__vdpl` deployment ID cookie
+ * onto every outgoing document response (`continue: true` keeps route
+ * matching going afterwards). Setting the cookie at the routing layer —
+ * rather than in the rendering function's response — keeps the origin
+ * response free of `Set-Cookie`, which would otherwise prevent the CDN
+ * from caching documents (silently defeating `Cache-Control: s-maxage`
+ * from route `headers()` exports). The cookie is applied to CDN cache
+ * HITs and prerendered static files as well.
+ *
+ * Returns `undefined` when Skew Protection is not enabled or no
+ * deployment ID is available.
+ */
+export function getSkewProtectionRoute(env: NodeJS.ProcessEnv = process.env):
+  | {
+      src: string;
+      has: { type: 'header'; key: string; value: string }[];
+      headers: Record<string, string>;
+      continue: true;
+    }
+  | undefined {
+  const deploymentId = env.VERCEL_DEPLOYMENT_ID;
+  if (env.VERCEL_SKEW_PROTECTION_ENABLED !== '1' || !deploymentId) {
+    return undefined;
+  }
+  return {
+    src: '/(.*)',
+    has: [{ type: 'header', key: 'Sec-Fetch-Dest', value: 'document' }],
+    headers: {
+      'Set-Cookie': `__vdpl=${deploymentId}; Path=/; SameSite=Strict; Secure; HttpOnly`,
+    },
+    continue: true,
+  };
+}
+
+/**
  * Updates the `dest` process.env object to match the `source` one.
  * A function is returned to restore the `dest` env back to how
  * it was originally.

--- a/packages/remix/test/unit.get-skew-protection-route.test.ts
+++ b/packages/remix/test/unit.get-skew-protection-route.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { getSkewProtectionRoute } from '../src/utils';
+
+describe('getSkewProtectionRoute()', () => {
+  it('returns a header route with `continue: true` when Skew Protection is enabled', () => {
+    const route = getSkewProtectionRoute({
+      VERCEL_SKEW_PROTECTION_ENABLED: '1',
+      VERCEL_DEPLOYMENT_ID: 'dpl_123abc',
+    });
+    expect(route).toEqual({
+      src: '/(.*)',
+      has: [{ type: 'header', key: 'Sec-Fetch-Dest', value: 'document' }],
+      headers: {
+        'Set-Cookie':
+          '__vdpl=dpl_123abc; Path=/; SameSite=Strict; Secure; HttpOnly',
+      },
+      continue: true,
+    });
+  });
+
+  it('sets the cookie at the routing layer, not on the origin response', () => {
+    // The whole point of the route-level rule: the function response must
+    // stay free of `Set-Cookie` so the CDN can cache documents. The rule
+    // must `continue` so it only decorates the response without swallowing
+    // the request before the filesystem handle / SSR catch-all.
+    const route = getSkewProtectionRoute({
+      VERCEL_SKEW_PROTECTION_ENABLED: '1',
+      VERCEL_DEPLOYMENT_ID: 'dpl_123abc',
+    });
+    expect(route?.continue).toBe(true);
+    // Only document requests get the cookie; asset/data requests do not.
+    expect(route?.has).toEqual([
+      { type: 'header', key: 'Sec-Fetch-Dest', value: 'document' },
+    ]);
+  });
+
+  it('returns undefined when Skew Protection is not enabled', () => {
+    expect(
+      getSkewProtectionRoute({
+        VERCEL_DEPLOYMENT_ID: 'dpl_123abc',
+      })
+    ).toBeUndefined();
+    expect(
+      getSkewProtectionRoute({
+        VERCEL_SKEW_PROTECTION_ENABLED: '0',
+        VERCEL_DEPLOYMENT_ID: 'dpl_123abc',
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when no deployment ID is available', () => {
+    expect(
+      getSkewProtectionRoute({
+        VERCEL_SKEW_PROTECTION_ENABLED: '1',
+      })
+    ).toBeUndefined();
+    expect(
+      getSkewProtectionRoute({
+        VERCEL_SKEW_PROTECTION_ENABLED: '1',
+        VERCEL_DEPLOYMENT_ID: '',
+      })
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Enabling Skew Protection currently disables CDN caching for React Router document responses because `entry.server` adds `Set-Cookie: __vdpl=…` to every SSR response. Since responses with `Set-Cookie` are not cached, document requests always result in `BYPASS`.

This PR moves the Skew Protection cookie from the function response to a Build Output route matched on `Sec-Fetch-Dest: document`. The routing layer adds the cookie after cache lookup, allowing SSR documents to remain cacheable while still pinning document responses to the deployment.

Changes:

* Add a Skew Protection route for React Router builds
* Remove `Set-Cookie` handling from Node and Edge entry servers
* Add unit tests

This also means prerendered documents now receive the deployment cookie. Clients without `Sec-Fetch-Dest` do not.
