### PR TITLE
[flags] Guard destructive flag operations

### DIFF
--- a/.changeset/safe-flag-deletion.md
+++ b/.changeset/safe-flag-deletion.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add safety checks (no production usage) for `vercel flags archive` and `vercel flags rm`. Checks can be overridden with `--dangerously-force`.

--- a/packages/cli/src/commands/flags/archive.ts
+++ b/packages/cli/src/commands/flags/archive.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import stripAnsi from 'strip-ansi';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -10,6 +11,13 @@ import output from '../../output-manager';
 import { FlagsArchiveTelemetryClient } from '../../util/telemetry/commands/flags/archive';
 import { archiveSubcommand } from './command';
 import { getLinkedFlagsProject, getProjectNameFromFlags } from './project';
+import {
+  buildFlagSafetyRetryCommand,
+  formatFlagSafetyFailure,
+  getFlagSafetyBlockers,
+} from '../../util/flags/safety-check';
+import { outputAgentError } from '../../util/agent-output';
+import { AGENT_STATUS } from '../../util/agent-output-constants';
 
 export default async function archive(
   client: Client,
@@ -33,6 +41,7 @@ export default async function archive(
   const { args, flags } = parsedArgs;
   const [flagArg] = args;
   const skipConfirmation = flags['--yes'] as boolean | undefined;
+  const dangerouslyForce = flags['--dangerously-force'] as boolean | undefined;
   const projectName = getProjectNameFromFlags(flags);
 
   if (!flagArg) {
@@ -44,6 +53,7 @@ export default async function archive(
   telemetryClient.trackCliArgumentFlag(flagArg);
   telemetryClient.trackCliOptionProject(projectName);
   telemetryClient.trackCliFlagYes(skipConfirmation);
+  telemetryClient.trackCliFlagDangerouslyForce(dangerouslyForce);
 
   const link = await getLinkedFlagsProject(client, projectName);
   if (link.status === 'error') {
@@ -71,6 +81,47 @@ export default async function archive(
       return 0;
     }
 
+    let blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: project.id,
+      ownerId: link.org.id,
+      slug: flag.slug,
+    });
+
+    if (blockers.length && !dangerouslyForce) {
+      const retryCmd = buildFlagSafetyRetryCommand({
+        client,
+        operation: 'archive',
+        slug: flag.slug,
+        includeYes: Boolean(skipConfirmation || client.nonInteractive),
+      });
+
+      const errorMessage = formatFlagSafetyFailure({
+        flagName: chalk.bold(flag.slug),
+        operation: 'archive',
+        blockers,
+        retryCommand: retryCmd,
+      });
+
+      if (client.nonInteractive) {
+        outputAgentError(client, {
+          status: AGENT_STATUS.ERROR,
+          reason: 'production_safety_check_failed',
+          message: stripAnsi(errorMessage),
+          next: [
+            {
+              command: retryCmd,
+              when: 'override the production safety check',
+            },
+          ],
+        });
+        return 1;
+      }
+
+      output.error(errorMessage);
+      return 1;
+    }
+
     // Confirm archival
     if (!skipConfirmation) {
       if (!client.stdin.isTTY) {
@@ -89,6 +140,40 @@ export default async function archive(
         output.log('Aborted');
         return 0;
       }
+
+      // Recheck safety after interactive confirmation to catch race conditions
+      blockers = await getFlagSafetyBlockers({
+        client,
+        projectId: project.id,
+        ownerId: link.org.id,
+        slug: flag.slug,
+      });
+
+      if (blockers.length && !dangerouslyForce) {
+        const retryCmd = buildFlagSafetyRetryCommand({
+          client,
+          operation: 'archive',
+          slug: flag.slug,
+          includeYes: false,
+        });
+
+        output.error(
+          formatFlagSafetyFailure({
+            flagName: chalk.bold(flag.slug),
+            operation: 'archive',
+            blockers,
+            retryCommand: retryCmd,
+            detectedAfterConfirmation: true,
+          })
+        );
+        return 1;
+      }
+    }
+
+    if (blockers.length) {
+      output.warn(
+        `Archiving ${chalk.bold(flag.slug)} despite production activity because --dangerously-force was provided.`
+      );
     }
 
     // Archive the flag by setting state to 'archived'

--- a/packages/cli/src/commands/flags/command.ts
+++ b/packages/cli/src/commands/flags/command.ts
@@ -1027,6 +1027,15 @@ export const rulesSubcommand = {
   examples: [],
 } as const;
 
+const dangerouslyForceOption = {
+  name: 'dangerously-force',
+  shorthand: null,
+  type: Boolean,
+  deprecated: false,
+  description:
+    'Bypass production activity and deployment-reference safety checks',
+} as const;
+
 export const removeSubcommand = {
   name: 'remove',
   aliases: ['rm'],
@@ -1043,6 +1052,7 @@ export const removeSubcommand = {
       ...yesOption,
       description: 'Skip the confirmation prompt when deleting a flag',
     },
+    dangerouslyForceOption,
   ],
   examples: [
     {
@@ -1052,6 +1062,10 @@ export const removeSubcommand = {
     {
       name: 'Delete without confirmation',
       value: `${packageName} flags rm my-feature-flag --yes`,
+    },
+    {
+      name: 'DANGER: bypass safety checks and delete the flag',
+      value: `${packageName} flags rm my-feature-flag --yes --dangerously-force`,
     },
   ],
 } as const;
@@ -1072,6 +1086,7 @@ export const archiveSubcommand = {
       ...yesOption,
       description: 'Skip the confirmation prompt when archiving a flag',
     },
+    dangerouslyForceOption,
   ],
   examples: [
     {
@@ -1081,6 +1096,10 @@ export const archiveSubcommand = {
     {
       name: 'Archive without confirmation',
       value: `${packageName} flags archive my-feature-flag --yes`,
+    },
+    {
+      name: 'DANGER: bypass safety checks and archive the flag',
+      value: `${packageName} flags archive my-feature-flag --yes --dangerously-force`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/flags/rm.ts
+++ b/packages/cli/src/commands/flags/rm.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import stripAnsi from 'strip-ansi';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -10,6 +11,13 @@ import output from '../../output-manager';
 import { FlagsRmTelemetryClient } from '../../util/telemetry/commands/flags/rm';
 import { removeSubcommand } from './command';
 import { getLinkedFlagsProject, getProjectNameFromFlags } from './project';
+import {
+  buildFlagSafetyRetryCommand,
+  formatFlagSafetyFailure,
+  getFlagSafetyBlockers,
+} from '../../util/flags/safety-check';
+import { outputAgentError } from '../../util/agent-output';
+import { AGENT_STATUS } from '../../util/agent-output-constants';
 
 export default async function rm(
   client: Client,
@@ -33,6 +41,7 @@ export default async function rm(
   const { args, flags } = parsedArgs;
   const [flagArg] = args;
   const skipConfirmation = flags['--yes'] as boolean | undefined;
+  const dangerouslyForce = flags['--dangerously-force'] as boolean | undefined;
   const projectName = getProjectNameFromFlags(flags);
 
   if (!flagArg) {
@@ -44,6 +53,7 @@ export default async function rm(
   telemetryClient.trackCliArgumentFlag(flagArg);
   telemetryClient.trackCliOptionProject(projectName);
   telemetryClient.trackCliFlagYes(skipConfirmation);
+  telemetryClient.trackCliFlagDangerouslyForce(dangerouslyForce);
 
   const link = await getLinkedFlagsProject(client, projectName);
   if (link.status === 'error') {
@@ -74,6 +84,47 @@ export default async function rm(
       return 1;
     }
 
+    let blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: project.id,
+      ownerId: link.org.id,
+      slug: flag.slug,
+    });
+
+    if (blockers.length && !dangerouslyForce) {
+      const retryCmd = buildFlagSafetyRetryCommand({
+        client,
+        operation: 'rm',
+        slug: flag.slug,
+        includeYes: Boolean(skipConfirmation || client.nonInteractive),
+      });
+
+      const errorMessage = formatFlagSafetyFailure({
+        flagName: chalk.bold(flag.slug),
+        operation: 'delete',
+        blockers,
+        retryCommand: retryCmd,
+      });
+
+      if (client.nonInteractive) {
+        outputAgentError(client, {
+          status: AGENT_STATUS.ERROR,
+          reason: 'production_safety_check_failed',
+          message: stripAnsi(errorMessage),
+          next: [
+            {
+              command: retryCmd,
+              when: 'override the production safety check',
+            },
+          ],
+        });
+        return 1;
+      }
+
+      output.error(errorMessage);
+      return 1;
+    }
+
     // Confirm deletion
     if (!skipConfirmation) {
       if (!client.stdin.isTTY) {
@@ -92,6 +143,40 @@ export default async function rm(
         output.log('Aborted');
         return 0;
       }
+
+      // Recheck safety after interactive confirmation to catch race conditions
+      blockers = await getFlagSafetyBlockers({
+        client,
+        projectId: project.id,
+        ownerId: link.org.id,
+        slug: flag.slug,
+      });
+
+      if (blockers.length && !dangerouslyForce) {
+        const retryCmd = buildFlagSafetyRetryCommand({
+          client,
+          operation: 'rm',
+          slug: flag.slug,
+          includeYes: false,
+        });
+
+        output.error(
+          formatFlagSafetyFailure({
+            flagName: chalk.bold(flag.slug),
+            operation: 'delete',
+            blockers,
+            retryCommand: retryCmd,
+            detectedAfterConfirmation: true,
+          })
+        );
+        return 1;
+      }
+    }
+
+    if (blockers.length) {
+      output.warn(
+        `Deleting ${chalk.bold(flag.slug)} despite production activity because --dangerously-force was provided. This action cannot be undone.`
+      );
     }
 
     // Delete the flag

--- a/packages/cli/src/util/flags/safety-check.ts
+++ b/packages/cli/src/util/flags/safety-check.ts
@@ -1,0 +1,247 @@
+import type Client from '../client';
+import { buildCommandWithGlobalFlags } from '../agent-output';
+import { quoteArg } from './quote-arg';
+import type {
+  MetricsQueryResponse,
+  ProjectScope,
+} from '../../commands/metrics/types';
+
+const METRICS_URL = 'https://vercel.com/api/observability/metrics';
+const EVALUATION_ROLLUP = 'vercel_flag_evaluation_flag_evaluations_sum';
+const LOOKBACK_HOURS = 72;
+
+type FlagSafetyBlockerKind =
+  | 'evaluations'
+  | 'evaluations-unavailable'
+  | 'reference'
+  | 'reference-unavailable';
+
+export type FlagSafetyBlocker = {
+  kind: FlagSafetyBlockerKind;
+  message: string;
+};
+
+function metricsUrl(ownerId: string): string {
+  const url = new URL(
+    process.env.VERCEL_FLAG_EVALUATIONS_API_URL || METRICS_URL
+  );
+  url.searchParams.set('ownerId', ownerId);
+  return url.href;
+}
+
+async function productionEvaluationBlocker(
+  client: Client,
+  projectId: string,
+  ownerId: string,
+  slug: string
+): Promise<FlagSafetyBlocker | undefined> {
+  // Calculate exactly 72 hours back from a single aligned boundary
+  const now = Date.now();
+  const alignedEnd = Math.ceil(now / 3_600_000) * 3_600_000;
+  const startTime = new Date(alignedEnd - LOOKBACK_HOURS * 3_600_000);
+  const endTime = new Date(alignedEnd);
+  const scope: ProjectScope = {
+    type: 'project',
+    ownerId,
+    projectIds: [projectId],
+  };
+
+  try {
+    const response = await client.fetch<MetricsQueryResponse>(
+      metricsUrl(ownerId),
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          scope,
+          // The metrics API currently accepts this registered query reason.
+          reason: 'flag_evaluation_chart',
+          event: 'flagEvaluation',
+          rollups: {
+            [EVALUATION_ROLLUP]: {
+              measure: 'flagEvaluations',
+              aggregation: 'sum',
+            },
+          },
+          granularity: { hours: 1 },
+          // Request one ungrouped total. A grouped, limited response can omit
+          // variants and make a destructive-operation warning undercount.
+          groupBy: [],
+          summaryOnly: true,
+          filter:
+            `flagKey eq '${slug.replace(/'/g, "''")}' and ` +
+            "(environment eq 'production' or sdkKeyEnvironment eq 'production')",
+          startTime: startTime.toISOString(),
+          endTime: endTime.toISOString(),
+        }),
+        headers: { 'Content-Type': 'application/json' },
+        useCurrentTeam: false,
+        bailOn429: true,
+      }
+    );
+    const count = response.summary.reduce((total, row) => {
+      const value = row[EVALUATION_ROLLUP];
+      if (typeof value === 'number') {
+        return total + value;
+      }
+      // Handle numeric strings that the metrics API sometimes returns
+      if (typeof value === 'string') {
+        const parsed = Number(value);
+        return total + (Number.isFinite(parsed) ? parsed : 0);
+      }
+      return total;
+    }, 0);
+    return count
+      ? {
+          kind: 'evaluations',
+          message: `${count} production evaluation${count === 1 ? '' : 's'} in the last ${LOOKBACK_HOURS} hours`,
+        }
+      : undefined;
+  } catch {
+    return {
+      kind: 'evaluations-unavailable',
+      message: 'could not verify production evaluation activity',
+    };
+  }
+}
+
+async function productionReferenceBlocker(
+  client: Client,
+  projectId: string,
+  slug: string
+): Promise<FlagSafetyBlocker | undefined> {
+  try {
+    // This endpoint identifies the deployment currently serving Production,
+    // unlike the deployment-list endpoint which only returns historical targets.
+    const { deployment } = await client.fetch<{
+      deployment: { id: string } | null;
+    }>(`/projects/${encodeURIComponent(projectId)}/production-deployment`);
+    if (!deployment?.id) {
+      return {
+        kind: 'reference-unavailable',
+        message: 'could not find the active production deployment',
+      };
+    }
+
+    const response = await client.fetch<{
+      flags?: Array<{ slug: string; projectMismatch?: boolean }>;
+      status?: { responseStatus: number } | null;
+    }>(`/v1/deployments/${encodeURIComponent(deployment.id)}/feature-flags`);
+
+    // `responseStatus` is the status of feature-flag discovery in the
+    // deployment sync. Missing status, null status, or non-200 status
+    // means discovery did not complete, so fail closed.
+    if (
+      !response.status ||
+      response.status.responseStatus !== 200 ||
+      !Array.isArray(response.flags)
+    ) {
+      return {
+        kind: 'reference-unavailable',
+        message:
+          'could not verify feature flag discovery status on the active production deployment',
+      };
+    }
+
+    return response.flags.some(
+      item => item.slug === slug && !item.projectMismatch
+    )
+      ? {
+          kind: 'reference',
+          message:
+            'the active production deployment still references this flag',
+        }
+      : undefined;
+  } catch {
+    return {
+      kind: 'reference-unavailable',
+      message: 'could not verify the active production deployment',
+    };
+  }
+}
+
+/** Returns reasons to stop a destructive flag operation; unavailable checks block. */
+export async function getFlagSafetyBlockers({
+  client,
+  projectId,
+  ownerId,
+  slug,
+}: {
+  client: Client;
+  projectId: string;
+  ownerId: string;
+  slug: string;
+}): Promise<FlagSafetyBlocker[]> {
+  const blockers = await Promise.all([
+    productionEvaluationBlocker(client, projectId, ownerId, slug),
+    productionReferenceBlocker(client, projectId, slug),
+  ]);
+  return blockers.filter((blocker): blocker is FlagSafetyBlocker =>
+    Boolean(blocker)
+  );
+}
+
+/** Explains the next safe action for the checks that blocked deletion. */
+export function getFlagSafetyRemediation(
+  blockers: FlagSafetyBlocker[]
+): string {
+  const kinds = new Set(blockers.map(blocker => blocker.kind));
+  const hasEvaluations = kinds.has('evaluations');
+  const hasReference = kinds.has('reference');
+
+  if (hasEvaluations && hasReference) {
+    return 'Remove this flag from your application code, deploy the change to Production, and wait for evaluation activity to stop, then try again.';
+  }
+  if (hasEvaluations) {
+    return 'Wait for Production evaluation activity to stop, then try again.';
+  }
+  if (hasReference) {
+    return 'Remove this flag from your application code and deploy the change to Production, then try again.';
+  }
+  return 'Resolve the Production safety-check issues above, then try again.';
+}
+
+/** Builds an actionable override command while retaining the caller's global context. */
+export function buildFlagSafetyRetryCommand({
+  client,
+  operation,
+  slug,
+  includeYes,
+}: {
+  client: Client;
+  operation: 'archive' | 'rm';
+  slug: string;
+  includeYes: boolean;
+}): string {
+  return buildCommandWithGlobalFlags(
+    client.argv,
+    `flags ${operation} ${quoteArg(slug)}${includeYes ? ' --yes' : ''} --dangerously-force`,
+    undefined,
+    { preserveProject: true }
+  );
+}
+
+/** Formats a consistent destructive-operation error from Production safety checks. */
+export function formatFlagSafetyFailure({
+  flagName,
+  operation,
+  blockers,
+  retryCommand,
+  detectedAfterConfirmation = false,
+}: {
+  flagName: string;
+  operation: 'archive' | 'delete';
+  blockers: FlagSafetyBlocker[];
+  retryCommand: string;
+  detectedAfterConfirmation?: boolean;
+}): string {
+  const state = detectedAfterConfirmation ? 'is now' : 'may still be';
+  const pastTenseOperation = operation === 'archive' ? 'archived' : 'deleted';
+
+  return [
+    `Flag ${flagName} ${state} in use in Production and can't be ${pastTenseOperation}.`,
+    ...blockers.map(blocker => `- ${blocker.message}`),
+    '',
+    getFlagSafetyRemediation(blockers),
+    `To override this check, rerun with ${retryCommand}`,
+  ].join('\n');
+}

--- a/packages/cli/src/util/telemetry/commands/flags/archive.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/archive.ts
@@ -15,4 +15,10 @@ export class FlagsArchiveTelemetryClient extends TelemetryClient {
       this.trackCliFlag('yes');
     }
   }
+
+  trackCliFlagDangerouslyForce(dangerouslyForce: boolean | undefined) {
+    if (dangerouslyForce) {
+      this.trackCliFlag('dangerously-force');
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/flags/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/flags/rm.ts
@@ -15,4 +15,10 @@ export class FlagsRmTelemetryClient extends TelemetryClient {
       this.trackCliFlag('yes');
     }
   }
+
+  trackCliFlagDangerouslyForce(dangerouslyForce: boolean | undefined) {
+    if (dangerouslyForce) {
+      this.trackCliFlag('dangerously-force');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/flags/archive.test.ts
+++ b/packages/cli/test/unit/commands/flags/archive.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { afterEach, describe, expect, it, beforeEach } from 'vitest';
 import flags from '../../../../src/commands/flags';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
@@ -94,9 +94,15 @@ function createTestFlags(): Flag[] {
 
 describe('flags archive', () => {
   let testFlags: Flag[];
+  let productionEvaluations: number;
 
   beforeEach(() => {
     testFlags = createTestFlags();
+    productionEvaluations = 0;
+    process.env.VERCEL_FLAG_EVALUATIONS_API_URL = new URL(
+      '/api/observability/metrics',
+      client.apiUrl
+    ).href;
     useUser();
     useTeams('team_dummy');
     useProject({
@@ -104,9 +110,38 @@ describe('flags archive', () => {
       id: 'vercel-flags-test',
       name: 'vercel-flags-test',
     });
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({
+        data: [],
+        summary: productionEvaluations
+          ? [
+              {
+                vercel_flag_evaluation_flag_evaluations_sum:
+                  productionEvaluations,
+              },
+            ]
+          : [],
+      });
+    });
+    client.scenario.get(
+      '/projects/vercel-flags-test/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: { id: 'dpl_active_production' } });
+      }
+    );
+    client.scenario.get(
+      '/v1/deployments/dpl_active_production/feature-flags',
+      (_req, res) => {
+        res.json({ flags: [], status: { responseStatus: 200 } });
+      }
+    );
     useFlags(testFlags);
     const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
     client.cwd = cwd;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_FLAG_EVALUATIONS_API_URL;
   });
 
   describe('--help', () => {
@@ -153,6 +188,47 @@ describe('flags archive', () => {
     expect(exitCode).toEqual(0);
   });
 
+  it('blocks archival when the flag has recent production evaluations', async () => {
+    productionEvaluations = 2;
+    client.setArgv('flags', 'archive', testFlags[0].slug, '--yes');
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '2 production evaluations in the last 72 hours'
+    );
+    expect(client.stderr.getFullOutput()).toContain(
+      'To override this check, rerun with vercel flags archive my-feature --yes --dangerously-force'
+    );
+  });
+
+  it('provides agents structured JSON output for safety blockers', async () => {
+    productionEvaluations = 2;
+    client.isAgent = true;
+    client.nonInteractive = true;
+    client.setArgv('flags', 'archive', testFlags[0].slug, '--yes');
+
+    const exitCode = await flags(client);
+    expect(exitCode).toEqual(1);
+
+    const payload = JSON.parse(client.stdout.getFullOutput());
+    // Note: stderr may contain progress messages before the agent error
+    expect(payload).toMatchObject({
+      status: 'error',
+      reason: 'production_safety_check_failed',
+      message: expect.stringContaining(
+        '2 production evaluations in the last 72 hours'
+      ),
+      next: [
+        {
+          command: 'vercel flags archive my-feature --yes --dangerously-force',
+          when: 'override the production safety check',
+        },
+      ],
+    });
+  });
+
   it('errors in non-interactive mode without --yes', async () => {
     (client.stdin as any).isTTY = false;
     client.setArgv('flags', 'archive', testFlags[0].slug);
@@ -185,5 +261,64 @@ describe('flags archive', () => {
     const exitCode = await flags(client);
     expect(exitCode).toEqual(0);
     expect(client.stderr.getFullOutput()).toContain('already archived');
+  });
+
+  it('uses warning gutter for forced override notices', async () => {
+    productionEvaluations = 2;
+    client.setArgv(
+      'flags',
+      'archive',
+      testFlags[0].slug,
+      '--yes',
+      '--dangerously-force'
+    );
+
+    const exitCode = await flags(client);
+    expect(exitCode).toEqual(0);
+    expect(client.stdout.getFullOutput()).not.toContain(
+      'Archiving my-feature despite production activity'
+    );
+    expect(client.stderr.getFullOutput()).toContain(
+      'Archiving my-feature despite production activity'
+    );
+  });
+
+  it('does not warn about a forced archive when confirmation is declined', async () => {
+    productionEvaluations = 2;
+    (client.stdin as any).isTTY = true;
+    client.input.confirm = async () => false;
+    client.setArgv(
+      'flags',
+      'archive',
+      testFlags[0].slug,
+      '--dangerously-force'
+    );
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(client.stderr.getFullOutput()).toContain('Aborted');
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Archiving my-feature despite production activity'
+    );
+  });
+
+  it('rechecks safety after interactive confirmation', async () => {
+    productionEvaluations = 0;
+    (client.stdin as any).isTTY = true;
+    client.input.confirm = async () => {
+      // Simulate evaluations starting during the confirmation prompt
+      productionEvaluations = 3;
+      return true;
+    };
+
+    client.setArgv('flags', 'archive', testFlags[0].slug);
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'is now in use in Production'
+    );
+    expect(client.stderr.getFullOutput()).toContain('3 production evaluations');
   });
 });

--- a/packages/cli/test/unit/commands/flags/rm.test.ts
+++ b/packages/cli/test/unit/commands/flags/rm.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { afterEach, describe, expect, it, beforeEach } from 'vitest';
 import flags from '../../../../src/commands/flags';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
@@ -55,9 +55,15 @@ function createTestFlags(): Flag[] {
 
 describe('flags rm', () => {
   let testFlags: Flag[];
+  let productionEvaluations: number;
 
   beforeEach(() => {
     testFlags = createTestFlags();
+    productionEvaluations = 0;
+    process.env.VERCEL_FLAG_EVALUATIONS_API_URL = new URL(
+      '/api/observability/metrics',
+      client.apiUrl
+    ).href;
     useUser();
     useTeams('team_dummy');
     useProject({
@@ -65,9 +71,38 @@ describe('flags rm', () => {
       id: 'vercel-flags-test',
       name: 'vercel-flags-test',
     });
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({
+        data: [],
+        summary: productionEvaluations
+          ? [
+              {
+                vercel_flag_evaluation_flag_evaluations_sum:
+                  productionEvaluations,
+              },
+            ]
+          : [],
+      });
+    });
+    client.scenario.get(
+      '/projects/vercel-flags-test/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: { id: 'dpl_active_production' } });
+      }
+    );
+    client.scenario.get(
+      '/v1/deployments/dpl_active_production/feature-flags',
+      (_req, res) => {
+        res.json({ flags: [], status: { responseStatus: 200 } });
+      }
+    );
     useFlags(testFlags);
     const cwd = setupUnitFixture('commands/flags/vercel-flags-test');
     client.cwd = cwd;
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_FLAG_EVALUATIONS_API_URL;
   });
 
   describe('--help', () => {
@@ -120,6 +155,49 @@ describe('flags rm', () => {
     expect(exitCode).toEqual(0);
   });
 
+  it('blocks deletion when the flag has recent production evaluations', async () => {
+    testFlags[0].state = 'archived';
+    productionEvaluations = 2;
+    client.setArgv('flags', 'rm', testFlags[0].slug, '--yes');
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      '2 production evaluations in the last 72 hours'
+    );
+    expect(client.stderr.getFullOutput()).toContain(
+      'To override this check, rerun with vercel flags rm my-feature --yes --dangerously-force'
+    );
+  });
+
+  it('provides agents structured JSON output for safety blockers', async () => {
+    testFlags[0].state = 'archived';
+    productionEvaluations = 2;
+    client.isAgent = true;
+    client.nonInteractive = true;
+    client.setArgv('flags', 'rm', testFlags[0].slug, '--yes');
+
+    const exitCode = await flags(client);
+    expect(exitCode).toEqual(1);
+
+    const payload = JSON.parse(client.stdout.getFullOutput());
+    // Note: stderr may contain progress messages before the agent error
+    expect(payload).toMatchObject({
+      status: 'error',
+      reason: 'production_safety_check_failed',
+      message: expect.stringContaining(
+        '2 production evaluations in the last 72 hours'
+      ),
+      next: [
+        {
+          command: 'vercel flags rm my-feature --yes --dangerously-force',
+          when: 'override the production safety check',
+        },
+      ],
+    });
+  });
+
   it('errors in non-interactive mode without --yes', async () => {
     testFlags[0].state = 'archived';
     (client.stdin as any).isTTY = false;
@@ -152,5 +230,65 @@ describe('flags rm', () => {
     const exitCode = await flags(client);
     expect(exitCode).toEqual(1);
     expect(client.stderr.getFullOutput()).toContain('Flag not found');
+  });
+
+  it('uses warning gutter for forced override notices', async () => {
+    testFlags[0].state = 'archived';
+    productionEvaluations = 2;
+    client.setArgv(
+      'flags',
+      'rm',
+      testFlags[0].slug,
+      '--yes',
+      '--dangerously-force'
+    );
+
+    const exitCode = await flags(client);
+    expect(exitCode).toEqual(0);
+    expect(client.stdout.getFullOutput()).not.toContain(
+      'Deleting my-feature despite production activity'
+    );
+    expect(client.stderr.getFullOutput()).toContain(
+      'Deleting my-feature despite production activity'
+    );
+    expect(client.stderr.getFullOutput()).toContain(
+      'This action cannot be undone'
+    );
+  });
+
+  it('does not warn about a forced deletion when confirmation is declined', async () => {
+    testFlags[0].state = 'archived';
+    productionEvaluations = 2;
+    (client.stdin as any).isTTY = true;
+    client.input.confirm = async () => false;
+    client.setArgv('flags', 'rm', testFlags[0].slug, '--dangerously-force');
+
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(0);
+    expect(client.stderr.getFullOutput()).toContain('Aborted');
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Deleting my-feature despite production activity'
+    );
+  });
+
+  it('rechecks safety after interactive confirmation', async () => {
+    testFlags[0].state = 'archived';
+    productionEvaluations = 0;
+    (client.stdin as any).isTTY = true;
+    client.input.confirm = async () => {
+      // Simulate evaluations starting during the confirmation prompt
+      productionEvaluations = 3;
+      return true;
+    };
+
+    client.setArgv('flags', 'rm', testFlags[0].slug);
+    const exitCode = await flags(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'is now in use in Production'
+    );
+    expect(client.stderr.getFullOutput()).toContain('3 production evaluations');
   });
 });

--- a/packages/cli/test/unit/util/flags/safety-check.test.ts
+++ b/packages/cli/test/unit/util/flags/safety-check.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getFlagSafetyBlockers,
+  getFlagSafetyRemediation,
+} from '../../../../src/util/flags/safety-check';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+
+describe('getFlagSafetyBlockers', () => {
+  beforeEach(() => {
+    process.env.VERCEL_FLAG_EVALUATIONS_API_URL = new URL(
+      '/api/observability/metrics',
+      client.apiUrl
+    ).href;
+    useUser();
+    useTeams('team_dummy');
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_FLAG_EVALUATIONS_API_URL;
+  });
+
+  it('blocks when production evaluations are detected as numbers', async () => {
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({
+        data: [],
+        summary: [{ vercel_flag_evaluation_flag_evaluations_sum: 5 }],
+      });
+    });
+    client.scenario.get(
+      '/projects/test-project/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: { id: 'dpl_test' } });
+      }
+    );
+    client.scenario.get(
+      '/v1/deployments/dpl_test/feature-flags',
+      (_req, res) => {
+        res.json({ flags: [], status: { responseStatus: 200 } });
+      }
+    );
+
+    const blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: 'test-project',
+      ownerId: 'team_dummy',
+      slug: 'test-flag',
+    });
+
+    expect(blockers).toEqual([
+      {
+        kind: 'evaluations',
+        message: '5 production evaluations in the last 72 hours',
+      },
+    ]);
+  });
+
+  it('blocks when production evaluations are detected as numeric strings', async () => {
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({
+        data: [],
+        summary: [{ vercel_flag_evaluation_flag_evaluations_sum: '42' }],
+      });
+    });
+    client.scenario.get(
+      '/projects/test-project/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: { id: 'dpl_test' } });
+      }
+    );
+    client.scenario.get(
+      '/v1/deployments/dpl_test/feature-flags',
+      (_req, res) => {
+        res.json({ flags: [], status: { responseStatus: 200 } });
+      }
+    );
+
+    const blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: 'test-project',
+      ownerId: 'team_dummy',
+      slug: 'test-flag',
+    });
+
+    expect(blockers).toEqual([
+      {
+        kind: 'evaluations',
+        message: '42 production evaluations in the last 72 hours',
+      },
+    ]);
+  });
+
+  it('blocks when no active production deployment exists', async () => {
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({ data: [], summary: [] });
+    });
+    client.scenario.get(
+      '/projects/test-project/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: null });
+      }
+    );
+
+    const blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: 'test-project',
+      ownerId: 'team_dummy',
+      slug: 'test-flag',
+    });
+
+    expect(blockers).toEqual([
+      {
+        kind: 'reference-unavailable',
+        message: 'could not find the active production deployment',
+      },
+    ]);
+  });
+
+  it('blocks when deployment flag discovery has missing sync status', async () => {
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({ data: [], summary: [] });
+    });
+    client.scenario.get(
+      '/projects/test-project/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: { id: 'dpl_test' } });
+      }
+    );
+    client.scenario.get(
+      '/v1/deployments/dpl_test/feature-flags',
+      (_req, res) => {
+        res.json({ flags: [], status: null });
+      }
+    );
+
+    const blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: 'test-project',
+      ownerId: 'team_dummy',
+      slug: 'test-flag',
+    });
+
+    expect(blockers).toEqual([
+      {
+        kind: 'reference-unavailable',
+        message:
+          'could not verify feature flag discovery status on the active production deployment',
+      },
+    ]);
+  });
+
+  it('blocks when deployment flag discovery has non-200 sync status', async () => {
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({ data: [], summary: [] });
+    });
+    client.scenario.get(
+      '/projects/test-project/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: { id: 'dpl_test' } });
+      }
+    );
+    client.scenario.get(
+      '/v1/deployments/dpl_test/feature-flags',
+      (_req, res) => {
+        res.json({ flags: [], status: { responseStatus: 404 } });
+      }
+    );
+
+    const blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: 'test-project',
+      ownerId: 'team_dummy',
+      slug: 'test-flag',
+    });
+
+    expect(blockers).toEqual([
+      {
+        kind: 'reference-unavailable',
+        message:
+          'could not verify feature flag discovery status on the active production deployment',
+      },
+    ]);
+  });
+
+  it('blocks when deployment references the flag', async () => {
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({ data: [], summary: [] });
+    });
+    client.scenario.get(
+      '/projects/test-project/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: { id: 'dpl_test' } });
+      }
+    );
+    client.scenario.get(
+      '/v1/deployments/dpl_test/feature-flags',
+      (_req, res) => {
+        res.json({
+          flags: [{ slug: 'test-flag', projectMismatch: false }],
+          status: { responseStatus: 200 },
+        });
+      }
+    );
+
+    const blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: 'test-project',
+      ownerId: 'team_dummy',
+      slug: 'test-flag',
+    });
+
+    expect(blockers).toEqual([
+      {
+        kind: 'reference',
+        message: 'the active production deployment still references this flag',
+      },
+    ]);
+  });
+
+  it('allows when no blockers are found', async () => {
+    client.scenario.post('/api/observability/metrics', (_req, res) => {
+      res.json({ data: [], summary: [] });
+    });
+    client.scenario.get(
+      '/projects/test-project/production-deployment',
+      (_req, res) => {
+        res.json({ deployment: { id: 'dpl_test' } });
+      }
+    );
+    client.scenario.get(
+      '/v1/deployments/dpl_test/feature-flags',
+      (_req, res) => {
+        res.json({ flags: [], status: { responseStatus: 200 } });
+      }
+    );
+
+    const blockers = await getFlagSafetyBlockers({
+      client,
+      projectId: 'test-project',
+      ownerId: 'team_dummy',
+      slug: 'test-flag',
+    });
+
+    expect(blockers).toEqual([]);
+  });
+});
+
+describe('getFlagSafetyRemediation', () => {
+  it('gives an evaluation-specific remediation', () => {
+    expect(
+      getFlagSafetyRemediation([
+        { kind: 'evaluations', message: '1 production evaluation' },
+      ])
+    ).toBe('Wait for Production evaluation activity to stop, then try again.');
+  });
+
+  it('gives a deployment-reference-specific remediation', () => {
+    expect(
+      getFlagSafetyRemediation([
+        { kind: 'reference', message: 'active deployment reference' },
+      ])
+    ).toBe(
+      'Remove this flag from your application code and deploy the change to Production, then try again.'
+    );
+  });
+
+  it('combines remediation when both checks detect usage', () => {
+    expect(
+      getFlagSafetyRemediation([
+        { kind: 'evaluations', message: '1 production evaluation' },
+        { kind: 'reference', message: 'active deployment reference' },
+      ])
+    ).toBe(
+      'Remove this flag from your application code, deploy the change to Production, and wait for evaluation activity to stop, then try again.'
+    );
+  });
+
+  it('uses a neutral remediation when safety checks are unavailable', () => {
+    expect(
+      getFlagSafetyRemediation([
+        { kind: 'evaluations-unavailable', message: 'metrics unavailable' },
+      ])
+    ).toBe('Resolve the Production safety-check issues above, then try again.');
+  });
+});


### PR DESCRIPTION
# Guard destructive feature-flag operations

Add a CLI safety gate to `vercel flags archive` and `vercel flags rm` before either destructive mutation. The gate checks whether the target flag has recent Production evaluations or is referenced by the deployment currently serving Production.

Production evaluations, live references in the production deploy, or unavailable safety evidence stop the operation and explain the remediation. An operator can deliberately proceed with `--dangerously-force`; the command records that option in CLI telemetry and emits its warning to human stderr only after confirmation succeeds.

Non-interactive and agent callers receive structured blocker output with a context-preserving override command. Retry commands include `--yes` when required, so they remain executable in non-interactive environments.

Safety checks fail when evaluation activity or deployment discovery cannot be retrieved. They use the active Production deployment rather than historical deployment listings and query an ungrouped, hour-aligned 72-hour evaluation summary. New tests cover safety checks, overrides, confirmation races, clean stdout, and structured agent responses.