### PR TITLE
Add Discord support to @vercel/connect/chat

### DIFF
--- a/.changeset/discord-chat-connect.md
+++ b/.changeset/discord-chat-connect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Add `connectDiscordAdapter` for Chat SDK Discord credentials and Connect-verified webhooks.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -5,7 +5,7 @@ SDK for obtaining scoped tokens for third-party services on behalf of apps or us
 Seven entrypoints, all ESM:
 
 - `@vercel/connect` — core token / authorization SDK
-- `@vercel/connect/chat` — adapter helpers for the [Chat SDK](https://chat-sdk.dev) (`chat`): `connectSlackAdapter`, `connectGitHubAdapter`, `connectLinearAdapter` (no Chat SDK dependency — returns structural config)
+- `@vercel/connect/chat` — adapter helpers for the [Chat SDK](https://chat-sdk.dev) (`chat`): `connectSlackAdapter`, `connectDiscordAdapter`, `connectGitHubAdapter`, `connectLinearAdapter` (no Chat SDK dependency — returns structural config)
 - `@vercel/connect/ai-sdk` — [Vercel AI SDK](https://ai-sdk.dev) glue: re-exports `connectAuthProvider` for MCP transports (optional peers: `ai`, `@ai-sdk/mcp`)
 - `@vercel/connect/mcp` — canonical MCP-spec `OAuthClientProvider` for any MCP client (optional peer: `@ai-sdk/mcp`)
 - `@vercel/connect/eve` — adapter helpers for [Eve](https://github.com/vercel/eve) connections (optional peer: `eve`)
@@ -62,7 +62,8 @@ createSlackAdapter({
 });
 ```
 
-`connectGitHubAdapter` (`installationToken`) and `connectLinearAdapter`
+`connectDiscordAdapter` (`botToken` and `applicationId`),
+`connectGitHubAdapter` (`installationToken`), and `connectLinearAdapter`
 (`accessToken`) follow the same shape. See the
 [Chat SDK integration guide](https://github.com/vercel/vercel/blob/main/packages/connect/docs/chat-integration.md)
 for connector setup, trigger forwarding, and per-platform examples.

--- a/packages/connect/docs/chat-integration.md
+++ b/packages/connect/docs/chat-integration.md
@@ -5,11 +5,11 @@
 the matching `create*Adapter` factory, wiring a Connect connector for both
 directions of traffic:
 
-- **Outbound** (your bot calls the provider API) — a function-form token field
-  (`botToken` / `installationToken` / `accessToken`) backed by `getToken` with
-  `subject: { type: 'app' }`. The adapter invokes it per API call, so it always
-  picks up a fresh, short-lived token; rotation, refresh, and tenancy stay
-  delegated to Vercel Connect.
+- **Outbound** (your bot calls the provider API) — function-form credential
+  fields (`botToken` / `applicationId` / `installationToken` / `accessToken`)
+  backed by Connect with `subject: { type: 'app' }`. The adapter invokes token
+  resolvers per API call, so rotation, refresh, and tenancy stay delegated to
+  Vercel Connect.
 - **Inbound** (the provider calls your bot) — a `webhookVerifier` that validates
   the Vercel OIDC token Connect attaches to
   [trigger-forwarded](https://vercel.com/docs/connect/concepts/triggers)
@@ -20,11 +20,12 @@ types, so installing it never pulls in the Chat SDK.
 
 ## Helpers
 
-| Helper                 | Adapter                | Outbound field      | Connector example    |
-| ---------------------- | ---------------------- | ------------------- | -------------------- |
-| `connectSlackAdapter`  | `@chat-adapter/slack`  | `botToken`          | `slack/acme-slack`   |
-| `connectGitHubAdapter` | `@chat-adapter/github` | `installationToken` | `github/acme-github` |
-| `connectLinearAdapter` | `@chat-adapter/linear` | `accessToken`       | `linear/acme-linear` |
+| Helper                  | Adapter                 | Outbound fields             | Connector example      |
+| ----------------------- | ----------------------- | --------------------------- | ---------------------- |
+| `connectSlackAdapter`   | `@chat-adapter/slack`   | `botToken`                  | `slack/acme-slack`     |
+| `connectDiscordAdapter` | `@chat-adapter/discord` | `botToken`, `applicationId` | `discord/acme-discord` |
+| `connectGitHubAdapter`  | `@chat-adapter/github`  | `installationToken`         | `github/acme-github`   |
+| `connectLinearAdapter`  | `@chat-adapter/linear`  | `accessToken`               | `linear/acme-linear`   |
 
 Each helper has the signature `(connector, params?, options?)`:
 
@@ -102,6 +103,22 @@ createSlackAdapter({
 
 Omit `signingSecret` / `SLACK_SIGNING_SECRET` — the Connect `webhookVerifier`
 is the freshness boundary.
+
+### Discord
+
+```ts
+import { createDiscordAdapter } from '@chat-adapter/discord';
+import { connectDiscordAdapter } from '@vercel/connect/chat';
+
+createDiscordAdapter({
+  ...connectDiscordAdapter('discord/acme-discord'),
+});
+```
+
+The helper resolves `botToken` and `applicationId` from the same Connect token
+response. Omit `DISCORD_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, and
+`DISCORD_APPLICATION_ID` — Connect OIDC verification replaces Discord's
+Ed25519 public-key check for trigger-forwarded interactions.
 
 ### GitHub
 

--- a/packages/connect/src/chat/discord-adapter.ts
+++ b/packages/connect/src/chat/discord-adapter.ts
@@ -1,0 +1,74 @@
+import {
+  getTokenResponse,
+  type ConnectOptions,
+  type ConnectTokenParams,
+} from '../index.js';
+import type { ConnectDiscordAdapterConfig } from './types.js';
+import { createConnectWebhookVerifier } from './webhook-verifier.js';
+
+/**
+ * Token parameters accepted by {@link connectDiscordAdapter}.
+ *
+ * Mirrors {@link ConnectTokenParams} from `@vercel/connect`, minus
+ * `subject` — Discord bot tokens are app-scoped, so this helper pins the
+ * subject to `{ type: "app" }`.
+ */
+export type ConnectDiscordAdapterParams = Omit<ConnectTokenParams, 'subject'>;
+
+/**
+ * Build a Discord adapter config fragment backed by a Vercel Connect Discord
+ * Bot connector.
+ *
+ * The bot token and application id are resolved from the same Connect token
+ * response. The webhook verifier accepts interactions forwarded by Connect
+ * using Vercel OIDC, so the deployment does not need Discord's public key.
+ *
+ * ```ts
+ * import { createDiscordAdapter } from "@chat-adapter/discord";
+ * import { connectDiscordAdapter } from "@vercel/connect/chat";
+ *
+ * createDiscordAdapter({
+ *   ...connectDiscordAdapter("discord/my-bot"),
+ * });
+ * ```
+ */
+export function connectDiscordAdapter(
+  connector: string,
+  params: ConnectDiscordAdapterParams = {},
+  options?: ConnectOptions
+): ConnectDiscordAdapterConfig {
+  type ResolvedCredentials = {
+    applicationId: string;
+    botToken: string;
+  };
+  let pending: Promise<ResolvedCredentials> | undefined;
+
+  function resolveCredentials(): Promise<ResolvedCredentials> {
+    if (!pending) {
+      pending = getTokenResponse(
+        connector,
+        { ...params, subject: { type: 'app' } },
+        options
+      )
+        .then(response => {
+          const applicationId = response.metadata?.applicationId;
+          if (typeof applicationId !== 'string' || applicationId.length === 0) {
+            throw new Error(
+              `Vercel Connect connector ${connector} did not return a Discord application id.`
+            );
+          }
+          return { applicationId, botToken: response.token };
+        })
+        .finally(() => {
+          pending = undefined;
+        });
+    }
+    return pending;
+  }
+
+  return {
+    applicationId: async () => (await resolveCredentials()).applicationId,
+    botToken: async () => (await resolveCredentials()).botToken,
+    webhookVerifier: createConnectWebhookVerifier(),
+  };
+}

--- a/packages/connect/src/chat/index.ts
+++ b/packages/connect/src/chat/index.ts
@@ -4,7 +4,7 @@
  * Holds helpers that adapt the Vercel Connect SDK to the Chat SDK
  * (`chat`) platform adapters. Each helper returns a config fragment you
  * spread into the matching `create*Adapter` factory, wiring a Connect
- * connector for both outbound tokens (`getToken`) and inbound
+ * connector for both outbound credentials and inbound
  * trigger-forwarded webhooks (Vercel OIDC verification).
  *
  * The helpers stay decoupled from `@chat-adapter/*`: they return
@@ -27,11 +27,16 @@ export {
 } from './webhook-verifier.js';
 
 export type {
+  ConnectDiscordAdapterConfig,
   ConnectGitHubAdapterConfig,
   ConnectLinearAdapterConfig,
   ConnectTokenResolver,
 } from './types.js';
 
+export {
+  connectDiscordAdapter,
+  type ConnectDiscordAdapterParams,
+} from './discord-adapter.js';
 export {
   connectSlackAdapter,
   type ConnectSlackAdapterConfig,

--- a/packages/connect/src/chat/types.ts
+++ b/packages/connect/src/chat/types.ts
@@ -9,6 +9,19 @@ import type { ConnectWebhookVerifier } from './webhook-verifier.js';
 export type ConnectTokenResolver = () => Promise<string>;
 
 /**
+ * Partial Discord adapter config backed by Vercel Connect.
+ *
+ * Structurally matches the `applicationId`, `botToken`, and
+ * `webhookVerifier` options of `createDiscordAdapter` from
+ * `@chat-adapter/discord`.
+ */
+export interface ConnectDiscordAdapterConfig {
+  applicationId: ConnectTokenResolver;
+  botToken: ConnectTokenResolver;
+  webhookVerifier: ConnectWebhookVerifier;
+}
+
+/**
  * Partial GitHub adapter config backed by Vercel Connect.
  *
  * Structurally matches the `installationToken` and `webhookVerifier`

--- a/packages/connect/src/chat/webhook-verifier.ts
+++ b/packages/connect/src/chat/webhook-verifier.ts
@@ -7,8 +7,8 @@ const BEARER_TOKEN_PATTERN = /^Bearer\s+(.+)$/i;
  * truthy value marks the request as verified; throwing (or returning a
  * falsy value) makes the adapter respond `401`.
  *
- * Mirrors the `webhookVerifier` option accepted by the Slack, GitHub,
- * and Linear adapters from the `chat` package, so the helpers in this
+ * Mirrors the `webhookVerifier` option accepted by the Slack, Discord,
+ * GitHub, and Linear adapters from the `chat` package, so the helpers in this
  * subpath stay decoupled from `@chat-adapter/*` while remaining
  * structurally compatible.
  */
@@ -35,8 +35,8 @@ export type ConnectWebhookVerifierOptions = Parameters<
  * the `Authorization` header. This verifier extracts that token and
  * validates it against Vercel's JWKS via
  * {@link verifyVercelOidcToken}, replacing the provider's native
- * signature check (Slack signing secret, GitHub webhook secret, Linear
- * webhook secret).
+ * signature check (Slack signing secret, Discord public key, GitHub webhook
+ * secret, Linear webhook secret).
  *
  * Trust boundary: by default the token must be issued by
  * `https://oidc.vercel.com` (issuer is hard-pinned) and match the

--- a/packages/connect/test/chat/adapter-config.test.ts
+++ b/packages/connect/test/chat/adapter-config.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  connectDiscordAdapter,
   connectGitHubAdapter,
   connectLinearAdapter,
   connectSlackAdapter,
@@ -16,6 +17,68 @@ describe('Chat SDK adapter config helpers', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it('builds Discord config from one app-scoped Connect token response', async () => {
+    fetchMock.mockResolvedValue(
+      jsonTokenResponse('discord_token', {
+        metadata: { applicationId: '123456789' },
+      })
+    );
+
+    const config = connectDiscordAdapter(
+      'discord/acme-discord',
+      { installationId: 'discord-installation' },
+      { vercelToken: 'vercel_token' }
+    );
+
+    expect(config.webhookVerifier).toEqual(expect.any(Function));
+    const [botToken, applicationId] = await Promise.all([
+      resolveToken(config.botToken),
+      resolveToken(config.applicationId),
+    ]);
+    expect(botToken).toBe('discord_token');
+    expect(applicationId).toBe('123456789');
+    expectTokenRequest('discord/acme-discord', {
+      installationId: 'discord-installation',
+      subject: { type: 'app' },
+    });
+  });
+
+  it('retries Discord config resolution after a failed shared request', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(
+        jsonTokenResponse('discord_token', {
+          metadata: { applicationId: '123456789' },
+        })
+      );
+
+    const config = connectDiscordAdapter(
+      'discord/retry',
+      {},
+      { vercelToken: 'vercel_token' }
+    );
+
+    await expect(resolveToken(config.botToken)).rejects.toThrow(
+      'temporary failure'
+    );
+    await expect(resolveToken(config.applicationId)).resolves.toBe('123456789');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails clearly when Discord application metadata is unavailable', async () => {
+    fetchMock.mockResolvedValue(jsonTokenResponse('discord_token'));
+
+    const config = connectDiscordAdapter(
+      'discord/missing-metadata',
+      {},
+      { vercelToken: 'vercel_token' }
+    );
+
+    await expect(resolveToken(config.applicationId)).rejects.toThrow(
+      'did not return a Discord application id'
+    );
   });
 
   it('builds Slack config backed by an app-scoped Connect token', async () => {
@@ -164,12 +227,16 @@ async function resolveToken(
   return token();
 }
 
-function jsonTokenResponse(token: string): Response {
+function jsonTokenResponse(
+  token: string,
+  overrides: Record<string, unknown> = {}
+): Response {
   return new Response(
     JSON.stringify({
       token,
       expiresAt: Date.now() + 60 * 60 * 1000,
       connector: { id: 'scl_abc', uid: 'oauth/test', type: 'oauth' },
+      ...overrides,
     }),
     { status: 200, headers: { 'Content-Type': 'application/json' } }
   );


### PR DESCRIPTION
Adds `connectDiscordAdapter` to `@vercel/connect/chat`, pairing an app-scoped Discord bot token with the application ID returned in Connect metadata. Both credentials share one in-flight token response, while trigger-forwarded interactions use the existing Vercel OIDC webhook verifier instead of Discord's public key.

```ts
import { createDiscordAdapter } from '@chat-adapter/discord';
import { connectDiscordAdapter } from '@vercel/connect/chat';

createDiscordAdapter({
  ...connectDiscordAdapter('discord/acme-discord'),
});
```

The helper retries after transient resolution failures and reports missing Discord application metadata clearly. Documentation and a minor changeset are included.

Companion Chat SDK adapter support: https://github.com/vercel/chat/pull/808

Validated with all 95 `@vercel/connect` tests, package type-check/build, and Prettier checks.