### PR TITLE
feat: add user scope to ai-gateway budgets commands

### DIFF
--- a/.changeset/ai-gateway-budgets-user-scope.md
+++ b/.changeset/ai-gateway-budgets-user-scope.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add the `user` scope to `vercel ai-gateway budgets set|remove` (resolving an email, username, or id to a team member) and show member handles for user-scoped rows in `budgets list`.

--- a/packages/cli/src/commands/ai-gateway/budgets-list.ts
+++ b/packages/cli/src/commands/ai-gateway/budgets-list.ts
@@ -6,6 +6,10 @@ import { ensureTeam } from '../../util/ai-gateway/ensure-team';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
 import { ProjectNotFound } from '../../util/errors-ts';
 import getTeamById from '../../util/teams/get-team-by-id';
+import {
+  getTeamMemberByIdentifier,
+  teamMemberLabel,
+} from '../../util/teams/get-team-member';
 import output from '../../output-manager';
 import { AiGatewayBudgetsListTelemetryClient } from '../../util/telemetry/commands/ai-gateway/budgets-list';
 import { budgetsListSubcommand } from './command';
@@ -88,22 +92,37 @@ export default async function list(client: Client, argv: string[]) {
 }
 
 // Budgets carry only the internal scope id; resolve it to a human name for the
