### PR TITLE
[cli] Add kms commands for issuers, signing keys, and grants

### DIFF
--- a/.changeset/kms-issuer-commands.md
+++ b/.changeset/kms-issuer-commands.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel kms` (beta) for managing KMS issuers, signing keys, and project grants. Issuers can be listed, inspected, created, imported, renamed, and deleted; signing keys can be added, imported, activated, and revoked; and project grants can be added, updated, and removed.

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -36,6 +36,7 @@ export { default as inspect } from './commands/inspect';
 export { default as install } from './commands/install';
 export { default as integration } from './commands/integration';
 export { default as integrationResource } from './commands/integration-resource';
+export { default as kms } from './commands/kms';
 export { default as login } from './commands/login';
 export { default as logout } from './commands/logout';
 export { default as logs } from './commands/logs';

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -32,6 +32,7 @@ import { inspectCommand } from './inspect/command';
 import { installCommand } from './install/command';
 import { integrationResourceCommand } from './integration-resource/command';
 import { integrationCommand } from './integration/command';
+import { kmsCommand } from './kms/command';
 import { linkCommand } from './link/command';
 import { listCommand } from './list/command';
 import { loginCommand } from './login/command';
@@ -100,6 +101,7 @@ const commandsStructs = [
   installCommand,
   integrationCommand,
   integrationResourceCommand,
+  kmsCommand,
   linkCommand,
   listCommand,
   loginCommand,

--- a/packages/cli/src/commands/kms/activate-key.ts
+++ b/packages/cli/src/commands/kms/activate-key.ts
@@ -1,0 +1,150 @@
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { activateSigningKey } from '../../util/kms/signing-keys';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  invalidInput,
+  kmsSuggestion,
+  missingArgument,
+} from '../../util/kms/args';
+import { printSigningKeyRows } from '../../util/kms/format';
+import type { SigningKey } from '../../util/kms/types';
+import { KmsActivateKeyTelemetryClient } from '../../util/telemetry/commands/kms/activate-key';
+import { activateKeySubcommand } from './command';
+
+const USAGE = 'kms activate-key <issuerId> <keyId>';
+
+export default async function activateKey(client: Client, argv: string[]) {
+  const telemetry = new KmsActivateKeyTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    activateKeySubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId, keyId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliArgumentKeyId(keyId);
+  telemetry.trackCliOptionRevokePreviousAfterHours(
+    opts['--revoke-previous-after-hours']
+  );
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: USAGE,
+    });
+  }
+  if (!keyId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_KEY_ID,
+      message: `A key ID is required. Run ${getCommandNamePlain(
+        `kms inspect ${issuerId}`
+      )} to list the issuer's keys.`,
+      usage: USAGE,
+    });
+  }
+  if (args.length > 2) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const revokePreviousAfterHours = opts['--revoke-previous-after-hours'];
+  if (revokePreviousAfterHours !== undefined && revokePreviousAfterHours < 0) {
+    return invalidInput(
+      client,
+      '--revoke-previous-after-hours must be 0 or more.'
+    );
+  }
+
+  const { contextName } = await getScope(client);
+  if (!client.nonInteractive) {
+    output.spinner(`Activating key ${keyId}`);
+  }
+
+  let key: SigningKey;
+  try {
+    key = await activateSigningKey(client, issuerId, keyId, {
+      ...(revokePreviousAfterHours !== undefined && {
+        revokePreviousAfterHours,
+      }),
+    });
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Key not found: ${keyId} on issuer ${issuerId}.`,
+      attempted: 'Activating a signing key',
+      contextName,
+      next: [
+        {
+          command: kmsSuggestion(`kms inspect ${issuerId}`, client.argv),
+          when: "List the issuer's keys",
+        },
+      ],
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          signingKey: key,
+          message: `Signing key ${key.keyId} activated.`,
+          next: [
+            {
+              command: getCommandNamePlain(`kms inspect ${issuerId}`),
+              when: 'Show the issuer and its keys',
+            },
+          ],
+        }
+      : key;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printSigningKeyRows(key, { label: 'Activated', gutter: '✓' });
+  printAlignedLabel('Issuer', issuerId);
+
+  output.print('\n');
+  output.log(
+    `The previous key keeps verifying until its grace period ends. Check status: ${getCommandName(
+      `kms inspect ${issuerId}`
+    )}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/add-grant.ts
+++ b/packages/cli/src/commands/kms/add-grant.ts
@@ -1,0 +1,178 @@
+import chalk from 'chalk';
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { createProjectGrant } from '../../util/kms/grants';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  invalidInput,
+  kmsSuggestion,
+  missingArgument,
+} from '../../util/kms/args';
+import { parseJsonObjectFlag } from '../../util/kms/parse-json-input';
+import type { ProjectGrantPolicy } from '../../util/kms/types';
+import { KmsAddGrantTelemetryClient } from '../../util/telemetry/commands/kms/add-grant';
+import { addGrantSubcommand } from './command';
+
+const USAGE =
+  'kms add-grant <issuerId> --project <projectId> --environment <environment>';
+
+export default async function addGrant(client: Client, argv: string[]) {
+  const telemetry = new KmsAddGrantTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(addGrantSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliOptionProject(opts['--project']);
+  telemetry.trackCliOptionEnvironment(opts['--environment']);
+  telemetry.trackCliOptionTokenClaims(opts['--token-claims']);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: USAGE,
+    });
+  }
+  if (args.length > 1) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const projectId = opts['--project'];
+  if (!projectId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_PROJECT,
+      message: 'A project is required. Pass --project with the project ID.',
+      usage: USAGE,
+    });
+  }
+
+  // Environments are free-form strings so custom environments work, but the API
+  // rejects duplicates.
+  const environments = Array.from(new Set(opts['--environment'] ?? []));
+  if (environments.length === 0) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ENVIRONMENT,
+      message:
+        'At least one environment is required. Pass --environment production, and repeat the flag for more.',
+      usage: USAGE,
+    });
+  }
+
+  let tokenClaims: JSONObject | undefined;
+  if (opts['--token-claims']) {
+    try {
+      tokenClaims = await parseJsonObjectFlag(
+        client,
+        '--token-claims',
+        opts['--token-claims']
+      );
+    } catch (err) {
+      return invalidInput(client, (err as Error).message);
+    }
+  }
+
+  const { contextName } = await getScope(client);
+  if (!client.nonInteractive) {
+    output.spinner(`Granting ${projectId} access to ${issuerId}`);
+  }
+
+  let grant: ProjectGrantPolicy;
+  try {
+    grant = await createProjectGrant(client, issuerId, {
+      projectId,
+      environments,
+      ...(tokenClaims && { tokenClaims }),
+    });
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      // The API collapses "no such issuer" and "no such project" into 404s, and
+      // never discloses a project the caller can't read.
+      notFound: `Couldn't find issuer ${issuerId} or project ${projectId} in ${contextName}.`,
+      attempted: 'Adding a project grant',
+      contextName,
+      next: [
+        {
+          command: kmsSuggestion('kms ls', client.argv),
+          when: 'List issuers in this team',
+        },
+        {
+          command: kmsSuggestion('project ls', client.argv),
+          when: 'List projects to find the right ID',
+        },
+      ],
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          grant,
+          message: `Project ${projectId} can now sign with issuer ${issuerId}.`,
+          next: [
+            {
+              command: getCommandNamePlain(`kms inspect ${issuerId}`),
+              when: "Show the issuer's grants",
+            },
+          ],
+        }
+      : grant;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printAlignedLabel('Granted', grant.projectId, { gutter: '✓' });
+  printAlignedLabel('Issuer', issuerId);
+  printAlignedLabel('Environments', grant.environments.join(', '));
+  printAlignedLabel(
+    'Token Claims',
+    grant.tokenClaims ? 'set' : chalk.gray('none')
+  );
+
+  output.print('\n');
+  output.log(
+    `Deployments in ${grant.environments.join(' and ')} can now sign with this issuer. Inspect it: ${getCommandName(
+      `kms inspect ${issuerId}`
+    )}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/add-key.ts
+++ b/packages/cli/src/commands/kms/add-key.ts
@@ -1,0 +1,175 @@
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { createSigningKey } from '../../util/kms/signing-keys';
+import type { CreateSigningKeyPayload } from '../../util/kms/signing-keys';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  invalidInput,
+  missingArgument,
+} from '../../util/kms/args';
+import { resolveIssuerForKeySource } from '../../util/kms/key-origin';
+import { printSigningKeyRows } from '../../util/kms/format';
+import type { SigningKey } from '../../util/kms/types';
+import { KmsAddKeyTelemetryClient } from '../../util/telemetry/commands/kms/add-key';
+import { addKeySubcommand } from './command';
+
+const USAGE = 'kms add-key <issuerId>';
+const ACTIVATION_MODES = ['automatic', 'manual'] as const;
+
+export default async function addKey(client: Client, argv: string[]) {
+  const telemetry = new KmsAddKeyTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(addKeySubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliOptionActivation(opts['--activation']);
+  telemetry.trackCliOptionRevokePreviousAfterHours(
+    opts['--revoke-previous-after-hours']
+  );
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: USAGE,
+    });
+  }
+  if (args.length > 1) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const activation = opts['--activation'];
+  if (
+    activation &&
+    !ACTIVATION_MODES.includes(activation as (typeof ACTIVATION_MODES)[number])
+  ) {
+    return invalidInput(
+      client,
+      `Invalid activation mode "${activation}". Use ${ACTIVATION_MODES.join(' or ')}.`
+    );
+  }
+
+  const revokePreviousAfterHours = opts['--revoke-previous-after-hours'];
+  if (revokePreviousAfterHours !== undefined && revokePreviousAfterHours < 0) {
+    return invalidInput(
+      client,
+      '--revoke-previous-after-hours must be 0 or more.'
+    );
+  }
+
+  const payload: CreateSigningKeyPayload = {
+    ...(activation && {
+      activation: activation as (typeof ACTIVATION_MODES)[number],
+    }),
+    ...(revokePreviousAfterHours !== undefined && { revokePreviousAfterHours }),
+  };
+
+  const { contextName } = await getScope(client);
+  const attempted = 'Adding a signing key';
+  const issuer = await resolveIssuerForKeySource(client, issuerId, {
+    source: 'generated',
+    attempted,
+    contextName,
+  });
+  if (typeof issuer === 'number') {
+    return issuer;
+  }
+
+  if (!client.nonInteractive) {
+    output.spinner(`Adding a signing key to ${issuerId}`);
+  }
+
+  let key: SigningKey;
+  try {
+    key = await createSigningKey(client, issuerId, payload);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Issuer not found: ${issuerId}.`,
+      attempted,
+      contextName,
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  const activateCommand = `kms activate-key ${issuerId} ${key.keyId}`;
+  const isManual = key.status === 'pending' && !key.activateAt;
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          signingKey: key,
+          message: `Signing key ${key.keyId} added to issuer ${issuerId}.`,
+          next: isManual
+            ? [
+                {
+                  command: getCommandNamePlain(activateCommand),
+                  when: 'Start signing with this key',
+                },
+              ]
+            : [
+                {
+                  command: getCommandNamePlain(`kms inspect ${issuerId}`),
+                  when: 'Check when the key becomes active',
+                },
+              ],
+        }
+      : key;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printSigningKeyRows(key, { label: 'Added', gutter: '✓' });
+  printAlignedLabel('Issuer', issuerId);
+
+  output.print('\n');
+  if (isManual) {
+    output.log(
+      `The key is staged and not signing yet. Activate it: ${getCommandName(activateCommand)}`
+    );
+  } else {
+    output.log(
+      `The key starts signing once its public key propagates. Check status: ${getCommandName(
+        `kms inspect ${issuerId}`
+      )}`
+    );
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/add.ts
+++ b/packages/cli/src/commands/kms/add.ts
@@ -1,0 +1,161 @@
+import chalk from 'chalk';
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { createIssuer } from '../../util/kms/issuers';
+import type { CreateIssuerPayload } from '../../util/kms/issuers';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  invalidInput,
+  missingArgument,
+} from '../../util/kms/args';
+import { parseJsonObjectFlag } from '../../util/kms/parse-json-input';
+import { activeSigningKey, printIssuerRows } from '../../util/kms/format';
+import {
+  KMS_ALGORITHMS,
+  issuerJwksUrl,
+  issuerUrl,
+  type Issuer,
+  type KmsAlgorithm,
+} from '../../util/kms/types';
+import { KmsAddTelemetryClient } from '../../util/telemetry/commands/kms/add';
+import { addSubcommand } from './command';
+
+const USAGE = 'kms add <name>';
+
+export default async function add(client: Client, argv: string[]) {
+  const telemetry = new KmsAddTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(addSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [name] = args;
+
+  telemetry.trackCliArgumentName(name);
+  telemetry.trackCliOptionAlgorithm(opts['--algorithm']);
+  telemetry.trackCliOptionClaimsSchema(opts['--claims-schema']);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!name) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_NAME,
+      message: 'An issuer name is required.',
+      usage: USAGE,
+    });
+  }
+  if (args.length > 1) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const algorithm = opts['--algorithm'];
+  if (algorithm && !KMS_ALGORITHMS.includes(algorithm as KmsAlgorithm)) {
+    return invalidInput(
+      client,
+      `Invalid algorithm "${algorithm}". Supported algorithms: ${KMS_ALGORITHMS.join(', ')}.`
+    );
+  }
+
+  // Read local input before the mutation so a bad file or malformed JSON never
+  // leaves a half-configured issuer behind.
+  let claimsSchema: JSONObject | undefined;
+  if (opts['--claims-schema']) {
+    try {
+      claimsSchema = await parseJsonObjectFlag(
+        client,
+        '--claims-schema',
+        opts['--claims-schema']
+      );
+    } catch (err) {
+      return invalidInput(client, (err as Error).message);
+    }
+  }
+
+  const payload: CreateIssuerPayload = {
+    name,
+    ...(algorithm && { algorithm: algorithm as KmsAlgorithm }),
+    ...(claimsSchema && { claimsSchema }),
+  };
+
+  const { contextName } = await getScope(client);
+  if (!client.nonInteractive) {
+    output.spinner(`Creating issuer under ${chalk.bold(contextName)}`);
+  }
+
+  let issuer: Issuer;
+  try {
+    issuer = await createIssuer(client, payload);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      attempted: 'Creating an issuer',
+      contextName,
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  const grantCommand = `kms add-grant ${issuer.id} --project <projectId> --environment production`;
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          issuer,
+          message: `Issuer ${issuer.id} created.`,
+          next: [
+            {
+              command: getCommandNamePlain(grantCommand),
+              when: 'Let a project sign with this issuer',
+            },
+          ],
+        }
+      : issuer;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printIssuerRows(issuer, { label: 'Created', gutter: '✓' });
+  printAlignedLabel('Issuer URL', chalk.cyan(issuerUrl(issuer.id)));
+  printAlignedLabel('JWKS', chalk.cyan(issuerJwksUrl(issuer.id)));
+  const active = activeSigningKey(issuer);
+  if (active) {
+    printAlignedLabel('Signing Key', active.keyId);
+  }
+
+  output.print('\n');
+  output.log(
+    `Let a project sign with this issuer: ${getCommandName(grantCommand)}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/command.ts
+++ b/packages/cli/src/commands/kms/command.ts
@@ -451,7 +451,7 @@ export const removeGrantSubcommand = {
 
 export const kmsCommand = {
   name: 'kms',
-  aliases: ['kms-issuer'],
+  aliases: [],
   description: 'Manage KMS issuers, signing keys, and project grants',
   arguments: [],
   subcommands: [

--- a/packages/cli/src/commands/kms/command.ts
+++ b/packages/cli/src/commands/kms/command.ts
@@ -1,0 +1,474 @@
+import { packageName } from '../../util/pkg-name';
+import { formatOption, limitOption, yesOption } from '../../util/arg-common';
+import { KMS_ALGORITHMS } from '../../util/kms/types';
+
+/**
+ * The list cursor is an opaque base64url token, so this cannot reuse the
+ * shared `nextOption`, which is a millisecond timestamp.
+ */
+const cursorOption = {
+  name: 'next',
+  shorthand: null,
+  type: String,
+  argument: 'CURSOR',
+  deprecated: false,
+  description:
+    'Show the next page of results, using a cursor from a prior page',
+} as const;
+
+const algorithmOption = {
+  name: 'algorithm',
+  shorthand: 'a',
+  type: String,
+  argument: 'ALGORITHM',
+  deprecated: false,
+  description: `Signing algorithm: ${KMS_ALGORITHMS.join(', ')} (default: RS512)`,
+} as const;
+
+/**
+ * On import the algorithm has to agree with the key material, so it is derived
+ * from the key when only one algorithm fits — every RSA algorithm fits an RSA
+ * key, so those need it stated.
+ */
+const importAlgorithmOption = {
+  name: 'algorithm',
+  shorthand: 'a',
+  type: String,
+  argument: 'ALGORITHM',
+  deprecated: false,
+  description: `Signing algorithm: ${KMS_ALGORITHMS.join(', ')} (required for RSA keys, otherwise derived from the key)`,
+} as const;
+
+const nameOption = {
+  name: 'name',
+  shorthand: null,
+  type: String,
+  argument: 'NAME',
+  deprecated: false,
+  description: 'New name for the issuer',
+} as const;
+
+const claimsSchemaOption = {
+  name: 'claims-schema',
+  shorthand: null,
+  type: String,
+  argument: 'JSON',
+  deprecated: false,
+  description:
+    'JSON Schema validating token claims, as inline JSON, `@<file>`, or `@-` for stdin',
+} as const;
+
+const removeClaimsSchemaOption = {
+  name: 'remove-claims-schema',
+  shorthand: null,
+  type: Boolean,
+  deprecated: false,
+  description: 'Remove the claims schema, so claims are no longer validated',
+} as const;
+
+const tokenClaimsOption = {
+  name: 'token-claims',
+  shorthand: null,
+  type: String,
+  argument: 'JSON',
+  deprecated: false,
+  description:
+    'Claims to include in tokens signed for this grant, as inline JSON, `@<file>`, or `@-` for stdin',
+} as const;
+
+const removeTokenClaimsOption = {
+  name: 'remove-token-claims',
+  shorthand: null,
+  type: Boolean,
+  deprecated: false,
+  description: 'Remove the token claims from the grant',
+} as const;
+
+const grantProjectOption = {
+  name: 'project',
+  shorthand: 'p',
+  type: String,
+  argument: 'PROJECT_ID',
+  deprecated: false,
+  description: 'Project the grant applies to',
+} as const;
+
+const environmentOption = {
+  name: 'environment',
+  shorthand: 'e',
+  type: [String],
+  argument: 'ENVIRONMENT',
+  deprecated: false,
+  description: 'Environment the grant applies to (repeatable)',
+} as const;
+
+const keyOption = {
+  name: 'key',
+  shorthand: 'k',
+  type: String,
+  argument: 'FILE',
+  deprecated: false,
+  description:
+    'Path to the PEM private key to import, or `-` to read it from stdin',
+} as const;
+
+const keyIdOption = {
+  name: 'key-id',
+  shorthand: null,
+  type: String,
+  argument: 'KID',
+  deprecated: false,
+  description: 'JWKS `kid` for the imported key (default: server-generated)',
+} as const;
+
+const revokePreviousAfterHoursOption = {
+  name: 'revoke-previous-after-hours',
+  shorthand: null,
+  type: Number,
+  argument: 'HOURS',
+  deprecated: false,
+  description:
+    'Hours the previous key keeps verifying after activation (default: 1)',
+} as const;
+
+const activationOption = {
+  name: 'activation',
+  shorthand: null,
+  type: String,
+  argument: 'MODE',
+  deprecated: false,
+  description:
+    'When the key starts signing: automatic or manual (default: automatic)',
+} as const;
+
+/**
+ * `--yes` carries a per-command description so help says what is being skipped.
+ */
+function skipConfirmationOption(action: string) {
+  return {
+    ...yesOption,
+    description: `Skip the confirmation prompt when ${action}`,
+  } as const;
+}
+
+export const listSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'Show all KMS issuers',
+  default: true,
+  arguments: [],
+  options: [formatOption, limitOption, cursorOption],
+  examples: [
+    {
+      name: 'List issuers as JSON',
+      value: `${packageName} kms ls --format json`,
+    },
+  ],
+} as const;
+
+export const inspectSubcommand = {
+  name: 'inspect',
+  aliases: ['get'],
+  description: 'Show an issuer with its signing keys and grants',
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+  ],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'Inspect an issuer',
+      value: `${packageName} kms inspect iss_1a2b3c4d`,
+    },
+  ],
+} as const;
+
+export const addSubcommand = {
+  name: 'add',
+  aliases: ['create'],
+  description: 'Create an issuer with a Vercel-generated signing key',
+  arguments: [
+    {
+      name: 'name',
+      required: true,
+    },
+  ],
+  options: [algorithmOption, claimsSchemaOption, formatOption],
+  examples: [
+    {
+      name: 'Create an issuer that signs with ES256',
+      value: `${packageName} kms add my-issuer --algorithm ES256`,
+    },
+  ],
+} as const;
+
+export const importSubcommand = {
+  name: 'import',
+  aliases: [],
+  description: 'Create an issuer from a private key you already have',
+  arguments: [
+    {
+      name: 'name',
+      required: true,
+    },
+  ],
+  options: [
+    keyOption,
+    keyIdOption,
+    importAlgorithmOption,
+    claimsSchemaOption,
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Import an EC private key, whose algorithm is derived from the key',
+      value: `${packageName} kms import my-issuer --key ./private-key.pem`,
+    },
+    {
+      name: 'Import an RSA private key from stdin',
+      value: `cat private-key.pem | ${packageName} kms import my-issuer --key - --algorithm RS256`,
+    },
+  ],
+} as const;
+
+export const updateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Rename an issuer or change its claims schema',
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+  ],
+  options: [
+    nameOption,
+    claimsSchemaOption,
+    removeClaimsSchemaOption,
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Rename an issuer',
+      value: `${packageName} kms update iss_1a2b3c4d --name billing-tokens`,
+    },
+    {
+      name: 'Replace the claims schema from a file',
+      value: `${packageName} kms update iss_1a2b3c4d --claims-schema @claims-schema.json`,
+    },
+  ],
+} as const;
+
+export const removeSubcommand = {
+  name: 'remove',
+  aliases: ['rm', 'delete'],
+  description: 'Delete an issuer and all of its keys',
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+  ],
+  options: [skipConfirmationOption('deleting an issuer')],
+  examples: [
+    {
+      name: 'Delete an issuer',
+      value: `${packageName} kms rm iss_1a2b3c4d`,
+    },
+  ],
+} as const;
+
+export const addKeySubcommand = {
+  name: 'add-key',
+  aliases: [],
+  description: 'Add a Vercel-generated signing key to an issuer',
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+  ],
+  options: [activationOption, revokePreviousAfterHoursOption, formatOption],
+  examples: [
+    {
+      name: 'Rotate to a new key, retiring the previous one after 24 hours',
+      value: `${packageName} kms add-key iss_1a2b3c4d --revoke-previous-after-hours 24`,
+    },
+    {
+      name: 'Stage a key without activating it',
+      value: `${packageName} kms add-key iss_1a2b3c4d --activation manual`,
+    },
+  ],
+} as const;
+
+export const importKeySubcommand = {
+  name: 'import-key',
+  aliases: [],
+  description: 'Add a signing key you already have to an imported issuer',
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+  ],
+  options: [
+    keyOption,
+    keyIdOption,
+    activationOption,
+    revokePreviousAfterHoursOption,
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Rotate an imported issuer to a new private key',
+      value: `${packageName} kms import-key iss_1a2b3c4d --key ./private-key.pem`,
+    },
+  ],
+} as const;
+
+export const activateKeySubcommand = {
+  name: 'activate-key',
+  aliases: [],
+  description: 'Start signing with a staged key',
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+    {
+      name: 'keyId',
+      required: true,
+    },
+  ],
+  options: [revokePreviousAfterHoursOption, formatOption],
+  examples: [
+    {
+      name: 'Activate a key',
+      value: `${packageName} kms activate-key iss_1a2b3c4d key_5e6f7g8h`,
+    },
+  ],
+} as const;
+
+export const revokeKeySubcommand = {
+  name: 'revoke-key',
+  aliases: [],
+  description: 'End a scheduled revocation now, so a key stops verifying',
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+    {
+      name: 'keyId',
+      required: true,
+    },
+  ],
+  options: [skipConfirmationOption('revoking a key')],
+  examples: [
+    {
+      name: 'Revoke a key that is already scheduled for revocation',
+      value: `${packageName} kms revoke-key iss_1a2b3c4d key_5e6f7g8h`,
+    },
+  ],
+} as const;
+
+export const addGrantSubcommand = {
+  name: 'add-grant',
+  aliases: [],
+  description: 'Grant a project permission to sign with an issuer',
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+  ],
+  options: [
+    grantProjectOption,
+    environmentOption,
+    tokenClaimsOption,
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Grant a project signing access in Production and Preview',
+      value: `${packageName} kms add-grant iss_1a2b3c4d --project prj_9i8h7g6f --environment production --environment preview`,
+    },
+  ],
+} as const;
+
+export const updateGrantSubcommand = {
+  name: 'update-grant',
+  aliases: [],
+  description: "Change a project grant's environments or token claims",
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+    {
+      name: 'projectId',
+      required: true,
+    },
+  ],
+  options: [
+    environmentOption,
+    tokenClaimsOption,
+    removeTokenClaimsOption,
+    formatOption,
+  ],
+  examples: [
+    {
+      name: 'Restrict a grant to Production',
+      value: `${packageName} kms update-grant iss_1a2b3c4d prj_9i8h7g6f --environment production`,
+    },
+  ],
+} as const;
+
+export const removeGrantSubcommand = {
+  name: 'remove-grant',
+  aliases: ['rm-grant', 'delete-grant'],
+  description: "Revoke a project's permission to sign with an issuer",
+  arguments: [
+    {
+      name: 'issuerId',
+      required: true,
+    },
+    {
+      name: 'projectId',
+      required: true,
+    },
+  ],
+  options: [skipConfirmationOption('removing a grant')],
+  examples: [
+    {
+      name: 'Remove a project grant',
+      value: `${packageName} kms rm-grant iss_1a2b3c4d prj_9i8h7g6f`,
+    },
+  ],
+} as const;
+
+export const kmsCommand = {
+  name: 'kms',
+  aliases: ['kms-issuer'],
+  description: 'Manage KMS issuers, signing keys, and project grants',
+  arguments: [],
+  subcommands: [
+    listSubcommand,
+    inspectSubcommand,
+    addSubcommand,
+    importSubcommand,
+    updateSubcommand,
+    removeSubcommand,
+    addKeySubcommand,
+    importKeySubcommand,
+    activateKeySubcommand,
+    revokeKeySubcommand,
+    addGrantSubcommand,
+    updateGrantSubcommand,
+    removeGrantSubcommand,
+  ],
+  options: [],
+  examples: [],
+} as const;

--- a/packages/cli/src/commands/kms/import-key.ts
+++ b/packages/cli/src/commands/kms/import-key.ts
@@ -1,0 +1,198 @@
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { createSigningKey } from '../../util/kms/signing-keys';
+import type { CreateSigningKeyPayload } from '../../util/kms/signing-keys';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  invalidInput,
+  missingArgument,
+} from '../../util/kms/args';
+import { resolveIssuerForKeySource } from '../../util/kms/key-origin';
+import { readPrivateKey } from '../../util/kms/parse-json-input';
+import { printSigningKeyRows } from '../../util/kms/format';
+import type { SigningKey } from '../../util/kms/types';
+import { KmsImportKeyTelemetryClient } from '../../util/telemetry/commands/kms/import-key';
+import { importKeySubcommand } from './command';
+
+const USAGE = 'kms import-key <issuerId> --key <file>';
+const ACTIVATION_MODES = ['automatic', 'manual'] as const;
+
+export default async function importKey(client: Client, argv: string[]) {
+  const telemetry = new KmsImportKeyTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(importKeySubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliOptionKey(opts['--key']);
+  telemetry.trackCliOptionKeyId(opts['--key-id']);
+  telemetry.trackCliOptionActivation(opts['--activation']);
+  telemetry.trackCliOptionRevokePreviousAfterHours(
+    opts['--revoke-previous-after-hours']
+  );
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: USAGE,
+    });
+  }
+  if (args.length > 1) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const keyFlag = opts['--key'];
+  if (!keyFlag) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_KEY,
+      message:
+        'A private key is required. Pass --key with a path to a PEM file, or `-` to read it from stdin.',
+      usage: USAGE,
+    });
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const activation = opts['--activation'];
+  if (
+    activation &&
+    !ACTIVATION_MODES.includes(activation as (typeof ACTIVATION_MODES)[number])
+  ) {
+    return invalidInput(
+      client,
+      `Invalid activation mode "${activation}". Use ${ACTIVATION_MODES.join(' or ')}.`
+    );
+  }
+
+  const revokePreviousAfterHours = opts['--revoke-previous-after-hours'];
+  if (revokePreviousAfterHours !== undefined && revokePreviousAfterHours < 0) {
+    return invalidInput(
+      client,
+      '--revoke-previous-after-hours must be 0 or more.'
+    );
+  }
+
+  let importKeyPem: string;
+  try {
+    importKeyPem = await readPrivateKey(client, keyFlag);
+  } catch (err) {
+    return invalidInput(client, (err as Error).message);
+  }
+
+  const keyId = opts['--key-id'];
+  const payload: CreateSigningKeyPayload = {
+    importKey: importKeyPem,
+    ...(keyId && { importKeyId: keyId }),
+    ...(activation && {
+      activation: activation as (typeof ACTIVATION_MODES)[number],
+    }),
+    ...(revokePreviousAfterHours !== undefined && { revokePreviousAfterHours }),
+  };
+
+  const { contextName } = await getScope(client);
+  const attempted = 'Importing a signing key';
+  const issuer = await resolveIssuerForKeySource(client, issuerId, {
+    source: 'imported',
+    attempted,
+    contextName,
+  });
+  if (typeof issuer === 'number') {
+    return issuer;
+  }
+
+  if (!client.nonInteractive) {
+    output.spinner(`Importing a signing key into ${issuerId}`);
+  }
+
+  let key: SigningKey;
+  try {
+    key = await createSigningKey(client, issuerId, payload);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Issuer not found: ${issuerId}.`,
+      attempted,
+      contextName,
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  const activateCommand = `kms activate-key ${issuerId} ${key.keyId}`;
+  const isManual = key.status === 'pending' && !key.activateAt;
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          signingKey: key,
+          message: `Signing key ${key.keyId} imported into issuer ${issuerId}.`,
+          next: isManual
+            ? [
+                {
+                  command: getCommandNamePlain(activateCommand),
+                  when: 'Start signing with this key',
+                },
+              ]
+            : [
+                {
+                  command: getCommandNamePlain(`kms inspect ${issuerId}`),
+                  when: 'Check when the key becomes active',
+                },
+              ],
+        }
+      : key;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printSigningKeyRows(key, { label: 'Imported', gutter: '✓' });
+  printAlignedLabel('Issuer', issuerId);
+
+  output.print('\n');
+  if (isManual) {
+    output.log(
+      `The key is staged and not signing yet. Activate it: ${getCommandName(activateCommand)}`
+    );
+  } else {
+    output.log(
+      `The key starts signing once its public key propagates. Check status: ${getCommandName(
+        `kms inspect ${issuerId}`
+      )}`
+    );
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/import.ts
+++ b/packages/cli/src/commands/kms/import.ts
@@ -1,0 +1,194 @@
+import chalk from 'chalk';
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { createIssuer } from '../../util/kms/issuers';
+import type { CreateIssuerPayload } from '../../util/kms/issuers';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  invalidInput,
+  missingArgument,
+} from '../../util/kms/args';
+import {
+  parseJsonObjectFlag,
+  readPrivateKey,
+} from '../../util/kms/parse-json-input';
+import { activeSigningKey, printIssuerRows } from '../../util/kms/format';
+import {
+  KMS_ALGORITHMS,
+  issuerJwksUrl,
+  issuerUrl,
+  type Issuer,
+  type KmsAlgorithm,
+} from '../../util/kms/types';
+import { KmsImportTelemetryClient } from '../../util/telemetry/commands/kms/import';
+import { importSubcommand } from './command';
+
+const USAGE = 'kms import <name> --key <file>';
+
+export default async function importIssuer(client: Client, argv: string[]) {
+  const telemetry = new KmsImportTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(importSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [name] = args;
+
+  telemetry.trackCliArgumentName(name);
+  telemetry.trackCliOptionKey(opts['--key']);
+  telemetry.trackCliOptionKeyId(opts['--key-id']);
+  telemetry.trackCliOptionAlgorithm(opts['--algorithm']);
+  telemetry.trackCliOptionClaimsSchema(opts['--claims-schema']);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!name) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_NAME,
+      message: 'An issuer name is required.',
+      usage: USAGE,
+    });
+  }
+  if (args.length > 1) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const keyFlag = opts['--key'];
+  if (!keyFlag) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_KEY,
+      message:
+        'A private key is required. Pass --key with a path to a PEM file, or `-` to read it from stdin.',
+      usage: USAGE,
+    });
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const algorithm = opts['--algorithm'];
+  if (algorithm && !KMS_ALGORITHMS.includes(algorithm as KmsAlgorithm)) {
+    return invalidInput(
+      client,
+      `Invalid algorithm "${algorithm}". Supported algorithms: ${KMS_ALGORITHMS.join(', ')}.`
+    );
+  }
+
+  // Read local input before the mutation so a bad file or malformed JSON never
+  // leaves a half-configured issuer behind.
+  let claimsSchema: JSONObject | undefined;
+  if (opts['--claims-schema']) {
+    try {
+      claimsSchema = await parseJsonObjectFlag(
+        client,
+        '--claims-schema',
+        opts['--claims-schema']
+      );
+    } catch (err) {
+      return invalidInput(client, (err as Error).message);
+    }
+  }
+
+  let importKey: string;
+  try {
+    importKey = await readPrivateKey(client, keyFlag);
+  } catch (err) {
+    return invalidInput(client, (err as Error).message);
+  }
+
+  const keyId = opts['--key-id'];
+  const payload: CreateIssuerPayload = {
+    name,
+    importKey,
+    ...(keyId && { importKeyId: keyId }),
+    ...(algorithm && { algorithm: algorithm as KmsAlgorithm }),
+    ...(claimsSchema && { claimsSchema }),
+  };
+
+  const { contextName } = await getScope(client);
+  if (!client.nonInteractive) {
+    output.spinner(`Importing issuer under ${chalk.bold(contextName)}`);
+  }
+
+  let issuer: Issuer;
+  try {
+    issuer = await createIssuer(client, payload);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      attempted: 'Importing an issuer',
+      contextName,
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  const grantCommand = `kms add-grant ${issuer.id} --project <projectId> --environment production`;
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          issuer,
+          message: `Issuer ${issuer.id} imported.`,
+          next: [
+            {
+              command: getCommandNamePlain(grantCommand),
+              when: 'Let a project sign with this issuer',
+            },
+          ],
+        }
+      : issuer;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printIssuerRows(issuer, { label: 'Imported', gutter: '✓' });
+  printAlignedLabel('Issuer URL', chalk.cyan(issuerUrl(issuer.id)));
+  printAlignedLabel('JWKS', chalk.cyan(issuerJwksUrl(issuer.id)));
+  const active = activeSigningKey(issuer);
+  if (active) {
+    printAlignedLabel('Signing Key', active.keyId);
+    if (active.importKeyId) {
+      printAlignedLabel('JWKS kid', active.importKeyId);
+    }
+  }
+
+  output.print('\n');
+  output.log(
+    `Every later key for this issuer is imported too: ${getCommandName(
+      `kms import-key ${issuer.id} --key <file>`
+    )}`
+  );
+  output.log(
+    `Let a project sign with this issuer: ${getCommandName(grantCommand)}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/index.ts
+++ b/packages/cli/src/commands/kms/index.ts
@@ -1,0 +1,198 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getSubcommand from '../../util/get-subcommand';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import { getCommandAliases } from '..';
+import { printError } from '../../util/error';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { KmsTelemetryClient } from '../../util/telemetry/commands/kms';
+import { type Command, help } from '../help';
+import output from '../../output-manager';
+import ls from './ls';
+import inspect from './inspect';
+import add from './add';
+import importIssuer from './import';
+import update from './update';
+import rm from './rm';
+import addKey from './add-key';
+import importKey from './import-key';
+import activateKey from './activate-key';
+import revokeKey from './revoke-key';
+import addGrant from './add-grant';
+import updateGrant from './update-grant';
+import rmGrant from './rm-grant';
+import {
+  activateKeySubcommand,
+  addGrantSubcommand,
+  addKeySubcommand,
+  addSubcommand,
+  importKeySubcommand,
+  importSubcommand,
+  inspectSubcommand,
+  kmsCommand,
+  listSubcommand,
+  removeGrantSubcommand,
+  removeSubcommand,
+  revokeKeySubcommand,
+  updateGrantSubcommand,
+  updateSubcommand,
+} from './command';
+
+const COMMAND_CONFIG = {
+  list: getCommandAliases(listSubcommand),
+  inspect: getCommandAliases(inspectSubcommand),
+  add: getCommandAliases(addSubcommand),
+  import: getCommandAliases(importSubcommand),
+  update: getCommandAliases(updateSubcommand),
+  remove: getCommandAliases(removeSubcommand),
+  'add-key': getCommandAliases(addKeySubcommand),
+  'import-key': getCommandAliases(importKeySubcommand),
+  'activate-key': getCommandAliases(activateKeySubcommand),
+  'revoke-key': getCommandAliases(revokeKeySubcommand),
+  'add-grant': getCommandAliases(addGrantSubcommand),
+  'update-grant': getCommandAliases(updateGrantSubcommand),
+  'remove-grant': getCommandAliases(removeGrantSubcommand),
+};
+
+export default async function main(client: Client) {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(kmsCommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const telemetry = new KmsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    parsedArgs.args.slice(1),
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('kms');
+    output.print(help(kmsCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, { parent: kmsCommand, columns: client.stderr.columns })
+    );
+    return 2;
+  }
+
+  switch (subcommand) {
+    case 'list':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(listSubcommand);
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return ls(client, args);
+    case 'inspect':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(inspectSubcommand);
+      }
+      telemetry.trackCliSubcommandInspect(subcommandOriginal);
+      return inspect(client, args);
+    case 'add':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(addSubcommand);
+      }
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
+      return add(client, args);
+    case 'import':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(importSubcommand);
+      }
+      telemetry.trackCliSubcommandImport(subcommandOriginal);
+      return importIssuer(client, args);
+    case 'update':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(updateSubcommand);
+      }
+      telemetry.trackCliSubcommandUpdate(subcommandOriginal);
+      return update(client, args);
+    case 'remove':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(removeSubcommand);
+      }
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
+      return rm(client, args);
+    case 'add-key':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(addKeySubcommand);
+      }
+      telemetry.trackCliSubcommandAddKey(subcommandOriginal);
+      return addKey(client, args);
+    case 'import-key':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(importKeySubcommand);
+      }
+      telemetry.trackCliSubcommandImportKey(subcommandOriginal);
+      return importKey(client, args);
+    case 'activate-key':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(activateKeySubcommand);
+      }
+      telemetry.trackCliSubcommandActivateKey(subcommandOriginal);
+      return activateKey(client, args);
+    case 'revoke-key':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(revokeKeySubcommand);
+      }
+      telemetry.trackCliSubcommandRevokeKey(subcommandOriginal);
+      return revokeKey(client, args);
+    case 'add-grant':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(addGrantSubcommand);
+      }
+      telemetry.trackCliSubcommandAddGrant(subcommandOriginal);
+      return addGrant(client, args);
+    case 'update-grant':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(updateGrantSubcommand);
+      }
+      telemetry.trackCliSubcommandUpdateGrant(subcommandOriginal);
+      return updateGrant(client, args);
+    case 'remove-grant':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('kms', subcommandOriginal);
+        return printHelp(removeGrantSubcommand);
+      }
+      telemetry.trackCliSubcommandRemoveGrant(subcommandOriginal);
+      return rmGrant(client, args);
+    default:
+      // Bare `vercel kms` runs the default subcommand. Anything else reaching
+      // here is a mistyped subcommand, not an argument to `list`.
+      if (args.length > 0) {
+        output.error(getInvalidSubcommand(COMMAND_CONFIG));
+        output.print(help(kmsCommand, { columns: client.stderr.columns }));
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return ls(client, args);
+  }
+}

--- a/packages/cli/src/commands/kms/inspect.ts
+++ b/packages/cli/src/commands/kms/inspect.ts
@@ -1,0 +1,152 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import formatDate from '../../util/format-date';
+import { getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { getIssuer } from '../../util/kms/issuers';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  kmsSuggestion,
+  missingArgument,
+} from '../../util/kms/args';
+import {
+  formatGrantsTable,
+  formatSigningKeysTable,
+  indentTable,
+  printIssuerRows,
+} from '../../util/kms/format';
+import { issuerJwksUrl, issuerUrl } from '../../util/kms/types';
+import type { Issuer } from '../../util/kms/types';
+import { KmsInspectTelemetryClient } from '../../util/telemetry/commands/kms/inspect';
+import { inspectSubcommand } from './command';
+
+const USAGE = 'kms inspect <issuerId>';
+
+export default async function inspect(client: Client, argv: string[]) {
+  const telemetry = new KmsInspectTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(inspectSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: USAGE,
+    });
+  }
+  if (args.length > 1) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const { contextName } = await getScope(client);
+  if (!client.nonInteractive) {
+    output.spinner(`Fetching issuer ${issuerId}`);
+  }
+
+  let issuer: Issuer;
+  try {
+    issuer = await getIssuer(client, issuerId);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Issuer not found: ${issuerId}.`,
+      attempted: 'Reading this issuer',
+      contextName,
+      next: [
+        {
+          command: kmsSuggestion('kms ls', client.argv),
+          when: 'List issuers in this team',
+        },
+      ],
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          issuer,
+          message: `Issuer ${issuer.id} found.`,
+          next: [
+            {
+              command: getCommandNamePlain(`kms add-key ${issuer.id}`),
+              when: 'Rotate to a new signing key',
+            },
+          ],
+        }
+      : issuer;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printIssuerRows(issuer);
+  printAlignedLabel('Issuer URL', chalk.cyan(issuerUrl(issuer.id)));
+  printAlignedLabel('JWKS', chalk.cyan(issuerJwksUrl(issuer.id)));
+  printAlignedLabel('Created', formatDate(issuer.createdAt));
+  printAlignedLabel(
+    'Claims Schema',
+    issuer.claimsSchema ? 'set' : chalk.gray('none')
+  );
+
+  output.print('\n');
+  output.print(`  ${chalk.bold('Signing keys')}\n`);
+  if (issuer.signingKeys.length === 0) {
+    output.print(`  ${chalk.gray('No signing keys.')}\n`);
+  } else {
+    output.print(indentTable(formatSigningKeysTable(issuer.signingKeys)));
+    output.print('\n');
+  }
+
+  output.print('\n');
+  output.print(`  ${chalk.bold('Grants')}\n`);
+  if (issuer.policies.length === 0) {
+    // The API returns an empty list both for an issuer with no grants and for
+    // a caller who can't read them, so don't claim there are none.
+    output.print(
+      `  ${chalk.gray('No grants visible. Only team owners can see grants.')}\n`
+    );
+  } else {
+    output.print(indentTable(formatGrantsTable(issuer.policies)));
+    output.print('\n');
+  }
+
+  output.print('\n');
+  return 0;
+}

