### PR TITLE
feat: show api key names in ai-gateway budgets list

### DIFF
--- a/.changeset/ai-gateway-budgets-apikey-names.md
+++ b/.changeset/ai-gateway-budgets-apikey-names.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Show the API key name instead of the raw id for api-key-scoped rows in `vercel ai-gateway budgets list`, using the name the API returns and falling back to the API key roster, then the id.

--- a/packages/cli/src/commands/ai-gateway/budgets-list.ts
+++ b/packages/cli/src/commands/ai-gateway/budgets-list.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import table from '../../util/output/table';
 import type Client from '../../util/client';
 import { listBudgets, type Budget } from '../../util/ai-gateway/budgets';
+import { listApiKeys } from '../../util/ai-gateway/api-keys';
 import { ensureTeam } from '../../util/ai-gateway/ensure-team';
 import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
 import { ProjectNotFound } from '../../util/errors-ts';
@@ -80,8 +81,20 @@ export default async function list(client: Client, argv: string[]) {
     return 0;
   }
 
+  // The API resolves a name for most api-key rows, but default-covered rows can
+  // arrive without one; fetch the key roster once to fill those gaps by id.
+  let apiKeyNames = new Map<string, string>();
+  if (budgets.some(budget => budget.scopeType === 'api-key' && !budget.name)) {
+    try {
+      const apiKeys = await listApiKeys(client);
+      apiKeyNames = new Map(apiKeys.map(key => [key.id, key.name]));
+    } catch {
+      // Non-fatal: fall back to the id for unresolved keys.
+    }
+  }
+
   const names = await Promise.all(
-    budgets.map(budget => resolveScopeName(client, budget))
+    budgets.map(budget => resolveScopeName(client, budget, apiKeyNames))
   );
 
   output.stopSpinner();
@@ -94,10 +107,12 @@ export default async function list(client: Client, argv: string[]) {
 // Budgets carry only the internal scope id; resolve it to a human name for the
 // table (team slug, project name, or member handle), falling back to the id when
 // the resource can't be resolved. JSON output keeps the raw scopeId as the stable
-// contract. The api-key scope is handled separately (name comes from the API).
+// contract. api-key rows use the name the API resolved, falling back to the
+// roster lookup and then the id.
 async function resolveScopeName(
   client: Client,
-  budget: Budget
+  budget: Budget,
+  apiKeyNames: Map<string, string>
 ): Promise<string> {
   try {
     switch (budget.scopeType) {
@@ -120,8 +135,7 @@ async function resolveScopeName(
         return member ? teamMemberLabel(member) : budget.scopeId;
       }
       default:
-        // api-key rows: name resolution handled separately.
-        return budget.scopeId;
+        return budget.name || apiKeyNames.get(budget.scopeId) || budget.scopeId;
     }
   } catch {
     return budget.scopeId;

--- a/packages/cli/src/util/ai-gateway/budgets.ts
+++ b/packages/cli/src/util/ai-gateway/budgets.ts
@@ -69,6 +69,8 @@ export type Budget = {
   // The list endpoint also returns `api-key` rows (explicit or default-covered).
   scopeType: BudgetScopeType | 'api-key';
   scopeId: string;
+  // Display name the API resolves for the scoped entity (api-key rows).
+  name?: string;
   limitAmount: number;
   currentSpend: number;
   currentByokSpend: number;

--- a/packages/cli/test/unit/commands/ai-gateway/budgets-list.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/budgets-list.test.ts
@@ -36,6 +36,14 @@ const userBudget = {
   limitAmount: 100,
 };
 
+const apiKeyBudget = {
+  ...teamBudget,
+  quotaEntityId: 'api_key_id_key_123',
+  scopeType: 'api-key',
+  scopeId: 'key_123',
+  limitAmount: 50,
+};
+
 function useListBudgets(budgets: unknown[] = [teamBudget, projectBudget]) {
   let query: unknown;
   client.scenario.get('/ai-gateway/budgets/list', (req, res) => {
@@ -43,6 +51,12 @@ function useListBudgets(budgets: unknown[] = [teamBudget, projectBudget]) {
     res.json({ budgets });
   });
   return () => query;
+}
+
+function useApiKeys(apiKeys: unknown[]) {
+  client.scenario.get('/v1/api-keys', (_req, res) => {
+    res.json({ apiKeys, pagination: { count: apiKeys.length, next: null } });
+  });
 }
 
 function useTeamMembers(
@@ -95,6 +109,33 @@ describe('ai-gateway budgets list', () => {
     const exitCodePromise = aiGateway(client);
 
     await expect(client.stdout).toOutput('teammate');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('uses the api-provided name for an api-key scope row', async () => {
+    const team = useTeam();
+    useUser();
+    useListBudgets([{ ...apiKeyBudget, name: 'production-key' }]);
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'budgets', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('production-key');
+    expect(await exitCodePromise).toBe(0);
+  });
+
+  it('resolves an api-key scope id from the key roster when unnamed', async () => {
+    const team = useTeam();
+    useUser();
+    useApiKeys([{ id: 'key_123', name: 'roster-key' }]);
+    useListBudgets([apiKeyBudget]);
+    client.config.currentTeam = team.id;
+    client.setArgv('ai-gateway', 'budgets', 'list');
+
+    const exitCodePromise = aiGateway(client);
+
+    await expect(client.stdout).toOutput('roster-key');
     expect(await exitCodePromise).toBe(0);
   });
 


### PR DESCRIPTION
## What

`vercel ai-gateway budgets list` now shows the API key name for api-key-scoped rows instead of the raw key id. Resolution order:

1. the `name` the API already returns on api-key budget rows (`serialize.ts`)
2. a one-shot lookup against the API key roster (`/v1/api-keys`) to fill default-covered rows that arrive without a name
3. the id, as a last resort

Team, project, and user rows are unchanged.

## Why

api-key budget rows previously rendered the internal key id, which isn't recognizable. The API resolves a display name for most rows; default-covered rows can arrive without one, hence the roster fallback (fetched once, only when needed).

## Notes

- Stacked on #17419 (user budget scope). Base is `jrmy/ai-gateway-budgets-user-scope`; merge that first, or rebase onto main if you want it standalone.
- JSON output is unchanged (still the raw `scopeId` + `name` as returned).

## Test plan

- `pnpm -F vercel test test/unit/commands/ai-gateway/budgets-list.test.ts` — 9 passing, incl. api-provided-name and roster-fallback cases
- `tsc --noEmit` clean, prettier/biome clean
