### PR TITLE
[vercel] Query custom metrics through v1

### DIFF
--- a/.changeset/metrics-schema-v1-catalog.md
+++ b/.changeset/metrics-schema-v1-catalog.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Return semantic metric descriptors from `vc metrics schema` using the Observability API metric catalog.

--- a/.changeset/metrics-schema-v1-catalog.md
+++ b/.changeset/metrics-schema-v1-catalog.md
@@ -2,4 +2,4 @@
 'vercel': minor
 ---
 
-Return semantic metric descriptors from `vc metrics schema` using the Observability API metric catalog.
+Return stable semantic metric schema fields from `vc metrics schema` using the Observability API metric catalog, and report unknown metric prefixes.

--- a/.changeset/metrics-schema-v1-catalog.md
+++ b/.changeset/metrics-schema-v1-catalog.md
@@ -2,4 +2,4 @@
 'vercel': minor
 ---
 
-Return semantic metric descriptors from `vc metrics schema` using the Observability API metric catalog.
+Return semantic metric descriptors from `vc metrics schema` using the Observability API metric catalog, including readable aggregation modifiers.

--- a/.changeset/metrics-schema-v1-catalog.md
+++ b/.changeset/metrics-schema-v1-catalog.md
@@ -2,4 +2,4 @@
 'vercel': minor
 ---
 
-Return stable semantic metric schema fields from `vc metrics schema` using the Observability API metric catalog, and report unknown metric prefixes.
+List custom metrics from the Observability API catalog and query them through `/v1/metrics`, while preserving the existing schema and query paths for `vercel.*` metrics.

--- a/.changeset/metrics-schema-v1-catalog.md
+++ b/.changeset/metrics-schema-v1-catalog.md
@@ -2,4 +2,4 @@
 'vercel': minor
 ---
 
-Return semantic metric descriptors from `vc metrics schema` using the Observability API metric catalog, including readable aggregation modifiers.
+Return semantic metric descriptors from `vc metrics schema` using the Observability API metric catalog.

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -101,6 +101,23 @@ function toBucketSeconds(granularity: MetricsQueryRequest['granularity']) {
   return granularity.days * 24 * 60 * 60;
 }
 