--- a/packages/cli/src/commands/kms/ls.ts
+++ b/packages/cli/src/commands/kms/ls.ts
@@ -1,0 +1,134 @@
+import chalk from 'chalk';
+import plural from 'pluralize';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import stamp from '../../util/output/stamp';
+import getCommandFlags from '../../util/get-command-flags';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { validateLsArgs } from '../../util/validate-ls-args';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { getIssuers } from '../../util/kms/issuers';
+import { formatIssuersTable, indentTable } from '../../util/kms/format';
+import { handleKmsApiError } from '../../util/kms/errors';
+import { KmsLsTelemetryClient } from '../../util/telemetry/commands/kms/ls';
+import { listSubcommand } from './command';
+import type { IssuerListResponse } from '../../util/kms/types';
+
+export default async function ls(client: Client, argv: string[]) {
+  const telemetry = new KmsLsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(listSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+
+  const validationResult = validateLsArgs({
+    commandName: 'kms ls',
+    args,
+    maxArgs: 0,
+    exitCode: 2,
+  });
+  if (validationResult !== 0) {
+    return validationResult;
+  }
+
+  telemetry.trackCliOptionFormat(opts['--format']);
+  telemetry.trackCliOptionLimit(opts['--limit']);
+  telemetry.trackCliOptionNext(opts['--next']);
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const { contextName } = await getScope(client);
+
+  const lsStamp = stamp();
+  if (!client.nonInteractive) {
+    output.spinner(`Fetching KMS issuers under ${chalk.bold(contextName)}`);
+  }
+
+  let response: IssuerListResponse;
+  try {
+    response = await getIssuers(client, {
+      limit: opts['--limit'],
+      next: opts['--next'],
+    });
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      attempted: 'Listing KMS issuers',
+      contextName,
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  const { issuers, pagination } = response;
+  output.stopSpinner();
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          issuers,
+          pagination,
+          message: `${plural('issuer', issuers.length, true)} found.`,
+          next: [
+            {
+              command: getCommandNamePlain('kms inspect <issuerId>'),
+              when: 'Show an issuer with its keys and grants',
+            },
+          ],
+        }
+      : { issuers, pagination };
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  if (issuers.length === 0) {
+    output.log(
+      `No issuers found under ${chalk.bold(contextName)}. Run ${getCommandName(
+        'kms add <name>'
+      )} to create one.`
+    );
+    return 0;
+  }
+
+  output.log(
+    `${plural('issuer', issuers.length, true)} found under ${chalk.bold(
+      contextName
+    )} ${chalk.gray(lsStamp())}`
+  );
+  output.print(indentTable(formatIssuersTable(issuers)));
+  output.print('\n\n');
+
+  if (pagination.next) {
+    const flags = getCommandFlags(opts, ['_', '--next']);
+    output.log(
+      `To display the next page, run ${getCommandName(
+        `kms ls${flags} --next ${pagination.next}`
+      )}`
+    );
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/revoke-key.ts
+++ b/packages/cli/src/commands/kms/revoke-key.ts
@@ -1,0 +1,220 @@
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import param from '../../util/output/param';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { buildCommandWithYes, outputAgentError } from '../../util/agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { getIssuer } from '../../util/kms/issuers';
+import { revokeSigningKey } from '../../util/kms/signing-keys';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  kmsSuggestion,
+  missingArgument,
+} from '../../util/kms/args';
+import { describeKeyStatus } from '../../util/kms/format';
+import type { Issuer } from '../../util/kms/types';
+import { KmsRevokeKeyTelemetryClient } from '../../util/telemetry/commands/kms/revoke-key';
+import { revokeKeySubcommand } from './command';
+
+const USAGE = 'kms revoke-key <issuerId> <keyId>';
+
+export default async function revokeKey(client: Client, argv: string[]) {
+  const telemetry = new KmsRevokeKeyTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(revokeKeySubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId, keyId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliArgumentKeyId(keyId);
+  telemetry.trackCliFlagYes(opts['--yes']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: `${USAGE} --yes`,
+    });
+  }
+  if (!keyId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_KEY_ID,
+      message: `A key ID is required. Run ${getCommandNamePlain(
+        `kms inspect ${issuerId}`
+      )} to list the issuer's keys.`,
+      usage: `${USAGE} --yes`,
+    });
+  }
+  if (args.length > 2) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const skipConfirmation = opts['--yes'] || false;
+  if (client.nonInteractive && !skipConfirmation) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+        message:
+          'Revoking a key ends its grace period immediately, so tokens it signed stop verifying. Re-run with --yes to confirm.',
+        next: [{ command: buildCommandWithYes(client.argv) }],
+      },
+      1
+    );
+  }
+
+  const { contextName } = await getScope(client);
+
+  // Only a key already scheduled for revocation can be revoked, so resolve it
+  // first and reject the other states without calling the mutation.
+  if (!client.nonInteractive) {
+    output.spinner(`Fetching issuer ${issuerId}`);
+  }
+  let issuer: Issuer;
+  try {
+    issuer = await getIssuer(client, issuerId);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Issuer not found: ${issuerId}.`,
+      attempted: 'Revoking a signing key',
+      contextName,
+      next: [
+        {
+          command: kmsSuggestion('kms ls', client.argv),
+          when: 'List issuers in this team',
+        },
+      ],
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+  output.stopSpinner();
+
+  const key = issuer.signingKeys.find(candidate => candidate.keyId === keyId);
+  const inspectCommand = kmsSuggestion(`kms inspect ${issuerId}`, client.argv);
+
+  if (!key) {
+    const message = `Key not found: ${keyId} on issuer ${issuerId}.`;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.NOT_FOUND,
+        message,
+        next: [{ command: inspectCommand, when: "List the issuer's keys" }],
+      },
+      1
+    );
+    output.error(message);
+    output.log(
+      `Run ${getCommandName(`kms inspect ${issuerId}`)} to list its keys.`
+    );
+    return 1;
+  }
+
+  if (key.status !== 'revoking') {
+    const message = `Key ${keyId} is ${key.status}, not scheduled for revocation. Only a key already retiring can be revoked immediately; activate a replacement key first.`;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.KEY_NOT_REVOKING,
+        message,
+        next: [
+          {
+            command: kmsSuggestion(`kms add-key ${issuerId}`, client.argv),
+            when: 'Rotate to a new key, which retires this one',
+          },
+        ],
+      },
+      1
+    );
+    output.error(message);
+    return 1;
+  }
+
+  if (!skipConfirmation) {
+    printAlignedLabel('Issuer', issuer.id);
+    printAlignedLabel('Key', key.keyId);
+    printAlignedLabel('Status', describeKeyStatus(key));
+    output.print('\n');
+    const confirmed = await client.input.confirm(
+      `Revoke ${param(key.keyId)} now? Tokens it signed stop verifying.`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  if (!client.nonInteractive) {
+    output.spinner(`Revoking key ${key.keyId}`);
+  }
+
+  let updated: Issuer;
+  try {
+    updated = await revokeSigningKey(client, issuerId, key.keyId);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Key not found: ${key.keyId} on issuer ${issuerId}.`,
+      attempted: 'Revoking a signing key',
+      contextName,
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  if (client.nonInteractive) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: AGENT_STATUS.OK,
+          issuer: updated,
+          message: `Signing key ${key.keyId} revoked.`,
+          next: [
+            {
+              command: getCommandNamePlain(`kms inspect ${issuerId}`),
+              when: "Show the issuer's remaining keys",
+            },
+          ],
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  printAlignedLabel('Revoked', key.keyId, { gutter: '✓' });
+  printAlignedLabel('Issuer', updated.id);
+  printAlignedLabel('Signing Keys', String(updated.signingKeys.length));
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/rm-grant.ts
+++ b/packages/cli/src/commands/kms/rm-grant.ts
@@ -1,0 +1,199 @@
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import param from '../../util/output/param';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { buildCommandWithYes, outputAgentError } from '../../util/agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { getIssuer } from '../../util/kms/issuers';
+import { deleteProjectGrant } from '../../util/kms/grants';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  kmsSuggestion,
+  missingArgument,
+} from '../../util/kms/args';
+import {
+  isProjectGrant,
+  type Issuer,
+  type ProjectGrantPolicy,
+} from '../../util/kms/types';
+import { KmsRmGrantTelemetryClient } from '../../util/telemetry/commands/kms/rm-grant';
+import { removeGrantSubcommand } from './command';
+
+const USAGE = 'kms rm-grant <issuerId> <projectId>';
+
+export default async function rmGrant(client: Client, argv: string[]) {
+  const telemetry = new KmsRmGrantTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    removeGrantSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId, projectId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliArgumentProjectId(projectId);
+  telemetry.trackCliFlagYes(opts['--yes']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: `${USAGE} --yes`,
+    });
+  }
+  if (!projectId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_PROJECT,
+      message: `A project ID is required. Run ${getCommandNamePlain(
+        `kms inspect ${issuerId}`
+      )} to list the issuer's grants.`,
+      usage: `${USAGE} --yes`,
+    });
+  }
+  if (args.length > 2) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const skipConfirmation = opts['--yes'] || false;
+  if (client.nonInteractive && !skipConfirmation) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+        message:
+          'Removing a grant stops the project from signing new tokens with this issuer. Re-run with --yes to confirm.',
+        next: [{ command: buildCommandWithYes(client.argv) }],
+      },
+      1
+    );
+  }
+
+  const { contextName } = await getScope(client);
+
+  // Resolve the grant first so the confirmation names the environments that
+  // lose access. Anyone allowed to delete a grant can also read it.
+  let grant: ProjectGrantPolicy | undefined;
+  if (!skipConfirmation) {
+    output.spinner(`Fetching issuer ${issuerId}`);
+    let issuer: Issuer;
+    try {
+      issuer = await getIssuer(client, issuerId);
+    } catch (err: unknown) {
+      output.stopSpinner();
+      const handled = handleKmsApiError(client, err, {
+        notFound: `Issuer not found: ${issuerId}.`,
+        attempted: 'Removing a project grant',
+        contextName,
+        next: [
+          {
+            command: kmsSuggestion('kms ls', client.argv),
+            when: 'List issuers in this team',
+          },
+        ],
+      });
+      if (handled !== undefined) {
+        return handled;
+      }
+      throw err;
+    }
+    output.stopSpinner();
+
+    grant = issuer.policies
+      .filter(isProjectGrant)
+      .find(policy => policy.projectId === projectId);
+
+    if (!grant) {
+      const message = `No grant for project ${projectId} on issuer ${issuerId}.`;
+      output.error(message);
+      output.log(
+        `Run ${getCommandName(`kms inspect ${issuerId}`)} to list its grants.`
+      );
+      return 1;
+    }
+
+    printAlignedLabel('Issuer', issuer.id);
+    printAlignedLabel('Project', grant.projectId);
+    printAlignedLabel('Environments', grant.environments.join(', '));
+    output.print('\n');
+    const confirmed = await client.input.confirm(
+      `Remove ${param(grant.projectId)}'s access to this issuer?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  if (!client.nonInteractive) {
+    output.spinner(`Removing grant for ${projectId}`);
+  }
+
+  try {
+    await deleteProjectGrant(client, issuerId, projectId);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `No grant for project ${projectId} on issuer ${issuerId}.`,
+      attempted: 'Removing a project grant',
+      contextName,
+      next: [
+        {
+          command: kmsSuggestion(`kms inspect ${issuerId}`, client.argv),
+          when: "List the issuer's grants",
+        },
+      ],
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  if (client.nonInteractive) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: AGENT_STATUS.OK,
+          grant: { issuerId, projectId },
+          message: `Grant for project ${projectId} removed.`,
+          next: [
+            {
+              command: getCommandNamePlain(`kms inspect ${issuerId}`),
+              when: "Show the issuer's remaining grants",
+            },
+          ],
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  printAlignedLabel('Removed', projectId, { gutter: '✓' });
+  printAlignedLabel('Issuer', issuerId);
+  printAlignedLabel('Team', contextName);
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/rm.ts
+++ b/packages/cli/src/commands/kms/rm.ts
@@ -1,0 +1,167 @@
+import plural from 'pluralize';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import param from '../../util/output/param';
+import { getCommandNamePlain } from '../../util/pkg-name';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { buildCommandWithYes, outputAgentError } from '../../util/agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { deleteIssuer, getIssuer } from '../../util/kms/issuers';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  kmsSuggestion,
+  missingArgument,
+} from '../../util/kms/args';
+import type { Issuer } from '../../util/kms/types';
+import { KmsRmTelemetryClient } from '../../util/telemetry/commands/kms/rm';
+import { removeSubcommand } from './command';
+
+const USAGE = 'kms rm <issuerId>';
+
+export default async function rm(client: Client, argv: string[]) {
+  const telemetry = new KmsRmTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(removeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliFlagYes(opts['--yes']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: `${USAGE} --yes`,
+    });
+  }
+  if (args.length > 1) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const skipConfirmation = opts['--yes'] || false;
+  if (client.nonInteractive && !skipConfirmation) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+        message:
+          'Deleting an issuer also deletes its signing keys, and tokens it signed stop verifying. Re-run with --yes to confirm.',
+        next: [{ command: buildCommandWithYes(client.argv) }],
+      },
+      1
+    );
+  }
+
+  const { contextName } = await getScope(client);
+
+  // Resolve the issuer first so the confirmation names what is being deleted.
+  if (!client.nonInteractive) {
+    output.spinner(`Fetching issuer ${issuerId}`);
+  }
+  let issuer: Issuer;
+  try {
+    issuer = await getIssuer(client, issuerId);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Issuer not found: ${issuerId}.`,
+      attempted: 'Deleting an issuer',
+      contextName,
+      next: [
+        {
+          command: kmsSuggestion('kms ls', client.argv),
+          when: 'List issuers in this team',
+        },
+      ],
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+  output.stopSpinner();
+
+  if (!skipConfirmation) {
+    printAlignedLabel('Issuer', issuer.id);
+    printAlignedLabel('Name', issuer.name);
+    printAlignedLabel(
+      'Signing Keys',
+      plural('key', issuer.signingKeys.length, true)
+    );
+    output.print('\n');
+    const confirmed = await client.input.confirm(
+      `Delete ${param(issuer.name)} and its signing keys? Tokens it signed stop verifying.`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  if (!client.nonInteractive) {
+    output.spinner(`Deleting issuer ${issuer.id}`);
+  }
+
+  try {
+    await deleteIssuer(client, issuer.id);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Issuer not found: ${issuer.id}.`,
+      attempted: 'Deleting an issuer',
+      contextName,
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  if (client.nonInteractive) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: AGENT_STATUS.OK,
+          issuer: { id: issuer.id, name: issuer.name },
+          message: `Issuer ${issuer.id} deleted.`,
+          next: [
+            {
+              command: getCommandNamePlain('kms ls'),
+              when: 'List remaining issuers',
+            },
+          ],
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  printAlignedLabel('Removed', issuer.name, { gutter: '✓' });
+  printAlignedLabel('Issuer', issuer.id);
+  printAlignedLabel('Team', contextName);
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/update-grant.ts
+++ b/packages/cli/src/commands/kms/update-grant.ts
@@ -1,0 +1,183 @@
+import chalk from 'chalk';
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { updateProjectGrant } from '../../util/kms/grants';
+import type { UpdateProjectGrantPayload } from '../../util/kms/grants';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  invalidInput,
+  kmsSuggestion,
+  missingArgument,
+} from '../../util/kms/args';
+import { parseJsonObjectFlag } from '../../util/kms/parse-json-input';
+import type { ProjectGrantPolicy } from '../../util/kms/types';
+import { KmsUpdateGrantTelemetryClient } from '../../util/telemetry/commands/kms/update-grant';
+import { updateGrantSubcommand } from './command';
+
+const USAGE = 'kms update-grant <issuerId> <projectId>';
+
+export default async function updateGrant(client: Client, argv: string[]) {
+  const telemetry = new KmsUpdateGrantTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    updateGrantSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId, projectId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliArgumentProjectId(projectId);
+  telemetry.trackCliOptionEnvironment(opts['--environment']);
+  telemetry.trackCliOptionTokenClaims(opts['--token-claims']);
+  telemetry.trackCliFlagRemoveTokenClaims(opts['--remove-token-claims']);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: USAGE,
+    });
+  }
+  if (!projectId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_PROJECT,
+      message: `A project ID is required. Run ${getCommandNamePlain(
+        `kms inspect ${issuerId}`
+      )} to list the issuer's grants.`,
+      usage: USAGE,
+    });
+  }
+  if (args.length > 2) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const tokenClaimsFlag = opts['--token-claims'];
+  const removeTokenClaims = opts['--remove-token-claims'];
+  const environments = opts['--environment']
+    ? Array.from(new Set(opts['--environment']))
+    : undefined;
+
+  if (tokenClaimsFlag && removeTokenClaims) {
+    return invalidInput(
+      client,
+      '--token-claims and --remove-token-claims conflict. Pass one or the other.'
+    );
+  }
+  if (!environments && !tokenClaimsFlag && !removeTokenClaims) {
+    return invalidInput(
+      client,
+      'Nothing to update. Pass --environment, --token-claims, or --remove-token-claims.'
+    );
+  }
+
+  let tokenClaims: JSONObject | undefined;
+  if (tokenClaimsFlag) {
+    try {
+      tokenClaims = await parseJsonObjectFlag(
+        client,
+        '--token-claims',
+        tokenClaimsFlag
+      );
+    } catch (err) {
+      return invalidInput(client, (err as Error).message);
+    }
+  }
+
+  const payload: UpdateProjectGrantPayload = {
+    ...(environments && { environments }),
+    ...(tokenClaims && { tokenClaims }),
+    // `null` is the API's clear signal, so it has to be sent explicitly.
+    ...(removeTokenClaims && { tokenClaims: null }),
+  };
+
+  const { contextName } = await getScope(client);
+  if (!client.nonInteractive) {
+    output.spinner(`Updating grant for ${projectId} on ${issuerId}`);
+  }
+
+  let grant: ProjectGrantPolicy;
+  try {
+    grant = await updateProjectGrant(client, issuerId, projectId, payload);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Couldn't find a grant for project ${projectId} on issuer ${issuerId}.`,
+      attempted: 'Updating a project grant',
+      contextName,
+      next: [
+        {
+          command: kmsSuggestion(`kms inspect ${issuerId}`, client.argv),
+          when: "List the issuer's grants",
+        },
+      ],
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          grant,
+          message: `Grant for project ${grant.projectId} updated.`,
+          next: [
+            {
+              command: getCommandNamePlain(`kms inspect ${issuerId}`),
+              when: "Show the issuer's grants",
+            },
+          ],
+        }
+      : grant;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printAlignedLabel('Updated', grant.projectId, { gutter: '✓' });
+  printAlignedLabel('Issuer', issuerId);
+  printAlignedLabel('Environments', grant.environments.join(', '));
+  printAlignedLabel(
+    'Token Claims',
+    grant.tokenClaims ? 'set' : chalk.gray('none')
+  );
+
+  output.print('\n');
+  output.log(
+    `Inspect the issuer: ${getCommandName(`kms inspect ${issuerId}`)}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/kms/update.ts
+++ b/packages/cli/src/commands/kms/update.ts
@@ -1,0 +1,165 @@
+import chalk from 'chalk';
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { getCommandName, getCommandNamePlain } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import output from '../../output-manager';
+import { updateIssuer } from '../../util/kms/issuers';
+import type { UpdateIssuerPayload } from '../../util/kms/issuers';
+import { handleKmsApiError } from '../../util/kms/errors';
+import {
+  invalidArgumentCount,
+  invalidInput,
+  kmsSuggestion,
+  missingArgument,
+} from '../../util/kms/args';
+import { parseJsonObjectFlag } from '../../util/kms/parse-json-input';
+import { printIssuerRows } from '../../util/kms/format';
+import type { Issuer } from '../../util/kms/types';
+import { KmsUpdateTelemetryClient } from '../../util/telemetry/commands/kms/update';
+import { updateSubcommand } from './command';
+
+const USAGE = 'kms update <issuerId>';
+
+export default async function update(client: Client, argv: string[]) {
+  const telemetry = new KmsUpdateTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(updateSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags: opts } = parsedArgs;
+  const [issuerId] = args;
+
+  telemetry.trackCliArgumentIssuerId(issuerId);
+  telemetry.trackCliOptionName(opts['--name']);
+  telemetry.trackCliOptionClaimsSchema(opts['--claims-schema']);
+  telemetry.trackCliFlagRemoveClaimsSchema(opts['--remove-claims-schema']);
+  telemetry.trackCliOptionFormat(opts['--format']);
+
+  if (!issuerId) {
+    return missingArgument(client, {
+      reason: AGENT_REASON.MISSING_ISSUER_ID,
+      message: 'An issuer ID is required.',
+      usage: USAGE,
+    });
+  }
+  if (args.length > 1) {
+    return invalidArgumentCount(client, USAGE);
+  }
+
+  const formatResult = validateJsonOutput(opts);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || client.nonInteractive;
+
+  const name = opts['--name'];
+  const claimsSchemaFlag = opts['--claims-schema'];
+  const removeClaimsSchema = opts['--remove-claims-schema'];
+
+  if (claimsSchemaFlag && removeClaimsSchema) {
+    return invalidInput(
+      client,
+      '--claims-schema and --remove-claims-schema conflict. Pass one or the other.'
+    );
+  }
+  if (!name && !claimsSchemaFlag && !removeClaimsSchema) {
+    return invalidInput(
+      client,
+      'Nothing to update. Pass --name, --claims-schema, or --remove-claims-schema.'
+    );
+  }
+
+  let claimsSchema: JSONObject | undefined;
+  if (claimsSchemaFlag) {
+    try {
+      claimsSchema = await parseJsonObjectFlag(
+        client,
+        '--claims-schema',
+        claimsSchemaFlag
+      );
+    } catch (err) {
+      return invalidInput(client, (err as Error).message);
+    }
+  }
+
+  const payload: UpdateIssuerPayload = {
+    ...(name && { name }),
+    ...(claimsSchema && { claimsSchema }),
+    // `null` is the API's clear signal, so it has to be sent explicitly.
+    ...(removeClaimsSchema && { claimsSchema: null }),
+  };
+
+  const { contextName } = await getScope(client);
+  if (!client.nonInteractive) {
+    output.spinner(`Updating issuer ${issuerId}`);
+  }
+
+  let issuer: Issuer;
+  try {
+    issuer = await updateIssuer(client, issuerId, payload);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleKmsApiError(client, err, {
+      notFound: `Issuer not found: ${issuerId}.`,
+      attempted: 'Updating an issuer',
+      contextName,
+      next: [
+        {
+          command: kmsSuggestion('kms ls', client.argv),
+          when: 'List issuers in this team',
+        },
+      ],
+    });
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+
+  output.stopSpinner();
+
+  if (asJson) {
+    const jsonOutput = client.nonInteractive
+      ? {
+          status: AGENT_STATUS.OK,
+          issuer,
+          message: `Issuer ${issuer.id} updated.`,
+          next: [
+            {
+              command: getCommandNamePlain(`kms inspect ${issuer.id}`),
+              when: 'Show the updated issuer',
+            },
+          ],
+        }
+      : issuer;
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    return 0;
+  }
+
+  printIssuerRows(issuer, { label: 'Updated', gutter: '✓' });
+  printAlignedLabel(
+    'Claims Schema',
+    issuer.claimsSchema ? 'set' : chalk.gray('none')
+  );
+  output.print('\n');
+  output.log(`Inspect it: ${getCommandName(`kms inspect ${issuer.id}`)}`);
+
+  return 0;
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -62,6 +62,7 @@ export const help = () => `
       flags                [cmd]       Manage feature flags for a Vercel project
       global-config        [cmd]       Manage Global Config stores
       httpstat             path        Visualize HTTP timing statistics for deployments
+      kms                  [cmd]       Manage KMS issuers, signing keys, and project grants [beta]
       logs                 [url]       Displays the logs for a deployment
       metrics              <metric>    Queries observability metrics for your project or team
       mcp                              Set up MCP agents and configuration

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -259,7 +259,7 @@ const main = async () => {
   const subSubCommand = parsedArgs.args[3];
 
   // If empty, leave this code here for easy adding of beta commands later
-  const betaCommands: string[] = ['api', 'crons', 'curl', 'webhooks'];
+  const betaCommands: string[] = ['api', 'crons', 'curl', 'kms', 'webhooks'];
   const versionBanner = isNativeBinaryInstall()
     ? `${getTitleName()} CLI ${pkg.version}`
     : `${getTitleName()} CLI ${pkg.version} (Node.js ${process.versions.node})`;
@@ -1086,6 +1086,10 @@ const main = async () => {
         case 'integration-resource':
           telemetry.trackCliCommandIntegrationResource(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).integrationResource;
+          break;
+        case 'kms':
+          telemetry.trackCliCommandKms(userSuppliedSubCommand);
+          func = (await import('./commands-bulk.js')).kms;
           break;
         case 'mcp':
           func = (await import('./commands-bulk.js')).mcp;

--- a/packages/cli/src/util/agent-output-constants.ts
+++ b/packages/cli/src/util/agent-output-constants.ts
@@ -88,6 +88,21 @@ export const AGENT_REASON = {
    * not `confirmation_required` — re-running with --yes would loop forever.
    */
   REQUIRES_CONSENT: 'requires_consent',
+  // KMS
+  MISSING_ISSUER_ID: 'missing_issuer_id',
+  MISSING_KEY: 'missing_key',
+  MISSING_KEY_ID: 'missing_key_id',
+  MISSING_PROJECT: 'missing_project',
+  ISSUER_NOT_FOUND: 'issuer_not_found',
+  /** The issuer is provisioned by another Vercel service and is read-only here. */
+  ISSUER_MANAGED: 'issuer_managed',
+  /** Keys for an imported issuer must be imported too, so `add-key` cannot serve it. */
+  ISSUER_REQUIRES_IMPORTED_KEY: 'issuer_requires_imported_key',
+  /** Vercel generates the keys for this issuer, so `import-key` cannot serve it. */
+  ISSUER_REQUIRES_GENERATED_KEY: 'issuer_requires_generated_key',
+  /** Immediate revocation only applies to a key already scheduled for revocation. */
+  KEY_NOT_REVOKING: 'key_not_revoking',
+  NO_CHANGES_REQUESTED: 'no_changes_requested',
   // Redirects
   REDIRECT_NOT_FOUND: 'redirect_not_found',
   VERSION_NOT_FOUND: 'version_not_found',

--- a/packages/cli/src/util/kms/args.ts
+++ b/packages/cli/src/util/kms/args.ts
@@ -1,0 +1,86 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../client';
+import { getGlobalFlagsFromArgs } from '../arg-common';
+import { getCommandName, getCommandNamePlain } from '../pkg-name';
+import { outputAgentError } from '../agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
+
+/**
+ * Suggested `kms` command with the caller's global flags (`--cwd`, `--scope`,
+ * …) preserved so the next command runs in the same context.
+ */
+export function kmsSuggestion(subcommand: string, argv: string[]): string {
+  const globalFlags = getGlobalFlagsFromArgs(argv.slice(2));
+  const full = globalFlags.length
+    ? `${subcommand} ${globalFlags.join(' ')}`
+    : subcommand;
+  return getCommandNamePlain(full);
+}
+
+/**
+ * Reports a missing positional argument. Non-interactive callers get the exact
+ * command to run instead of a prompt.
+ */
+export function missingArgument(
+  client: Client,
+  options: {
+    reason: string;
+    message: string;
+    /** Usage template, e.g. `kms inspect <issuerId>`. */
+    usage: string;
+  }
+): number {
+  outputAgentError(
+    client,
+    {
+      status: AGENT_STATUS.ERROR,
+      reason: options.reason,
+      message: options.message,
+      next: [
+        {
+          command: kmsSuggestion('kms ls', client.argv),
+          when: 'List issuers to find an ID',
+        },
+        { command: kmsSuggestion(options.usage, client.argv) },
+      ],
+    },
+    1
+  );
+  output.error(options.message);
+  output.log(`Usage: ${chalk.cyan(getCommandName(options.usage))}`);
+  return 1;
+}
+
+/** Reports extra positional arguments the subcommand can't interpret. */
+export function invalidArgumentCount(client: Client, usage: string): number {
+  const message = `Too many arguments. Usage: ${getCommandNamePlain(usage)}`;
+  outputAgentError(
+    client,
+    {
+      status: AGENT_STATUS.ERROR,
+      reason: AGENT_REASON.INVALID_ARGUMENTS,
+      message,
+    },
+    1
+  );
+  output.error(
+    `Invalid number of arguments. Usage: ${chalk.cyan(getCommandName(usage))}`
+  );
+  return 1;
+}
+
+/** Reports a local input failure (bad JSON, unreadable file) uniformly. */
+export function invalidInput(client: Client, message: string): number {
+  outputAgentError(
+    client,
+    {
+      status: AGENT_STATUS.ERROR,
+      reason: AGENT_REASON.INVALID_ARGUMENTS,
+      message,
+    },
+    1
+  );
+  output.error(message);
+  return 1;
+}

--- a/packages/cli/src/util/kms/errors.ts
+++ b/packages/cli/src/util/kms/errors.ts
@@ -1,0 +1,103 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../client';
+import { isAPIError } from '../errors-ts';
+import { outputAgentError } from '../agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
+
+/** `403` code the API returns when another service provisioned the issuer. */
+const MANAGED_ISSUER_CODE = 'issuer_managed_by_mismatch';
+
+type NextCommands = Array<{ command: string; when?: string }>;
+
+export interface HandleKmsApiErrorOptions {
+  /**
+   * Full sentence for a 404, e.g. `Issuer not found: iss_123.` Omit it when the
+   * route has no addressable resource, so a 404 reports as an API error.
+   */
+  notFound?: string;
+  /** What the caller tried to do, e.g. `Updating an issuer`. */
+  attempted: string;
+  /** Team or username the command ran against. */
+  contextName: string;
+  next?: NextCommands;
+}
+
+/**
+ * Translates a KMS API failure into human and agent output.
+ *
+ * Returns an exit code for failures the commands can explain, and `undefined`
+ * for anything unrecognized so the caller rethrows it.
+ */
+export function handleKmsApiError(
+  client: Client,
+  err: unknown,
+  { notFound, attempted, contextName, next }: HandleKmsApiErrorOptions
+): number | undefined {
+  if (!isAPIError(err)) {
+    return undefined;
+  }
+
+  if (err.status === 404 && notFound) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.ISSUER_NOT_FOUND,
+        message: notFound,
+        next,
+      },
+      1
+    );
+    output.error(notFound);
+    return 1;
+  }
+
+  if (err.status === 403 && err.code === MANAGED_ISSUER_CODE) {
+    const message = `${attempted} isn't available for this issuer. It was provisioned by another Vercel service, which manages its keys and grants.`;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.ISSUER_MANAGED,
+        message,
+      },
+      1
+    );
+    output.error(message);
+    return 1;
+  }
+
+  if (err.status === 403) {
+    const message = `${attempted} requires the Owner role on ${contextName}.`;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.PERMISSION_DENIED,
+        message,
+        ...(err.action && { action: err.action }),
+        ...(typeof err.resource === 'string' && { resource: err.resource }),
+      },
+      1
+    );
+    output.error(message);
+    output.log(
+      `Ask an Owner of ${chalk.bold(contextName)} to run it, or switch teams with ${chalk.cyan('--scope')}.`
+    );
+    return 1;
+  }
+
+  const message = err.serverMessage || err.message;
+  outputAgentError(
+    client,
+    {
+      status: AGENT_STATUS.ERROR,
+      reason: AGENT_REASON.API_ERROR,
+      message,
+    },
+    1
+  );
+  output.error(message);
+  return 1;
+}