-// table (team slug or project name), falling back to the id when the resource
-// can't be resolved. JSON output keeps the raw scopeId as the stable contract.
+// table (team slug, project name, or member handle), falling back to the id when
+// the resource can't be resolved. JSON output keeps the raw scopeId as the stable
+// contract. The api-key scope is handled separately (name comes from the API).
 async function resolveScopeName(
   client: Client,
   budget: Budget
 ): Promise<string> {
   try {
-    if (budget.scopeType === 'team') {
-      const team = await getTeamById(client, budget.scopeId);
-      return team.slug || team.name || budget.scopeId;
+    switch (budget.scopeType) {
+      case 'team': {
+        const team = await getTeamById(client, budget.scopeId);
+        return team.slug || team.name || budget.scopeId;
+      }
+      case 'project': {
+        const project = await getProjectByNameOrId(client, budget.scopeId);
+        return project instanceof ProjectNotFound
+          ? budget.scopeId
+          : project.name || budget.scopeId;
+      }
+      case 'user': {
+        const member = await getTeamMemberByIdentifier(
+          client,
+          client.config.currentTeam as string,
+          budget.scopeId
+        );
+        return member ? teamMemberLabel(member) : budget.scopeId;
+      }
+      default:
+        // api-key rows: name resolution handled separately.
+        return budget.scopeId;
     }
-    const project = await getProjectByNameOrId(client, budget.scopeId);
-    if (project instanceof ProjectNotFound) {
-      return budget.scopeId;
-    }
-    return project.name || budget.scopeId;
   } catch {
     return budget.scopeId;
   }

--- a/packages/cli/src/commands/ai-gateway/budgets-remove.ts
+++ b/packages/cli/src/commands/ai-gateway/budgets-remove.ts
@@ -3,6 +3,10 @@ import type Client from '../../util/client';
 import { removeBudget, parseBudgetScope } from '../../util/ai-gateway/budgets';
 import { ensureTeam } from '../../util/ai-gateway/ensure-team';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import {
+  getTeamMemberByIdentifier,
+  teamMemberLabel,
+} from '../../util/teams/get-team-member';
 import { ProjectNotFound } from '../../util/errors-ts';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
 import output from '../../output-manager';
@@ -59,6 +63,8 @@ export default async function remove(client: Client, argv: string[]) {
   }
 
   let projectId: string | undefined;
+  let userId: string | undefined;
+  let targetName = scope.scopeType === 'team' ? undefined : scope.name;
   if (scope.scopeType === 'project') {
     const resolved = await getProjectByNameOrId(client, scope.name);
     if (resolved instanceof ProjectNotFound) {
@@ -66,12 +72,24 @@ export default async function remove(client: Client, argv: string[]) {
       return 1;
     }
     projectId = resolved.id;
+  } else if (scope.scopeType === 'user') {
+    const member = await getTeamMemberByIdentifier(
+      client,
+      client.config.currentTeam as string,
+      scope.name
+    );
+    if (!member) {
+      output.error(`Team member not found: ${scope.name}`);
+      return 1;
+    }
+    userId = member.uid;
+    targetName = teamMemberLabel(member);
   }
 
   const target =
     scope.scopeType === 'team'
       ? 'the team budget'
-      : `the budget for ${chalk.bold(scope.name)}`;
+      : `the budget for ${chalk.bold(targetName as string)}`;
 
   if (!yes) {
     if (client.nonInteractive) {
@@ -88,7 +106,7 @@ export default async function remove(client: Client, argv: string[]) {
   output.spinner('Removing budget…');
 
   try {
-    await removeBudget(client, scope.scopeType, projectId);
+    await removeBudget(client, scope.scopeType, { projectId, userId });
     output.stopSpinner();
     if (asJson) {
       client.stdout.write(
@@ -96,6 +114,7 @@ export default async function remove(client: Client, argv: string[]) {
           {
             scopeType: scope.scopeType,
             ...(projectId ? { projectId } : {}),
+            ...(userId ? { userId } : {}),
             removed: true,
           },
           null,
@@ -104,7 +123,7 @@ export default async function remove(client: Client, argv: string[]) {
       );
     } else {
       const removedValue =
-        scope.scopeType === 'team' ? 'team budget' : `budget for ${scope.name}`;
+        scope.scopeType === 'team' ? 'team budget' : `budget for ${targetName}`;
       printAlignedLabel('Removed', removedValue, { gutter: '✓' });
     }
     return 0;

--- a/packages/cli/src/commands/ai-gateway/budgets-set.ts
+++ b/packages/cli/src/commands/ai-gateway/budgets-set.ts
@@ -6,6 +6,10 @@ import {
 } from '../../util/ai-gateway/budgets';
 import { ensureTeam } from '../../util/ai-gateway/ensure-team';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import {
+  getTeamMemberByIdentifier,
+  teamMemberLabel,
+} from '../../util/teams/get-team-member';
 import { ProjectNotFound } from '../../util/errors-ts';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
 import output from '../../output-manager';
@@ -87,6 +91,8 @@ export default async function set(client: Client, argv: string[]) {
   }
 
   let projectId: string | undefined;
+  let userId: string | undefined;
+  let scopeLabel = 'team';
   if (scope.scopeType === 'project') {
     const resolved = await getProjectByNameOrId(client, scope.name);
     if (resolved instanceof ProjectNotFound) {
@@ -94,6 +100,19 @@ export default async function set(client: Client, argv: string[]) {
       return 1;
     }
     projectId = resolved.id;
+    scopeLabel = `project ${scope.name}`;
+  } else if (scope.scopeType === 'user') {
+    const member = await getTeamMemberByIdentifier(
+      client,
+      client.config.currentTeam as string,
+      scope.name
+    );
+    if (!member) {
+      output.error(`Team member not found: ${scope.name}`);
+      return 1;
+    }
+    userId = member.uid;
+    scopeLabel = `user ${teamMemberLabel(member)}`;
   }
 
   output.spinner('Setting budget…');
@@ -102,6 +121,7 @@ export default async function set(client: Client, argv: string[]) {
     const budget = await setBudget(client, {
       scopeType: scope.scopeType,
       ...(projectId ? { projectId } : {}),
+      ...(userId ? { userId } : {}),
       limitAmount: limit,
       ...(refreshPeriod
         ? { refreshPeriod: refreshPeriod as BudgetRefreshPeriod }
@@ -114,8 +134,6 @@ export default async function set(client: Client, argv: string[]) {
     if (asJson) {
       client.stdout.write(`${JSON.stringify(budget, null, 2)}\n`);
     } else {
-      const scopeLabel =
-        scope.scopeType === 'project' ? `project ${scope.name}` : 'team';
       printAlignedLabel('Set budget', scopeLabel, { gutter: '✓' });
       printAlignedLabel('Limit', `$${budget.limitAmount}`);
       printAlignedLabel('Refresh', budget.refreshPeriod);

--- a/packages/cli/src/commands/ai-gateway/command.ts
+++ b/packages/cli/src/commands/ai-gateway/command.ts
@@ -521,7 +521,7 @@ export const budgetsSetSubcommand = {
   name: 'set',
   aliases: [],
   description:
-    'Create or update an AI Gateway budget for a scope (team or project <name>)',
+    'Create or update an AI Gateway budget for a scope (team, project <name>, or user <email>)',
   arguments: [
     { name: 'scope', required: true },
     { name: 'name', required: false },
@@ -563,6 +563,10 @@ export const budgetsSetSubcommand = {
       name: 'Set a project budget',
       value: `${packageName} ai-gateway budgets set project my-project --limit 200`,
     },
+    {
+      name: "Set a user's budget",
+      value: `${packageName} ai-gateway budgets set user teammate@example.com --limit 100`,
+    },
   ],
 } as const;
 
@@ -584,7 +588,7 @@ export const budgetsRemoveSubcommand = {
   name: 'remove',
   aliases: ['rm', 'delete'],
   description:
-    'Remove an AI Gateway budget for a scope (team or project <name>)',
+    'Remove an AI Gateway budget for a scope (team, project <name>, or user <email>)',
   arguments: [
     { name: 'scope', required: true },
     { name: 'name', required: false },
@@ -598,6 +602,10 @@ export const budgetsRemoveSubcommand = {
     {
       name: 'Remove a project budget',
       value: `${packageName} ai-gateway budgets rm project my-project`,
+    },
+    {
+      name: "Remove a user's budget",
+      value: `${packageName} ai-gateway budgets rm user teammate@example.com`,
     },
   ],
 } as const;

--- a/packages/cli/src/util/ai-gateway/budgets.ts
+++ b/packages/cli/src/util/ai-gateway/budgets.ts
@@ -1,14 +1,19 @@
 import type Client from '../client';
 
-export type BudgetScopeType = 'team' | 'project';
+export type BudgetScopeType = 'team' | 'project' | 'user';
 
-// Scopes currently accepted as the `budgets set|remove <scope>` positional.
-// `user` and `api-key` scopes are planned follow-ups.
-export const BUDGET_SCOPE_TYPES: BudgetScopeType[] = ['team', 'project'];
+// Scopes accepted as the `budgets set|remove <scope>` positional. The `api-key`
+// scope is set on the key itself (api-keys quota endpoint), not here.
+export const BUDGET_SCOPE_TYPES: BudgetScopeType[] = [
+  'team',
+  'project',
+  'user',
+];
 
 export type ParsedBudgetScope =
   | { scopeType: 'team' }
-  | { scopeType: 'project'; name: string };
+  | { scopeType: 'project'; name: string }
+  | { scopeType: 'user'; name: string };
 
 /**
  * Parses the positional scope for `budgets set|remove`. The team identity stays
@@ -44,19 +49,25 @@ export function parseBudgetScope(
 
   const [name, ...extra] = rest;
   if (!name) {
-    return { error: 'The project scope requires a project name or id.' };
+    return {
+      error:
+        scopeArg === 'project'
+          ? 'The project scope requires a project name or id.'
+          : 'The user scope requires a user email, username, or id.',
+    };
   }
   if (extra.length > 0) {
     return { error: `Unexpected argument "${extra[0]}".` };
   }
-  return { scope: { scopeType: 'project', name } };
+  return { scope: { scopeType: scopeArg as 'project' | 'user', name } };
 }
 
 export type BudgetRefreshPeriod = 'daily' | 'weekly' | 'monthly' | 'none';
 
 export type Budget = {
   quotaEntityId: string;
-  scopeType: BudgetScopeType;
+  // The list endpoint also returns `api-key` rows (explicit or default-covered).
+  scopeType: BudgetScopeType | 'api-key';
   scopeId: string;
   limitAmount: number;
   currentSpend: number;
@@ -72,6 +83,7 @@ export type Budget = {
 export type SetBudgetInput = {
   scopeType: BudgetScopeType;
   projectId?: string;
+  userId?: string;
   limitAmount: number;
   refreshPeriod?: BudgetRefreshPeriod;
   includeByokInQuota?: boolean;
@@ -102,11 +114,14 @@ export async function setBudget(
 export async function removeBudget(
   client: Client,
   scopeType: BudgetScopeType,
-  projectId?: string
+  opts: { projectId?: string; userId?: string } = {}
 ): Promise<void> {
   const params = new URLSearchParams({ scopeType });
-  if (projectId) {
-    params.set('projectId', projectId);
+  if (opts.projectId) {
+    params.set('projectId', opts.projectId);
+  }
+  if (opts.userId) {
+    params.set('userId', opts.userId);
   }
   await client.fetch(`/ai-gateway/budgets?${params.toString()}`, {
     method: 'DELETE',

--- a/packages/cli/src/util/teams/get-team-member.ts
+++ b/packages/cli/src/util/teams/get-team-member.ts
@@ -1,0 +1,59 @@
+import type Client from '../client';
+
+export interface TeamMember {
+  uid: string;
+  email?: string;
+  username?: string;
+  name?: string;
+  role?: string;
+}
+
+interface TeamMembersResponse {
+  members: TeamMember[];
+  pagination: {
+    count: number;
+    next: number | null;
+    prev: number | null;
+  };
+}
+
+/** Human label for a member, preferring the handle over the raw id. */
+export function teamMemberLabel(member: TeamMember): string {
+  return member.username || member.email || member.uid;
+}
+
+/**
+ * Resolve a team member by uid, email, or username (case-insensitive), paging
+ * through the roster. Returns null when no member matches so callers can render
+ * their own not-found message.
+ */
+export async function getTeamMemberByIdentifier(
+  client: Client,
+  teamId: string,
+  identifier: string
+): Promise<TeamMember | null> {
+  const needle = identifier.toLowerCase();
+  let until: number | undefined;
+
+  do {
+    const query = new URLSearchParams({ limit: '100' });
+    if (until) {
+      query.set('until', String(until));
+    }
+    const { members, pagination } = await client.fetch<TeamMembersResponse>(
+      `/v2/teams/${encodeURIComponent(teamId)}/members?${query}`
+    );
+    const match = (members ?? []).find(
+      member =>
+        member.uid === identifier ||
+        member.email?.toLowerCase() === needle ||
+        member.username?.toLowerCase() === needle
+    );
+    if (match) {
+      return match;
+    }
+    until = pagination?.next ?? undefined;
+  } while (until);
+
+  return null;
+}

--- a/packages/cli/test/unit/commands/ai-gateway/budgets-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/budgets-list.test.ts
@@ -28,6 +28,14 @@ const projectBudget = {
   limitAmount: 200,
 };
 
+const userBudget = {
+  ...teamBudget,
+  quotaEntityId: 'api_key_id_usr_member',
+  scopeType: 'user',
+  scopeId: 'usr_member',
+  limitAmount: 100,
+};
+
 function useListBudgets(budgets: unknown[] = [teamBudget, projectBudget]) {
   let query: unknown;
   client.scenario.get('/ai-gateway/budgets/list', (req, res) => {
@@ -35,6 +43,17 @@ function useListBudgets(budgets: unknown[] = [teamBudget, projectBudget]) {
     res.json({ budgets });
   });
   return () => query;
+}
+
+function useTeamMembers(
+  teamId: string,
+  members: unknown[] = [
+    { uid: 'usr_member', email: 'teammate@example.com', username: 'teammate' },
+  ]
+) {
+  client.scenario.get(`/v2/teams/${teamId}/members`, (_req, res) => {
+    res.json({ members, pagination: { count: members.length, next: null } });
+  });
 }
 
 describe('ai-gateway budgets list', () => {
@@ -62,6 +81,20 @@ describe('ai-gateway budgets list', () => {
     const exitCodePromise = aiGateway(client);
 
     await expect(client.stdout).toOutput(defaultProject.name!);
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('resolves a user scope id to a member handle', async () => {
+    const team = useTeam();
+    useUser();
+    useTeamMembers(team.id);
+    useListBudgets([userBudget]);
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'budgets', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('teammate');
     expect(await exitCodePromise).toBe(0);
   });
 

--- a/packages/cli/test/unit/commands/ai-gateway/budgets-remove.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/budgets-remove.test.ts
@@ -14,6 +14,19 @@ function useRemoveBudget() {
   return () => query;
 }
 
+const teamMember = {
+  uid: 'usr_member',
+  email: 'teammate@example.com',
+  username: 'teammate',
+  role: 'MEMBER',
+};
+
+function useTeamMembers(teamId: string, members = [teamMember]) {
+  client.scenario.get(`/v2/teams/${teamId}/members`, (_req, res) => {
+    res.json({ members, pagination: { count: members.length, next: null } });
+  });
+}
+
 describe('ai-gateway budgets remove', () => {
   describe('--help', () => {
     it('returns exit code 2', async () => {
@@ -111,11 +124,35 @@ describe('ai-gateway budgets remove', () => {
   });
 
   it('rejects an unknown scope', async () => {
-    client.setArgv('ai-gateway', 'budgets', 'remove', 'user', '--yes');
+    client.setArgv('ai-gateway', 'budgets', 'remove', 'org', '--yes');
 
     const exitCodePromise = aiGateway(client);
 
     await expect(client.stderr).toOutput('Unknown scope');
     expect(await exitCodePromise).toBe(1);
+  });
+
+  it('removes a user budget, resolving the identifier to a user id', async () => {
+    const team = useTeam();
+    useUser();
+    useTeamMembers(team.id);
+    const getQuery = useRemoveBudget();
+    client.config.currentTeam = team.id;
+    client.setArgv(
+      'ai-gateway',
+      'budgets',
+      'rm',
+      'user',
+      teamMember.email,
+      '--yes'
+    );
+
+    const exitCode = await aiGateway(client);
+
+    expect(exitCode).toBe(0);
+    expect(getQuery()).toMatchObject({
+      scopeType: 'user',
+      userId: teamMember.uid,
+    });
   });
 });

--- a/packages/cli/test/unit/commands/ai-gateway/budgets-set.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/budgets-set.test.ts
@@ -29,6 +29,19 @@ function useSetBudget(response: unknown = teamBudget) {
   return () => body;
 }
 
+const teamMember = {
+  uid: 'usr_member',
+  email: 'teammate@example.com',
+  username: 'teammate',
+  role: 'MEMBER',
+};
+
+function useTeamMembers(teamId: string, members = [teamMember]) {
+  client.scenario.get(`/v2/teams/${teamId}/members`, (_req, res) => {
+    res.json({ members, pagination: { count: members.length, next: null } });
+  });
+}
+
 describe('ai-gateway budgets set', () => {
   describe('--help', () => {
     it('returns exit code 2', async () => {
@@ -161,11 +174,73 @@ describe('ai-gateway budgets set', () => {
   });
 
   it('rejects an unknown scope', async () => {
-    client.setArgv('ai-gateway', 'budgets', 'set', 'user', '--limit', '100');
+    client.setArgv('ai-gateway', 'budgets', 'set', 'org', '--limit', '100');
 
     const exitCodePromise = aiGateway(client);
 
     await expect(client.stderr).toOutput('Unknown scope');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('sets a user budget, resolving the identifier to a user id', async () => {
+    const team = useTeam();
+    useUser();
+    useTeamMembers(team.id);
+    const getBody = useSetBudget({
+      ...teamBudget,
+      quotaEntityId: `api_key_id_${teamMember.uid}`,
+      scopeType: 'user',
+      scopeId: teamMember.uid,
+      limitAmount: 100,
+    });
+    client.config.currentTeam = team.id;
+    client.setArgv(
+      'ai-gateway',
+      'budgets',
+      'set',
+      'user',
+      teamMember.email,
+      '--limit',
+      '100'
+    );
+
+    const exitCode = await aiGateway(client);
+
+    expect(exitCode).toBe(0);
+    expect(getBody()).toMatchObject({
+      scopeType: 'user',
+      userId: teamMember.uid,
+      limitAmount: 100,
+    });
+  });
+
+  it('errors when the user identifier cannot be resolved', async () => {
+    const team = useTeam();
+    useUser();
+    useTeamMembers(team.id, []);
+    client.config.currentTeam = team.id;
+    client.setArgv(
+      'ai-gateway',
+      'budgets',
+      'set',
+      'user',
+      'nobody@example.com',
+      '--limit',
+      '100'
+    );
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('Team member not found');
+    expect(await exitCodePromise).toBe(1);
+  });
+
+  it('requires a user identifier', async () => {
+    client.setArgv('ai-gateway', 'budgets', 'set', 'user', '--limit', '100');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stderr).toOutput('user scope requires');
     expect(await exitCodePromise).toBe(1);
   });
 


### PR DESCRIPTION
## What

Adds the `user` scope to the AI Gateway budget commands:

- `vercel ai-gateway budgets set user <email|username|id> --limit <n> [--refresh-period] [--include-byok]`
- `vercel ai-gateway budgets remove user <email|username|id>`
- `vercel ai-gateway budgets list` now resolves user-scoped rows to a member handle (username → email → id fallback)

The positional identifier is resolved to a `userId` via the team members endpoint (`/v2/teams/{teamId}/members`), mirroring how the `project` scope resolves a name to an id. The set/remove requests hit the existing `PUT`/`DELETE /ai-gateway/budgets` with `scopeType: 'user'` + `userId`, a contract already present on `vercel/api` main (`UpsertBudgetSchema` / `DeleteBudgetQueryModel`).

## Why

Follows up the `team`/`project` budget scopes (the `budgets.ts` "planned follow-ups" note). User budgets are metered/enforced gateway-side already; this exposes managing them from the CLI.

## Notes

- api-key-scoped rows in `budgets list` still render the raw id here; the name display is a separate follow-up PR.
- New helper `util/teams/get-team-member.ts` (paginates the roster, matches uid/email/username).
- Telemetry unchanged: scope is tracked raw, the identifier is redacted.

## Test plan

- `pnpm -F vercel test test/unit/commands/ai-gateway/budgets-*.test.ts` — 42 passing, incl. new user set/remove + list member-resolution cases
- `tsc --noEmit` clean, prettier/biome clean