+function alignTimeRangeToGranularity(
+  startTime: Date,
+  endTime: Date,
+  granularity: MetricsQueryRequest['granularity']
+): { startTime: Date; endTime: Date } {
+  const bucketMs = toBucketSeconds(granularity) * 1000;
+  const alignedEndMs = Math.floor(endTime.getTime() / bucketMs) * bucketMs;
+  const alignedStartMs = Math.min(
+    Math.floor(startTime.getTime() / bucketMs) * bucketMs,
+    alignedEndMs - bucketMs
+  );
+  return {
+    startTime: new Date(alignedStartMs),
+    endTime: new Date(alignedEndMs),
+  };
+}
+
 function toCanonicalMetricSelection(
   metric: string,
   aggregation: string
@@ -145,8 +162,8 @@ function createCanonicalMetricsRequest(options: {
   scope: Scope;
   metric: string;
   selection: CanonicalMetricSelection;
-  startTime: string;
-  endTime: string;
+  startTime: Date;
+  endTime: Date;
   granularity: MetricsQueryRequest['granularity'];
   groupBy: string[];
   filter: string | undefined;
@@ -177,7 +194,10 @@ function createCanonicalMetricsRequest(options: {
         ? { projectIds: options.scope.projectIds }
         : {}),
     },
-    timeRange: { start: options.startTime, end: options.endTime },
+    timeRange: {
+      start: options.startTime.toISOString(),
+      end: options.endTime.toISOString(),
+    },
     bucketSeconds: toBucketSeconds(options.granularity),
     ...(options.groupBy.length > 0 ? { groupBy: options.groupBy } : {}),
     ...(options.filter ? { filter: options.filter } : {}),
@@ -492,6 +512,9 @@ export default async function query(
   // too fine for the time range (granResult.adjusted will be true in that case).
   const rangeMs = endTime.getTime() - startTime.getTime();
   const granResult = computeGranularity(rangeMs, granularity);
+  const queryTimeRange = isPlatformMetric
+    ? { startTime, endTime }
+    : alignTimeRangeToGranularity(startTime, endTime, granResult.duration);
   if (!jsonOutput && granResult.adjusted && granResult.notice) {
     output.log(`Notice: ${granResult.notice}`);
   }
@@ -502,8 +525,8 @@ export default async function query(
       scope,
       metric,
       aggregation: aggregation as Aggregation,
-      startTime: startTime.toISOString(),
-      endTime: endTime.toISOString(),
+      startTime: queryTimeRange.startTime.toISOString(),
+      endTime: queryTimeRange.endTime.toISOString(),
       granularity: granResult.duration,
       ...(bucketTimezone ? { bucketTimezone } : {}),
       ...(groupBy.length > 0 ? { groupBy } : {}),
@@ -545,8 +568,8 @@ export default async function query(
       scope,
       metric,
       selection,
-      startTime: startTime.toISOString(),
-      endTime: endTime.toISOString(),
+      startTime: queryTimeRange.startTime,
+      endTime: queryTimeRange.endTime,
       granularity: granResult.duration,
       groupBy,
       filter,
@@ -614,8 +637,8 @@ export default async function query(
           aggregation: aggregation as Aggregation,
           groupBy,
           filter,
-          startTime: startTime.toISOString(),
-          endTime: endTime.toISOString(),
+          startTime: queryTimeRange.startTime.toISOString(),
+          endTime: queryTimeRange.endTime.toISOString(),
           granularity: granResult.duration,
           ...(bucketTimezone ? { bucketTimezone } : {}),
           ...(orderByMode ? { orderBy: orderByMode } : {}),
@@ -635,8 +658,8 @@ export default async function query(
         scope,
         projectName,
         teamName,
-        periodStart: startTime.toISOString(),
-        periodEnd: endTime.toISOString(),
+        periodStart: queryTimeRange.startTime.toISOString(),
+        periodEnd: queryTimeRange.endTime.toISOString(),
         granularity: granResult.duration,
         bucketTimezone: bucketTimezone,
         orderBy: orderByMode,

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -65,8 +64,6 @@ function handleValidationError(
 const PRODUCTION_ENVIRONMENT_FILTER = "environment eq 'production'";
 const CUSTOM_METRIC_VALUE_ALIAS = 'value';
 const CUSTOM_METRIC_COUNT_ALIAS = '__seriesCount';
-const FILTER_DEPRECATION_WARNING =
-  'OData support in --filter is deprecated and will be removed soon. KQL will be the only supported filter syntax.';
 
 function combineFilters(
   filters: string[] | undefined,
@@ -382,9 +379,6 @@ export default async function query(
       ? flags['--order'].trim().toLowerCase()
       : undefined;
   const filters = flags['--filter'];
-  if (filters !== undefined) {
-    output.print(`${chalk.yellow('!')} ${FILTER_DEPRECATION_WARNING}\n`);
-  }
   const prod = flags['--prod'];
   const filter = combineFilters(filters, prod);
   const since = flags['--since'];

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -11,7 +11,12 @@ import {
   validateRequiredMetric,
 } from './validation';
 import { validateAllProjectMutualExclusivity } from '../../util/command-validation';
-import { fetchMetricDetailOrExit, getDefaultAggregation } from './schema-api';
+import {
+  fetchCustomMetricCatalogOrExit,
+  fetchMetricDetailOrExit,
+  getDefaultAggregation,
+  getObservabilityApiUrl,
+} from './schema-api';
 import {
   formatErrorJson,
   formatQueryJson,
@@ -24,6 +29,9 @@ import { resolveTimeRange } from '../../util/time-utils';
 import type { MetricsTelemetryClient } from '../../util/telemetry/commands/metrics';
 import type {
   Aggregation,
+  CanonicalMetricSelection,
+  CanonicalMetricsQueryRequest,
+  CanonicalMetricsQueryResponse,
   Scope,
   ValidationError,
   MetricsQueryRequest,
@@ -54,6 +62,8 @@ function handleValidationError(
 }
 
 const PRODUCTION_ENVIRONMENT_FILTER = "environment eq 'production'";
+const CUSTOM_METRIC_VALUE_ALIAS = 'value';
+const CUSTOM_METRIC_COUNT_ALIAS = '__seriesCount';
 
 function combineFilters(
   filters: string[] | undefined,
@@ -83,6 +93,148 @@ function getRequestOrderBy(
   return orderBy === 'value'
     ? getRollupColumnName(metric, aggregation)
     : undefined;
+}
+
+function toBucketSeconds(granularity: MetricsQueryRequest['granularity']) {
+  if ('minutes' in granularity) return granularity.minutes * 60;
+  if ('hours' in granularity) return granularity.hours * 60 * 60;
+  return granularity.days * 24 * 60 * 60;
+}
+
+function toCanonicalMetricSelection(
+  metric: string,
+  aggregation: string
+): CanonicalMetricSelection | ValidationError {
+  if (aggregation === 'persecond') {
+    return { metric, aggregation: 'sum', per: 'second' };
+  }
+  if (aggregation === 'percent') {
+    return { metric, aggregation: 'sum', normalize: 'percent' };
+  }
+  if (aggregation === 'unique') {
+    return {
+      valid: false,
+      code: 'UNSUPPORTED_AGGREGATION',
+      message:
+        'The unique aggregation for custom metrics requires an explicit distinct dimension, which vc metrics does not support yet.',
+    };
+  }
+  if (
+    aggregation === 'count' ||
+    aggregation === 'sum' ||
+    aggregation === 'avg' ||
+    aggregation === 'min' ||
+    aggregation === 'max' ||
+    aggregation === 'p50' ||
+    aggregation === 'p75' ||
+    aggregation === 'p90' ||
+    aggregation === 'p95' ||
+    aggregation === 'p99' ||
+    aggregation === 'stddev'
+  ) {
+    return { metric, aggregation };
+  }
+  return {
+    valid: false,
+    code: 'INVALID_AGGREGATION',
+    message: `Aggregation "${aggregation}" is not supported for custom metrics.`,
+  };
+}
+
+function createCanonicalMetricsRequest(options: {
+  scope: Scope;
+  metric: string;
+  selection: CanonicalMetricSelection;
+  startTime: string;
+  endTime: string;
+  granularity: MetricsQueryRequest['granularity'];
+  groupBy: string[];
+  filter: string | undefined;
+  limit: number;
+  orderBy: OrderBy | undefined;
+  orderDirection: 'asc' | 'desc' | undefined;
+}): CanonicalMetricsQueryRequest {
+  const metrics: Record<string, CanonicalMetricSelection> = {
+    [CUSTOM_METRIC_VALUE_ALIAS]: options.selection,
+  };
+  let rankMetric = CUSTOM_METRIC_VALUE_ALIAS;
+  if (
+    options.groupBy.length > 0 &&
+    options.orderBy !== 'value' &&
+    options.selection.aggregation !== 'count'
+  ) {
+    metrics[CUSTOM_METRIC_COUNT_ALIAS] = {
+      metric: options.metric,
+      aggregation: 'count',
+    };
+    rankMetric = CUSTOM_METRIC_COUNT_ALIAS;
+  }
+
+  return {
+    scope: {
+      ownerId: options.scope.ownerId,
+      ...(options.scope.type === 'project'
+        ? { projectIds: options.scope.projectIds }
+        : {}),
+    },
+    timeRange: { start: options.startTime, end: options.endTime },
+    bucketSeconds: toBucketSeconds(options.granularity),
+    ...(options.groupBy.length > 0 ? { groupBy: options.groupBy } : {}),
+    ...(options.filter ? { filter: options.filter } : {}),
+    metrics,
+    outputs: [CUSTOM_METRIC_VALUE_ALIAS],
+    ...(options.groupBy.length > 0
+      ? {
+          seriesSelection: {
+            limit: options.limit,
+            mode: 'exact',
+            rankBy: [
+              {
+                metric: rankMetric,
+                direction: options.orderDirection ?? 'desc',
+              },
+            ],
+          },
+        }
+      : {}),
+  };
+}
+
+function canonicalResponseToMetricsResponse(
+  response: CanonicalMetricsQueryResponse,
+  rollupColumn: string,
+  orderBy: OrderBy | undefined,
+  orderDirection: 'asc' | 'desc' | undefined
+): MetricsQueryResponse {
+  const toRow = (point: {
+    dimensions: Record<string, string | null>;
+    values: Record<string, number | null>;
+  }) => ({
+    ...point.dimensions,
+    [rollupColumn]: point.values[CUSTOM_METRIC_VALUE_ALIAS] ?? null,
+  });
+  return {
+    ...(response.series
+      ? {
+          data: response.series.map(point => ({
+            timestamp: point.timestamp,
+            ...toRow(point),
+          })),
+        }
+      : {}),
+    summary: response.summary.map(toRow),
+    statistics: {
+      rowsRead: response.meta.statistics.rowsRead,
+      bytesRead: response.meta.statistics.bytesRead,
+      dbTimeSeconds: response.meta.statistics.databaseElapsedMs / 1_000,
+      engineTimeSeconds: response.meta.statistics.elapsedMs / 1_000,
+      queryTable: [...new Set(response.meta.sources.map(source => source.id))]
+        .sort()
+        .join(','),
+    },
+    ...(orderBy ? { orderBy } : {}),
+    ...(orderDirection ? { orderDirection } : {}),
+  };
 }
 
 async function resolveQueryScope(
@@ -272,20 +424,52 @@ export default async function query(
   }
   const { scope, accountId, teamName, projectName } = scopeResult;
 
-  const detailOrExitCode = await fetchMetricDetailOrExit(
-    client,
-    accountId,
-    metric,
-    jsonOutput
-  );
-  // fetchMetricDetailOrExit() returns a numeric exit code when it already
-  // handled the error output for us.
-  if (typeof detailOrExitCode === 'number') {
-    return detailOrExitCode;
+  const isPlatformMetric = metric.startsWith('vercel.');
+  let metricUnit: string;
+  let aggregationInput: string;
+  let customMetricAggregations: readonly string[] = [];
+  if (isPlatformMetric) {
+    const detailOrExitCode = await fetchMetricDetailOrExit(
+      client,
+      accountId,
+      metric,
+      jsonOutput
+    );
+    if (typeof detailOrExitCode === 'number') {
+      return detailOrExitCode;
+    }
+    aggregationInput =
+      aggregationFlag ??
+      getDefaultAggregation(detailOrExitCode, metric) ??
+      'sum';
+    metricUnit =
+      detailOrExitCode.find(item => item.id === metric)?.unit ?? 'count';
+  } else {
+    const catalogOrExitCode = await fetchCustomMetricCatalogOrExit(
+      client,
+      accountId,
+      jsonOutput,
+      metric
+    );
+    if (typeof catalogOrExitCode === 'number') {
+      return catalogOrExitCode;
+    }
+    const customMetric = catalogOrExitCode.find(item => item.id === metric);
+    if (!customMetric) {
+      return handleValidationError(
+        {
+          valid: false,
+          code: 'METRIC_NOT_FOUND',
+          message: `Custom metric "${metric}" was not found. Run \`vercel metrics schema\` to see available metrics.`,
+        },
+        jsonOutput,
+        client
+      );
+    }
+    aggregationInput = aggregationFlag ?? 'sum';
+    metricUnit = customMetric.unit;
+    customMetricAggregations = customMetric.aggregations;
   }
-
-  const aggregationInput =
-    aggregationFlag ?? getDefaultAggregation(detailOrExitCode, metric) ?? 'sum';
   const aggregation = aggregationInput;
   const orderBy = getRequestOrderBy(metric, aggregation, orderByMode);
 
@@ -312,37 +496,99 @@ export default async function query(
     output.log(`Notice: ${granResult.notice}`);
   }
 
-  // Build request body
-  const body: MetricsQueryRequest = {
-    scope,
-    metric,
-    aggregation: aggregation as Aggregation,
-    startTime: startTime.toISOString(),
-    endTime: endTime.toISOString(),
-    granularity: granResult.duration,
-    ...(bucketTimezone ? { bucketTimezone } : {}),
-    ...(groupBy.length > 0 ? { groupBy } : {}),
-    ...(filter ? { filter } : {}),
-    limit: limit ?? 10,
-    ...(orderBy ? { orderBy } : {}),
-    ...(orderDirection ? { orderDirection } : {}),
-  };
+  let body: MetricsQueryRequest | CanonicalMetricsQueryRequest;
+  if (isPlatformMetric) {
+    body = {
+      scope,
+      metric,
+      aggregation: aggregation as Aggregation,
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      granularity: granResult.duration,
+      ...(bucketTimezone ? { bucketTimezone } : {}),
+      ...(groupBy.length > 0 ? { groupBy } : {}),
+      ...(filter ? { filter } : {}),
+      limit: limit ?? 10,
+      ...(orderBy ? { orderBy } : {}),
+      ...(orderDirection ? { orderDirection } : {}),
+    };
+  } else {
+    if (bucketTimezone) {
+      return handleValidationError(
+        {
+          valid: false,
+          code: 'UNSUPPORTED_BUCKET_TIMEZONE',
+          message: '--bucket-timezone is not supported for custom metrics yet.',
+        },
+        jsonOutput,
+        client
+      );
+    }
+    const selection = toCanonicalMetricSelection(metric, aggregation);
+    if ('valid' in selection) {
+      return handleValidationError(selection, jsonOutput, client);
+    }
+    const supportedAggregation = selection.aggregation;
+    if (!customMetricAggregations.includes(supportedAggregation)) {
+      return handleValidationError(
+        {
+          valid: false,
+          code: 'INVALID_AGGREGATION',
+          message: `Aggregation "${aggregation}" is not valid for custom metric "${metric}".`,
+          allowedValues: [...customMetricAggregations],
+        },
+        jsonOutput,
+        client
+      );
+    }
+    body = createCanonicalMetricsRequest({
+      scope,
+      metric,
+      selection,
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      granularity: granResult.duration,
+      groupBy,
+      filter,
+      limit: limit ?? 10,
+      orderBy: orderByMode,
+      orderDirection,
+    });
+  }
 
   if (!jsonOutput) {
     output.spinner('Querying metrics...');
   }
   let response: MetricsQueryResponse;
   try {
-    response = await client.fetch<MetricsQueryResponse>(
-      '/v2/observability/query',
-      {
-        method: 'POST',
-        body: JSON.stringify(body),
-        headers: { 'Content-Type': 'application/json' },
-        accountId,
-        bailOn429: true,
-      }
-    );
+    if (isPlatformMetric) {
+      response = await client.fetch<MetricsQueryResponse>(
+        '/v2/observability/query',
+        {
+          method: 'POST',
+          body: JSON.stringify(body),
+          headers: { 'Content-Type': 'application/json' },
+          accountId,
+          bailOn429: true,
+        }
+      );
+    } else {
+      const url = getObservabilityApiUrl(client, '/v1/metrics');
+      const canonicalResponse =
+        await client.fetch<CanonicalMetricsQueryResponse>(url.href, {
+          method: 'POST',
+          body: JSON.stringify(body),
+          headers: { 'Content-Type': 'application/json' },
+          accountId,
+          bailOn429: true,
+        });
+      response = canonicalResponseToMetricsResponse(
+        canonicalResponse,
+        getRollupColumnName(metric, aggregation),
+        groupBy.length > 0 ? (orderByMode ?? 'count') : undefined,
+        groupBy.length > 0 ? (orderDirection ?? 'desc') : undefined
+      );
+    }
   } catch (err: unknown) {
     if (isAPIError(err)) {
       return handleApiError(err, jsonOutput, client);
@@ -382,8 +628,7 @@ export default async function query(
     client.stdout.write(
       formatText(response, {
         metric,
-        metricUnit:
-          detailOrExitCode.find(item => item.id === metric)?.unit ?? 'count',
+        metricUnit,
         aggregation: aggregation as Aggregation,
         groupBy,
         filter,

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -101,6 +101,18 @@ function toBucketSeconds(granularity: MetricsQueryRequest['granularity']) {
   return granularity.days * 24 * 60 * 60;
 }
 
+function alignTimeRangeToGranularity(
+  startTime: Date,
+  endTime: Date,
+  granularity: MetricsQueryRequest['granularity']
+): { startTime: Date; endTime: Date } {
+  const bucketMs = toBucketSeconds(granularity) * 1000;
+  return {
+    startTime: new Date(Math.floor(startTime.getTime() / bucketMs) * bucketMs),
+    endTime: new Date(Math.ceil(endTime.getTime() / bucketMs) * bucketMs),
+  };
+}
+
 function toCanonicalMetricSelection(
   metric: string,
   aggregation: string
@@ -481,6 +493,9 @@ export default async function query(
   // too fine for the time range (granResult.adjusted will be true in that case).
   const rangeMs = endTime.getTime() - startTime.getTime();
   const granResult = computeGranularity(rangeMs, granularity);
+  const queryTimeRange = isPlatformMetric
+    ? { startTime, endTime }
+    : alignTimeRangeToGranularity(startTime, endTime, granResult.duration);
   if (!jsonOutput && granResult.adjusted && granResult.notice) {
     output.log(`Notice: ${granResult.notice}`);
   }
@@ -537,8 +552,8 @@ export default async function query(
       scope,
       metric,
       selection,
-      startTime,
-      endTime,
+      startTime: queryTimeRange.startTime,
+      endTime: queryTimeRange.endTime,
       granularity: granResult.duration,
       groupBy,
       filter,
@@ -606,8 +621,8 @@ export default async function query(
           aggregation: aggregation as Aggregation,
           groupBy,
           filter,
-          startTime: startTime.toISOString(),
-          endTime: endTime.toISOString(),
+          startTime: queryTimeRange.startTime.toISOString(),
+          endTime: queryTimeRange.endTime.toISOString(),
           granularity: granResult.duration,
           ...(bucketTimezone ? { bucketTimezone } : {}),
           ...(orderByMode ? { orderBy: orderByMode } : {}),
@@ -627,8 +642,8 @@ export default async function query(
         scope,
         projectName,
         teamName,
-        periodStart: startTime.toISOString(),
-        periodEnd: endTime.toISOString(),
+        periodStart: queryTimeRange.startTime.toISOString(),
+        periodEnd: queryTimeRange.endTime.toISOString(),
         granularity: granResult.duration,
         bucketTimezone: bucketTimezone,
         orderBy: orderByMode,

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -64,6 +65,8 @@ function handleValidationError(
 const PRODUCTION_ENVIRONMENT_FILTER = "environment eq 'production'";
 const CUSTOM_METRIC_VALUE_ALIAS = 'value';
 const CUSTOM_METRIC_COUNT_ALIAS = '__seriesCount';
+const FILTER_DEPRECATION_WARNING =
+  'OData support in --filter is deprecated and will be removed soon. KQL will be the only supported filter syntax.';
 
 function combineFilters(
   filters: string[] | undefined,
@@ -379,6 +382,9 @@ export default async function query(
       ? flags['--order'].trim().toLowerCase()
       : undefined;
   const filters = flags['--filter'];
+  if (filters !== undefined) {
+    output.print(`${chalk.yellow('!')} ${FILTER_DEPRECATION_WARNING}\n`);
+  }
   const prod = flags['--prod'];
   const filter = combineFilters(filters, prod);
   const since = flags['--since'];

--- a/packages/cli/src/commands/metrics/query.ts
+++ b/packages/cli/src/commands/metrics/query.ts
@@ -12,7 +12,7 @@ import {
 } from './validation';
 import { validateAllProjectMutualExclusivity } from '../../util/command-validation';
 import {
-  fetchCustomMetricCatalogOrExit,
+  fetchCustomMetricCatalog,
   fetchMetricDetailOrExit,
   getDefaultAggregation,
   getObservabilityApiUrl,
@@ -99,23 +99,6 @@ function toBucketSeconds(granularity: MetricsQueryRequest['granularity']) {
   if ('minutes' in granularity) return granularity.minutes * 60;
   if ('hours' in granularity) return granularity.hours * 60 * 60;
   return granularity.days * 24 * 60 * 60;
-}
-
-function alignTimeRangeToGranularity(
-  startTime: Date,
-  endTime: Date,
-  granularity: MetricsQueryRequest['granularity']
-): { startTime: Date; endTime: Date } {
-  const bucketMs = toBucketSeconds(granularity) * 1000;
-  const alignedEndMs = Math.floor(endTime.getTime() / bucketMs) * bucketMs;
-  const alignedStartMs = Math.min(
-    Math.floor(startTime.getTime() / bucketMs) * bucketMs,
-    alignedEndMs - bucketMs
-  );
-  return {
-    startTime: new Date(alignedStartMs),
-    endTime: new Date(alignedEndMs),
-  };
 }
 
 function toCanonicalMetricSelection(
@@ -444,10 +427,24 @@ export default async function query(
   }
   const { scope, accountId, teamName, projectName } = scopeResult;
 
+  let startTime: Date;
+  let endTime: Date;
+  try {
+    ({ startTime, endTime } = resolveTimeRange(since, until));
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    if (jsonOutput) {
+      client.stdout.write(formatErrorJson('INVALID_TIME', errMsg));
+    } else {
+      output.error(errMsg);
+    }
+    return 1;
+  }
+
   const isPlatformMetric = metric.startsWith('vercel.');
   let metricUnit: string;
   let aggregationInput: string;
-  let customMetricAggregations: readonly string[] = [];
+  let customMetricAggregations: readonly string[] | undefined;
   if (isPlatformMetric) {
     const detailOrExitCode = await fetchMetricDetailOrExit(
       client,
@@ -465,56 +462,25 @@ export default async function query(
     metricUnit =
       detailOrExitCode.find(item => item.id === metric)?.unit ?? 'count';
   } else {
-    const catalogOrExitCode = await fetchCustomMetricCatalogOrExit(
+    const customMetric = await fetchCustomMetricCatalog(
       client,
       accountId,
-      jsonOutput,
-      metric
-    );
-    if (typeof catalogOrExitCode === 'number') {
-      return catalogOrExitCode;
-    }
-    const customMetric = catalogOrExitCode.find(item => item.id === metric);
-    if (!customMetric) {
-      return handleValidationError(
-        {
-          valid: false,
-          code: 'METRIC_NOT_FOUND',
-          message: `Custom metric "${metric}" was not found. Run \`vercel metrics schema\` to see available metrics.`,
-        },
-        jsonOutput,
-        client
-      );
-    }
+      metric,
+      startTime.toISOString()
+    )
+      .then(metrics => metrics.find(item => item.id === metric))
+      .catch(() => undefined);
     aggregationInput = aggregationFlag ?? 'sum';
-    metricUnit = customMetric.unit;
-    customMetricAggregations = customMetric.aggregations;
+    metricUnit = customMetric?.unit ?? 'count';
+    customMetricAggregations = customMetric?.aggregations;
   }
   const aggregation = aggregationInput;
   const orderBy = getRequestOrderBy(metric, aggregation, orderByMode);
-
-  // Resolve time range
-  let startTime: Date;
-  let endTime: Date;
-  try {
-    ({ startTime, endTime } = resolveTimeRange(since, until));
-  } catch (err) {
-    const errMsg = err instanceof Error ? err.message : String(err);
-    if (jsonOutput) {
-      client.stdout.write(formatErrorJson('INVALID_TIME', errMsg));
-    } else {
-      output.error(errMsg);
-    }
-    return 1;
-  }
 
   // Compute granularity — may adjust the user's --granularity upward if it's
   // too fine for the time range (granResult.adjusted will be true in that case).
   const rangeMs = endTime.getTime() - startTime.getTime();
   const granResult = computeGranularity(rangeMs, granularity);
-  const queryTimeRange = isPlatformMetric
-    ? { startTime, endTime }
-    : alignTimeRangeToGranularity(startTime, endTime, granResult.duration);
   if (!jsonOutput && granResult.adjusted && granResult.notice) {
     output.log(`Notice: ${granResult.notice}`);
   }
@@ -525,8 +491,8 @@ export default async function query(
       scope,
       metric,
       aggregation: aggregation as Aggregation,
-      startTime: queryTimeRange.startTime.toISOString(),
-      endTime: queryTimeRange.endTime.toISOString(),
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
       granularity: granResult.duration,
       ...(bucketTimezone ? { bucketTimezone } : {}),
       ...(groupBy.length > 0 ? { groupBy } : {}),
@@ -552,7 +518,10 @@ export default async function query(
       return handleValidationError(selection, jsonOutput, client);
     }
     const supportedAggregation = selection.aggregation;
-    if (!customMetricAggregations.includes(supportedAggregation)) {
+    if (
+      customMetricAggregations &&
+      !customMetricAggregations.includes(supportedAggregation)
+    ) {
       return handleValidationError(
         {
           valid: false,
@@ -568,8 +537,8 @@ export default async function query(
       scope,
       metric,
       selection,
-      startTime: queryTimeRange.startTime,
-      endTime: queryTimeRange.endTime,
+      startTime,
+      endTime,
       granularity: granResult.duration,
       groupBy,
       filter,
@@ -637,8 +606,8 @@ export default async function query(
           aggregation: aggregation as Aggregation,
           groupBy,
           filter,
-          startTime: queryTimeRange.startTime.toISOString(),
-          endTime: queryTimeRange.endTime.toISOString(),
+          startTime: startTime.toISOString(),
+          endTime: endTime.toISOString(),
           granularity: granResult.duration,
           ...(bucketTimezone ? { bucketTimezone } : {}),
           ...(orderByMode ? { orderBy: orderByMode } : {}),
@@ -658,8 +627,8 @@ export default async function query(
         scope,
         projectName,
         teamName,
-        periodStart: queryTimeRange.startTime.toISOString(),
-        periodEnd: queryTimeRange.endTime.toISOString(),
+        periodStart: startTime.toISOString(),
+        periodEnd: endTime.toISOString(),
         granularity: granResult.duration,
         bucketTimezone: bucketTimezone,
         orderBy: orderByMode,

--- a/packages/cli/src/commands/metrics/schema-api.ts
+++ b/packages/cli/src/commands/metrics/schema-api.ts
@@ -2,13 +2,26 @@ import type Client from '../../util/client';
 import output from '../../output-manager';
 import { isAPIError } from '../../util/errors-ts';
 import { formatErrorJson, handleApiError } from './output';
-import type {
-  Aggregation,
-  MetricDetail,
-  MetricDetailResponse,
-  MetricListItem,
-  MetricListResponse,
-} from './types';
+import type { Aggregation, MetricDetail, MetricDetailResponse } from './types';
+
+const OBSERVABILITY_API_URL = 'https://observability-api.vercel.sh';
+const METRIC_CATALOG_PAGE_SIZE = 250;
+
+export interface MetricCatalogMetric {
+  readonly id: string;
+  readonly description: string;
+  readonly dimensions: readonly string[];
+  readonly unit: string;
+  readonly aggregations: readonly string[];
+}
+
+interface MetricCatalogResponse {
+  metrics: MetricCatalogMetric[];
+  pagination: {
+    hasMore: boolean;
+    nextCursor: string | null;
+  };
+}
 
 function toMetricDetail(metric: MetricDetailResponse[number]): MetricDetail {
   return {
@@ -21,10 +34,6 @@ function toMetricDetail(metric: MetricDetailResponse[number]): MetricDetail {
   };
 }
 
-export function getMetricIds(metrics: MetricListItem[]): string[] {
-  return metrics.map(metric => metric.id).sort();
-}
-
 export function getDefaultAggregation(
   detail: MetricDetail[],
   metricId: string
@@ -32,15 +41,40 @@ export function getDefaultAggregation(
   return detail.find(metric => metric.id === metricId)?.defaultAggregation;
 }
 
-export async function fetchMetricList(
+export async function fetchMetricCatalog(
   client: Client,
-  accountId: string
-): Promise<MetricListItem[]> {
-  const { metrics } = await client.fetch<MetricListResponse>(
-    '/v2/observability/schema',
-    { accountId }
-  );
-  return metrics;
+  accountId: string,
+  search?: string
+): Promise<MetricCatalogMetric[]> {
+  const metrics: MetricCatalogMetric[] = [];
+  let cursor: string | null = null;
+
+  do {
+    const baseUrl =
+      client.apiUrl === 'https://api.vercel.com'
+        ? OBSERVABILITY_API_URL
+        : client.apiUrl;
+    const url = new URL('/v1/metrics', baseUrl);
+    url.searchParams.set('limit', String(METRIC_CATALOG_PAGE_SIZE));
+    if (search) {
+      url.searchParams.set('search', search);
+    }
+    if (cursor) {
+      url.searchParams.set('cursor', cursor);
+    }
+
+    const response = await client.fetch<MetricCatalogResponse>(url.href, {
+      accountId,
+    });
+    metrics.push(...response.metrics);
+    cursor = response.pagination.hasMore
+      ? response.pagination.nextCursor
+      : null;
+  } while (cursor);
+
+  return metrics
+    .filter(metric => !search || metric.id.startsWith(search))
+    .sort((left, right) => left.id.localeCompare(right.id));
 }
 
 export async function fetchMetricDetail(
@@ -56,13 +90,14 @@ export async function fetchMetricDetail(
   return detail.map(toMetricDetail);
 }
 
-export async function fetchMetricListOrExit(
+export async function fetchMetricCatalogOrExit(
   client: Client,
   accountId: string,
-  jsonOutput: boolean
-): Promise<MetricListItem[] | number> {
+  jsonOutput: boolean,
+  search?: string
+): Promise<MetricCatalogMetric[] | number> {
   try {
-    return await fetchMetricList(client, accountId);
+    return await fetchMetricCatalog(client, accountId, search);
   } catch (err: unknown) {
     if (isAPIError(err)) {
       return handleApiError(err, jsonOutput, client, {

--- a/packages/cli/src/commands/metrics/schema-api.ts
+++ b/packages/cli/src/commands/metrics/schema-api.ts
@@ -56,6 +56,7 @@ export async function fetchMetricCatalog(
         : client.apiUrl;
     const url = new URL('/v1/metrics', baseUrl);
     url.searchParams.set('limit', String(METRIC_CATALOG_PAGE_SIZE));
+    url.searchParams.set('includeLogs', 'false');
     if (search) {
       url.searchParams.set('search', search);
     }

--- a/packages/cli/src/commands/metrics/schema-api.ts
+++ b/packages/cli/src/commands/metrics/schema-api.ts
@@ -2,7 +2,13 @@ import type Client from '../../util/client';
 import output from '../../output-manager';
 import { isAPIError } from '../../util/errors-ts';
 import { formatErrorJson, handleApiError } from './output';
-import type { Aggregation, MetricDetail, MetricDetailResponse } from './types';
+import type {
+  Aggregation,
+  MetricDetail,
+  MetricDetailResponse,
+  MetricListItem,
+  MetricListResponse,
+} from './types';
 
 const OBSERVABILITY_API_URL = 'https://observability-api.vercel.sh';
 const METRIC_CATALOG_PAGE_SIZE = 250;
@@ -41,7 +47,26 @@ export function getDefaultAggregation(
   return detail.find(metric => metric.id === metricId)?.defaultAggregation;
 }
 
-export async function fetchMetricCatalog(
+export function getObservabilityApiUrl(client: Client, path: string): URL {
+  const baseUrl =
+    client.apiUrl === 'https://api.vercel.com'
+      ? OBSERVABILITY_API_URL
+      : client.apiUrl;
+  return new URL(path, baseUrl);
+}
+
+export async function fetchMetricList(
+  client: Client,
+  accountId: string
+): Promise<MetricListItem[]> {
+  const { metrics } = await client.fetch<MetricListResponse>(
+    '/v2/observability/schema',
+    { accountId }
+  );
+  return metrics;
+}
+
+export async function fetchCustomMetricCatalog(
   client: Client,
   accountId: string,
   search?: string
@@ -50,13 +75,9 @@ export async function fetchMetricCatalog(
   let cursor: string | null = null;
 
   do {
-    const baseUrl =
-      client.apiUrl === 'https://api.vercel.com'
-        ? OBSERVABILITY_API_URL
-        : client.apiUrl;
-    const url = new URL('/v1/metrics', baseUrl);
+    const url = getObservabilityApiUrl(client, '/v1/metrics');
     url.searchParams.set('limit', String(METRIC_CATALOG_PAGE_SIZE));
-    url.searchParams.set('includeLogs', 'false');
+    url.searchParams.set('kind', 'custom');
     if (search) {
       url.searchParams.set('search', search);
     }
@@ -82,7 +103,11 @@ export async function fetchMetricCatalog(
   } while (cursor);
 
   return metrics
-    .filter(metric => !search || metric.id.startsWith(search))
+    .filter(
+      metric =>
+        !metric.id.startsWith('vercel.') &&
+        (!search || metric.id.startsWith(search))
+    )
     .sort((left, right) => left.id.localeCompare(right.id));
 }
 
@@ -99,14 +124,13 @@ export async function fetchMetricDetail(
   return detail.map(toMetricDetail);
 }
 
-export async function fetchMetricCatalogOrExit(
+async function fetchSchemaOrExit<T>(
   client: Client,
-  accountId: string,
   jsonOutput: boolean,
-  search?: string
-): Promise<MetricCatalogMetric[] | number> {
+  operation: () => Promise<T>
+): Promise<T | number> {
   try {
-    return await fetchMetricCatalog(client, accountId, search);
+    return await operation();
   } catch (err: unknown) {
     if (isAPIError(err)) {
       return handleApiError(err, jsonOutput, client, {
@@ -136,39 +160,41 @@ export async function fetchMetricCatalogOrExit(
   }
 }
 
+export function fetchCustomMetricCatalogOrExit(
+  client: Client,
+  accountId: string,
+  jsonOutput: boolean,
+  search?: string
+): Promise<MetricCatalogMetric[] | number> {
+  return fetchSchemaOrExit(client, jsonOutput, () =>
+    fetchCustomMetricCatalog(client, accountId, search)
+  );
+}
+
+export function fetchCombinedMetricListOrExit(
+  client: Client,
+  accountId: string,
+  jsonOutput: boolean
+): Promise<MetricListItem[] | number> {
+  return fetchSchemaOrExit(client, jsonOutput, async () => {
+    const [platformMetrics, customMetrics] = await Promise.all([
+      fetchMetricList(client, accountId),
+      fetchCustomMetricCatalog(client, accountId),
+    ]);
+    return [
+      ...platformMetrics,
+      ...customMetrics.map(({ id, description }) => ({ id, description })),
+    ].sort((left, right) => left.id.localeCompare(right.id));
+  });
+}
+
 export async function fetchMetricDetailOrExit(
   client: Client,
   accountId: string,
   metricId: string,
   jsonOutput: boolean
 ): Promise<MetricDetail[] | number> {
-  try {
-    return await fetchMetricDetail(client, accountId, metricId);
-  } catch (err: unknown) {
-    if (isAPIError(err)) {
-      return handleApiError(err, jsonOutput, client, {
-        401: {
-          code: 'SCHEMA_UNAUTHORIZED',
-          message:
-            'The metrics schema API request was not authorized. Run `vercel login` to authenticate and `vercel switch` to select a team, then try again.',
-        },
-        403: {
-          code: 'SCHEMA_UNAUTHORIZED',
-          message:
-            'The metrics schema API request was not authorized. Run `vercel login` to authenticate and `vercel switch` to select a team, then try again.',
-        },
-      });
-    }
-
-    const message =
-      err instanceof Error
-        ? `Failed to fetch metrics schema: ${err.message}`
-        : `Failed to fetch metrics schema: ${String(err)}`;
-    if (jsonOutput) {
-      client.stdout.write(formatErrorJson('SCHEMA_FETCH_FAILED', message));
-    } else {
-      output.error(message);
-    }
-    return 1;
-  }
+  return fetchSchemaOrExit(client, jsonOutput, () =>
+    fetchMetricDetail(client, accountId, metricId)
+  );
 }

--- a/packages/cli/src/commands/metrics/schema-api.ts
+++ b/packages/cli/src/commands/metrics/schema-api.ts
@@ -182,7 +182,7 @@ export function fetchCombinedMetricListOrExit(
       fetchCustomMetricCatalog(client, accountId),
     ]);
     return [
-      ...platformMetrics,
+      ...platformMetrics.filter(metric => metric.id.startsWith('vercel.')),
       ...customMetrics.map(({ id, description }) => ({ id, description })),
     ].sort((left, right) => left.id.localeCompare(right.id));
   });

--- a/packages/cli/src/commands/metrics/schema-api.ts
+++ b/packages/cli/src/commands/metrics/schema-api.ts
@@ -13,6 +13,15 @@ export interface MetricCatalogMetric {
   readonly dimensions: readonly string[];
   readonly unit: string;
   readonly aggregations: readonly string[];
+  readonly aggregationModifiers?: Readonly<
+    Record<
+      string,
+      {
+        readonly per?: readonly string[];
+        readonly normalize?: readonly string[];
+      }
+    >
+  >;
 }
 
 interface MetricCatalogResponse {

--- a/packages/cli/src/commands/metrics/schema-api.ts
+++ b/packages/cli/src/commands/metrics/schema-api.ts
@@ -67,7 +67,15 @@ export async function fetchMetricCatalog(
     const response = await client.fetch<MetricCatalogResponse>(url.href, {
       accountId,
     });
-    metrics.push(...response.metrics);
+    metrics.push(
+      ...response.metrics.map(metric => ({
+        id: metric.id,
+        description: metric.description,
+        dimensions: metric.dimensions,
+        unit: metric.unit,
+        aggregations: metric.aggregations,
+      }))
+    );
     cursor = response.pagination.hasMore
       ? response.pagination.nextCursor
       : null;

--- a/packages/cli/src/commands/metrics/schema-api.ts
+++ b/packages/cli/src/commands/metrics/schema-api.ts
@@ -69,7 +69,8 @@ export async function fetchMetricList(
 export async function fetchCustomMetricCatalog(
   client: Client,
   accountId: string,
-  search?: string
+  search?: string,
+  activeSince?: string
 ): Promise<MetricCatalogMetric[]> {
   const metrics: MetricCatalogMetric[] = [];
   let cursor: string | null = null;
@@ -80,6 +81,9 @@ export async function fetchCustomMetricCatalog(
     url.searchParams.set('kind', 'custom');
     if (search) {
       url.searchParams.set('search', search);
+    }
+    if (activeSince) {
+      url.searchParams.set('activeSince', activeSince);
     }
     if (cursor) {
       url.searchParams.set('cursor', cursor);
@@ -179,7 +183,7 @@ export function fetchCombinedMetricListOrExit(
   return fetchSchemaOrExit(client, jsonOutput, async () => {
     const [platformMetrics, customMetrics] = await Promise.all([
       fetchMetricList(client, accountId),
-      fetchCustomMetricCatalog(client, accountId),
+      fetchCustomMetricCatalog(client, accountId).catch(() => []),
     ]);
     return [
       ...platformMetrics.filter(metric => metric.id.startsWith('vercel.')),

--- a/packages/cli/src/commands/metrics/schema-api.ts
+++ b/packages/cli/src/commands/metrics/schema-api.ts
@@ -13,15 +13,6 @@ export interface MetricCatalogMetric {
   readonly dimensions: readonly string[];
   readonly unit: string;
   readonly aggregations: readonly string[];
-  readonly aggregationModifiers?: Readonly<
-    Record<
-      string,
-      {
-        readonly per?: readonly string[];
-        readonly normalize?: readonly string[];
-      }
-    >
-  >;
 }
 
 interface MetricCatalogResponse {

--- a/packages/cli/src/commands/metrics/schema.ts
+++ b/packages/cli/src/commands/metrics/schema.ts
@@ -137,7 +137,7 @@ function formatMetricsTable(metrics: MetricCatalogMetric[]) {
       .filter(dimension => !sharedDimensions.includes(dimension))
       .map(dimension => `+${dimension}`);
 
-    const aggregations = formatAggregations(metric);
+    const aggregations = metric.aggregations.join(', ');
 
     return {
       metric: metric.id,
@@ -184,41 +184,4 @@ function formatMetricsTable(metrics: MetricCatalogMetric[]) {
   return sharedDimensionsLine
     ? `\n${table}\n\n${sharedDimensionsLine}`
     : `\n${table}`;
-}
-
-function formatAggregations(metric: MetricCatalogMetric): string {
-  const values: string[] = [];
-
-  for (const aggregation of metric.aggregations) {
-    values.push(formatAggregationName(aggregation));
-
-    const modifiers = metric.aggregationModifiers?.[aggregation];
-    for (const period of modifiers?.per ?? []) {
-      values.push(`${formatAggregationName(aggregation)} per ${period}`);
-    }
-    for (const normalization of modifiers?.normalize ?? []) {
-      values.push(
-        `${formatAggregationName(aggregation)} as ${normalization} of total`
-      );
-    }
-  }
-
-  return values.join(', ');
-}
-
-function formatAggregationName(aggregation: string): string {
-  switch (aggregation) {
-    case 'avg':
-      return 'average';
-    case 'min':
-      return 'minimum';
-    case 'max':
-      return 'maximum';
-    case 'stddev':
-      return 'standard deviation';
-    case 'unique':
-      return 'unique by dimension';
-    default:
-      return aggregation;
-  }
 }

--- a/packages/cli/src/commands/metrics/schema.ts
+++ b/packages/cli/src/commands/metrics/schema.ts
@@ -137,7 +137,7 @@ function formatMetricsTable(metrics: MetricCatalogMetric[]) {
       .filter(dimension => !sharedDimensions.includes(dimension))
       .map(dimension => `+${dimension}`);
 
-    const aggregations = metric.aggregations.join(', ');
+    const aggregations = formatAggregations(metric);
 
     return {
       metric: metric.id,
@@ -184,4 +184,41 @@ function formatMetricsTable(metrics: MetricCatalogMetric[]) {
   return sharedDimensionsLine
     ? `\n${table}\n\n${sharedDimensionsLine}`
     : `\n${table}`;
+}
+
+function formatAggregations(metric: MetricCatalogMetric): string {
+  const values: string[] = [];
+
+  for (const aggregation of metric.aggregations) {
+    values.push(formatAggregationName(aggregation));
+
+    const modifiers = metric.aggregationModifiers?.[aggregation];
+    for (const period of modifiers?.per ?? []) {
+      values.push(`${formatAggregationName(aggregation)} per ${period}`);
+    }
+    for (const normalization of modifiers?.normalize ?? []) {
+      values.push(
+        `${formatAggregationName(aggregation)} as ${normalization} of total`
+      );
+    }
+  }
+
+  return values.join(', ');
+}
+
+function formatAggregationName(aggregation: string): string {
+  switch (aggregation) {
+    case 'avg':
+      return 'average';
+    case 'min':
+      return 'minimum';
+    case 'max':
+      return 'maximum';
+    case 'stddev':
+      return 'standard deviation';
+    case 'unique':
+      return 'unique by dimension';
+    default:
+      return aggregation;
+  }
 }

--- a/packages/cli/src/commands/metrics/schema.ts
+++ b/packages/cli/src/commands/metrics/schema.ts
@@ -7,7 +7,9 @@ import output from '../../output-manager';
 import { schemaSubcommand } from './command';
 import { validateJsonOutput } from '../../util/output-format';
 import {
-  fetchMetricCatalogOrExit,
+  fetchCombinedMetricListOrExit,
+  fetchCustomMetricCatalogOrExit,
+  fetchMetricDetailOrExit,
   type MetricCatalogMetric,
 } from './schema-api';
 import { formatErrorJson } from './output';
@@ -15,6 +17,7 @@ import formatTable from '../../util/format-table';
 import indent from '../../util/output/indent';
 import type { MetricsTelemetryClient } from '../../util/telemetry/commands/metrics';
 import getScope from '../../util/get-scope';
+import type { MetricDetail, MetricListItem } from './types';
 
 export default async function schema(
   client: Client,
@@ -59,20 +62,29 @@ export default async function schema(
   }
 
   if (metric) {
-    // Metric detail
-    const detailOrExitCode = await fetchMetricCatalogOrExit(
-      client,
-      team.id,
-      jsonOutput,
-      metric
-    );
-    // The helper returns a numeric exit code when it already
-    // handled the error output for us.
-    if (typeof detailOrExitCode === 'number') {
-      return detailOrExitCode;
+    const isPlatformMetric = metric.startsWith('vercel.');
+    let detail: MetricDetail[] | MetricCatalogMetric[];
+    if (isPlatformMetric) {
+      const result = await fetchMetricDetailOrExit(
+        client,
+        team.id,
+        metric,
+        jsonOutput
+      );
+      if (typeof result === 'number') return result;
+      detail = result;
+    } else {
+      const result = await fetchCustomMetricCatalogOrExit(
+        client,
+        team.id,
+        jsonOutput,
+        metric
+      );
+      if (typeof result === 'number') return result;
+      detail = result;
     }
 
-    if (detailOrExitCode.length === 0) {
+    if (detail.length === 0) {
       const message = `No metrics match "${metric}". Run \`vercel metrics schema\` to see available metrics.`;
       if (jsonOutput) {
         client.stdout.write(formatErrorJson('METRIC_NOT_FOUND', message));
@@ -83,12 +95,12 @@ export default async function schema(
     }
 
     if (jsonOutput) {
-      client.stdout.write(JSON.stringify(detailOrExitCode, null, 2));
+      client.stdout.write(JSON.stringify(detail, null, 2));
       return 0;
     }
 
     output.log(`Metric: ${metric}`);
-    const metricsTable = formatMetricsTable(detailOrExitCode);
+    const metricsTable = formatMetricsTable(toDisplayMetrics(detail));
     if (metricsTable) {
       output.print(metricsTable);
       output.print('\n');
@@ -98,7 +110,7 @@ export default async function schema(
   }
 
   // Metric list
-  const metricsOrExitCode = await fetchMetricCatalogOrExit(
+  const metricsOrExitCode = await fetchCombinedMetricListOrExit(
     client,
     team.id,
     jsonOutput
@@ -120,7 +132,7 @@ export default async function schema(
   return 0;
 }
 
-function formatMetricListTable(metrics: MetricCatalogMetric[]) {
+function formatMetricListTable(metrics: MetricListItem[]) {
   return indent(
     formatTable(
       ['Metric', 'Description'],
@@ -131,7 +143,34 @@ function formatMetricListTable(metrics: MetricCatalogMetric[]) {
   );
 }
 
-function formatMetricsTable(metrics: MetricCatalogMetric[]) {
+interface DisplayMetric {
+  readonly id: string;
+  readonly description: string;
+  readonly dimensions: readonly string[];
+  readonly unit: string;
+  readonly aggregations: readonly string[];
+}
+
+function toDisplayMetrics(
+  metrics: readonly (MetricDetail | MetricCatalogMetric)[]
+): DisplayMetric[] {
+  return metrics.map(metric => ({
+    id: metric.id,
+    description: metric.description,
+    dimensions: metric.dimensions.map(dimension =>
+      typeof dimension === 'string' ? dimension : dimension.name
+    ),
+    unit: metric.unit,
+    aggregations: metric.aggregations.map(aggregation =>
+      'defaultAggregation' in metric &&
+      aggregation === metric.defaultAggregation
+        ? `${aggregation} (default)`
+        : aggregation
+    ),
+  }));
+}
+
+function formatMetricsTable(metrics: readonly DisplayMetric[]) {
   if (metrics.length === 0) {
     return null;
   }

--- a/packages/cli/src/commands/metrics/schema.ts
+++ b/packages/cli/src/commands/metrics/schema.ts
@@ -6,13 +6,15 @@ import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { schemaSubcommand } from './command';
 import { validateJsonOutput } from '../../util/output-format';
-import { fetchMetricDetailOrExit, fetchMetricListOrExit } from './schema-api';
+import {
+  fetchMetricCatalogOrExit,
+  type MetricCatalogMetric,
+} from './schema-api';
 import { formatErrorJson } from './output';
 import formatTable from '../../util/format-table';
 import indent from '../../util/output/indent';
 import type { MetricsTelemetryClient } from '../../util/telemetry/commands/metrics';
 import getScope from '../../util/get-scope';
-import type { MetricDetail, MetricListItem } from './types';
 
 export default async function schema(
   client: Client,
@@ -58,13 +60,13 @@ export default async function schema(
 
   if (metric) {
     // Metric detail
-    const detailOrExitCode = await fetchMetricDetailOrExit(
+    const detailOrExitCode = await fetchMetricCatalogOrExit(
       client,
       team.id,
-      metric,
-      jsonOutput
+      jsonOutput,
+      metric
     );
-    // fetchMetricDetailOrExit() returns a numeric exit code when it already
+    // The helper returns a numeric exit code when it already
     // handled the error output for us.
     if (typeof detailOrExitCode === 'number') {
       return detailOrExitCode;
@@ -86,12 +88,12 @@ export default async function schema(
   }
 
   // Metric list
-  const metricsOrExitCode = await fetchMetricListOrExit(
+  const metricsOrExitCode = await fetchMetricCatalogOrExit(
     client,
     team.id,
     jsonOutput
   );
-  // fetchMetricListOrExit() returns a numeric exit code when it already
+  // The helper returns a numeric exit code when it already
   // handled the error output for us.
   if (typeof metricsOrExitCode === 'number') {
     return metricsOrExitCode;
@@ -108,7 +110,7 @@ export default async function schema(
   return 0;
 }
 
-function formatMetricListTable(metrics: MetricListItem[]) {
+function formatMetricListTable(metrics: MetricCatalogMetric[]) {
   return indent(
     formatTable(
       ['Metric', 'Description'],
@@ -119,13 +121,11 @@ function formatMetricListTable(metrics: MetricListItem[]) {
   );
 }
 
-function formatMetricsTable(metrics: MetricDetail[]) {
+function formatMetricsTable(metrics: MetricCatalogMetric[]) {
   if (metrics.length === 0) {
     return null;
   }
-  const dimensionsByMetric = metrics.map(metric =>
-    metric.dimensions.map(dimension => dimension.name)
-  );
+  const dimensionsByMetric = metrics.map(metric => metric.dimensions);
   const sharedDimensions = dimensionsByMetric[0]!.filter(dimension =>
     dimensionsByMetric.every(metricDimensions =>
       metricDimensions.includes(dimension)
@@ -134,17 +134,10 @@ function formatMetricsTable(metrics: MetricDetail[]) {
 
   const rows = metrics.map(metric => {
     const extraDimensions = metric.dimensions
-      .map(dimension => dimension.name)
       .filter(dimension => !sharedDimensions.includes(dimension))
       .map(dimension => `+${dimension}`);
 
-    const aggregations = metric.aggregations
-      .map(aggregation =>
-        aggregation === metric.defaultAggregation
-          ? `${aggregation} (default)`
-          : aggregation
-      )
-      .join(', ');
+    const aggregations = metric.aggregations.join(', ');
 
     return {
       metric: metric.id,

--- a/packages/cli/src/commands/metrics/schema.ts
+++ b/packages/cli/src/commands/metrics/schema.ts
@@ -72,6 +72,16 @@ export default async function schema(
       return detailOrExitCode;
     }
 
+    if (detailOrExitCode.length === 0) {
+      const message = `No metrics match "${metric}". Run \`vercel metrics schema\` to see available metrics.`;
+      if (jsonOutput) {
+        client.stdout.write(formatErrorJson('METRIC_NOT_FOUND', message));
+      } else {
+        output.error(message);
+      }
+      return 1;
+    }
+
     if (jsonOutput) {
       client.stdout.write(JSON.stringify(detailOrExitCode, null, 2));
       return 0;

--- a/packages/cli/src/commands/metrics/types.ts
+++ b/packages/cli/src/commands/metrics/types.ts
@@ -42,11 +42,6 @@ export interface MetricDimension {
   label: string;
 }
 
-export interface MetricListItem {
-  id: string;
-  description: string;
-}
-
 export interface MetricDetail {
   id: string;
   description: string;
@@ -57,10 +52,6 @@ export interface MetricDetail {
 }
 
 export type MetricDetailResponse = MetricDetail[];
-
-export interface MetricListResponse {
-  metrics: MetricListItem[];
-}
 
 export interface MetricsQueryRequest {
   scope: Scope;

--- a/packages/cli/src/commands/metrics/types.ts
+++ b/packages/cli/src/commands/metrics/types.ts
@@ -53,6 +53,15 @@ export interface MetricDetail {
 
 export type MetricDetailResponse = MetricDetail[];
 
+export interface MetricListItem {
+  id: string;
+  description: string;
+}
+
+export interface MetricListResponse {
+  metrics: MetricListItem[];
+}
+
 export interface MetricsQueryRequest {
   scope: Scope;
   metric: string;
@@ -107,6 +116,68 @@ export interface MetricsQueryResponse {
   statistics: MetricsQueryStatistics;
   orderBy?: string;
   orderDirection?: OrderDirection;
+}
+
+export interface CanonicalMetricSelection {
+  metric: string;
+  aggregation:
+    | 'count'
+    | 'sum'
+    | 'avg'
+    | 'min'
+    | 'max'
+    | 'p50'
+    | 'p75'
+    | 'p90'
+    | 'p95'
+    | 'p99'
+    | 'stddev';
+  per?: 'second';
+  normalize?: 'percent';
+  filter?: string;
+}
+
+export interface CanonicalMetricsQueryRequest {
+  scope: {
+    ownerId: string;
+    projectIds?: string[];
+  };
+  timeRange: {
+    start: string;
+    end: string;
+  };
+  bucketSeconds: number;
+  groupBy?: string[];
+  filter?: string;
+  metrics: Record<string, CanonicalMetricSelection>;
+  outputs: string[];
+  seriesSelection?: {
+    limit: number;
+    mode: 'exact';
+    rankBy: Array<{ metric: string; direction: OrderDirection }>;
+  };
+}
+
+export interface CanonicalMetricsQueryResponse {
+  series?: Array<{
+    timestamp: string;
+    dimensions: Record<string, string | null>;
+    values: Record<string, number | null>;
+  }>;
+  summary: Array<{
+    dimensions: Record<string, string | null>;
+    values: Record<string, number | null>;
+  }>;
+  queryId: string;
+  meta: {
+    sources: Array<{ id: string }>;
+    statistics: {
+      elapsedMs: number;
+      databaseElapsedMs: number;
+      rowsRead: number;
+      bytesRead: number;
+    };
+  };
 }
 
 export type ValidationError = {

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -223,7 +223,7 @@ describe('metrics query v2', () => {
       expect(postedBody?.metric).toBe('vercel.request.count');
     });
 
-    it('queries custom metrics with their exact time range', async () => {
+    it('queries custom metrics with a complete bucket range', async () => {
       mockCustomMetricCatalog();
       mockCanonicalApiSuccess();
       client.setArgv(
@@ -249,8 +249,8 @@ describe('metrics query v2', () => {
           projectIds: ['prj_metricstest'],
         },
         timeRange: {
-          start: '2026-07-29T09:00:42.123Z',
-          end: '2026-07-29T10:00:42.123Z',
+          start: '2026-07-29T09:00:00.000Z',
+          end: '2026-07-29T10:01:00.000Z',
         },
         bucketSeconds: 60,
         groupBy: ['source'],
@@ -271,8 +271,8 @@ describe('metrics query v2', () => {
       });
       const result = JSON.parse(client.stdout.getFullOutput());
       expect(result.query).toMatchObject({
-        startTime: '2026-07-29T09:00:42.123Z',
-        endTime: '2026-07-29T10:00:42.123Z',
+        startTime: '2026-07-29T09:00:00.000Z',
+        endTime: '2026-07-29T10:01:00.000Z',
       });
       expect(result.data).toEqual([
         {
@@ -290,6 +290,30 @@ describe('metrics query v2', () => {
         dbTimeSeconds: 0.02,
         engineTimeSeconds: 0.025,
         queryTable: 'vercel-main-custom-metrics',
+      });
+    });
+
+    it('expands a short custom metric range to one complete bucket', async () => {
+      mockCustomMetricCatalog();
+      mockCanonicalApiSuccess();
+      client.setArgv(
+        'metrics',
+        'checkout.latency',
+        '--since',
+        '2026-07-29T10:00:42.123Z',
+        '--until',
+        '2026-07-29T10:00:45.456Z',
+        '--granularity',
+        '1m',
+        '--format=json'
+      );
+
+      const exitCode = await query(client, new MockTelemetry());
+
+      expect(exitCode).toBe(0);
+      expect(postedBody?.timeRange).toEqual({
+        start: '2026-07-29T10:00:00.000Z',
+        end: '2026-07-29T10:01:00.000Z',
       });
     });
 
@@ -1594,7 +1618,7 @@ describe('metrics query v2', () => {
       expect(postedBody?.orderDirection).toBeUndefined();
     });
 
-    it('should send the requested time bounds without rounding them', async () => {
+    it('should preserve exact time bounds for platform metrics', async () => {
       mockMetricDetail();
       mockApiSuccess();
       client.setArgv(

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -111,6 +111,7 @@ function mockCustomMetricCatalog(
       kind: 'custom',
       limit: '250',
       search: metricId,
+      activeSince: '2026-07-29T09:00:42.123Z',
       teamId: 'team_dummy',
     });
     res.json({
@@ -222,7 +223,7 @@ describe('metrics query v2', () => {
       expect(postedBody?.metric).toBe('vercel.request.count');
     });
 
-    it('queries custom metrics with bucket-aligned timestamps', async () => {
+    it('queries custom metrics with their exact time range', async () => {
       mockCustomMetricCatalog();
       mockCanonicalApiSuccess();
       client.setArgv(
@@ -248,8 +249,8 @@ describe('metrics query v2', () => {
           projectIds: ['prj_metricstest'],
         },
         timeRange: {
-          start: '2026-07-29T09:00:00.000Z',
-          end: '2026-07-29T10:00:00.000Z',
+          start: '2026-07-29T09:00:42.123Z',
+          end: '2026-07-29T10:00:42.123Z',
         },
         bucketSeconds: 60,
         groupBy: ['source'],
@@ -270,8 +271,8 @@ describe('metrics query v2', () => {
       });
       const result = JSON.parse(client.stdout.getFullOutput());
       expect(result.query).toMatchObject({
-        startTime: '2026-07-29T09:00:00.000Z',
-        endTime: '2026-07-29T10:00:00.000Z',
+        startTime: '2026-07-29T09:00:42.123Z',
+        endTime: '2026-07-29T10:00:42.123Z',
       });
       expect(result.data).toEqual([
         {
@@ -289,6 +290,36 @@ describe('metrics query v2', () => {
         dbTimeSeconds: 0.02,
         engineTimeSeconds: 0.025,
         queryTable: 'vercel-main-custom-metrics',
+      });
+    });
+
+    it('queries custom metrics when catalog enrichment fails', async () => {
+      const metric = `checkout.${'x'.repeat(101)}`;
+      client.scenario.get('/v1/metrics', (req, res) => {
+        expect(req.query.search).toBe(metric);
+        res.status(400).json({
+          error: {
+            code: 'invalid_query',
+            message: 'search cannot exceed 100 characters',
+          },
+        });
+      });
+      mockCanonicalApiSuccess();
+      client.setArgv(
+        'metrics',
+        metric,
+        '--since',
+        '2026-07-29T09:00:42.123Z',
+        '--until',
+        '2026-07-29T10:00:42.123Z',
+        '--format=json'
+      );
+
+      const exitCode = await query(client, new MockTelemetry());
+
+      expect(exitCode).toBe(0);
+      expect(postedBody).toMatchObject({
+        metrics: { value: { metric, aggregation: 'sum' } },
       });
     });
   });

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -97,6 +97,42 @@ function mockMetricDetail(
   );
 }
 
+function mockCustomMetricCatalog(
+  metricId = 'checkout.latency',
+  overrides: Partial<{
+    description: string;
+    unit: string;
+    aggregations: string[];
+    dimensions: string[];
+  }> = {}
+) {
+  client.scenario.get('/v1/metrics', (req, res) => {
+    expect(req.query).toEqual({
+      kind: 'custom',
+      limit: '250',
+      search: metricId,
+      teamId: 'team_dummy',
+    });
+    res.json({
+      metrics: [
+        {
+          id: metricId,
+          description: overrides.description ?? 'Checkout latency',
+          unit: overrides.unit ?? 'milliseconds',
+          aggregations: overrides.aggregations ?? [
+            'count',
+            'sum',
+            'avg',
+            'p95',
+          ],
+          dimensions: overrides.dimensions ?? ['source', 'functionRegion'],
+        },
+      ],
+      pagination: { hasMore: false, nextCursor: null },
+    });
+  });
+}
+
 function mockApiSuccess(
   data: Record<string, unknown>[] = [],
   summary: Record<string, unknown>[] = [],
@@ -112,6 +148,41 @@ function mockApiSuccess(
       summary,
       statistics: { rowsRead: 100 },
       ...extra,
+    });
+  });
+}
+
+function mockCanonicalApiSuccess() {
+  client.scenario.post('/v1/metrics', (req, res) => {
+    postedBody =
+      typeof req.body === 'string'
+        ? JSON.parse(req.body)
+        : (req.body as Record<string, unknown>);
+    res.json({
+      series: [
+        {
+          timestamp: '2026-07-29T10:00:00.000Z',
+          dimensions: { source: 'edge' },
+          values: { value: 125 },
+        },
+      ],
+      summary: [
+        {
+          dimensions: { source: 'edge' },
+          values: { value: 125 },
+        },
+      ],
+      queryId: 'query_custom',
+      meta: {
+        outputs: {},
+        sources: [{ id: 'vercel-main-custom-metrics' }],
+        statistics: {
+          elapsedMs: 25,
+          databaseElapsedMs: 20,
+          rowsRead: 100,
+          bytesRead: 2048,
+        },
+      },
     });
   });
 }
@@ -150,20 +221,82 @@ describe('metrics query v2', () => {
       expect(exitCode).toBe(0);
       expect(postedBody?.metric).toBe('vercel.request.count');
     });
+
+    it('queries custom metrics through the canonical endpoint', async () => {
+      mockCustomMetricCatalog();
+      mockCanonicalApiSuccess();
+      client.setArgv(
+        'metrics',
+        'checkout.latency',
+        '--group-by',
+        'source',
+        '--filter',
+        "source eq 'edge'",
+        '--since',
+        '1h',
+        '--format=json'
+      );
+
+      const exitCode = await query(client, new MockTelemetry());
+
+      expect(exitCode).toBe(0);
+      expect(postedBody).toMatchObject({
+        scope: {
+          ownerId: 'team_dummy',
+          projectIds: ['prj_metricstest'],
+        },
+        groupBy: ['source'],
+        filter: "source eq 'edge'",
+        metrics: {
+          value: { metric: 'checkout.latency', aggregation: 'sum' },
+          __seriesCount: {
+            metric: 'checkout.latency',
+            aggregation: 'count',
+          },
+        },
+        outputs: ['value'],
+        seriesSelection: {
+          limit: 10,
+          mode: 'exact',
+          rankBy: [{ metric: '__seriesCount', direction: 'desc' }],
+        },
+      });
+      const result = JSON.parse(client.stdout.getFullOutput());
+      expect(result.data).toEqual([
+        {
+          timestamp: '2026-07-29T10:00:00.000Z',
+          source: 'edge',
+          checkout_latency_sum: 125,
+        },
+      ]);
+      expect(result.summary).toEqual([
+        { source: 'edge', checkout_latency_sum: 125 },
+      ]);
+      expect(result.statistics).toEqual({
+        rowsRead: 100,
+        bytesRead: 2048,
+        dbTimeSeconds: 0.02,
+        engineTimeSeconds: 0.025,
+        queryTable: 'vercel-main-custom-metrics',
+      });
+    });
   });
 
   describe('metric validation', () => {
     it('should return error with available metrics', async () => {
-      client.scenario.get('/v2/observability/schema/bogus', (_req, res) => {
-        res.status(400).json({
-          error: {
-            code: 'unknown_metric',
-            message: 'Unknown metric "bogus".',
-            allowedValues: ['vercel.request.count'],
-          },
-        });
-      });
-      client.setArgv('metrics', 'bogus');
+      client.scenario.get(
+        '/v2/observability/schema/vercel.bogus',
+        (_req, res) => {
+          res.status(400).json({
+            error: {
+              code: 'unknown_metric',
+              message: 'Unknown metric "bogus".',
+              allowedValues: ['vercel.request.count'],
+            },
+          });
+        }
+      );
+      client.setArgv('metrics', 'vercel.bogus');
 
       const exitCode = await query(client, new MockTelemetry());
 
@@ -175,16 +308,19 @@ describe('metrics query v2', () => {
     });
 
     it('should return JSON error with --format=json', async () => {
-      client.scenario.get('/v2/observability/schema/bogus', (_req, res) => {
-        res.status(400).json({
-          error: {
-            code: 'unknown_metric',
-            message: 'Unknown metric "bogus".',
-            allowedValues: ['vercel.request.count'],
-          },
-        });
-      });
-      client.setArgv('metrics', 'bogus', '--format=json');
+      client.scenario.get(
+        '/v2/observability/schema/vercel.bogus',
+        (_req, res) => {
+          res.status(400).json({
+            error: {
+              code: 'unknown_metric',
+              message: 'Unknown metric "bogus".',
+              allowedValues: ['vercel.request.count'],
+            },
+          });
+        }
+      );
+      client.setArgv('metrics', 'vercel.bogus', '--format=json');
 
       const exitCode = await query(client, new MockTelemetry());
 

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -1,3 +1,4 @@
+import stripAnsi from 'strip-ansi';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import query from '../../../../src/commands/metrics/query';
@@ -1205,6 +1206,9 @@ describe('metrics query v2', () => {
 
       expect(exitCode).toBe(0);
       expect(postedBody?.filter).toBe('http_status ge 500');
+      expect(stripAnsi(client.stderr.getFullOutput())).toContain(
+        '! OData support in --filter is deprecated and will be removed soon. KQL will be the only supported filter syntax.'
+      );
     });
 
     it('should AND repeated filter strings before sending them to API', async () => {
@@ -1224,6 +1228,33 @@ describe('metrics query v2', () => {
       expect(exitCode).toBe(0);
       expect(postedBody?.filter).toBe(
         "(http_status ge 500) and (contains(request_path, '/api'))"
+      );
+      expect(
+        stripAnsi(client.stderr.getFullOutput()).match(
+          /OData support in --filter is deprecated/g
+        )
+      ).toHaveLength(1);
+    });
+
+    it('should keep JSON stdout parseable when warning about OData', async () => {
+      mockMetricDetail();
+      mockApiSuccess();
+      client.setArgv(
+        'metrics',
+        'vercel.request.count',
+        '--filter',
+        'http_status ge 500',
+        '--format=json'
+      );
+
+      const exitCode = await query(client, new MockTelemetry());
+
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(client.stdout.getFullOutput()).query.filter).toBe(
+        'http_status ge 500'
+      );
+      expect(stripAnsi(client.stderr.getFullOutput())).toContain(
+        '! OData support in --filter is deprecated and will be removed soon. KQL will be the only supported filter syntax.'
       );
     });
 

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -1,4 +1,3 @@
-import stripAnsi from 'strip-ansi';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import query from '../../../../src/commands/metrics/query';
@@ -1206,9 +1205,6 @@ describe('metrics query v2', () => {
 
       expect(exitCode).toBe(0);
       expect(postedBody?.filter).toBe('http_status ge 500');
-      expect(stripAnsi(client.stderr.getFullOutput())).toContain(
-        '! OData support in --filter is deprecated and will be removed soon. KQL will be the only supported filter syntax.'
-      );
     });
 
     it('should AND repeated filter strings before sending them to API', async () => {
@@ -1228,33 +1224,6 @@ describe('metrics query v2', () => {
       expect(exitCode).toBe(0);
       expect(postedBody?.filter).toBe(
         "(http_status ge 500) and (contains(request_path, '/api'))"
-      );
-      expect(
-        stripAnsi(client.stderr.getFullOutput()).match(
-          /OData support in --filter is deprecated/g
-        )
-      ).toHaveLength(1);
-    });
-
-    it('should keep JSON stdout parseable when warning about OData', async () => {
-      mockMetricDetail();
-      mockApiSuccess();
-      client.setArgv(
-        'metrics',
-        'vercel.request.count',
-        '--filter',
-        'http_status ge 500',
-        '--format=json'
-      );
-
-      const exitCode = await query(client, new MockTelemetry());
-
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(client.stdout.getFullOutput()).query.filter).toBe(
-        'http_status ge 500'
-      );
-      expect(stripAnsi(client.stderr.getFullOutput())).toContain(
-        '! OData support in --filter is deprecated and will be removed soon. KQL will be the only supported filter syntax.'
       );
     });
 

--- a/packages/cli/test/unit/commands/metrics/query.test.ts
+++ b/packages/cli/test/unit/commands/metrics/query.test.ts
@@ -222,7 +222,7 @@ describe('metrics query v2', () => {
       expect(postedBody?.metric).toBe('vercel.request.count');
     });
 
-    it('queries custom metrics through the canonical endpoint', async () => {
+    it('queries custom metrics with bucket-aligned timestamps', async () => {
       mockCustomMetricCatalog();
       mockCanonicalApiSuccess();
       client.setArgv(
@@ -233,7 +233,9 @@ describe('metrics query v2', () => {
         '--filter',
         "source eq 'edge'",
         '--since',
-        '1h',
+        '2026-07-29T09:00:42.123Z',
+        '--until',
+        '2026-07-29T10:00:42.123Z',
         '--format=json'
       );
 
@@ -245,6 +247,11 @@ describe('metrics query v2', () => {
           ownerId: 'team_dummy',
           projectIds: ['prj_metricstest'],
         },
+        timeRange: {
+          start: '2026-07-29T09:00:00.000Z',
+          end: '2026-07-29T10:00:00.000Z',
+        },
+        bucketSeconds: 60,
         groupBy: ['source'],
         filter: "source eq 'edge'",
         metrics: {
@@ -262,6 +269,10 @@ describe('metrics query v2', () => {
         },
       });
       const result = JSON.parse(client.stdout.getFullOutput());
+      expect(result.query).toMatchObject({
+        startTime: '2026-07-29T09:00:00.000Z',
+        endTime: '2026-07-29T10:00:00.000Z',
+      });
       expect(result.data).toEqual([
         {
           timestamp: '2026-07-29T10:00:00.000Z',

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -113,7 +113,7 @@ describe('metrics schema v1', () => {
     expect(output).toContain('vercel.request.count');
   });
 
-  it('returns complete v1 descriptors as JSON', async () => {
+  it('returns stable metric fields as JSON', async () => {
     client.scenario.get('/v1/metrics', (_req, res) => {
       res.json({
         metrics: [
@@ -142,17 +142,50 @@ describe('metrics schema v1', () => {
     expect(result).toEqual([
       {
         id: 'vercel.request.count',
-        kind: 'system',
         description: 'Request Count',
         dimensions: ['route', 'httpStatus'],
         unit: 'count',
         aggregations: ['count', 'unique'],
-        derivedFrom: {
-          event: 'vercel.request',
-          input: { kind: 'count' },
-        },
       },
     ]);
+  });
+
+  it('reports an unknown metric prefix', async () => {
+    client.scenario.get('/v1/metrics', (_req, res) => {
+      res.json({
+        metrics: [],
+        pagination: { hasMore: false, nextCursor: null },
+      });
+    });
+    client.setArgv('metrics', 'schema', 'vercel.unknown');
+
+    const exitCode = await schema(client, new MockTelemetry());
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'No metrics match "vercel.unknown". Run `vercel metrics schema` to see available metrics.'
+    );
+  });
+
+  it('reports an unknown metric prefix as JSON', async () => {
+    client.scenario.get('/v1/metrics', (_req, res) => {
+      res.json({
+        metrics: [],
+        pagination: { hasMore: false, nextCursor: null },
+      });
+    });
+    client.setArgv('metrics', 'schema', 'vercel.unknown', '--format=json');
+
+    const exitCode = await schema(client, new MockTelemetry());
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual({
+      error: {
+        code: 'METRIC_NOT_FOUND',
+        message:
+          'No metrics match "vercel.unknown". Run `vercel metrics schema` to see available metrics.',
+      },
+    });
   });
 
   it('shows prefix detail with a positional metric', async () => {

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -170,6 +170,33 @@ describe('metrics schema', () => {
     ]);
   });
 
+  it('returns platform metrics when the custom catalog is unavailable', async () => {
+    client.scenario.get('/v2/observability/schema', (_req, res) => {
+      res.json({
+        metrics: [{ id: 'vercel.request.count', description: 'Request Count' }],
+      });
+    });
+    client.scenario.get('/v1/metrics', (_req, res) => {
+      res.status(403).json({
+        error: {
+          code: 'forbidden',
+          message: 'Custom metric discovery is not available',
+        },
+      });
+    });
+    client.setArgv('metrics', 'schema', '--format=json');
+
+    const exitCode = await schema(client, new MockTelemetry());
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(client.stdout.getFullOutput())).toEqual([
+      {
+        id: 'vercel.request.count',
+        description: 'Request Count',
+      },
+    ]);
+  });
+
   it('reports an unknown metric prefix', async () => {
     client.scenario.get('/v1/metrics', (_req, res) => {
       res.json({

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -43,9 +43,6 @@ describe('metrics schema v1', () => {
             dimensions: ['route'],
             unit: 'count',
             aggregations: ['count', 'unique'],
-            aggregationModifiers: {
-              count: { per: ['second'], normalize: ['percent'] },
-            },
             derivedFrom: {
               event: 'vercel.request',
               input: { kind: 'count' },
@@ -127,9 +124,6 @@ describe('metrics schema v1', () => {
             dimensions: ['route', 'httpStatus'],
             unit: 'count',
             aggregations: ['count', 'unique'],
-            aggregationModifiers: {
-              count: { per: ['second'], normalize: ['percent'] },
-            },
             derivedFrom: {
               event: 'vercel.request',
               input: { kind: 'count' },
@@ -153,9 +147,6 @@ describe('metrics schema v1', () => {
         dimensions: ['route', 'httpStatus'],
         unit: 'count',
         aggregations: ['count', 'unique'],
-        aggregationModifiers: {
-          count: { per: ['second'], normalize: ['percent'] },
-        },
         derivedFrom: {
           event: 'vercel.request',
           input: { kind: 'count' },
@@ -180,9 +171,6 @@ describe('metrics schema v1', () => {
             dimensions: ['route', 'httpStatus'],
             unit: 'count',
             aggregations: ['count', 'unique'],
-            aggregationModifiers: {
-              count: { per: ['second'], normalize: ['percent'] },
-            },
           },
           {
             id: 'vercel.request.route_cpu_duration_ms',
@@ -190,10 +178,6 @@ describe('metrics schema v1', () => {
             dimensions: ['route', 'httpStatus', 'cacheResult'],
             unit: 'milliseconds',
             aggregations: ['count', 'sum', 'avg', 'p95'],
-            aggregationModifiers: {
-              count: { per: ['second'], normalize: ['percent'] },
-              sum: { per: ['second'], normalize: ['percent'] },
-            },
           },
         ],
         pagination: { hasMore: false, nextCursor: null },
@@ -215,15 +199,11 @@ describe('metrics schema v1', () => {
     expect(output).toContain('vercel.request.count');
     expect(output).toContain('Count');
     expect(output).toContain('count');
-    expect(output).toContain(
-      'count, count per second, count as percent of total, unique by dimension'
-    );
+    expect(output).toContain('count, unique');
     expect(output).toContain('vercel.request.route_cpu_duration_ms');
     expect(output).toContain('Request Duration');
     expect(output).toContain('milliseconds');
-    expect(output).toContain(
-      'count, count per second, count as percent of total, sum, sum per second, sum as percent of total, average, p95'
-    );
+    expect(output).toContain('count, sum, avg, p95');
     expect(output).toContain('+cacheResult');
     expect(output).toContain('—');
   });

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -30,6 +30,7 @@ describe('metrics schema v1', () => {
   it('lists metrics by default', async () => {
     client.scenario.get('/v1/metrics', (req, res) => {
       expect(req.query).toEqual({
+        includeLogs: 'false',
         limit: '250',
         teamId: 'team_dummy',
       });
@@ -68,6 +69,7 @@ describe('metrics schema v1', () => {
     client.scenario.get('/v1/metrics', (req, res) => {
       if (req.query.cursor === 'next_page') {
         expect(req.query).toEqual({
+          includeLogs: 'false',
           limit: '250',
           cursor: 'next_page',
           teamId: 'team_dummy',
@@ -156,6 +158,7 @@ describe('metrics schema v1', () => {
   it('shows prefix detail with a positional metric', async () => {
     client.scenario.get('/v1/metrics', (req, res) => {
       expect(req.query).toEqual({
+        includeLogs: 'false',
         limit: '250',
         search: 'vercel.request',
         teamId: 'team_dummy',

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -16,7 +16,7 @@ class MockTelemetry extends MetricsTelemetryClient {
   }
 }
 
-describe('metrics schema v2', () => {
+describe('metrics schema v1', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     client.reset();
@@ -28,9 +28,27 @@ describe('metrics schema v2', () => {
   });
 
   it('lists metrics by default', async () => {
-    client.scenario.get('/v2/observability/schema', (_req, res) => {
+    client.scenario.get('/v1/metrics', (req, res) => {
+      expect(req.query).toEqual({
+        limit: '250',
+        teamId: 'team_dummy',
+      });
       res.json({
-        metrics: [{ id: 'vercel.request.count', description: 'Count' }],
+        metrics: [
+          {
+            id: 'vercel.request.count',
+            kind: 'system',
+            description: 'Count',
+            dimensions: ['route'],
+            unit: 'count',
+            aggregations: ['count', 'unique'],
+            derivedFrom: {
+              event: 'vercel.request',
+              input: { kind: 'count' },
+            },
+          },
+        ],
+        pagination: { hasMore: false, nextCursor: null },
       });
     });
     client.setArgv('metrics', 'schema');
@@ -46,37 +64,122 @@ describe('metrics schema v2', () => {
     expect(output).toContain('Count');
   });
 
+  it('follows metric catalog pagination', async () => {
+    client.scenario.get('/v1/metrics', (req, res) => {
+      if (req.query.cursor === 'next_page') {
+        expect(req.query).toEqual({
+          limit: '250',
+          cursor: 'next_page',
+          teamId: 'team_dummy',
+        });
+        res.json({
+          metrics: [
+            {
+              id: 'vercel.request.count',
+              description: 'Request Count',
+              dimensions: ['route'],
+              unit: 'count',
+              aggregations: ['count', 'unique'],
+            },
+          ],
+          pagination: { hasMore: false, nextCursor: null },
+        });
+        return;
+      }
+
+      res.json({
+        metrics: [
+          {
+            id: 'vercel.log.count',
+            description: 'Log Count',
+            dimensions: ['level'],
+            unit: 'count',
+            aggregations: ['count', 'unique'],
+          },
+        ],
+        pagination: { hasMore: true, nextCursor: 'next_page' },
+      });
+    });
+    client.setArgv('metrics', 'schema');
+
+    const exitCode = await schema(client, new MockTelemetry());
+
+    expect(exitCode).toBe(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('2 Metrics found');
+    expect(output).toContain('vercel.log.count');
+    expect(output).toContain('vercel.request.count');
+  });
+
+  it('returns complete v1 descriptors as JSON', async () => {
+    client.scenario.get('/v1/metrics', (_req, res) => {
+      res.json({
+        metrics: [
+          {
+            id: 'vercel.request.count',
+            kind: 'system',
+            description: 'Request Count',
+            dimensions: ['route', 'httpStatus'],
+            unit: 'count',
+            aggregations: ['count', 'unique'],
+            derivedFrom: {
+              event: 'vercel.request',
+              input: { kind: 'count' },
+            },
+          },
+        ],
+        pagination: { hasMore: false, nextCursor: null },
+      });
+    });
+    client.setArgv('metrics', 'schema', '--format=json');
+
+    const exitCode = await schema(client, new MockTelemetry());
+
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(client.stdout.getFullOutput());
+    expect(result).toEqual([
+      {
+        id: 'vercel.request.count',
+        kind: 'system',
+        description: 'Request Count',
+        dimensions: ['route', 'httpStatus'],
+        unit: 'count',
+        aggregations: ['count', 'unique'],
+        derivedFrom: {
+          event: 'vercel.request',
+          input: { kind: 'count' },
+        },
+      },
+    ]);
+  });
+
   it('shows prefix detail with a positional metric', async () => {
-    client.scenario.get(
-      '/v2/observability/schema/vercel.request',
-      (_req, res) => {
-        res.json([
+    client.scenario.get('/v1/metrics', (req, res) => {
+      expect(req.query).toEqual({
+        limit: '250',
+        search: 'vercel.request',
+        teamId: 'team_dummy',
+      });
+      res.json({
+        metrics: [
           {
             id: 'vercel.request.count',
             description: 'Count',
-            dimensions: [
-              { name: 'route', label: 'Route' },
-              { name: 'http_status', label: 'HTTP Status' },
-            ],
+            dimensions: ['route', 'httpStatus'],
             unit: 'count',
-            aggregations: ['sum'],
-            defaultAggregation: 'sum',
+            aggregations: ['count', 'unique'],
           },
           {
             id: 'vercel.request.route_cpu_duration_ms',
             description: 'Request Duration',
-            dimensions: [
-              { name: 'route', label: 'Route' },
-              { name: 'http_status', label: 'HTTP Status' },
-              { name: 'cache_result', label: 'Cache Result' },
-            ],
+            dimensions: ['route', 'httpStatus', 'cacheResult'],
             unit: 'milliseconds',
-            aggregations: ['avg', 'p95'],
-            defaultAggregation: 'avg',
+            aggregations: ['count', 'sum', 'avg', 'p95'],
           },
-        ]);
-      }
-    );
+        ],
+        pagination: { hasMore: false, nextCursor: null },
+      });
+    });
     client.setArgv('metrics', 'schema', 'vercel.request');
 
     const exitCode = await schema(client, new MockTelemetry());
@@ -84,7 +187,7 @@ describe('metrics schema v2', () => {
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
     expect(output).toContain('Shared dimensions:');
-    expect(output).toContain('route, http_status');
+    expect(output).toContain('route, httpStatus');
     expect(output).toContain('Metric');
     expect(output).toContain('Description');
     expect(output).toContain('Unit');
@@ -93,45 +196,37 @@ describe('metrics schema v2', () => {
     expect(output).toContain('vercel.request.count');
     expect(output).toContain('Count');
     expect(output).toContain('count');
-    expect(output).toContain('sum (default)');
+    expect(output).toContain('count, unique');
     expect(output).toContain('vercel.request.route_cpu_duration_ms');
     expect(output).toContain('Request Duration');
     expect(output).toContain('milliseconds');
-    expect(output).toContain('avg (default), p95');
-    expect(output).toContain('+cache_result');
+    expect(output).toContain('count, sum, avg, p95');
+    expect(output).toContain('+cacheResult');
     expect(output).toContain('—');
   });
 
   it('omits the dimensions column when no metric has extra dimensions', async () => {
-    client.scenario.get(
-      '/v2/observability/schema/vercel.request',
-      (_req, res) => {
-        res.json([
+    client.scenario.get('/v1/metrics', (_req, res) => {
+      res.json({
+        metrics: [
           {
             id: 'vercel.request.count',
             description: 'Count',
-            dimensions: [
-              { name: 'route', label: 'Route' },
-              { name: 'http_status', label: 'HTTP Status' },
-            ],
+            dimensions: ['route', 'httpStatus'],
             unit: 'count',
-            aggregations: ['sum'],
-            defaultAggregation: 'sum',
+            aggregations: ['count', 'unique'],
           },
           {
             id: 'vercel.request.route_cpu_duration_ms',
             description: 'Request Duration',
-            dimensions: [
-              { name: 'route', label: 'Route' },
-              { name: 'http_status', label: 'HTTP Status' },
-            ],
+            dimensions: ['route', 'httpStatus'],
             unit: 'milliseconds',
-            aggregations: ['avg', 'p95'],
-            defaultAggregation: 'avg',
+            aggregations: ['count', 'sum', 'avg', 'p95'],
           },
-        ]);
-      }
-    );
+        ],
+        pagination: { hasMore: false, nextCursor: null },
+      });
+    });
     client.setArgv('metrics', 'schema', 'vercel.request');
 
     const exitCode = await schema(client, new MockTelemetry());
@@ -139,7 +234,7 @@ describe('metrics schema v2', () => {
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
     expect(output).toContain('Shared dimensions:');
-    expect(output).toContain('route, http_status');
+    expect(output).toContain('route, httpStatus');
     expect(output).toContain('Metric');
     expect(output).toContain('Description');
     expect(output).toContain('Unit');
@@ -154,24 +249,20 @@ describe('metrics schema v2', () => {
 
   describe('telemetry', () => {
     it('should track metric argument', async () => {
-      client.scenario.get(
-        '/v2/observability/schema/vercel.request.count',
-        (_req, res) => {
-          res.json([
+      client.scenario.get('/v1/metrics', (_req, res) => {
+        res.json({
+          metrics: [
             {
               id: 'vercel.request.count',
               description: 'Count',
-              dimensions: [
-                { name: 'route', label: 'Route' },
-                { name: 'http_status', label: 'HTTP Status' },
-              ],
+              dimensions: ['route', 'httpStatus'],
               unit: 'count',
-              aggregations: ['sum'],
-              defaultAggregation: 'sum',
+              aggregations: ['count', 'unique'],
             },
-          ]);
-        }
-      );
+          ],
+          pagination: { hasMore: false, nextCursor: null },
+        });
+      });
       client.setArgv('metrics', 'schema', 'vercel.request.count');
 
       await schema(client, new MockTelemetry());
@@ -182,9 +273,18 @@ describe('metrics schema v2', () => {
     });
 
     it('should track format option', async () => {
-      client.scenario.get('/v2/observability/schema', (_req, res) => {
+      client.scenario.get('/v1/metrics', (_req, res) => {
         res.json({
-          metrics: [{ id: 'vercel.request.count', description: 'Count' }],
+          metrics: [
+            {
+              id: 'vercel.request.count',
+              description: 'Count',
+              dimensions: ['route'],
+              unit: 'count',
+              aggregations: ['count', 'unique'],
+            },
+          ],
+          pagination: { hasMore: false, nextCursor: null },
         });
       });
       client.setArgv('metrics', 'schema', '--format=json');

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -30,7 +30,13 @@ describe('metrics schema', () => {
   it('lists metrics by default', async () => {
     client.scenario.get('/v2/observability/schema', (_req, res) => {
       res.json({
-        metrics: [{ id: 'vercel.request.count', description: 'Count' }],
+        metrics: [
+          { id: 'vercel.request.count', description: 'Count' },
+          {
+            id: 'checkout.duration',
+            description: 'Legacy custom metric entry',
+          },
+        ],
       });
     });
     client.scenario.get('/v1/metrics', (req, res) => {

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -43,6 +43,9 @@ describe('metrics schema v1', () => {
             dimensions: ['route'],
             unit: 'count',
             aggregations: ['count', 'unique'],
+            aggregationModifiers: {
+              count: { per: ['second'], normalize: ['percent'] },
+            },
             derivedFrom: {
               event: 'vercel.request',
               input: { kind: 'count' },
@@ -124,6 +127,9 @@ describe('metrics schema v1', () => {
             dimensions: ['route', 'httpStatus'],
             unit: 'count',
             aggregations: ['count', 'unique'],
+            aggregationModifiers: {
+              count: { per: ['second'], normalize: ['percent'] },
+            },
             derivedFrom: {
               event: 'vercel.request',
               input: { kind: 'count' },
@@ -147,6 +153,9 @@ describe('metrics schema v1', () => {
         dimensions: ['route', 'httpStatus'],
         unit: 'count',
         aggregations: ['count', 'unique'],
+        aggregationModifiers: {
+          count: { per: ['second'], normalize: ['percent'] },
+        },
         derivedFrom: {
           event: 'vercel.request',
           input: { kind: 'count' },
@@ -171,6 +180,9 @@ describe('metrics schema v1', () => {
             dimensions: ['route', 'httpStatus'],
             unit: 'count',
             aggregations: ['count', 'unique'],
+            aggregationModifiers: {
+              count: { per: ['second'], normalize: ['percent'] },
+            },
           },
           {
             id: 'vercel.request.route_cpu_duration_ms',
@@ -178,6 +190,10 @@ describe('metrics schema v1', () => {
             dimensions: ['route', 'httpStatus', 'cacheResult'],
             unit: 'milliseconds',
             aggregations: ['count', 'sum', 'avg', 'p95'],
+            aggregationModifiers: {
+              count: { per: ['second'], normalize: ['percent'] },
+              sum: { per: ['second'], normalize: ['percent'] },
+            },
           },
         ],
         pagination: { hasMore: false, nextCursor: null },
@@ -199,11 +215,15 @@ describe('metrics schema v1', () => {
     expect(output).toContain('vercel.request.count');
     expect(output).toContain('Count');
     expect(output).toContain('count');
-    expect(output).toContain('count, unique');
+    expect(output).toContain(
+      'count, count per second, count as percent of total, unique by dimension'
+    );
     expect(output).toContain('vercel.request.route_cpu_duration_ms');
     expect(output).toContain('Request Duration');
     expect(output).toContain('milliseconds');
-    expect(output).toContain('count, sum, avg, p95');
+    expect(output).toContain(
+      'count, count per second, count as percent of total, sum, sum per second, sum as percent of total, average, p95'
+    );
     expect(output).toContain('+cacheResult');
     expect(output).toContain('—');
   });

--- a/packages/cli/test/unit/commands/metrics/schema.test.ts
+++ b/packages/cli/test/unit/commands/metrics/schema.test.ts
@@ -16,7 +16,7 @@ class MockTelemetry extends MetricsTelemetryClient {
   }
 }
 
-describe('metrics schema v1', () => {
+describe('metrics schema', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     client.reset();
@@ -28,25 +28,32 @@ describe('metrics schema v1', () => {
   });
 
   it('lists metrics by default', async () => {
+    client.scenario.get('/v2/observability/schema', (_req, res) => {
+      res.json({
+        metrics: [{ id: 'vercel.request.count', description: 'Count' }],
+      });
+    });
     client.scenario.get('/v1/metrics', (req, res) => {
       expect(req.query).toEqual({
-        includeLogs: 'false',
+        kind: 'custom',
         limit: '250',
         teamId: 'team_dummy',
       });
       res.json({
         metrics: [
           {
-            id: 'vercel.request.count',
-            kind: 'system',
-            description: 'Count',
-            dimensions: ['route'],
+            id: 'checkout.duration',
+            description: 'Checkout duration',
+            dimensions: ['source'],
+            unit: 'milliseconds',
+            aggregations: ['count', 'sum', 'avg', 'p95'],
+          },
+          {
+            id: 'vercel.accidental.custom',
+            description: 'Must not be listed from the custom catalog',
+            dimensions: [],
             unit: 'count',
-            aggregations: ['count', 'unique'],
-            derivedFrom: {
-              event: 'vercel.request',
-              input: { kind: 'count' },
-            },
+            aggregations: ['count'],
           },
         ],
         pagination: { hasMore: false, nextCursor: null },
@@ -58,18 +65,24 @@ describe('metrics schema v1', () => {
 
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
-    expect(output).toContain('1 Metric found');
+    expect(output).toContain('2 Metrics found');
     expect(output).toContain('Metric');
     expect(output).toContain('Description');
     expect(output).toContain('vercel.request.count');
     expect(output).toContain('Count');
+    expect(output).toContain('checkout.duration');
+    expect(output).toContain('Checkout duration');
+    expect(output).not.toContain('vercel.accidental.custom');
   });
 
   it('follows metric catalog pagination', async () => {
+    client.scenario.get('/v2/observability/schema', (_req, res) => {
+      res.json({ metrics: [] });
+    });
     client.scenario.get('/v1/metrics', (req, res) => {
       if (req.query.cursor === 'next_page') {
         expect(req.query).toEqual({
-          includeLogs: 'false',
+          kind: 'custom',
           limit: '250',
           cursor: 'next_page',
           teamId: 'team_dummy',
@@ -77,11 +90,11 @@ describe('metrics schema v1', () => {
         res.json({
           metrics: [
             {
-              id: 'vercel.request.count',
-              description: 'Request Count',
-              dimensions: ['route'],
+              id: 'checkout.revenue',
+              description: 'Checkout revenue',
+              dimensions: ['source'],
               unit: 'count',
-              aggregations: ['count', 'unique'],
+              aggregations: ['count', 'sum'],
             },
           ],
           pagination: { hasMore: false, nextCursor: null },
@@ -92,9 +105,9 @@ describe('metrics schema v1', () => {
       res.json({
         metrics: [
           {
-            id: 'vercel.log.count',
-            description: 'Log Count',
-            dimensions: ['level'],
+            id: 'checkout.duration',
+            description: 'Checkout duration',
+            dimensions: ['source'],
             unit: 'count',
             aggregations: ['count', 'unique'],
           },
@@ -109,25 +122,25 @@ describe('metrics schema v1', () => {
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
     expect(output).toContain('2 Metrics found');
-    expect(output).toContain('vercel.log.count');
-    expect(output).toContain('vercel.request.count');
+    expect(output).toContain('checkout.duration');
+    expect(output).toContain('checkout.revenue');
   });
 
-  it('returns stable metric fields as JSON', async () => {
+  it('returns the combined legacy list shape as JSON', async () => {
+    client.scenario.get('/v2/observability/schema', (_req, res) => {
+      res.json({
+        metrics: [{ id: 'vercel.request.count', description: 'Request Count' }],
+      });
+    });
     client.scenario.get('/v1/metrics', (_req, res) => {
       res.json({
         metrics: [
           {
-            id: 'vercel.request.count',
-            kind: 'system',
-            description: 'Request Count',
-            dimensions: ['route', 'httpStatus'],
-            unit: 'count',
-            aggregations: ['count', 'unique'],
-            derivedFrom: {
-              event: 'vercel.request',
-              input: { kind: 'count' },
-            },
+            id: 'checkout.duration',
+            description: 'Checkout duration',
+            dimensions: ['source'],
+            unit: 'milliseconds',
+            aggregations: ['count', 'sum', 'avg'],
           },
         ],
         pagination: { hasMore: false, nextCursor: null },
@@ -141,11 +154,12 @@ describe('metrics schema v1', () => {
     const result = JSON.parse(client.stdout.getFullOutput());
     expect(result).toEqual([
       {
+        id: 'checkout.duration',
+        description: 'Checkout duration',
+      },
+      {
         id: 'vercel.request.count',
         description: 'Request Count',
-        dimensions: ['route', 'httpStatus'],
-        unit: 'count',
-        aggregations: ['count', 'unique'],
       },
     ]);
   });
@@ -157,13 +171,13 @@ describe('metrics schema v1', () => {
         pagination: { hasMore: false, nextCursor: null },
       });
     });
-    client.setArgv('metrics', 'schema', 'vercel.unknown');
+    client.setArgv('metrics', 'schema', 'checkout.unknown');
 
     const exitCode = await schema(client, new MockTelemetry());
 
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain(
-      'No metrics match "vercel.unknown". Run `vercel metrics schema` to see available metrics.'
+      'No metrics match "checkout.unknown". Run `vercel metrics schema` to see available metrics.'
     );
   });
 
@@ -174,7 +188,7 @@ describe('metrics schema v1', () => {
         pagination: { hasMore: false, nextCursor: null },
       });
     });
-    client.setArgv('metrics', 'schema', 'vercel.unknown', '--format=json');
+    client.setArgv('metrics', 'schema', 'checkout.unknown', '--format=json');
 
     const exitCode = await schema(client, new MockTelemetry());
 
@@ -183,39 +197,42 @@ describe('metrics schema v1', () => {
       error: {
         code: 'METRIC_NOT_FOUND',
         message:
-          'No metrics match "vercel.unknown". Run `vercel metrics schema` to see available metrics.',
+          'No metrics match "checkout.unknown". Run `vercel metrics schema` to see available metrics.',
       },
     });
   });
 
   it('shows prefix detail with a positional metric', async () => {
-    client.scenario.get('/v1/metrics', (req, res) => {
-      expect(req.query).toEqual({
-        includeLogs: 'false',
-        limit: '250',
-        search: 'vercel.request',
-        teamId: 'team_dummy',
-      });
-      res.json({
-        metrics: [
+    client.scenario.get(
+      '/v2/observability/schema/vercel.request',
+      (_req, res) => {
+        res.json([
           {
             id: 'vercel.request.count',
             description: 'Count',
-            dimensions: ['route', 'httpStatus'],
+            dimensions: [
+              { name: 'route', label: 'Route' },
+              { name: 'http_status', label: 'HTTP Status' },
+            ],
             unit: 'count',
-            aggregations: ['count', 'unique'],
+            aggregations: ['sum'],
+            defaultAggregation: 'sum',
           },
           {
             id: 'vercel.request.route_cpu_duration_ms',
             description: 'Request Duration',
-            dimensions: ['route', 'httpStatus', 'cacheResult'],
+            dimensions: [
+              { name: 'route', label: 'Route' },
+              { name: 'http_status', label: 'HTTP Status' },
+              { name: 'cache_result', label: 'Cache Result' },
+            ],
             unit: 'milliseconds',
-            aggregations: ['count', 'sum', 'avg', 'p95'],
+            aggregations: ['avg', 'p95'],
+            defaultAggregation: 'avg',
           },
-        ],
-        pagination: { hasMore: false, nextCursor: null },
-      });
-    });
+        ]);
+      }
+    );
     client.setArgv('metrics', 'schema', 'vercel.request');
 
     const exitCode = await schema(client, new MockTelemetry());
@@ -223,7 +240,7 @@ describe('metrics schema v1', () => {
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
     expect(output).toContain('Shared dimensions:');
-    expect(output).toContain('route, httpStatus');
+    expect(output).toContain('route, http_status');
     expect(output).toContain('Metric');
     expect(output).toContain('Description');
     expect(output).toContain('Unit');
@@ -232,30 +249,29 @@ describe('metrics schema v1', () => {
     expect(output).toContain('vercel.request.count');
     expect(output).toContain('Count');
     expect(output).toContain('count');
-    expect(output).toContain('count, unique');
+    expect(output).toContain('sum (default)');
     expect(output).toContain('vercel.request.route_cpu_duration_ms');
     expect(output).toContain('Request Duration');
     expect(output).toContain('milliseconds');
-    expect(output).toContain('count, sum, avg, p95');
-    expect(output).toContain('+cacheResult');
+    expect(output).toContain('avg (default), p95');
+    expect(output).toContain('+cache_result');
     expect(output).toContain('—');
   });
 
-  it('omits the dimensions column when no metric has extra dimensions', async () => {
-    client.scenario.get('/v1/metrics', (_req, res) => {
+  it('reads custom metric detail from the v1 catalog', async () => {
+    client.scenario.get('/v1/metrics', (req, res) => {
+      expect(req.query).toEqual({
+        kind: 'custom',
+        limit: '250',
+        search: 'checkout.duration',
+        teamId: 'team_dummy',
+      });
       res.json({
         metrics: [
           {
-            id: 'vercel.request.count',
-            description: 'Count',
-            dimensions: ['route', 'httpStatus'],
-            unit: 'count',
-            aggregations: ['count', 'unique'],
-          },
-          {
-            id: 'vercel.request.route_cpu_duration_ms',
-            description: 'Request Duration',
-            dimensions: ['route', 'httpStatus'],
+            id: 'checkout.duration',
+            description: 'Checkout duration',
+            dimensions: ['source', 'functionRegion'],
             unit: 'milliseconds',
             aggregations: ['count', 'sum', 'avg', 'p95'],
           },
@@ -263,6 +279,48 @@ describe('metrics schema v1', () => {
         pagination: { hasMore: false, nextCursor: null },
       });
     });
+    client.setArgv('metrics', 'schema', 'checkout.duration');
+
+    const exitCode = await schema(client, new MockTelemetry());
+
+    expect(exitCode).toBe(0);
+    const output = client.stderr.getFullOutput();
+    expect(output).toContain('checkout.duration');
+    expect(output).toContain('Checkout duration');
+    expect(output).toContain('count, sum, avg, p95');
+    expect(output).toContain('source, functionRegion');
+  });
+
+  it('omits the dimensions column when no metric has extra dimensions', async () => {
+    client.scenario.get(
+      '/v2/observability/schema/vercel.request',
+      (_req, res) => {
+        res.json([
+          {
+            id: 'vercel.request.count',
+            description: 'Count',
+            dimensions: [
+              { name: 'route', label: 'Route' },
+              { name: 'http_status', label: 'HTTP Status' },
+            ],
+            unit: 'count',
+            aggregations: ['sum'],
+            defaultAggregation: 'sum',
+          },
+          {
+            id: 'vercel.request.route_cpu_duration_ms',
+            description: 'Request Duration',
+            dimensions: [
+              { name: 'route', label: 'Route' },
+              { name: 'http_status', label: 'HTTP Status' },
+            ],
+            unit: 'milliseconds',
+            aggregations: ['avg', 'p95'],
+            defaultAggregation: 'avg',
+          },
+        ]);
+      }
+    );
     client.setArgv('metrics', 'schema', 'vercel.request');
 
     const exitCode = await schema(client, new MockTelemetry());
@@ -270,7 +328,7 @@ describe('metrics schema v1', () => {
     expect(exitCode).toBe(0);
     const output = client.stderr.getFullOutput();
     expect(output).toContain('Shared dimensions:');
-    expect(output).toContain('route, httpStatus');
+    expect(output).toContain('route, http_status');
     expect(output).toContain('Metric');
     expect(output).toContain('Description');
     expect(output).toContain('Unit');
@@ -285,20 +343,21 @@ describe('metrics schema v1', () => {
 
   describe('telemetry', () => {
     it('should track metric argument', async () => {
-      client.scenario.get('/v1/metrics', (_req, res) => {
-        res.json({
-          metrics: [
+      client.scenario.get(
+        '/v2/observability/schema/vercel.request.count',
+        (_req, res) => {
+          res.json([
             {
               id: 'vercel.request.count',
               description: 'Count',
-              dimensions: ['route', 'httpStatus'],
+              dimensions: [{ name: 'route', label: 'Route' }],
               unit: 'count',
-              aggregations: ['count', 'unique'],
+              aggregations: ['sum'],
+              defaultAggregation: 'sum',
             },
-          ],
-          pagination: { hasMore: false, nextCursor: null },
-        });
-      });
+          ]);
+        }
+      );
       client.setArgv('metrics', 'schema', 'vercel.request.count');
 
       await schema(client, new MockTelemetry());
@@ -309,17 +368,14 @@ describe('metrics schema v1', () => {
     });
 
     it('should track format option', async () => {
+      client.scenario.get('/v2/observability/schema', (_req, res) => {
+        res.json({
+          metrics: [{ id: 'vercel.request.count', description: 'Count' }],
+        });
+      });
       client.scenario.get('/v1/metrics', (_req, res) => {
         res.json({
-          metrics: [
-            {
-              id: 'vercel.request.count',
-              description: 'Count',
-              dimensions: ['route'],
-              unit: 'count',
-              aggregations: ['count', 'unique'],
-            },
-          ],
+          metrics: [],
           pagination: { hasMore: false, nextCursor: null },
         });
       });


### PR DESCRIPTION
## Why / Summary

- preserve the existing schema and query behavior for all `vercel.*` metrics
- discover custom metrics through authenticated `GET /v1/metrics?kind=custom`, follow cursor pagination, and defensively remove any `vercel.*` catalog entries
- combine legacy platform metrics and custom metrics in `vc metrics schema`; return the platform schema even when custom discovery is unavailable
- route metric IDs without the `vercel.` prefix through `POST /v1/metrics`
- use catalog discovery only for optional aggregation/unit enrichment, with `activeSince` matching the requested interval; do not reject queries when recent discovery misses a historical or long-named metric
- align custom-metric request bounds to complete buckets by rounding the start down and the end up; preserve exact bounds for the existing platform-metric endpoint
- keep `--filter` backward-compatible: platform metrics continue using OData through the legacy endpoint, while custom metrics pass OData or KQL to `/v1/metrics`
- adapt the canonical v1 response into the existing CLI text and JSON result shape

The OData compatibility path is provided by vercel/api#85014. Strict complete-bucket validation was restored by vercel/api#85499.

## Local manual verification

Check out the PR and install its dependencies:

```bash
gh pr checkout 17415
pnpm install
cd packages/cli
```

Confirm the custom metric is discoverable and its dimensions and aggregations are shown:

```bash
pnpm vercel --scope vercel metrics schema browser_api.browser.launch_total --format=json
```

Query that custom metric through `POST /v1/metrics`:

```bash
pnpm vercel --scope vercel metrics browser_api.browser.launch_total \
  --project browser-api \
  --since 1h
```

Confirm an OData filter remains accepted for a custom metric using a dimension advertised by its schema:

```bash
pnpm vercel --scope vercel metrics browser_api.browser.launch_total \
  --project browser-api \
  --since 1h \
  --filter "source eq 'lambda'"
```

Confirm a KQL filter is accepted for a custom metric routed to `/v1/metrics`:

```bash
pnpm vercel --scope vercel metrics browser_api.browser.launch_total \
  --project browser-api \
  --since 1h \
  --filter 'source: "lambda"'
```

KQL is not yet supported for `vercel.*` metrics because those continue to use the legacy endpoint.

Confirm custom-metric ranges are expanded to complete buckets. In the JSON `query`, the start and end should both be 5-minute boundaries, with the start rounded down and the end rounded up:

```bash
pnpm vercel --scope vercel metrics browser_api.browser.launch_total \
  --project browser-api \
  --since 61m \
  --granularity 5m \
  --format=json
```

Confirm an existing platform metric still uses the existing endpoint and result shape:

```bash
pnpm vercel --scope vercel metrics vercel.request.count \
  --project browser-api \
  --since 1h \
  --format=json
```

Run the focused automated tests:

```bash
pnpm test test/unit/commands/metrics/query.test.ts
pnpm test test/unit/commands/metrics/schema.test.ts
```

## Validation

- all metrics command tests pass
- CLI build passes
- Biome checks pass for all changed TypeScript files
- full CLI typecheck remains blocked by unrelated existing workspace/generated-output errors in `@vercel/fs-detectors` and prerender types; it reported no metrics errors