--- a/packages/cli/src/util/kms/format.ts
+++ b/packages/cli/src/util/kms/format.ts
@@ -1,0 +1,138 @@
+import chalk from 'chalk';
+import ms from 'ms';
+import formatTable from '../format-table';
+import { printAlignedLabel } from '../output/print-aligned-label';
+import type { Issuer, IssuerPolicy, SigningKey } from './types';
+import { isProjectGrant } from './types';
+
+/** Relative age of an ISO timestamp, e.g. `3m`. */
+export function relativeAge(isoDate: string): string {
+  const elapsed = Date.now() - new Date(isoDate).getTime();
+  return elapsed > 0 ? `${ms(elapsed)} ago` : ms(-elapsed);
+}
+
+/** The active key is what KMS signs with; everything else is context. */
+export function activeSigningKey(issuer: Issuer): SigningKey | undefined {
+  return issuer.signingKeys.find(key => key.status === 'active');
+}
+
+/**
+ * Key status plus the schedule that explains it, since `pending` and
+ * `revoking` are only actionable alongside their timestamps.
+ */
+export function describeKeyStatus(key: SigningKey): string {
+  if (key.status === 'pending') {
+    return key.activateAt
+      ? `pending · activates in ${ms(Math.max(0, new Date(key.activateAt).getTime() - Date.now()))}`
+      : 'pending · activate manually';
+  }
+  if (key.status === 'revoking') {
+    return key.revokeAt
+      ? `revoking · revoked in ${ms(Math.max(0, new Date(key.revokeAt).getTime() - Date.now()))}`
+      : 'revoking';
+  }
+  return 'active';
+}
+
+export function formatIssuersTable(issuers: Issuer[]): string {
+  const rows = issuers.map(issuer => {
+    const active = activeSigningKey(issuer);
+    return [
+      issuer.id,
+      issuer.name,
+      issuer.algorithm,
+      active ? active.keyId : chalk.gray('none'),
+      chalk.gray(relativeAge(issuer.createdAt)),
+    ];
+  });
+
+  return formatTable(
+    ['ID', 'Name', 'Algorithm', 'Active Key', 'Age'],
+    ['l', 'l', 'l', 'l', 'l'],
+    [{ rows }]
+  );
+}
+
+export function formatSigningKeysTable(keys: SigningKey[]): string {
+  const rows = keys.map(key => [
+    key.keyId,
+    key.algorithm,
+    describeKeyStatus(key),
+    key.importKeyId ?? chalk.gray('-'),
+    chalk.gray(relativeAge(key.createdAt)),
+  ]);
+
+  return formatTable(
+    ['Key ID', 'Algorithm', 'Status', 'JWKS kid', 'Age'],
+    ['l', 'l', 'l', 'l', 'l'],
+    [{ rows }]
+  );
+}
+
+export function formatGrantsTable(policies: IssuerPolicy[]): string {
+  const rows = policies.map(policy =>
+    isProjectGrant(policy)
+      ? [
+          policy.kind,
+          policy.projectId,
+          policy.environments.join(', '),
+          policy.tokenClaims ? 'yes' : chalk.gray('no'),
+        ]
+      : [
+          policy.kind,
+          policy.clientId,
+          chalk.gray('-'),
+          policy.tokenClaims ? 'yes' : chalk.gray('no'),
+        ]
+  );
+
+  return formatTable(
+    ['Kind', 'Target', 'Environments', 'Token Claims'],
+    ['l', 'l', 'l', 'l'],
+    [{ rows }]
+  );
+}
+
+/** Indents a table one space so it sits inside the two-space body gutter. */
+export function indentTable(table: string): string {
+  return table.replace(/^(.*)/gm, ' $1');
+}
+
+/**
+ * Durable identity of an issuer, printed after a mutation and at the top of
+ * `inspect`. `gutterLabel` carries the completed phase (e.g. `Created`).
+ */
+export function printIssuerRows(
+  issuer: Issuer,
+  gutterLabel?: { label: string; gutter: string }
+): void {
+  if (gutterLabel) {
+    printAlignedLabel(gutterLabel.label, issuer.name, {
+      gutter: gutterLabel.gutter,
+    });
+    printAlignedLabel('Issuer', issuer.id);
+  } else {
+    printAlignedLabel('Issuer', issuer.id);
+    printAlignedLabel('Name', issuer.name);
+  }
+  printAlignedLabel('Algorithm', issuer.algorithm);
+  printAlignedLabel('Origin', issuer.origin);
+  if (issuer.managedBy) {
+    printAlignedLabel('Managed By', issuer.managedBy);
+  }
+}
+
+/** Signing-key identity rows shared by the key subcommands. */
+export function printSigningKeyRows(
+  key: SigningKey,
+  gutterLabel: { label: string; gutter: string }
+): void {
+  printAlignedLabel(gutterLabel.label, key.keyId, {
+    gutter: gutterLabel.gutter,
+  });
+  printAlignedLabel('Algorithm', key.algorithm);
+  printAlignedLabel('Status', describeKeyStatus(key));
+  if (key.importKeyId) {
+    printAlignedLabel('JWKS kid', key.importKeyId);
+  }
+}

--- a/packages/cli/src/util/kms/grants.ts
+++ b/packages/cli/src/util/kms/grants.ts
@@ -1,0 +1,63 @@
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../client';
+import type { ProjectGrantPolicy } from './types';
+import { PROJECT_GRANT_POLICY_KIND } from './types';
+
+function policiesPath(issuerId: string): string {
+  return `/v1/kms/issuers/${encodeURIComponent(issuerId)}/policies`;
+}
+
+/** Project grants are keyed by project ID. */
+function projectGrantPath(issuerId: string, projectId: string): string {
+  return `${policiesPath(issuerId)}/${PROJECT_GRANT_POLICY_KIND}/${encodeURIComponent(
+    projectId
+  )}`;
+}
+
+export type CreateProjectGrantPayload = {
+  projectId: string;
+  environments: string[];
+  tokenClaims?: JSONObject;
+};
+
+export async function createProjectGrant(
+  client: Client,
+  issuerId: string,
+  payload: CreateProjectGrantPayload
+): Promise<ProjectGrantPolicy> {
+  return client.fetch<ProjectGrantPolicy>(policiesPath(issuerId), {
+    method: 'POST',
+    body: { kind: PROJECT_GRANT_POLICY_KIND, ...payload },
+  });
+}
+
+export type UpdateProjectGrantPayload = {
+  environments?: string[];
+  /** `null` clears the claims; an object replaces them. */
+  tokenClaims?: JSONObject | null;
+};
+
+export async function updateProjectGrant(
+  client: Client,
+  issuerId: string,
+  projectId: string,
+  payload: UpdateProjectGrantPayload
+): Promise<ProjectGrantPolicy> {
+  return client.fetch<ProjectGrantPolicy>(
+    projectGrantPath(issuerId, projectId),
+    {
+      method: 'PATCH',
+      body: payload,
+    }
+  );
+}
+
+export async function deleteProjectGrant(
+  client: Client,
+  issuerId: string,
+  projectId: string
+): Promise<void> {
+  await client.fetch(projectGrantPath(issuerId, projectId), {
+    method: 'DELETE',
+  });
+}

--- a/packages/cli/src/util/kms/issuers.ts
+++ b/packages/cli/src/util/kms/issuers.ts
@@ -1,0 +1,81 @@
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../client';
+import type { Issuer, IssuerListResponse, KmsAlgorithm } from './types';
+
+const ISSUERS_PATH = '/v1/kms/issuers';
+
+function issuerPath(issuerId: string): string {
+  return `${ISSUERS_PATH}/${encodeURIComponent(issuerId)}`;
+}
+
+export type ListIssuersOptions = {
+  limit?: number;
+  /** Opaque cursor from a previous page's `pagination.next`. */
+  next?: string;
+};
+
+export async function getIssuers(
+  client: Client,
+  { limit, next }: ListIssuersOptions = {}
+): Promise<IssuerListResponse> {
+  const query = new URLSearchParams();
+  if (limit !== undefined) {
+    query.set('limit', String(limit));
+  }
+  if (next !== undefined) {
+    query.set('next', next);
+  }
+  const search = query.toString();
+  return client.fetch<IssuerListResponse>(
+    search ? `${ISSUERS_PATH}?${search}` : ISSUERS_PATH
+  );
+}
+
+export async function getIssuer(
+  client: Client,
+  issuerId: string
+): Promise<Issuer> {
+  return client.fetch<Issuer>(issuerPath(issuerId));
+}
+
+export type CreateIssuerPayload = {
+  name: string;
+  algorithm?: KmsAlgorithm;
+  claimsSchema?: JSONObject;
+  importKey?: string;
+  importKeyId?: string;
+};
+
+export async function createIssuer(
+  client: Client,
+  payload: CreateIssuerPayload
+): Promise<Issuer> {
+  return client.fetch<Issuer>(ISSUERS_PATH, {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export type UpdateIssuerPayload = {
+  name?: string;
+  /** `null` clears the schema; an object replaces it. */
+  claimsSchema?: JSONObject | null;
+};
+
+export async function updateIssuer(
+  client: Client,
+  issuerId: string,
+  payload: UpdateIssuerPayload
+): Promise<Issuer> {
+  return client.fetch<Issuer>(issuerPath(issuerId), {
+    method: 'PATCH',
+    body: payload,
+  });
+}
+
+export async function deleteIssuer(
+  client: Client,
+  issuerId: string
+): Promise<void> {
+  await client.fetch(issuerPath(issuerId), { method: 'DELETE' });
+}

--- a/packages/cli/src/util/kms/key-origin.ts
+++ b/packages/cli/src/util/kms/key-origin.ts
@@ -1,0 +1,105 @@
+import output from '../../output-manager';
+import type Client from '../client';
+import { getCommandName } from '../pkg-name';
+import { outputAgentError } from '../agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../agent-output-constants';
+import { getIssuer } from './issuers';
+import { handleKmsApiError } from './errors';
+import { kmsSuggestion } from './args';
+import type { Issuer } from './types';
+
+/** Where the key material for a new signing key comes from. */
+export type KeySource = 'generated' | 'imported';
+
+/**
+ * Resolves the issuer a new signing key is for, and rejects the mismatch
+ * between the issuer and the command. Key material is fixed per issuer: an
+ * issuer created by importing a key (`origin: external`) takes imported keys
+ * only, and every other issuer takes generated keys only. The API answers a
+ * mismatch with a 400, so resolve it here and name the command that works.
+ */
+export async function resolveIssuerForKeySource(
+  client: Client,
+  issuerId: string,
+  options: { source: KeySource; attempted: string; contextName: string }
+): Promise<Issuer | number> {
+  if (!client.nonInteractive) {
+    output.spinner(`Fetching issuer ${issuerId}`);
+  }
+
+  let issuer: Issuer;
+  try {
+    issuer = await getIssuer(client, issuerId);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const handled = handleIssuerLookupError(client, err, issuerId, options);
+    if (handled !== undefined) {
+      return handled;
+    }
+    throw err;
+  }
+  output.stopSpinner();
+
+  const takesImportedKeys = issuer.origin === 'external';
+  if (takesImportedKeys && options.source === 'generated') {
+    return rejectMismatch(client, {
+      reason: AGENT_REASON.ISSUER_REQUIRES_IMPORTED_KEY,
+      message: `Issuer ${issuerId} was created from a key you imported, so its keys must be imported too.`,
+      command: `kms import-key ${issuerId} --key <file>`,
+      when: 'Import the next signing key',
+    });
+  }
+  if (!takesImportedKeys && options.source === 'imported') {
+    return rejectMismatch(client, {
+      reason: AGENT_REASON.ISSUER_REQUIRES_GENERATED_KEY,
+      message: `Vercel generates the signing keys for issuer ${issuerId}, so a key cannot be imported into it.`,
+      command: `kms add-key ${issuerId}`,
+      when: 'Add a Vercel-generated key instead',
+    });
+  }
+
+  return issuer;
+}
+
+function rejectMismatch(
+  client: Client,
+  options: { reason: string; message: string; command: string; when: string }
+): number {
+  outputAgentError(
+    client,
+    {
+      status: AGENT_STATUS.ERROR,
+      reason: options.reason,
+      message: options.message,
+      next: [
+        {
+          command: kmsSuggestion(options.command, client.argv),
+          when: options.when,
+        },
+      ],
+    },
+    1
+  );
+  output.error(options.message);
+  output.log(`Run ${getCommandName(options.command)} instead.`);
+  return 1;
+}
+
+function handleIssuerLookupError(
+  client: Client,
+  err: unknown,
+  issuerId: string,
+  options: { attempted: string; contextName: string }
+): number | undefined {
+  return handleKmsApiError(client, err, {
+    notFound: `Issuer not found: ${issuerId}.`,
+    attempted: options.attempted,
+    contextName: options.contextName,
+    next: [
+      {
+        command: kmsSuggestion('kms ls', client.argv),
+        when: 'List issuers in this team',
+      },
+    ],
+  });
+}

--- a/packages/cli/src/util/kms/parse-json-input.ts
+++ b/packages/cli/src/util/kms/parse-json-input.ts
@@ -1,0 +1,109 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { text } from 'node:stream/consumers';
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../client';
+
+async function readStdinToEnd(stdin: Client['stdin']): Promise<string> {
+  if (stdin.isTTY) {
+    return '';
+  }
+  return text(stdin);
+}
+
+/**
+ * Resolves a flag value that may be inline content, `@<path>` to read a file
+ * (relative paths resolved against `cwd`), or `@-` to read stdin. File and
+ * stdin sources keep sensitive input out of argv, shell history, and process
+ * listings.
+ */
+export async function resolveFlagSource(
+  client: Client,
+  flagName: string,
+  raw: string
+): Promise<string> {
+  if (!raw.startsWith('@')) {
+    return raw;
+  }
+  const source = raw.slice(1);
+  if (source === '-') {
+    return readStdinToEnd(client.stdin);
+  }
+  if (source.length === 0) {
+    throw new Error(
+      `Invalid ${flagName} value. Use \`@<path>\` to read from a file or \`@-\` to read from stdin.`
+    );
+  }
+  try {
+    return await readFile(resolve(client.cwd, source), 'utf8');
+  } catch (err) {
+    throw new Error(
+      `Couldn't read ${flagName} file at "${source}": ${(err as Error).message}`
+    );
+  }
+}
+
+/**
+ * Resolves and parses a JSON-object flag. Accepts inline JSON, `@<path>`, or
+ * `@-`. Throws with an actionable message so the caller can surface it without
+ * exposing the raw value.
+ */
+export async function parseJsonObjectFlag(
+  client: Client,
+  flagName: string,
+  raw: string
+): Promise<JSONObject> {
+  const source = await resolveFlagSource(client, flagName, raw);
+  if (source.trim().length === 0) {
+    throw new Error(`${flagName} requires a non-empty JSON object.`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    throw new Error(`Invalid JSON for ${flagName}. Expected a JSON object.`);
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${flagName} must be a JSON object.`);
+  }
+
+  return parsed as JSONObject;
+}
+
+/**
+ * Reads a PEM private key from a file path, or from stdin when the value is
+ * `-`. A private key is never accepted as an inline argv value: argv is
+ * visible in shell history and process listings.
+ */
+export async function readPrivateKey(
+  client: Client,
+  raw: string
+): Promise<string> {
+  const pem =
+    raw === '-'
+      ? await readStdinToEnd(client.stdin)
+      : await readPem(client, raw);
+  if (pem.trim().length === 0) {
+    throw new Error(
+      '--key is empty. Pass a path to a PEM private key file, or `-` to read it from stdin.'
+    );
+  }
+  if (!pem.includes('-----BEGIN')) {
+    throw new Error(
+      '--key must be a PEM-encoded private key. Pass a path to a `.pem` file, or `-` to read it from stdin.'
+    );
+  }
+  return pem;
+}
+
+async function readPem(client: Client, path: string): Promise<string> {
+  try {
+    return await readFile(resolve(client.cwd, path), 'utf8');
+  } catch (err) {
+    throw new Error(
+      `Couldn't read --key file at "${path}": ${(err as Error).message}`
+    );
+  }
+}

--- a/packages/cli/src/util/kms/signing-keys.ts
+++ b/packages/cli/src/util/kms/signing-keys.ts
@@ -1,0 +1,61 @@
+import type Client from '../client';
+import type { Issuer, SigningKey } from './types';
+
+function keysPath(issuerId: string): string {
+  return `/v1/kms/issuers/${encodeURIComponent(issuerId)}/keys`;
+}
+
+function keyPath(issuerId: string, keyId: string): string {
+  return `${keysPath(issuerId)}/${encodeURIComponent(keyId)}`;
+}
+
+export type CreateSigningKeyPayload = {
+  activation?: 'automatic' | 'manual';
+  /** Hours after activation before the previous key stops signing. */
+  revokePreviousAfterHours?: number;
+  /** PEM private key. Only accepted for issuers with `origin: 'external'`. */
+  importKey?: string;
+  importKeyId?: string;
+};
+
+export async function createSigningKey(
+  client: Client,
+  issuerId: string,
+  payload: CreateSigningKeyPayload
+): Promise<SigningKey> {
+  return client.fetch<SigningKey>(keysPath(issuerId), {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export type ActivateSigningKeyPayload = {
+  revokePreviousAfterHours?: number;
+};
+
+export async function activateSigningKey(
+  client: Client,
+  issuerId: string,
+  keyId: string,
+  payload: ActivateSigningKeyPayload
+): Promise<SigningKey> {
+  return client.fetch<SigningKey>(`${keyPath(issuerId, keyId)}/activate`, {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+/**
+ * Revokes a key that is already scheduled for revocation, ending its grace
+ * period immediately. Returns the full issuer rather than the key.
+ */
+export async function revokeSigningKey(
+  client: Client,
+  issuerId: string,
+  keyId: string
+): Promise<Issuer> {
+  return client.fetch<Issuer>(`${keyPath(issuerId, keyId)}/revoke`, {
+    method: 'POST',
+    body: {},
+  });
+}

--- a/packages/cli/src/util/kms/types.ts
+++ b/packages/cli/src/util/kms/types.ts
@@ -1,0 +1,105 @@
+import type { JSONObject } from '@vercel-internals/types';
+
+export const KMS_ALGORITHMS = [
+  'RS256',
+  'RS384',
+  'RS512',
+  'PS256',
+  'PS384',
+  'PS512',
+  'ES256',
+  'ES384',
+  'ES512',
+  'EdDSA',
+] as const;
+
+export type KmsAlgorithm = (typeof KMS_ALGORITHMS)[number];
+
+export type IssuerOrigin = 'vercel' | 'external';
+
+export type SigningKeyStatus = 'pending' | 'active' | 'revoking';
+
+export const PROJECT_GRANT_POLICY_KIND = 'project-grant';
+export const CONNEX_GRANT_POLICY_KIND = 'connex-grant';
+
+export interface SigningKey {
+  keyId: string;
+  /** JWT/JWKS `kid` for an imported key; may differ from `keyId`. */
+  importKeyId?: string;
+  issuerId: string;
+  algorithm: string;
+  status: SigningKeyStatus;
+  publicKey?: JSONObject;
+  publicKeyFingerprint?: string;
+  publicKeyPem?: string;
+  certificatePem?: string;
+  createdAt: string;
+  updatedAt: string;
+  revokeAt?: string;
+  activateAt?: string;
+  activatedAt?: string;
+}
+
+export interface ProjectGrantPolicy {
+  kind: typeof PROJECT_GRANT_POLICY_KIND;
+  teamId: string;
+  projectId: string;
+  environments: string[];
+  tokenClaims?: JSONObject;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ConnexGrantPolicy {
+  kind: typeof CONNEX_GRANT_POLICY_KIND;
+  clientId: string;
+  tokenClaims?: JSONObject;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type IssuerPolicy = ProjectGrantPolicy | ConnexGrantPolicy;
+
+export interface Issuer {
+  id: string;
+  ownerId: string;
+  name: string;
+  algorithm: KmsAlgorithm;
+  origin: IssuerOrigin;
+  /** Set when another service (e.g. Vercel Connect) owns this issuer. */
+  managedBy?: string;
+  claimsSchema?: JSONObject;
+  createdAt: string;
+  updatedAt: string;
+  signingKeys: SigningKey[];
+  /**
+   * Empty unless the caller can manage grants, which the API does not
+   * distinguish from an issuer that genuinely has none.
+   */
+  policies: IssuerPolicy[];
+}
+
+export interface IssuerListResponse {
+  issuers: Issuer[];
+  pagination: {
+    count: number;
+    /** Opaque base64url cursor, or null on the last page. */
+    next: string | null;
+  };
+}
+
+export function isProjectGrant(
+  policy: IssuerPolicy
+): policy is ProjectGrantPolicy {
+  return policy.kind === PROJECT_GRANT_POLICY_KIND;
+}
+
+/** The issuer URL KMS publishes keys under, and the `iss` claim it signs. */
+export function issuerUrl(issuerId: string): string {
+  return `https://kms.vercel.com/${issuerId}`;
+}
+
+/** Where the issuer's public keys are published. */
+export function issuerJwksUrl(issuerId: string): string {
+  return `${issuerUrl(issuerId)}/jwks.json`;
+}

--- a/packages/cli/src/util/telemetry/commands/kms/activate-key.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/activate-key.ts
@@ -1,0 +1,44 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { activateKeySubcommand } from '../../../../commands/kms/command';
+
+export class KmsActivateKeyTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof activateKeySubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentKeyId(keyId: string | undefined) {
+    if (keyId) {
+      this.trackCliArgument({
+        arg: 'keyId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionRevokePreviousAfterHours(hours: number | undefined) {
+    if (hours !== undefined) {
+      this.trackCliOption({
+        option: 'revoke-previous-after-hours',
+        value: String(hours),
+      });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/add-grant.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/add-grant.ts
@@ -1,0 +1,53 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { addGrantSubcommand } from '../../../../commands/kms/command';
+
+export class KmsAddGrantTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof addGrantSubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionProject(project: string | undefined) {
+    if (project) {
+      this.trackCliOption({
+        option: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEnvironment(environments: string[] | undefined) {
+    if (environments && environments.length > 0) {
+      this.trackCliOption({
+        option: 'environment',
+        value: String(environments.length),
+      });
+    }
+  }
+
+  trackCliOptionTokenClaims(tokenClaims: string | undefined) {
+    if (tokenClaims) {
+      this.trackCliOption({
+        option: 'token-claims',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/add-key.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/add-key.ts
@@ -1,0 +1,44 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { addKeySubcommand } from '../../../../commands/kms/command';
+
+export class KmsAddKeyTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof addKeySubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionActivation(activation: string | undefined) {
+    if (activation) {
+      this.trackCliOption({
+        option: 'activation',
+        value: activation,
+      });
+    }
+  }
+
+  trackCliOptionRevokePreviousAfterHours(hours: number | undefined) {
+    if (hours !== undefined) {
+      this.trackCliOption({
+        option: 'revoke-previous-after-hours',
+        value: String(hours),
+      });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/add.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/add.ts
@@ -1,0 +1,44 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { addSubcommand } from '../../../../commands/kms/command';
+
+export class KmsAddTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof addSubcommand>
+{
+  trackCliArgumentName(name: string | undefined) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionAlgorithm(algorithm: string | undefined) {
+    if (algorithm) {
+      this.trackCliOption({
+        option: 'algorithm',
+        value: algorithm,
+      });
+    }
+  }
+
+  trackCliOptionClaimsSchema(claimsSchema: string | undefined) {
+    if (claimsSchema) {
+      this.trackCliOption({
+        option: 'claims-schema',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/import-key.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/import-key.ts
@@ -1,0 +1,62 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { importKeySubcommand } from '../../../../commands/kms/command';
+
+export class KmsImportKeyTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof importKeySubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionKey(key: string | undefined) {
+    if (key) {
+      this.trackCliOption({
+        option: 'key',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionKeyId(keyId: string | undefined) {
+    if (keyId) {
+      this.trackCliOption({
+        option: 'key-id',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionActivation(activation: string | undefined) {
+    if (activation) {
+      this.trackCliOption({
+        option: 'activation',
+        value: activation,
+      });
+    }
+  }
+
+  trackCliOptionRevokePreviousAfterHours(hours: number | undefined) {
+    if (hours !== undefined) {
+      this.trackCliOption({
+        option: 'revoke-previous-after-hours',
+        value: String(hours),
+      });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/import.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/import.ts
@@ -1,0 +1,62 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { importSubcommand } from '../../../../commands/kms/command';
+
+export class KmsImportTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof importSubcommand>
+{
+  trackCliArgumentName(name: string | undefined) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionKey(key: string | undefined) {
+    if (key) {
+      this.trackCliOption({
+        option: 'key',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionKeyId(keyId: string | undefined) {
+    if (keyId) {
+      this.trackCliOption({
+        option: 'key-id',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionAlgorithm(algorithm: string | undefined) {
+    if (algorithm) {
+      this.trackCliOption({
+        option: 'algorithm',
+        value: algorithm,
+      });
+    }
+  }
+
+  trackCliOptionClaimsSchema(claimsSchema: string | undefined) {
+    if (claimsSchema) {
+      this.trackCliOption({
+        option: 'claims-schema',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/index.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/index.ts
@@ -1,0 +1,99 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { kmsCommand } from '../../../../commands/kms/command';
+
+export class KmsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof kmsCommand>
+{
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandImport(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'import',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandUpdate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandAddKey(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add-key',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandImportKey(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'import-key',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandActivateKey(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'activate-key',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRevokeKey(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'revoke-key',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandAddGrant(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add-grant',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandUpdateGrant(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update-grant',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemoveGrant(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove-grant',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/inspect.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/inspect.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { inspectSubcommand } from '../../../../commands/kms/command';
+
+export class KmsInspectTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof inspectSubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/ls.ts
@@ -1,0 +1,35 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { listSubcommand } from '../../../../commands/kms/command';
+
+export class KmsLsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof listSubcommand>
+{
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+
+  trackCliOptionLimit(limit: number | undefined) {
+    if (limit !== undefined) {
+      this.trackCliOption({
+        option: 'limit',
+        value: String(limit),
+      });
+    }
+  }
+
+  trackCliOptionNext(next: string | undefined) {
+    if (next) {
+      this.trackCliOption({
+        option: 'next',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/revoke-key.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/revoke-key.ts
@@ -1,0 +1,32 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { revokeKeySubcommand } from '../../../../commands/kms/command';
+
+export class KmsRevokeKeyTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof revokeKeySubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentKeyId(keyId: string | undefined) {
+    if (keyId) {
+      this.trackCliArgument({
+        arg: 'keyId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/rm-grant.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/rm-grant.ts
@@ -1,0 +1,32 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { removeGrantSubcommand } from '../../../../commands/kms/command';
+
+export class KmsRmGrantTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof removeGrantSubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentProjectId(projectId: string | undefined) {
+    if (projectId) {
+      this.trackCliArgument({
+        arg: 'projectId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/rm.ts
@@ -1,0 +1,23 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { removeSubcommand } from '../../../../commands/kms/command';
+
+export class KmsRmTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof removeSubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/update-grant.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/update-grant.ts
@@ -1,0 +1,59 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { updateGrantSubcommand } from '../../../../commands/kms/command';
+
+export class KmsUpdateGrantTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof updateGrantSubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentProjectId(projectId: string | undefined) {
+    if (projectId) {
+      this.trackCliArgument({
+        arg: 'projectId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEnvironment(environments: string[] | undefined) {
+    if (environments && environments.length > 0) {
+      this.trackCliOption({
+        option: 'environment',
+        value: String(environments.length),
+      });
+    }
+  }
+
+  trackCliOptionTokenClaims(tokenClaims: string | undefined) {
+    if (tokenClaims) {
+      this.trackCliOption({
+        option: 'token-claims',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagRemoveTokenClaims(removeTokenClaims: boolean | undefined) {
+    if (removeTokenClaims) {
+      this.trackCliFlag('remove-token-claims');
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/kms/update.ts
+++ b/packages/cli/src/util/telemetry/commands/kms/update.ts
@@ -1,0 +1,50 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { updateSubcommand } from '../../../../commands/kms/command';
+
+export class KmsUpdateTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof updateSubcommand>
+{
+  trackCliArgumentIssuerId(issuerId: string | undefined) {
+    if (issuerId) {
+      this.trackCliArgument({
+        arg: 'issuerId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionName(name: string | undefined) {
+    if (name) {
+      this.trackCliOption({
+        option: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionClaimsSchema(claimsSchema: string | undefined) {
+    if (claimsSchema) {
+      this.trackCliOption({
+        option: 'claims-schema',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagRemoveClaimsSchema(removeClaimsSchema: boolean | undefined) {
+    if (removeClaimsSchema) {
+      this.trackCliFlag('remove-claims-schema');
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -264,6 +264,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandKms(actual: string) {
+    this.trackCliCommand({
+      command: 'kms',
+      value: actual,
+    });
+  }
+
   trackCliCommandLink(actual: string) {
     this.trackCliCommand({
       command: 'link',

--- a/packages/cli/test/mocks/kms.ts
+++ b/packages/cli/test/mocks/kms.ts
@@ -1,0 +1,266 @@
+import chance from 'chance';
+import { client } from './client';
+import type {
+  Issuer,
+  ProjectGrantPolicy,
+  SigningKey,
+} from '../../src/util/kms/types';
+import { PROJECT_GRANT_POLICY_KIND } from '../../src/util/kms/types';
+
+const ISSUERS_PATH = '/v1/kms/issuers';
+
+export function createSigningKey(
+  overrides: Partial<SigningKey> = {}
+): SigningKey {
+  const now = new Date().toISOString();
+  return {
+    keyId: `key_${chance().string({ length: 12, alpha: true, numeric: true })}`,
+    issuerId: 'iss_1a2b3c4d',
+    algorithm: 'RS256',
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+export function createProjectGrant(
+  overrides: Partial<ProjectGrantPolicy> = {}
+): ProjectGrantPolicy {
+  const now = new Date().toISOString();
+  return {
+    kind: PROJECT_GRANT_POLICY_KIND,
+    teamId: 'team_dummy',
+    projectId: 'prj_9i8h7g6f',
+    environments: ['production'],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+export function createIssuer(
+  id?: string,
+  overrides: Partial<Issuer> = {}
+): Issuer {
+  const issuerId =
+    id || `iss_${chance().string({ length: 12, alpha: true, numeric: true })}`;
+  const now = new Date().toISOString();
+  return {
+    id: issuerId,
+    ownerId: 'team_dummy',
+    name: `issuer-${issuerId}`,
+    algorithm: 'RS256',
+    origin: 'vercel',
+    createdAt: now,
+    updatedAt: now,
+    signingKeys: [createSigningKey({ issuerId })],
+    policies: [],
+    ...overrides,
+  };
+}
+
+export function useIssuers(count = 3, next: string | null = null) {
+  const issuers = Array.from({ length: count }, (_, i) =>
+    createIssuer(`iss_${i}`)
+  );
+
+  client.scenario.get(ISSUERS_PATH, (_req, res) => {
+    res.json({ issuers, pagination: { count: issuers.length, next } });
+  });
+
+  return issuers;
+}
+
+export function useIssuer(id: string, overrides: Partial<Issuer> = {}) {
+  const issuer = createIssuer(id, overrides);
+
+  client.scenario.get(
+    `${ISSUERS_PATH}/${encodeURIComponent(id)}`,
+    (_req, res) => {
+      res.json(issuer);
+    }
+  );
+
+  return issuer;
+}
+
+export function useCreateIssuer() {
+  client.scenario.post(ISSUERS_PATH, (req, res) => {
+    const { name, algorithm, claimsSchema, importKey, importKeyId } = req.body;
+    const issuer = createIssuer(undefined, {
+      name,
+      ...(algorithm && { algorithm }),
+      ...(claimsSchema && { claimsSchema }),
+      ...(importKey && { origin: 'external' }),
+    });
+    res.json({
+      ...issuer,
+      signingKeys: issuer.signingKeys.map(key => ({
+        ...key,
+        ...(importKeyId && { importKeyId }),
+      })),
+    });
+  });
+}
+
+export function useUpdateIssuer(id: string, overrides: Partial<Issuer> = {}) {
+  client.scenario.patch(
+    `${ISSUERS_PATH}/${encodeURIComponent(id)}`,
+    (req, res) => {
+      const { name, claimsSchema } = req.body;
+      res.json(
+        createIssuer(id, {
+          ...overrides,
+          ...(name && { name }),
+          ...(claimsSchema ? { claimsSchema } : { claimsSchema: undefined }),
+        })
+      );
+    }
+  );
+}
+
+export function useDeleteIssuer(id: string) {
+  client.scenario.delete(
+    `${ISSUERS_PATH}/${encodeURIComponent(id)}`,
+    (_req, res) => {
+      res.status(204).end();
+    }
+  );
+}
+
+export function useCreateSigningKey(
+  issuerId: string,
+  overrides: Partial<SigningKey> = {}
+) {
+  client.scenario.post(
+    `${ISSUERS_PATH}/${encodeURIComponent(issuerId)}/keys`,
+    (req, res) => {
+      const { importKeyId } = req.body;
+      res.json(
+        createSigningKey({
+          issuerId,
+          ...(importKeyId && { importKeyId }),
+          ...overrides,
+        })
+      );
+    }
+  );
+}
+
+export function useActivateSigningKey(issuerId: string, keyId: string) {
+  client.scenario.post(
+    `${ISSUERS_PATH}/${encodeURIComponent(issuerId)}/keys/${encodeURIComponent(
+      keyId
+    )}/activate`,
+    (_req, res) => {
+      res.json(createSigningKey({ issuerId, keyId, status: 'active' }));
+    }
+  );
+}
+
+/** Immediate revocation returns the issuer, not the key. */
+export function useRevokeSigningKey(issuerId: string, keyId: string) {
+  client.scenario.post(
+    `${ISSUERS_PATH}/${encodeURIComponent(issuerId)}/keys/${encodeURIComponent(
+      keyId
+    )}/revoke`,
+    (_req, res) => {
+      res.json(
+        createIssuer(issuerId, {
+          signingKeys: [createSigningKey({ issuerId, keyId: `${keyId}-next` })],
+        })
+      );
+    }
+  );
+}
+
+export function useCreateProjectGrant(issuerId: string) {
+  client.scenario.post(
+    `${ISSUERS_PATH}/${encodeURIComponent(issuerId)}/policies`,
+    (req, res) => {
+      const { projectId, environments, tokenClaims } = req.body;
+      res.json(
+        createProjectGrant({
+          projectId,
+          environments,
+          ...(tokenClaims && { tokenClaims }),
+        })
+      );
+    }
+  );
+}
+
+export function useUpdateProjectGrant(issuerId: string, projectId: string) {
+  client.scenario.patch(
+    `${ISSUERS_PATH}/${encodeURIComponent(
+      issuerId
+    )}/policies/${PROJECT_GRANT_POLICY_KIND}/${encodeURIComponent(projectId)}`,
+    (req, res) => {
+      const { environments, tokenClaims } = req.body;
+      res.json(
+        createProjectGrant({
+          projectId,
+          ...(environments && { environments }),
+          ...(tokenClaims && { tokenClaims }),
+        })
+      );
+    }
+  );
+}
+
+export function useDeleteProjectGrant(issuerId: string, projectId: string) {
+  client.scenario.delete(
+    `${ISSUERS_PATH}/${encodeURIComponent(
+      issuerId
+    )}/policies/${PROJECT_GRANT_POLICY_KIND}/${encodeURIComponent(projectId)}`,
+    (_req, res) => {
+      res.status(204).end();
+    }
+  );
+}
+
+type ErrorRoute = {
+  method: 'get' | 'post' | 'patch' | 'delete';
+  path: string;
+};
+
+/** Responds to a single KMS route with an API error payload. */
+export function useKmsError(
+  { method, path }: ErrorRoute,
+  status: number,
+  code: string,
+  message: string
+) {
+  client.scenario[method](path, (_req, res) => {
+    res.status(status).json({ error: { code, message } });
+  });
+}
+
+export function useIssuerNotFound(id: string) {
+  useKmsError(
+    { method: 'get', path: `${ISSUERS_PATH}/${encodeURIComponent(id)}` },
+    404,
+    'not_found',
+    'Issuer not found'
+  );
+}
+
+export function useIssuerForbidden(id: string) {
+  useKmsError(
+    { method: 'delete', path: `${ISSUERS_PATH}/${encodeURIComponent(id)}` },
+    403,
+    'forbidden',
+    'Not authorized'
+  );
+}
+
+/** The 403 the API returns when another service provisioned the issuer. */
+export function useManagedIssuerRejection(id: string) {
+  useKmsError(
+    { method: 'patch', path: `${ISSUERS_PATH}/${encodeURIComponent(id)}` },
+    403,
+    'issuer_managed_by_mismatch',
+    'Issuer is managed by another service'
+  );
+}

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -57,6 +57,7 @@ exports[`base level help output > help 1`] = `
       flags                [cmd]       Manage feature flags for a Vercel project
       global-config        [cmd]       Manage Global Config stores
       httpstat             path        Visualize HTTP timing statistics for deployments
+      kms                  [cmd]       Manage KMS issuers, signing keys, and project grants [beta]
       logs                 [url]       Displays the logs for a deployment
       metrics              <metric>    Queries observability metrics for your project or team
       mcp                              Set up MCP agents and configuration

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -849,7 +849,8 @@ exports[`help command > connex help output snapshots > connex create subcommand 
        --icon <PATH>             Path to a PNG or JPEG image to use as the connector icon (uploaded to Vercel)               
        --json                    Output as JSON                                                                              
   -n,  --name <NAME>             Name of the connector                                                                       
-       --trigger-event <EVENT>   Webhook event to receive. Repeatable.                                                       
+       --trigger-event <EVENT>   Webhook event to receive. Repeatable. Requires --triggers and replaces the provider's       
+                                 default events.                                                                             
        --triggers                Enable webhook triggers for this connector                                                  
 
 

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -48,6 +48,7 @@ describe('index', () => {
         ['integration', 'integration'],
         ['integration-resource', 'integration-resource'],
         ['ir', 'integration-resource'],
+        ['kms', 'kms'],
         ['link', 'link'],
         ['list', 'list'],
         ['ln', 'alias'],

--- a/packages/cli/test/unit/commands/kms/activate-key.test.ts
+++ b/packages/cli/test/unit/commands/kms/activate-key.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useActivateSigningKey, useKmsError } from '../../../mocks/kms';
+
+describe('kms activate-key', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'activate-key', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:activate-key' },
+      ]);
+    });
+  });
+
+  it('activates a staged key', async () => {
+    useUser();
+    useActivateSigningKey('iss_test', 'key_1');
+    client.setArgv('kms', 'activate-key', 'iss_test', 'key_1');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Activated');
+    expect(stderr).toContain('key_1');
+  });
+
+  it('tracks both arguments and the grace period', async () => {
+    useUser();
+    useActivateSigningKey('iss_test', 'key_1');
+    client.setArgv(
+      'kms',
+      'activate-key',
+      'iss_test',
+      'key_1',
+      '--revoke-previous-after-hours',
+      '4'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:activate-key', value: 'activate-key' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+      { key: 'argument:keyId', value: '[REDACTED]' },
+      { key: 'option:revoke-previous-after-hours', value: '4' },
+    ]);
+  });
+
+  it('reports a missing key', async () => {
+    useUser();
+    useKmsError(
+      {
+        method: 'post',
+        path: '/v1/kms/issuers/iss_test/keys/key_missing/activate',
+      },
+      404,
+      'not_found',
+      'Key not found'
+    );
+    client.setArgv('kms', 'activate-key', 'iss_test', 'key_missing');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Key not found: key_missing on issuer iss_test.'
+    );
+  });
+
+  describe('non-interactive', () => {
+    it('emits an agent payload when the key ID is missing', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'activate-key', 'iss_test');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_key_id',
+      });
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/kms/add-grant.test.ts
+++ b/packages/cli/test/unit/commands/kms/add-grant.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useCreateProjectGrant, useKmsError } from '../../../mocks/kms';
+
+describe('kms add-grant', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'add-grant', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:add-grant' },
+      ]);
+    });
+  });
+
+  it('grants a project access in the given environments', async () => {
+    useUser();
+    useCreateProjectGrant('iss_test');
+    client.setArgv(
+      'kms',
+      'add-grant',
+      'iss_test',
+      '--project',
+      'prj_1',
+      '--environment',
+      'production',
+      '--environment',
+      'preview'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('prj_1');
+    expect(stderr).toContain('production, preview');
+  });
+
+  it('tracks the environment count without the claim contents', async () => {
+    useUser();
+    useCreateProjectGrant('iss_test');
+    client.setArgv(
+      'kms',
+      'add-grant',
+      'iss_test',
+      '--project',
+      'prj_1',
+      '--environment',
+      'production',
+      '--token-claims',
+      '{"role":"admin"}'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:add-grant', value: 'add-grant' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'option:environment', value: '1' },
+      { key: 'option:token-claims', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('requires a project', async () => {
+    useUser();
+    client.setArgv(
+      'kms',
+      'add-grant',
+      'iss_test',
+      '--environment',
+      'production'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('A project is required');
+  });
+
+  it('requires at least one environment', async () => {
+    useUser();
+    client.setArgv('kms', 'add-grant', 'iss_test', '--project', 'prj_1');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'At least one environment is required'
+    );
+  });
+
+  it('rejects malformed --token-claims JSON', async () => {
+    useUser();
+    client.setArgv(
+      'kms',
+      'add-grant',
+      'iss_test',
+      '--project',
+      'prj_1',
+      '--environment',
+      'production',
+      '--token-claims',
+      '[]'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      '--token-claims must be a JSON object'
+    );
+  });
+
+  describe('--format json', () => {
+    it('writes the grant to stdout', async () => {
+      useUser();
+      useCreateProjectGrant('iss_test');
+      client.setArgv(
+        'kms',
+        'add-grant',
+        'iss_test',
+        '--project',
+        'prj_1',
+        '--environment',
+        'production',
+        '--format',
+        'json'
+      );
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        kind: 'project-grant',
+        projectId: 'prj_1',
+        environments: ['production'],
+      });
+    });
+  });
+
+  describe('non-interactive', () => {
+    it('emits an agent payload when --project is missing', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv(
+        'kms',
+        'add-grant',
+        'iss_test',
+        '--environment',
+        'production'
+      );
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_project',
+      });
+    });
+  });
+
+  it('explains a 403 as a permissions problem', async () => {
+    useUser();
+    useKmsError(
+      { method: 'post', path: '/v1/kms/issuers/iss_test/policies' },
+      403,
+      'forbidden',
+      'Not authorized'
+    );
+    client.setArgv(
+      'kms',
+      'add-grant',
+      'iss_test',
+      '--project',
+      'prj_1',
+      '--environment',
+      'production'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('requires the Owner role');
+  });
+});

--- a/packages/cli/test/unit/commands/kms/add-key.test.ts
+++ b/packages/cli/test/unit/commands/kms/add-key.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import {
+  useCreateSigningKey,
+  useIssuer,
+  useIssuerNotFound,
+  useKmsError,
+} from '../../../mocks/kms';
+
+describe('kms add-key', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'add-key', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:add-key' },
+      ]);
+    });
+  });
+
+  it('adds a key and explains when it starts signing', async () => {
+    useUser();
+    useIssuer('iss_test');
+    useCreateSigningKey('iss_test', { keyId: 'key_new' });
+    client.setArgv('kms', 'add-key', 'iss_test');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('key_new');
+    expect(stderr).toContain('starts signing');
+  });
+
+  it('tells the user to activate a staged key', async () => {
+    useUser();
+    useIssuer('iss_test');
+    useCreateSigningKey('iss_test', { keyId: 'key_new', status: 'pending' });
+    client.setArgv('kms', 'add-key', 'iss_test', '--activation', 'manual');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('kms activate-key iss_test key_new');
+  });
+
+  it('rejects an unknown activation mode', async () => {
+    useUser();
+    client.setArgv('kms', 'add-key', 'iss_test', '--activation', 'later');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid activation mode "later"');
+  });
+
+  it('rejects a negative grace period', async () => {
+    useUser();
+    client.setArgv(
+      'kms',
+      'add-key',
+      'iss_test',
+      '--revoke-previous-after-hours=-1'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      '--revoke-previous-after-hours must be 0 or more'
+    );
+  });
+
+  it('sends the user to import-key for an imported issuer', async () => {
+    useUser();
+    useIssuer('iss_external', { origin: 'external' });
+    client.setArgv('kms', 'add-key', 'iss_external');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('was created from a key you imported');
+    expect(stderr).toContain('kms import-key iss_external');
+  });
+
+  it('tracks options without recording the key material', async () => {
+    useUser();
+    useIssuer('iss_test');
+    useCreateSigningKey('iss_test');
+    client.setArgv(
+      'kms',
+      'add-key',
+      'iss_test',
+      '--activation',
+      'automatic',
+      '--revoke-previous-after-hours',
+      '2'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:add-key', value: 'add-key' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+      { key: 'option:activation', value: 'automatic' },
+      { key: 'option:revoke-previous-after-hours', value: '2' },
+    ]);
+  });
+
+  describe('non-interactive', () => {
+    it('emits an agent payload when the issuer ID is missing', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'add-key');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_issuer_id',
+      });
+    });
+
+    it('emits the origin mismatch as a structured error', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      useUser();
+      useIssuer('iss_external', { origin: 'external' });
+      client.nonInteractive = true;
+      client.setArgv('kms', 'add-key', 'iss_external');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'issuer_requires_imported_key',
+      });
+      expect(payload.next[0].command).toContain('kms import-key iss_external');
+    });
+  });
+
+  it('reports a missing issuer', async () => {
+    useUser();
+    useIssuerNotFound('iss_missing');
+    client.setArgv('kms', 'add-key', 'iss_missing');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Issuer not found: iss_missing.');
+  });
+
+  it('explains a 403 on the key route as a permissions problem', async () => {
+    useUser();
+    useIssuer('iss_test');
+    useKmsError(
+      { method: 'post', path: '/v1/kms/issuers/iss_test/keys' },
+      403,
+      'forbidden',
+      'Not authorized'
+    );
+    client.setArgv('kms', 'add-key', 'iss_test');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('requires the Owner role');
+  });
+});

--- a/packages/cli/test/unit/commands/kms/add.test.ts
+++ b/packages/cli/test/unit/commands/kms/add.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useCreateIssuer, useKmsError } from '../../../mocks/kms';
+
+describe('kms add', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'add', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:add' },
+      ]);
+    });
+  });
+
+  it('creates an issuer and shows how to grant a project access', async () => {
+    useUser();
+    useCreateIssuer();
+    client.setArgv('kms', 'add', 'my-issuer');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('my-issuer');
+    expect(stderr).toContain('kms add-grant');
+  });
+
+  it('tracks the redacted name and the algorithm', async () => {
+    useUser();
+    useCreateIssuer();
+    client.setArgv('kms', 'add', 'my-issuer', '--algorithm', 'ES256');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:add', value: 'add' },
+      { key: 'argument:name', value: '[REDACTED]' },
+      { key: 'option:algorithm', value: 'ES256' },
+    ]);
+  });
+
+  it('rejects an unsupported algorithm before calling the API', async () => {
+    useUser();
+    client.setArgv('kms', 'add', 'my-issuer', '--algorithm', 'HS256');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid algorithm "HS256"');
+  });
+
+  it('does not accept a key to import', async () => {
+    useUser();
+    client.setArgv('kms', 'add', 'my-issuer', '--key', './private-key.pem');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('unknown or unexpected option: --key');
+  });
+
+  it('rejects malformed --claims-schema JSON', async () => {
+    useUser();
+    client.setArgv('kms', 'add', 'my-issuer', '--claims-schema', '{nope');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid JSON for --claims-schema');
+  });
+
+  describe('--format json', () => {
+    it('writes the issuer to stdout', async () => {
+      useUser();
+      useCreateIssuer();
+      client.setArgv('kms', 'add', 'my-issuer', '--format', 'json');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({ name: 'my-issuer' });
+    });
+  });
+
+  describe('non-interactive', () => {
+    it('emits an agent payload when the name is missing', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'add');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_name',
+      });
+    });
+
+    it('emits a success payload with the grant follow-up', async () => {
+      useUser();
+      useCreateIssuer();
+      client.nonInteractive = true;
+      client.setArgv('kms', 'add', 'my-issuer');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload.status).toBe('ok');
+      expect(payload.next[0].command).toContain('kms add-grant');
+    });
+  });
+
+  it('explains a 403 as a permissions problem', async () => {
+    useUser();
+    useKmsError(
+      { method: 'post', path: '/v1/kms/issuers' },
+      403,
+      'forbidden',
+      'Not authorized'
+    );
+    client.setArgv('kms', 'add', 'my-issuer');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('requires the Owner role');
+  });
+});

--- a/packages/cli/test/unit/commands/kms/import-key.test.ts
+++ b/packages/cli/test/unit/commands/kms/import-key.test.ts
@@ -1,0 +1,199 @@
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import {
+  useCreateSigningKey,
+  useIssuer,
+  useIssuerNotFound,
+} from '../../../mocks/kms';
+
+const PEM = '-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n';
+
+describe('kms import-key', () => {
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'kms-import-key-'));
+    writeFileSync(join(dir, 'private-key.pem'), PEM);
+    client.cwd = dir;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'import-key', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:import-key' },
+      ]);
+    });
+  });
+
+  it('imports a key into an imported issuer', async () => {
+    useUser();
+    useIssuer('iss_external', { origin: 'external' });
+    useCreateSigningKey('iss_external', { keyId: 'key_new' });
+    client.setArgv(
+      'kms',
+      'import-key',
+      'iss_external',
+      '--key',
+      'private-key.pem'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('key_new');
+    expect(stderr).toContain('starts signing');
+  });
+
+  it('tells the user to activate a staged key', async () => {
+    useUser();
+    useIssuer('iss_external', { origin: 'external' });
+    useCreateSigningKey('iss_external', {
+      keyId: 'key_new',
+      status: 'pending',
+    });
+    client.setArgv(
+      'kms',
+      'import-key',
+      'iss_external',
+      '--key',
+      'private-key.pem',
+      '--activation',
+      'manual'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      'kms activate-key iss_external key_new'
+    );
+  });
+
+  it('requires a key', async () => {
+    useUser();
+    client.setArgv('kms', 'import-key', 'iss_external');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('A private key is required.');
+  });
+
+  it('rejects a key path that does not exist', async () => {
+    useUser();
+    client.setArgv(
+      'kms',
+      'import-key',
+      'iss_external',
+      '--key',
+      'missing-key.pem'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput("Couldn't read --key file");
+  });
+
+  it('sends the user to add-key for a Vercel-generated issuer', async () => {
+    useUser();
+    useIssuer('iss_test');
+    client.setArgv('kms', 'import-key', 'iss_test', '--key', 'private-key.pem');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Vercel generates the signing keys');
+    expect(stderr).toContain('kms add-key iss_test');
+  });
+
+  it('tracks options without recording the key material', async () => {
+    useUser();
+    useIssuer('iss_external', { origin: 'external' });
+    useCreateSigningKey('iss_external');
+    client.setArgv(
+      'kms',
+      'import-key',
+      'iss_external',
+      '--key',
+      'private-key.pem',
+      '--key-id',
+      'kid-1',
+      '--revoke-previous-after-hours',
+      '2'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:import-key', value: 'import-key' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+      { key: 'option:key', value: '[REDACTED]' },
+      { key: 'option:key-id', value: '[REDACTED]' },
+      { key: 'option:revoke-previous-after-hours', value: '2' },
+    ]);
+  });
+
+  describe('non-interactive', () => {
+    it('emits an agent payload when the key is missing', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'import-key', 'iss_external');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_key',
+      });
+    });
+
+    it('emits the origin mismatch as a structured error', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      useUser();
+      useIssuer('iss_test');
+      client.nonInteractive = true;
+      client.setArgv(
+        'kms',
+        'import-key',
+        'iss_test',
+        '--key',
+        'private-key.pem'
+      );
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'issuer_requires_generated_key',
+      });
+      expect(payload.next[0].command).toContain('kms add-key iss_test');
+    });
+  });
+
+  it('reports a missing issuer', async () => {
+    useUser();
+    useIssuerNotFound('iss_missing');
+    client.setArgv(
+      'kms',
+      'import-key',
+      'iss_missing',
+      '--key',
+      'private-key.pem'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Issuer not found: iss_missing.');
+  });
+});

--- a/packages/cli/test/unit/commands/kms/import.test.ts
+++ b/packages/cli/test/unit/commands/kms/import.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useCreateIssuer, useKmsError } from '../../../mocks/kms';
+
+// The CLI only checks that the file looks like PEM; the API validates the key.
+const PEM = '-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n';
+
+describe('kms import', () => {
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'kms-import-'));
+    writeFileSync(join(dir, 'private-key.pem'), PEM);
+    client.cwd = dir;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'import', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:import' },
+      ]);
+    });
+  });
+
+  it('imports an issuer and says later keys are imported too', async () => {
+    useUser();
+    useCreateIssuer();
+    client.setArgv('kms', 'import', 'my-issuer', '--key', 'private-key.pem');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('my-issuer');
+    expect(stderr).toContain('external');
+    expect(stderr).toContain('kms import-key');
+    expect(stderr).toContain('kms add-grant');
+  });
+
+  it('reads the key from stdin', async () => {
+    useUser();
+    useCreateIssuer();
+    client.stdin.isTTY = false;
+    client.stdin.end(PEM);
+    client.setArgv('kms', 'import', 'my-issuer', '--key', '-');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('my-issuer');
+  });
+
+  it('requires a key', async () => {
+    useUser();
+    client.setArgv('kms', 'import', 'my-issuer');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('A private key is required.');
+  });
+
+  it('rejects a key path that does not exist', async () => {
+    useUser();
+    client.setArgv('kms', 'import', 'my-issuer', '--key', 'missing-key.pem');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput("Couldn't read --key file");
+  });
+
+  it('rejects a file that is not PEM', async () => {
+    useUser();
+    writeFileSync(join(client.cwd, 'not-a-key.txt'), 'hello');
+    client.setArgv('kms', 'import', 'my-issuer', '--key', 'not-a-key.txt');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      '--key must be a PEM-encoded private key'
+    );
+  });
+
+  it('rejects an unsupported algorithm before reading the key', async () => {
+    useUser();
+    client.setArgv(
+      'kms',
+      'import',
+      'my-issuer',
+      '--key',
+      'private-key.pem',
+      '--algorithm',
+      'HS256'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid algorithm "HS256"');
+  });
+
+  it('sends the JWKS kid through and keeps the key material out of telemetry', async () => {
+    useUser();
+    useCreateIssuer();
+    client.setArgv(
+      'kms',
+      'import',
+      'my-issuer',
+      '--key',
+      'private-key.pem',
+      '--key-id',
+      'kid-1',
+      '--algorithm',
+      'RS256'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('kid-1');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:import', value: 'import' },
+      { key: 'argument:name', value: '[REDACTED]' },
+      { key: 'option:key', value: '[REDACTED]' },
+      { key: 'option:key-id', value: '[REDACTED]' },
+      { key: 'option:algorithm', value: 'RS256' },
+    ]);
+  });
+
+  describe('non-interactive', () => {
+    it('emits an agent payload when the key is missing', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'import', 'my-issuer');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_key',
+      });
+    });
+
+    it('emits a success payload with the grant follow-up', async () => {
+      useUser();
+      useCreateIssuer();
+      client.nonInteractive = true;
+      client.setArgv('kms', 'import', 'my-issuer', '--key', 'private-key.pem');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload.status).toBe('ok');
+      expect(payload.issuer.origin).toBe('external');
+      expect(payload.next[0].command).toContain('kms add-grant');
+    });
+  });
+
+  it('surfaces a key the API rejects', async () => {
+    useUser();
+    useKmsError(
+      { method: 'post', path: '/v1/kms/issuers' },
+      400,
+      'invalid_signing_key_algorithm',
+      'algorithm is required when it cannot be derived from privateKey'
+    );
+    client.setArgv('kms', 'import', 'my-issuer', '--key', 'private-key.pem');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('algorithm is required');
+  });
+});

--- a/packages/cli/test/unit/commands/kms/index.test.ts
+++ b/packages/cli/test/unit/commands/kms/index.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import * as ls from '../../../../src/commands/kms/ls';
+import { client } from '../../../mocks/client';
+
+describe('kms', () => {
+  const lsSpy = vi.spyOn(ls, 'default').mockResolvedValue(0);
+
+  afterEach(() => {
+    lsSpy.mockClear();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'kms';
+
+      client.setArgv(command, '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: command,
+        },
+      ]);
+    });
+  });
+
+  it('routes to ls by default', async () => {
+    client.setArgv('kms');
+    await kms(client);
+    expect(lsSpy).toHaveBeenCalledWith(client, []);
+  });
+
+  it('routes create and import to separate subcommands', async () => {
+    client.setArgv('kms', 'import', '--help');
+    await expect(kms(client)).resolves.toEqual(2);
+    expect(lsSpy).not.toHaveBeenCalled();
+    await expect(client.stderr).toOutput('kms import');
+  });
+
+  it('rejects an unrecognized subcommand instead of listing', async () => {
+    client.setArgv('kms', 'not-a-command');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(2);
+    expect(lsSpy).not.toHaveBeenCalled();
+    await expect(client.stderr).toOutput('Please specify a valid subcommand');
+  });
+});

--- a/packages/cli/test/unit/commands/kms/inspect.test.ts
+++ b/packages/cli/test/unit/commands/kms/inspect.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import {
+  createProjectGrant,
+  createSigningKey,
+  useIssuer,
+  useIssuerNotFound,
+} from '../../../mocks/kms';
+
+describe('kms inspect', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'inspect', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:inspect' },
+      ]);
+    });
+  });
+
+  it('shows the issuer, its keys, and its grants', async () => {
+    useUser();
+    useIssuer('iss_test', {
+      signingKeys: [createSigningKey({ issuerId: 'iss_test', keyId: 'key_1' })],
+      policies: [createProjectGrant({ projectId: 'prj_1' })],
+    });
+    client.setArgv('kms', 'inspect', 'iss_test');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('iss_test');
+    expect(stderr).toContain('key_1');
+    expect(stderr).toContain('prj_1');
+  });
+
+  it('does not claim an issuer has no grants when they are hidden', async () => {
+    useUser();
+    useIssuer('iss_test', { policies: [] });
+    client.setArgv('kms', 'inspect', 'iss_test');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('No grants visible');
+  });
+
+  it('tracks the redacted issuer ID', async () => {
+    useUser();
+    useIssuer('iss_test');
+    client.setArgv('kms', 'inspect', 'iss_test');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:inspect', value: 'inspect' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('reports a missing issuer', async () => {
+    useUser();
+    useIssuerNotFound('iss_missing');
+    client.setArgv('kms', 'inspect', 'iss_missing');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Issuer not found: iss_missing.');
+  });
+
+  describe('--format json', () => {
+    it('writes the issuer to stdout', async () => {
+      useUser();
+      useIssuer('iss_test');
+      client.setArgv('kms', 'inspect', 'iss_test', '--format', 'json');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({ id: 'iss_test', algorithm: 'RS256' });
+    });
+  });
+
+  describe('non-interactive', () => {
+    it('emits an agent payload when the issuer ID is missing', async () => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'inspect');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'missing_issuer_id',
+      });
+      expect(payload.next[1].command).toBe('vercel kms inspect <issuerId>');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/kms/ls.test.ts
+++ b/packages/cli/test/unit/commands/kms/ls.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useIssuers, useKmsError } from '../../../mocks/kms';
+
+describe('kms ls', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'ls', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'kms:ls',
+        },
+      ]);
+    });
+  });
+
+  it('lists issuers', async () => {
+    useUser();
+    useIssuers(3);
+    client.setArgv('kms', 'ls');
+    const exitCode = await kms(client);
+    expect(exitCode, 'exit code for "kms ls"').toEqual(0);
+    await expect(client.stderr).toOutput('3 issuers found');
+  });
+
+  it('tracks the subcommand and its options', async () => {
+    useUser();
+    useIssuers(1);
+    client.setArgv('kms', 'ls', '--limit', '5', '--format', 'json');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:list', value: 'ls' },
+      { key: 'option:format', value: 'json' },
+      { key: 'option:limit', value: '5' },
+    ]);
+  });
+
+  it('points at the next page when the API returns a cursor', async () => {
+    useUser();
+    useIssuers(2, 'Y3Vyc29y');
+    client.setArgv('kms', 'ls');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('--next Y3Vyc29y');
+  });
+
+  it('suggests creating an issuer when there are none', async () => {
+    useUser();
+    useIssuers(0);
+    client.setArgv('kms', 'ls');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('No issuers found');
+  });
+
+  describe('--format json', () => {
+    it('writes issuers and pagination to stdout', async () => {
+      useUser();
+      useIssuers(2);
+      client.setArgv('kms', 'ls', '--format', 'json');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload.issuers).toHaveLength(2);
+      expect(payload.pagination).toMatchObject({ count: 2 });
+    });
+  });
+
+  describe('non-interactive', () => {
+    it('emits an agent payload with a plain next command', async () => {
+      useUser();
+      useIssuers(0);
+      client.nonInteractive = true;
+      client.setArgv('kms', 'ls');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'ok',
+        issuers: [],
+        message: '0 issuers found.',
+      });
+      expect(payload.next[0].command).toBe('vercel kms inspect <issuerId>');
+    });
+  });
+
+  it('explains a 403 as a permissions problem', async () => {
+    useUser();
+    useKmsError(
+      { method: 'get', path: '/v1/kms/issuers' },
+      403,
+      'forbidden',
+      'Not authorized'
+    );
+    client.setArgv('kms', 'ls');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('requires the Owner role');
+  });
+});

--- a/packages/cli/test/unit/commands/kms/revoke-key.test.ts
+++ b/packages/cli/test/unit/commands/kms/revoke-key.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import {
+  createSigningKey,
+  useIssuer,
+  useRevokeSigningKey,
+} from '../../../mocks/kms';
+
+function useRevokingIssuer(issuerId: string, keyId: string) {
+  return useIssuer(issuerId, {
+    signingKeys: [
+      createSigningKey({
+        issuerId,
+        keyId,
+        status: 'revoking',
+        revokeAt: new Date(Date.now() + 3_600_000).toISOString(),
+      }),
+    ],
+  });
+}
+
+describe('kms revoke-key', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'revoke-key', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:revoke-key' },
+      ]);
+    });
+  });
+
+  it('revokes a key that is already retiring', async () => {
+    useUser();
+    useRevokingIssuer('iss_test', 'key_old');
+    useRevokeSigningKey('iss_test', 'key_old');
+    client.setArgv('kms', 'revoke-key', 'iss_test', 'key_old', '--yes');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Revoked');
+  });
+
+  it('confirms before revoking', async () => {
+    useUser();
+    useRevokingIssuer('iss_test', 'key_old');
+    useRevokeSigningKey('iss_test', 'key_old');
+    client.setArgv('kms', 'revoke-key', 'iss_test', 'key_old');
+    const exitCodePromise = kms(client);
+    await expect(client.stderr).toOutput('Revoke');
+    client.stdin.write('y\n');
+    await expect(exitCodePromise).resolves.toEqual(0);
+  });
+
+  it('refuses to revoke an active key', async () => {
+    useUser();
+    useIssuer('iss_test', {
+      signingKeys: [createSigningKey({ issuerId: 'iss_test', keyId: 'key_1' })],
+    });
+    client.setArgv('kms', 'revoke-key', 'iss_test', 'key_1', '--yes');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('not scheduled for revocation');
+  });
+
+  it('reports a key that is not on the issuer', async () => {
+    useUser();
+    useIssuer('iss_test');
+    client.setArgv('kms', 'revoke-key', 'iss_test', 'key_missing', '--yes');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Key not found: key_missing');
+  });
+
+  describe('non-interactive', () => {
+    it('requires --yes', async () => {
+      useUser();
+      useRevokingIssuer('iss_test', 'key_old');
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'revoke-key', 'iss_test', 'key_old');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'confirmation_required',
+      });
+    });
+
+    it('emits a success payload with --yes', async () => {
+      useUser();
+      useRevokingIssuer('iss_test', 'key_old');
+      useRevokeSigningKey('iss_test', 'key_old');
+      client.nonInteractive = true;
+      client.setArgv('kms', 'revoke-key', 'iss_test', 'key_old', '--yes');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({ status: 'ok' });
+      expect(payload.message).toContain('key_old');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/kms/rm-grant.test.ts
+++ b/packages/cli/test/unit/commands/kms/rm-grant.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import {
+  createProjectGrant,
+  useDeleteProjectGrant,
+  useIssuer,
+  useKmsError,
+} from '../../../mocks/kms';
+
+describe('kms rm-grant', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'rm-grant', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:rm-grant' },
+      ]);
+    });
+  });
+
+  it('removes a grant after confirmation', async () => {
+    useUser();
+    useIssuer('iss_test', {
+      policies: [createProjectGrant({ projectId: 'prj_1' })],
+    });
+    useDeleteProjectGrant('iss_test', 'prj_1');
+    client.setArgv('kms', 'rm-grant', 'iss_test', 'prj_1');
+    const exitCodePromise = kms(client);
+    await expect(client.stderr).toOutput('Remove');
+    client.stdin.write('y\n');
+    await expect(exitCodePromise).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Removed');
+  });
+
+  it('skips the prompt with --yes and tracks the flag', async () => {
+    useUser();
+    useDeleteProjectGrant('iss_test', 'prj_1');
+    client.setArgv('kms', 'rm-grant', 'iss_test', 'prj_1', '--yes');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:remove-grant', value: 'rm-grant' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+      { key: 'argument:projectId', value: '[REDACTED]' },
+      { key: 'flag:yes', value: 'TRUE' },
+    ]);
+  });
+
+  it('reports a project that has no grant on the issuer', async () => {
+    useUser();
+    useIssuer('iss_test', { policies: [] });
+    client.setArgv('kms', 'rm-grant', 'iss_test', 'prj_missing');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'No grant for project prj_missing on issuer iss_test.'
+    );
+  });
+
+  it('explains a 403 as a permissions problem', async () => {
+    useUser();
+    useKmsError(
+      {
+        method: 'delete',
+        path: '/v1/kms/issuers/iss_test/policies/project-grant/prj_1',
+      },
+      403,
+      'forbidden',
+      'Not authorized'
+    );
+    client.setArgv('kms', 'rm-grant', 'iss_test', 'prj_1', '--yes');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('requires the Owner role');
+  });
+
+  describe('non-interactive', () => {
+    it('requires --yes', async () => {
+      useUser();
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'rm-grant', 'iss_test', 'prj_1');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'confirmation_required',
+      });
+    });
+
+    it('emits a success payload with --yes', async () => {
+      useUser();
+      useDeleteProjectGrant('iss_test', 'prj_1');
+      client.nonInteractive = true;
+      client.setArgv('kms', 'rm-grant', 'iss_test', 'prj_1', '--yes');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'ok',
+        grant: { issuerId: 'iss_test', projectId: 'prj_1' },
+      });
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/kms/rm.test.ts
+++ b/packages/cli/test/unit/commands/kms/rm.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import {
+  useDeleteIssuer,
+  useIssuer,
+  useIssuerForbidden,
+} from '../../../mocks/kms';
+
+describe('kms rm', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'rm', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:rm' },
+      ]);
+    });
+  });
+
+  it('confirms before deleting', async () => {
+    useUser();
+    useIssuer('iss_test', { name: 'my-issuer' });
+    useDeleteIssuer('iss_test');
+    client.setArgv('kms', 'rm', 'iss_test');
+    const exitCodePromise = kms(client);
+    await expect(client.stderr).toOutput('Delete');
+    client.stdin.write('y\n');
+    await expect(exitCodePromise).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Removed');
+  });
+
+  it('cancels when the prompt is declined', async () => {
+    useUser();
+    useIssuer('iss_test');
+    client.setArgv('kms', 'rm', 'iss_test');
+    const exitCodePromise = kms(client);
+    await expect(client.stderr).toOutput('Delete');
+    client.stdin.write('n\n');
+    await expect(exitCodePromise).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('Canceled');
+  });
+
+  it('skips the prompt with --yes and tracks the flag', async () => {
+    useUser();
+    useIssuer('iss_test');
+    useDeleteIssuer('iss_test');
+    client.setArgv('kms', 'rm', 'iss_test', '--yes');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:remove', value: 'rm' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+      { key: 'flag:yes', value: 'TRUE' },
+    ]);
+  });
+
+  it('explains a 403 as a permissions problem', async () => {
+    useUser();
+    useIssuer('iss_test');
+    useIssuerForbidden('iss_test');
+    client.setArgv('kms', 'rm', 'iss_test', '--yes');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('requires the Owner role');
+  });
+
+  describe('non-interactive', () => {
+    it('requires --yes', async () => {
+      useUser();
+      useIssuer('iss_test');
+      vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.nonInteractive = true;
+      client.setArgv('kms', 'rm', 'iss_test');
+      await expect(kms(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'confirmation_required',
+      });
+      expect(payload.next[0].command).toBe('vercel kms rm iss_test --yes');
+    });
+
+    it('emits a success payload with --yes', async () => {
+      useUser();
+      useIssuer('iss_test', { name: 'my-issuer' });
+      useDeleteIssuer('iss_test');
+      client.nonInteractive = true;
+      client.setArgv('kms', 'rm', 'iss_test', '--yes');
+      const exitCode = await kms(client);
+      expect(exitCode).toEqual(0);
+
+      const payload = JSON.parse(client.stdout.getFullOutput());
+      expect(payload).toMatchObject({
+        status: 'ok',
+        issuer: { id: 'iss_test', name: 'my-issuer' },
+      });
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/kms/update-grant.test.ts
+++ b/packages/cli/test/unit/commands/kms/update-grant.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useKmsError, useUpdateProjectGrant } from '../../../mocks/kms';
+
+describe('kms update-grant', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'update-grant', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:update-grant' },
+      ]);
+    });
+  });
+
+  it('narrows a grant to one environment', async () => {
+    useUser();
+    useUpdateProjectGrant('iss_test', 'prj_1');
+    client.setArgv(
+      'kms',
+      'update-grant',
+      'iss_test',
+      'prj_1',
+      '--environment',
+      'production'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Updated');
+    expect(stderr).toContain('production');
+  });
+
+  it('clears token claims with --remove-token-claims', async () => {
+    useUser();
+    useUpdateProjectGrant('iss_test', 'prj_1');
+    client.setArgv(
+      'kms',
+      'update-grant',
+      'iss_test',
+      'prj_1',
+      '--remove-token-claims'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:update-grant', value: 'update-grant' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+      { key: 'argument:projectId', value: '[REDACTED]' },
+      { key: 'flag:remove-token-claims', value: 'TRUE' },
+    ]);
+  });
+
+  it('rejects conflicting token-claims flags', async () => {
+    useUser();
+    client.setArgv(
+      'kms',
+      'update-grant',
+      'iss_test',
+      'prj_1',
+      '--token-claims',
+      '{}',
+      '--remove-token-claims'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      '--token-claims and --remove-token-claims conflict'
+    );
+  });
+
+  it('requires at least one change', async () => {
+    useUser();
+    client.setArgv('kms', 'update-grant', 'iss_test', 'prj_1');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Nothing to update');
+  });
+
+  it('reports a grant that does not exist', async () => {
+    useUser();
+    useKmsError(
+      {
+        method: 'patch',
+        path: '/v1/kms/issuers/iss_test/policies/project-grant/prj_missing',
+      },
+      404,
+      'not_found',
+      'Policy not found'
+    );
+    client.setArgv(
+      'kms',
+      'update-grant',
+      'iss_test',
+      'prj_missing',
+      '--environment',
+      'production'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      "Couldn't find a grant for project prj_missing"
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/kms/update.test.ts
+++ b/packages/cli/test/unit/commands/kms/update.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import kms from '../../../../src/commands/kms';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useManagedIssuerRejection, useUpdateIssuer } from '../../../mocks/kms';
+
+describe('kms update', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('kms', 'update', '--help');
+      const exitCodePromise = kms(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:help', value: 'kms:update' },
+      ]);
+    });
+  });
+
+  it('renames an issuer', async () => {
+    useUser();
+    useUpdateIssuer('iss_test');
+    client.setArgv('kms', 'update', 'iss_test', '--name', 'renamed');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('renamed');
+  });
+
+  it('clears the claims schema with --remove-claims-schema', async () => {
+    useUser();
+    useUpdateIssuer('iss_test', { claimsSchema: { type: 'object' } });
+    client.setArgv('kms', 'update', 'iss_test', '--remove-claims-schema');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:update', value: 'update' },
+      { key: 'argument:issuerId', value: '[REDACTED]' },
+      { key: 'flag:remove-claims-schema', value: 'TRUE' },
+    ]);
+  });
+
+  it('rejects conflicting claims-schema flags', async () => {
+    useUser();
+    client.setArgv(
+      'kms',
+      'update',
+      'iss_test',
+      '--claims-schema',
+      '{}',
+      '--remove-claims-schema'
+    );
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      '--claims-schema and --remove-claims-schema conflict'
+    );
+  });
+
+  it('requires at least one change', async () => {
+    useUser();
+    client.setArgv('kms', 'update', 'iss_test');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Nothing to update');
+  });
+
+  it('explains that a managed issuer cannot be changed here', async () => {
+    useUser();
+    useManagedIssuerRejection('iss_managed');
+    client.setArgv('kms', 'update', 'iss_managed', '--name', 'renamed');
+    const exitCode = await kms(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'provisioned by another Vercel service'
+    );
+  });
+});


### PR DESCRIPTION
## Why

- Managing KMS issuers, signing keys, and project grants currently means hand-written calls to the KMS API. This adds `vercel kms` (beta) so teams and agents can provision and rotate them from the CLI. Signing stays out of scope: this is management only.
- An issuer's key material is fixed when the issuer is created — the API takes imported keys only for issuers created from an imported key, and generated keys only for the rest. So generating and importing are separate commands rather than one command with an `--import-key` flag, which also lets `--algorithm` document itself accurately (defaults to RS512 when generating; required for RSA keys when importing, otherwise derived from the key).

## Commands

| Command | Purpose |
| --- | --- |
| `kms ls`, `kms inspect` | List issuers; show one with its keys and grants |
| `kms add`, `kms import` | Create an issuer with a generated key, or from your own key |
| `kms update`, `kms rm` | Rename or retire an issuer |
| `kms add-key`, `kms import-key` | Rotate to a new generated or imported key |
| `kms activate-key`, `kms revoke-key` | Promote a staged key; end a retiring key's grace period |
| `kms add-grant`, `kms update-grant`, `kms rm-grant` | Let a project sign with an issuer |

## Validation

- The key commands resolve the issuer before mutating and refuse an origin mismatch locally, naming the command that works, instead of passing through the API's 400.
- Private keys are read only from a file path or stdin, never from argv; key material, issuer names, and claim payloads are redacted in telemetry.
- `rm`, `revoke-key`, and `rm-grant` require an interactive confirmation or `--yes`, and emit `confirmation_required` for non-interactive callers rather than proceeding.
- Non-interactive runs emit structured payloads with a `next` command for every failure path, exercised in the unit tests for each subcommand.

Made with [Cursor](https://cursor.com)