### PR TITLE
[CLI] Add drains manage commands: add, update, test, rm, pause, resume

### DIFF
--- a/.changeset/drains-manage-commands.md
+++ b/.changeset/drains-manage-commands.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel drains` manage subcommands: add, update, test, remove, pause, and resume

--- a/packages/cli/src/commands/drains/add.ts
+++ b/packages/cli/src/commands/drains/add.ts
@@ -1,0 +1,218 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { DrainsTelemetryClient } from '../../util/telemetry/commands/drains';
+import createDrain from '../../util/drains/create-drain';
+import { redactDrainForJson } from '../../util/drains/format';
+import { handleDrainsError } from '../../util/drains/error';
+import type {
+  CreateDrainRequestBody,
+  DrainDeliveryHttp,
+  DrainSchemaName,
+} from '../../util/drains/types';
+import { addSubcommand } from './command';
+import {
+  DRAIN_COMPRESSIONS,
+  DRAIN_ENCODINGS,
+  DRAIN_SCHEMA_NAMES,
+  SAMPLING_ENVIRONMENTS,
+  buildSamplingRules,
+  isDrainCompression,
+  isDrainEncoding,
+  isDrainSchemaName,
+  isSamplingEnvironment,
+  parseHeaderFlags,
+  validateEndpointUrl,
+  validateSamplingRate,
+} from './flags';
+
+export default async function add(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new DrainsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(addSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  telemetry.trackCliOptionName(flags['--name']);
+  telemetry.trackCliOptionType(flags['--type']);
+  telemetry.trackCliOptionEndpoint(flags['--endpoint']);
+  telemetry.trackCliOptionEncoding(flags['--encoding']);
+  telemetry.trackCliOptionCompression(flags['--compression']);
+  telemetry.trackCliOptionHeader(flags['--header']);
+  telemetry.trackCliOptionSecret(flags['--secret']);
+  telemetry.trackCliOptionProject(flags['--project']);
+  telemetry.trackCliOptionSampling(flags['--sampling']);
+  telemetry.trackCliOptionEnvironment(flags['--environment']);
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const interactive = client.stdin.isTTY && !client.nonInteractive;
+
+  let name = flags['--name'];
+  let type = flags['--type'];
+  let endpoint = flags['--endpoint'];
+
+  if (type !== undefined && !isDrainSchemaName(type)) {
+    output.error(
+      `Invalid --type value: "${type}". Valid types: ${DRAIN_SCHEMA_NAMES.join(', ')}.`
+    );
+    return 1;
+  }
+  if (endpoint !== undefined) {
+    const endpointError = validateEndpointUrl(endpoint);
+    if (endpointError) {
+      output.error(endpointError);
+      return 1;
+    }
+  }
+  const encoding = flags['--encoding'] ?? 'json';
+  if (!isDrainEncoding(encoding)) {
+    output.error(
+      `Invalid --encoding value: "${encoding}". Valid encodings: ${DRAIN_ENCODINGS.join(', ')}.`
+    );
+    return 1;
+  }
+  const compression = flags['--compression'];
+  if (compression !== undefined && !isDrainCompression(compression)) {
+    output.error(
+      `Invalid --compression value: "${compression}". Valid values: ${DRAIN_COMPRESSIONS.join(', ')}.`
+    );
+    return 1;
+  }
+  const environment = flags['--environment'];
+  if (environment !== undefined && !isSamplingEnvironment(environment)) {
+    output.error(
+      `Invalid --environment value: "${environment}". Valid environments: ${SAMPLING_ENVIRONMENTS.join(', ')}.`
+    );
+    return 1;
+  }
+  const sampling = flags['--sampling'];
+  if (sampling !== undefined) {
+    const samplingError = validateSamplingRate(sampling);
+    if (samplingError) {
+      output.error(samplingError);
+      return 1;
+    }
+  }
+  if (environment !== undefined && sampling === undefined) {
+    output.error('The --environment flag requires --sampling.');
+    return 1;
+  }
+  const parsedHeaders = parseHeaderFlags(flags['--header'] ?? []);
+  if (!parsedHeaders.ok) {
+    output.error(parsedHeaders.error);
+    return 1;
+  }
+
+  if (!name || !type || !endpoint) {
+    if (!interactive) {
+      const missing = [
+        !name && '--name',
+        !type && '--type',
+        !endpoint && '--endpoint',
+      ]
+        .filter(Boolean)
+        .join(', ');
+      output.error(
+        `Missing required flags: ${missing}. See ${getCommandName('drains add --help')}.`
+      );
+      return 1;
+    }
+
+    if (!name) {
+      name = await client.input.text({
+        message: 'Name?',
+        validate: value => (value.trim().length > 0 ? true : 'Enter a name'),
+      });
+      name = name.trim();
+    }
+    if (!type) {
+      type = await client.input.select<DrainSchemaName>({
+        message: 'Data type?',
+        choices: DRAIN_SCHEMA_NAMES.map(schemaName => ({
+          name: schemaName,
+          value: schemaName,
+        })),
+      });
+    }
+    if (!endpoint) {
+      endpoint = await client.input.text({
+        message: 'Endpoint URL?',
+        validate: value => validateEndpointUrl(value) ?? true,
+      });
+    }
+  }
+
+  const schemaName = type as DrainSchemaName;
+
+  const delivery: DrainDeliveryHttp = {
+    type: 'http',
+    endpoint,
+    encoding,
+    headers: parsedHeaders.headers,
+  };
+  if (compression !== undefined) {
+    delivery.compression = compression;
+  }
+  const secret = flags['--secret'];
+  if (secret !== undefined) {
+    delivery.secret = secret;
+  }
+
+  const projectIds = flags['--project'];
+  const body: CreateDrainRequestBody = {
+    name,
+    projects: projectIds && projectIds.length > 0 ? 'some' : 'all',
+    schemas: { [schemaName]: { version: 'v1' } },
+    delivery,
+  };
+  if (projectIds && projectIds.length > 0) {
+    body.projectIds = projectIds;
+  }
+  if (sampling !== undefined) {
+    body.sampling = buildSamplingRules(schemaName, sampling, environment);
+  }
+
+  const addStamp = stamp();
+  let drain;
+  try {
+    drain = await createDrain(client, body);
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(redactDrainForJson(drain), null, 2)}\n`
+    );
+    return 0;
+  }
+
+  output.success(
+    `Drain ${chalk.bold(drain.name)} created (${drain.id}) ${chalk.gray(addStamp())}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/drains/command.ts
+++ b/packages/cli/src/commands/drains/command.ts
@@ -1,5 +1,87 @@
 import { packageName } from '../../util/pkg-name';
-import { formatOption, jsonOption } from '../../util/arg-common';
+import { formatOption, jsonOption, yesOption } from '../../util/arg-common';
+
+const nameOption = {
+  name: 'name',
+  shorthand: null,
+  type: String,
+  argument: 'NAME',
+  deprecated: false,
+  description: 'Name of the drain',
+} as const;
+
+const endpointOption = {
+  name: 'endpoint',
+  shorthand: null,
+  type: String,
+  argument: 'URL',
+  deprecated: false,
+  description: 'HTTPS endpoint that receives the events',
+} as const;
+
+const encodingOption = {
+  name: 'encoding',
+  shorthand: null,
+  type: String,
+  argument: 'ENCODING',
+  deprecated: false,
+  description: 'Delivery encoding (json, ndjson)',
+} as const;
+
+const compressionOption = {
+  name: 'compression',
+  shorthand: null,
+  type: String,
+  argument: 'COMPRESSION',
+  deprecated: false,
+  description: 'Delivery compression (gzip, none)',
+} as const;
+
+const headerOption = {
+  name: 'header',
+  shorthand: null,
+  type: [String],
+  argument: 'KEY: VALUE',
+  deprecated: false,
+  description: 'Custom HTTP header sent with each delivery (repeatable)',
+} as const;
+
+const secretOption = {
+  name: 'secret',
+  shorthand: null,
+  type: String,
+  argument: 'VALUE',
+  deprecated: false,
+  description: 'Secret used to sign delivered payloads (x-vercel-signature)',
+} as const;
+
+const drainProjectOption = {
+  name: 'project',
+  shorthand: null,
+  type: [String],
+  argument: 'ID',
+  deprecated: false,
+  description: 'Project ID to scope the drain to (repeatable, default all)',
+} as const;
+
+const samplingOption = {
+  name: 'sampling',
+  shorthand: null,
+  type: Number,
+  argument: 'RATE',
+  deprecated: false,
+  description: 'Sampling rate from 0 to 1 (e.g. 0.1 delivers 10%)',
+} as const;
+
+const environmentOption = {
+  name: 'environment',
+  shorthand: null,
+  type: String,
+  argument: 'ENVIRONMENT',
+  deprecated: false,
+  description:
+    'Environment the sampling rate applies to (production, preview); requires --sampling',
+} as const;
 
 export const listSubcommand = {
   name: 'list',
@@ -35,12 +117,182 @@ export const inspectSubcommand = {
   ],
 } as const;
 
+export const addSubcommand = {
+  name: 'add',
+  aliases: [],
+  description: 'Create a drain that delivers events to an HTTPS endpoint',
+  arguments: [],
+  options: [
+    nameOption,
+    {
+      name: 'type',
+      shorthand: null,
+      type: String,
+      argument: 'TYPE',
+      deprecated: false,
+      description:
+        'Data type to deliver (log, trace, analytics, speed_insights, ai_gateway, audit_log, connect)',
+    },
+    endpointOption,
+    encodingOption,
+    compressionOption,
+    headerOption,
+    secretOption,
+    drainProjectOption,
+    samplingOption,
+    environmentOption,
+    formatOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'Create a log drain',
+      value: `${packageName} drains add --name prod-logs --type log --endpoint https://logs.example.com/ingest`,
+    },
+    {
+      name: 'Create a sampled trace drain scoped to a project',
+      value: `${packageName} drains add --name traces --type trace --endpoint https://traces.example.com --project prj_1a2b3c --sampling 0.25`,
+    },
+  ],
+} as const;
+
+export const updateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Update an existing drain using its ID',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [
+    nameOption,
+    endpointOption,
+    encodingOption,
+    compressionOption,
+    headerOption,
+    secretOption,
+    drainProjectOption,
+    samplingOption,
+    environmentOption,
+    formatOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'Rename a drain',
+      value: `${packageName} drains update drn_1a2b3c4d5e6f --name staging-logs`,
+    },
+    {
+      name: 'Point a drain at a new endpoint',
+      value: `${packageName} drains update drn_1a2b3c4d5e6f --endpoint https://logs.example.com/v2`,
+    },
+  ],
+} as const;
+
+export const testSubcommand = {
+  name: 'test',
+  aliases: [],
+  description: 'Send a test event through a drain to validate its delivery',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Send a test event to a drain',
+      value: `${packageName} drains test drn_1a2b3c4d5e6f`,
+    },
+  ],
+} as const;
+
+export const removeSubcommand = {
+  name: 'remove',
+  aliases: ['rm'],
+  description: 'Remove a drain using its ID',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when removing a drain',
+    },
+    formatOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'Remove a drain',
+      value: `${packageName} drains rm drn_1a2b3c4d5e6f`,
+    },
+    {
+      name: 'Remove a drain without the confirmation prompt',
+      value: `${packageName} drains rm drn_1a2b3c4d5e6f --yes`,
+    },
+  ],
+} as const;
+
+export const pauseSubcommand = {
+  name: 'pause',
+  aliases: [],
+  description: 'Pause a drain using its ID',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Pause a drain',
+      value: `${packageName} drains pause drn_1a2b3c4d5e6f`,
+    },
+  ],
+} as const;
+
+export const resumeSubcommand = {
+  name: 'resume',
+  aliases: [],
+  description: 'Resume a paused drain using its ID',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Resume a paused drain',
+      value: `${packageName} drains resume drn_1a2b3c4d5e6f`,
+    },
+  ],
+} as const;
+
 export const drainsCommand = {
   name: 'drains',
   aliases: [],
   description: 'Manage Log, Trace, and other observability Drains',
   arguments: [],
-  subcommands: [listSubcommand, inspectSubcommand],
+  subcommands: [
+    listSubcommand,
+    inspectSubcommand,
+    addSubcommand,
+    updateSubcommand,
+    testSubcommand,
+    removeSubcommand,
+    pauseSubcommand,
+    resumeSubcommand,
+  ],
   options: [],
   examples: [
     {
@@ -50,6 +302,21 @@ export const drainsCommand = {
     {
       name: 'Show a drain in full',
       value: `${packageName} drains inspect drn_a1b2c3d4e5f6`,
+    },
+    {
+      name: 'Create a log drain',
+      value: `${packageName} drains add --name prod-logs --type log --endpoint https://logs.example.com/ingest`,
+    },
+    {
+      name: 'Remove a drain',
+      value: `${packageName} drains rm drn_a1b2c3d4e5f6`,
+    },
+    {
+      name: 'Pause and resume a drain',
+      value: [
+        `${packageName} drains pause drn_a1b2c3d4e5f6`,
+        `${packageName} drains resume drn_a1b2c3d4e5f6`,
+      ],
     },
   ],
 } as const;

--- a/packages/cli/src/commands/drains/flags.ts
+++ b/packages/cli/src/commands/drains/flags.ts
@@ -1,0 +1,98 @@
+import type {
+  DrainSamplingRule,
+  DrainSchemaName,
+} from '../../util/drains/types';
+
+export const DRAIN_SCHEMA_NAMES: readonly DrainSchemaName[] = [
+  'log',
+  'trace',
+  'analytics',
+  'speed_insights',
+  'ai_gateway',
+  'audit_log',
+  'connect',
+] as const;
+
+export const DRAIN_ENCODINGS = ['json', 'ndjson'] as const;
+export type DrainEncoding = (typeof DRAIN_ENCODINGS)[number];
+
+export const DRAIN_COMPRESSIONS = ['gzip', 'none'] as const;
+export type DrainCompression = (typeof DRAIN_COMPRESSIONS)[number];
+
+export const SAMPLING_ENVIRONMENTS = ['production', 'preview'] as const;
+export type SamplingEnvironment = (typeof SAMPLING_ENVIRONMENTS)[number];
+
+export function isDrainSchemaName(value: string): value is DrainSchemaName {
+  return (DRAIN_SCHEMA_NAMES as readonly string[]).includes(value);
+}
+
+export function isDrainEncoding(value: string): value is DrainEncoding {
+  return (DRAIN_ENCODINGS as readonly string[]).includes(value);
+}
+
+export function isDrainCompression(value: string): value is DrainCompression {
+  return (DRAIN_COMPRESSIONS as readonly string[]).includes(value);
+}
+
+export function isSamplingEnvironment(
+  value: string
+): value is SamplingEnvironment {
+  return (SAMPLING_ENVIRONMENTS as readonly string[]).includes(value);
+}
+
+export function validateEndpointUrl(value: string): string | undefined {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return 'The --endpoint value must be a valid HTTP(S) URL, e.g. https://logs.example.com/ingest.';
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return 'The --endpoint value must use the http or https protocol.';
+  }
+  return undefined;
+}
+
+export type ParsedHeaders =
+  | { ok: true; headers: Record<string, string> }
+  | { ok: false; error: string };
+
+/**
+ * Parses repeatable `--header 'Key: Value'` flags into a headers record.
+ * Splits on the first colon; later duplicates of a key win.
+ */
+export function parseHeaderFlags(values: string[]): ParsedHeaders {
+  const headers: Record<string, string> = {};
+  for (const value of values) {
+    const sep = value.indexOf(':');
+    const key = sep === -1 ? '' : value.slice(0, sep).trim();
+    const headerValue = sep === -1 ? '' : value.slice(sep + 1).trim();
+    if (!key || !headerValue) {
+      return {
+        ok: false,
+        error: `Couldn't parse header. Use --header 'Key: Value' with a colon between the name and the value.`,
+      };
+    }
+    headers[key] = headerValue;
+  }
+  return { ok: true, headers };
+}
+
+export function validateSamplingRate(rate: number): string | undefined {
+  if (!Number.isFinite(rate) || rate < 0 || rate > 1) {
+    return 'The --sampling value must be a number between 0 and 1, e.g. 0.1 for 10%.';
+  }
+  return undefined;
+}
+
+export function buildSamplingRules(
+  schemaName: DrainSchemaName,
+  rate: number,
+  env?: SamplingEnvironment
+): DrainSamplingRule[] {
+  const rule: DrainSamplingRule = { type: schemaName, rate };
+  if (env) {
+    rule.env = env;
+  }
+  return [rule];
+}

--- a/packages/cli/src/commands/drains/index.ts
+++ b/packages/cli/src/commands/drains/index.ts
@@ -1,9 +1,25 @@
 import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import { printError } from '../../util/error';
+import add from './add';
 import inspect from './inspect';
 import ls from './ls';
-import { drainsCommand, inspectSubcommand, listSubcommand } from './command';
+import pause from './pause';
+import resume from './resume';
+import rm from './rm';
+import test from './test';
+import update from './update';
+import {
+  addSubcommand,
+  drainsCommand,
+  inspectSubcommand,
+  listSubcommand,
+  pauseSubcommand,
+  removeSubcommand,
+  resumeSubcommand,
+  testSubcommand,
+  updateSubcommand,
+} from './command';
 import { type Command, help } from '../help';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -14,6 +30,12 @@ import { getCommandAliases } from '..';
 const COMMAND_CONFIG = {
   inspect: getCommandAliases(inspectSubcommand),
   ls: getCommandAliases(listSubcommand),
+  add: getCommandAliases(addSubcommand),
+  update: getCommandAliases(updateSubcommand),
+  test: getCommandAliases(testSubcommand),
+  rm: getCommandAliases(removeSubcommand),
+  pause: getCommandAliases(pauseSubcommand),
+  resume: getCommandAliases(resumeSubcommand),
 };
 
 export default async function drains(client: Client) {
@@ -64,6 +86,54 @@ export default async function drains(client: Client) {
       }
       telemetry.trackCliSubcommandInspect(subcommandOriginal);
       return inspect(client, args);
+    case 'add':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('drains', subcommandOriginal);
+        printHelp(addSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
+      return add(client, args);
+    case 'update':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('drains', subcommandOriginal);
+        printHelp(updateSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandUpdate(subcommandOriginal);
+      return update(client, args);
+    case 'test':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('drains', subcommandOriginal);
+        printHelp(testSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandTest(subcommandOriginal);
+      return test(client, args);
+    case 'rm':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('drains', subcommandOriginal);
+        printHelp(removeSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
+      return rm(client, args);
+    case 'pause':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('drains', subcommandOriginal);
+        printHelp(pauseSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandPause(subcommandOriginal);
+      return pause(client, args);
+    case 'resume':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('drains', subcommandOriginal);
+        printHelp(resumeSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandResume(subcommandOriginal);
+      return resume(client, args);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('drains', subcommandOriginal);

--- a/packages/cli/src/commands/drains/pause.ts
+++ b/packages/cli/src/commands/drains/pause.ts
@@ -1,0 +1,68 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import updateDrain from '../../util/drains/update-drain';
+import { handleDrainsError } from '../../util/drains/error';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { validateJsonOutput } from '../../util/output-format';
+import { DrainsTelemetryClient } from '../../util/telemetry/commands/drains';
+import { pauseSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+
+export default async function pause(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new DrainsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(pauseSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const id = parsedArgs.args[0];
+  if (!id) {
+    output.error(
+      `Please provide a drain id. See ${getCommandName('drains pause <id>')}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const s = stamp();
+  let updated;
+  try {
+    updated = await updateDrain(client, id, { status: 'disabled' });
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify({ id, status: updated.status }, null, 2)}\n`
+    );
+    return 0;
+  }
+
+  output.success(`Drain ${chalk.gray(id)} paused ${chalk.gray(s())}`);
+  return 0;
+}

--- a/packages/cli/src/commands/drains/resume.ts
+++ b/packages/cli/src/commands/drains/resume.ts
@@ -1,0 +1,68 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import updateDrain from '../../util/drains/update-drain';
+import { handleDrainsError } from '../../util/drains/error';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { validateJsonOutput } from '../../util/output-format';
+import { DrainsTelemetryClient } from '../../util/telemetry/commands/drains';
+import { resumeSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+
+export default async function resume(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new DrainsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(resumeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const id = parsedArgs.args[0];
+  if (!id) {
+    output.error(
+      `Please provide a drain id. See ${getCommandName('drains resume <id>')}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const s = stamp();
+  let updated;
+  try {
+    updated = await updateDrain(client, id, { status: 'enabled' });
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify({ id, status: updated.status }, null, 2)}\n`
+    );
+    return 0;
+  }
+
+  output.success(`Drain ${chalk.gray(id)} resumed ${chalk.gray(s())}`);
+  return 0;
+}

--- a/packages/cli/src/commands/drains/rm.ts
+++ b/packages/cli/src/commands/drains/rm.ts
@@ -1,0 +1,125 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import type Client from '../../util/client';
+import type { Drain } from '../../util/drains/types';
+import getDrainById from '../../util/drains/get-drain-by-id';
+import deleteDrain from '../../util/drains/delete-drain';
+import { formatDataType, formatDestination } from '../../util/drains/format';
+import { handleDrainsError } from '../../util/drains/error';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { validateJsonOutput } from '../../util/output-format';
+import { DrainsTelemetryClient } from '../../util/telemetry/commands/drains';
+import { removeSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import {
+  buildCommandWithYes,
+  outputActionRequired,
+} from '../../util/agent-output';
+import {
+  AGENT_ACTION,
+  AGENT_REASON,
+  AGENT_STATUS,
+} from '../../util/agent-output-constants';
+
+export default async function rm(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new DrainsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(removeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const id = parsedArgs.args[0];
+  if (!id) {
+    output.error(
+      `Please provide a drain id. See ${getCommandName('drains rm <id>')}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliFlagYes(flags['--yes']);
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  let drain;
+  try {
+    drain = await getDrainById(client, id);
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  const skipConfirmation = flags['--yes'];
+
+  if (client.nonInteractive && !skipConfirmation) {
+    outputActionRequired(
+      client,
+      {
+        status: AGENT_STATUS.ACTION_REQUIRED,
+        reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+        action: AGENT_ACTION.CONFIRMATION_REQUIRED,
+        message: 'In non-interactive mode --yes is required to remove a drain.',
+        next: [
+          {
+            command: buildCommandWithYes(client.argv),
+            when: 'to confirm removal',
+          },
+        ],
+      },
+      1
+    );
+    return 1;
+  }
+
+  const yes = skipConfirmation || (await readConfirmation(client, drain));
+  if (!yes) {
+    output.error('User canceled.');
+    return 0;
+  }
+
+  const rmStamp = stamp();
+  try {
+    await deleteDrain(client, id);
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify({ removed: true, id }, null, 2)}\n`);
+    return 0;
+  }
+
+  output.success(`Drain ${chalk.gray(id)} removed ${chalk.gray(rmStamp())}`);
+  return 0;
+}
+
+function readConfirmation(client: Client, drain: Drain): Promise<boolean> {
+  output.log('The following drain will be removed permanently');
+  output.print(
+    `${table(
+      [[drain.id, drain.name, formatDataType(drain), formatDestination(drain)]],
+      { align: ['l', 'l', 'l', 'l'], hsep: 3 }
+    ).replace(/^(.*)/gm, '  $1')}\n`
+  );
+  return client.input.confirm(chalk.red('Are you sure?'), false);
+}

--- a/packages/cli/src/commands/drains/test.ts
+++ b/packages/cli/src/commands/drains/test.ts
@@ -1,0 +1,117 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { DrainsTelemetryClient } from '../../util/telemetry/commands/drains';
+import getDrainById from '../../util/drains/get-drain-by-id';
+import testDrain from '../../util/drains/test-drain';
+import { handleDrainsError } from '../../util/drains/error';
+import type { DrainDeliveryInput } from '../../util/drains/types';
+import { testSubcommand } from './command';
+
+export default async function test(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new DrainsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(testSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const id = parsedArgs.args[0];
+  if (!id) {
+    output.error(
+      `Please provide a drain id. See ${getCommandName('drains test <id>')}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  let drain;
+  try {
+    drain = await getDrainById(client, id);
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  if (
+    drain.delivery.type !== 'http' &&
+    drain.delivery.type !== 'otlphttp' &&
+    drain.delivery.type !== 's3'
+  ) {
+    output.error(
+      `Can't test a ${drain.delivery.type} drain. Only http, otlphttp, and s3 drains are supported.`
+    );
+    return 1;
+  }
+
+  // Re-send the drain's own configuration to the validation endpoint.
+  // Integration-managed secrets (placeholder objects) can't be re-sent.
+  const delivery = structuredClone(drain.delivery) as DrainDeliveryInput;
+  if ('secret' in delivery && typeof delivery.secret !== 'string') {
+    delete delivery.secret;
+  }
+
+  const testStamp = stamp();
+  let result;
+  try {
+    result = await testDrain(client, {
+      schemas: drain.schemas,
+      delivery,
+    });
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  const passed = !result.error;
+
+  if (asJson) {
+    const payload: {
+      id: string;
+      passed: boolean;
+      error?: string;
+      endpoint?: string;
+    } = { id, passed };
+    if (result.error !== undefined) {
+      payload.error = result.error;
+    }
+    if (result.endpoint !== undefined) {
+      payload.endpoint = result.endpoint;
+    }
+    client.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return passed ? 0 : 1;
+  }
+
+  if (!passed) {
+    output.error(`Test delivery failed: ${result.error}`);
+    return 1;
+  }
+
+  output.success(
+    `Test event delivered for drain ${chalk.gray(id)} ${chalk.gray(testStamp())}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/drains/update.ts
+++ b/packages/cli/src/commands/drains/update.ts
@@ -1,0 +1,228 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { DrainsTelemetryClient } from '../../util/telemetry/commands/drains';
+import getDrainById from '../../util/drains/get-drain-by-id';
+import updateDrain from '../../util/drains/update-drain';
+import { redactDrainForJson } from '../../util/drains/format';
+import { handleDrainsError } from '../../util/drains/error';
+import type {
+  DrainDeliveryHttp,
+  DrainSchemaName,
+  UpdateDrainRequestBody,
+} from '../../util/drains/types';
+import { updateSubcommand } from './command';
+import {
+  DRAIN_COMPRESSIONS,
+  DRAIN_ENCODINGS,
+  SAMPLING_ENVIRONMENTS,
+  buildSamplingRules,
+  isDrainCompression,
+  isDrainEncoding,
+  isSamplingEnvironment,
+  parseHeaderFlags,
+  validateEndpointUrl,
+  validateSamplingRate,
+} from './flags';
+
+export default async function update(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new DrainsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(updateSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const id = parsedArgs.args[0];
+  if (!id) {
+    output.error(
+      `Please provide a drain id. See ${getCommandName('drains update <id>')}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentId(id);
+  telemetry.trackCliOptionName(flags['--name']);
+  telemetry.trackCliOptionEndpoint(flags['--endpoint']);
+  telemetry.trackCliOptionEncoding(flags['--encoding']);
+  telemetry.trackCliOptionCompression(flags['--compression']);
+  telemetry.trackCliOptionHeader(flags['--header']);
+  telemetry.trackCliOptionSecret(flags['--secret']);
+  telemetry.trackCliOptionProject(flags['--project']);
+  telemetry.trackCliOptionSampling(flags['--sampling']);
+  telemetry.trackCliOptionEnvironment(flags['--environment']);
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const name = flags['--name'];
+  const endpoint = flags['--endpoint'];
+  const encoding = flags['--encoding'];
+  const compression = flags['--compression'];
+  const headerFlags = flags['--header'];
+  const secret = flags['--secret'];
+  const projectIds = flags['--project'];
+  const sampling = flags['--sampling'];
+  const environment = flags['--environment'];
+
+  const hasDeliveryChange =
+    endpoint !== undefined ||
+    encoding !== undefined ||
+    compression !== undefined ||
+    (headerFlags !== undefined && headerFlags.length > 0) ||
+    secret !== undefined;
+  const hasChange =
+    hasDeliveryChange ||
+    name !== undefined ||
+    (projectIds !== undefined && projectIds.length > 0) ||
+    sampling !== undefined;
+
+  if (!hasChange) {
+    output.error(
+      `Provide at least one flag to update, e.g. --name or --endpoint. See ${getCommandName('drains update --help')}.`
+    );
+    return 1;
+  }
+
+  if (endpoint !== undefined) {
+    const endpointError = validateEndpointUrl(endpoint);
+    if (endpointError) {
+      output.error(endpointError);
+      return 1;
+    }
+  }
+  if (encoding !== undefined && !isDrainEncoding(encoding)) {
+    output.error(
+      `Invalid --encoding value: "${encoding}". Valid encodings: ${DRAIN_ENCODINGS.join(', ')}.`
+    );
+    return 1;
+  }
+  if (compression !== undefined && !isDrainCompression(compression)) {
+    output.error(
+      `Invalid --compression value: "${compression}". Valid values: ${DRAIN_COMPRESSIONS.join(', ')}.`
+    );
+    return 1;
+  }
+  if (environment !== undefined && !isSamplingEnvironment(environment)) {
+    output.error(
+      `Invalid --environment value: "${environment}". Valid environments: ${SAMPLING_ENVIRONMENTS.join(', ')}.`
+    );
+    return 1;
+  }
+  if (sampling !== undefined) {
+    const samplingError = validateSamplingRate(sampling);
+    if (samplingError) {
+      output.error(samplingError);
+      return 1;
+    }
+  }
+  if (environment !== undefined && sampling === undefined) {
+    output.error('The --environment flag requires --sampling.');
+    return 1;
+  }
+  const parsedHeaders = parseHeaderFlags(headerFlags ?? []);
+  if (!parsedHeaders.ok) {
+    output.error(parsedHeaders.error);
+    return 1;
+  }
+
+  // Fetch the current drain: delivery is replaced wholesale by PATCH, so
+  // partial delivery edits must be merged with the existing configuration.
+  let drain;
+  try {
+    drain = await getDrainById(client, id);
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  const body: UpdateDrainRequestBody = {};
+
+  if (name !== undefined) {
+    body.name = name;
+  }
+  if (projectIds !== undefined && projectIds.length > 0) {
+    body.projects = 'some';
+    body.projectIds = projectIds;
+  }
+  if (sampling !== undefined) {
+    const [schemaName] = Object.keys(drain.schemas ?? {}) as DrainSchemaName[];
+    body.sampling = buildSamplingRules(
+      schemaName ?? 'log',
+      sampling,
+      environment
+    );
+  }
+
+  if (hasDeliveryChange) {
+    if (drain.delivery.type !== 'http') {
+      output.error(
+        `Can't update delivery settings of a ${drain.delivery.type} drain from the CLI. Only HTTP drains are supported.`
+      );
+      return 1;
+    }
+    const current = drain.delivery;
+    const delivery: DrainDeliveryHttp = {
+      type: 'http',
+      endpoint: endpoint ?? current.endpoint,
+      encoding: encoding ?? current.encoding,
+      headers:
+        headerFlags !== undefined && headerFlags.length > 0
+          ? parsedHeaders.headers
+          : current.headers,
+    };
+    const mergedCompression = compression ?? current.compression;
+    if (mergedCompression !== undefined) {
+      delivery.compression = mergedCompression;
+    }
+    // Preserve an existing string secret; integration-managed secrets
+    // (placeholder objects) can't be re-sent and are omitted.
+    const mergedSecret =
+      secret ??
+      (typeof current.secret === 'string' ? current.secret : undefined);
+    if (mergedSecret !== undefined) {
+      delivery.secret = mergedSecret;
+    }
+    body.delivery = delivery;
+  }
+
+  const updateStamp = stamp();
+  let updated;
+  try {
+    updated = await updateDrain(client, id, body);
+  } catch (err) {
+    return handleDrainsError(err);
+  }
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(redactDrainForJson(updated), null, 2)}\n`
+    );
+    return 0;
+  }
+
+  output.success(
+    `Drain ${chalk.gray(id)} updated ${chalk.gray(updateStamp())}`
+  );
+  return 0;
+}

--- a/packages/cli/src/util/drains/create-drain.ts
+++ b/packages/cli/src/util/drains/create-drain.ts
@@ -1,0 +1,13 @@
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../client';
+import type { CreateDrainRequestBody, Drain } from './types';
+
+export default async function createDrain(
+  client: Client,
+  body: CreateDrainRequestBody
+): Promise<Drain> {
+  return client.fetch<Drain>('/v1/drains', {
+    method: 'POST',
+    body: body as unknown as JSONObject,
+  });
+}

--- a/packages/cli/src/util/drains/delete-drain.ts
+++ b/packages/cli/src/util/drains/delete-drain.ts
@@ -1,0 +1,7 @@
+import type Client from '../client';
+
+export default async function deleteDrain(client: Client, id: string) {
+  return client.fetch(`/v1/drains/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}

--- a/packages/cli/src/util/drains/test-drain.ts
+++ b/packages/cli/src/util/drains/test-drain.ts
@@ -1,0 +1,13 @@
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../client';
+import type { TestDrainRequestBody, TestDrainResponse } from './types';
+
+export default async function testDrain(
+  client: Client,
+  body: TestDrainRequestBody
+): Promise<TestDrainResponse> {
+  return client.fetch<TestDrainResponse>('/v1/drains/test', {
+    method: 'POST',
+    body: body as unknown as JSONObject,
+  });
+}

--- a/packages/cli/src/util/drains/types.ts
+++ b/packages/cli/src/util/drains/types.ts
@@ -125,3 +125,46 @@ export interface Drain {
 export interface ListDrainsResponse {
   drains: Drain[];
 }
+
+// Delivery types accepted by POST /v1/drains, PATCH /v1/drains/:id, and
+// POST /v1/drains/test. `clickhouse` and `internal` are not creatable via
+// the public API.
+export type DrainDeliveryInput =
+  | DrainDeliveryHttp
+  | DrainDeliveryOtlpHttp
+  | DrainDeliveryS3;
+
+export interface CreateDrainRequestBody {
+  name: string;
+  projects: 'all' | 'some';
+  projectIds?: string[];
+  schemas: DrainSchemas;
+  delivery: DrainDeliveryInput;
+  sampling?: DrainSampling;
+}
+
+// PATCH body: every field optional; only send what changed. `delivery` is a
+// complete replacement object, not a partial merge, so callers must send the
+// full delivery when changing any delivery field.
+export interface UpdateDrainRequestBody {
+  name?: string;
+  projects?: 'all' | 'some';
+  projectIds?: string[];
+  schemas?: DrainSchemas;
+  delivery?: DrainDeliveryInput;
+  sampling?: DrainSampling;
+  status?: 'enabled' | 'disabled';
+}
+
+export interface TestDrainRequestBody {
+  schemas: DrainSchemas;
+  delivery: DrainDeliveryInput;
+}
+
+// 200 response is `{}` on success, or `{status, error, endpoint}` when the
+// sample delivery failed.
+export interface TestDrainResponse {
+  status?: string;
+  error?: string;
+  endpoint?: string;
+}

--- a/packages/cli/src/util/drains/update-drain.ts
+++ b/packages/cli/src/util/drains/update-drain.ts
@@ -1,0 +1,14 @@
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../client';
+import type { Drain, UpdateDrainRequestBody } from './types';
+
+export default async function updateDrain(
+  client: Client,
+  id: string,
+  body: UpdateDrainRequestBody
+): Promise<Drain> {
+  return client.fetch<Drain>(`/v1/drains/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    body: body as unknown as JSONObject,
+  });
+}

--- a/packages/cli/src/util/telemetry/commands/drains/index.ts
+++ b/packages/cli/src/util/telemetry/commands/drains/index.ts
@@ -2,6 +2,19 @@ import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { drainsCommand } from '../../../../commands/drains/command';
 
+const TRACKED_TYPES = [
+  'log',
+  'trace',
+  'analytics',
+  'speed_insights',
+  'ai_gateway',
+  'audit_log',
+  'connect',
+];
+const TRACKED_ENCODINGS = ['json', 'ndjson'];
+const TRACKED_COMPRESSIONS = ['gzip', 'none'];
+const TRACKED_ENVIRONMENTS = ['production', 'preview'];
+
 export class DrainsTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof drainsCommand>
@@ -13,9 +26,51 @@ export class DrainsTelemetryClient
     });
   }
 
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandUpdate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandTest(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'test',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandInspect(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'inspect',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandPause(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'pause',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandResume(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'resume',
       value: actual,
     });
   }
@@ -25,6 +80,99 @@ export class DrainsTelemetryClient
       this.trackCliArgument({
         arg: 'id',
         value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliOptionName(name: string | undefined) {
+    if (name) {
+      this.trackCliOption({
+        option: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionType(type: string | undefined) {
+    if (type) {
+      this.trackCliOption({
+        option: 'type',
+        value: TRACKED_TYPES.includes(type) ? type : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEndpoint(endpoint: string | undefined) {
+    if (endpoint) {
+      this.trackCliOption({
+        option: 'endpoint',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEncoding(encoding: string | undefined) {
+    if (encoding) {
+      this.trackCliOption({
+        option: 'encoding',
+        value: TRACKED_ENCODINGS.includes(encoding)
+          ? encoding
+          : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionCompression(compression: string | undefined) {
+    if (compression) {
+      this.trackCliOption({
+        option: 'compression',
+        value: TRACKED_COMPRESSIONS.includes(compression)
+          ? compression
+          : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionHeader(headers: string[] | undefined) {
+    if (headers && headers.length > 0) {
+      this.trackCliOption({
+        option: 'header',
+        value: this.redactedArgumentsLength(headers),
+      });
+    }
+  }
+
+  trackCliOptionSecret(secret: string | undefined) {
+    if (secret) {
+      this.trackCliOption({
+        option: 'secret',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSampling(sampling: number | undefined) {
+    if (sampling !== undefined) {
+      this.trackCliOption({
+        option: 'sampling',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEnvironment(environment: string | undefined) {
+    if (environment) {
+      this.trackCliOption({
+        option: 'environment',
+        value: TRACKED_ENVIRONMENTS.includes(environment)
+          ? environment
+          : this.redactedValue,
       });
     }
   }

--- a/packages/cli/test/mocks/drains.ts
+++ b/packages/cli/test/mocks/drains.ts
@@ -1,5 +1,10 @@
 import { client } from './client';
-import type { Drain } from '../../src/util/drains/types';
+import type {
+  CreateDrainRequestBody,
+  Drain,
+  TestDrainRequestBody,
+  UpdateDrainRequestBody,
+} from '../../src/util/drains/types';
 
 export const defaultDrain: Drain = {
   id: 'drn_1',
@@ -19,8 +24,8 @@ export const defaultDrain: Drain = {
   source: { kind: 'self-served' },
 };
 
-// Registers the happy-path list/find routes. Error cases register their own
-// handlers instead of calling this.
+// Registers the happy-path list/find/delete/patch routes. Error cases register
+// their own handlers instead of calling this.
 export function useDrains(drains: Drain[] = [defaultDrain]) {
   client.scenario.get('/v1/drains', (_req, res) => {
     res.json({ drains });
@@ -30,7 +35,50 @@ export function useDrains(drains: Drain[] = [defaultDrain]) {
     client.scenario.get(`/v1/drains/${drain.id}`, (_req, res) => {
       res.json(drain);
     });
+    client.scenario.delete(`/v1/drains/${drain.id}`, (_req, res) => {
+      res.json({});
+    });
+    client.scenario.patch(`/v1/drains/${drain.id}`, (req, res) => {
+      // Echo the drain merged with the PATCH body the way the server would:
+      // `projects` is a request-only field and never appears on the resource.
+      const { projects: _projects, ...rest } = (req.body ??
+        {}) as UpdateDrainRequestBody;
+      res.json({ ...drain, ...rest });
+    });
   }
 
   return drains;
+}
+
+// Registers a happy-path POST /v1/drains route that echoes the request body
+// back as a created drain. Returns a recorder holding the last request body.
+export function useCreateDrain(id = 'drn_new') {
+  const recorder: { body?: CreateDrainRequestBody } = {};
+  client.scenario.post('/v1/drains', (req, res) => {
+    recorder.body = req.body as CreateDrainRequestBody;
+    const { projects: _projects, ...rest } = recorder.body;
+    res.json({
+      id,
+      createdAt: 1600000000000,
+      updatedAt: 1600000000000,
+      ownerId: 'team_dummy',
+      status: 'enabled',
+      source: { kind: 'self-served' },
+      ...rest,
+    });
+  });
+  return recorder;
+}
+
+// Registers a POST /v1/drains/test route. Pass a failure object to simulate a
+// failed sample delivery ({} means success). Returns a request-body recorder.
+export function useTestDrain(
+  result: { status?: string; error?: string; endpoint?: string } = {}
+) {
+  const recorder: { body?: TestDrainRequestBody } = {};
+  client.scenario.post('/v1/drains/test', (req, res) => {
+    recorder.body = req.body as TestDrainRequestBody;
+    res.json(result);
+  });
+  return recorder;
 }

--- a/packages/cli/test/unit/commands/drains/add.test.ts
+++ b/packages/cli/test/unit/commands/drains/add.test.ts
@@ -1,0 +1,322 @@
+import { describe, beforeEach, afterEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import drains from '../../../../src/commands/drains';
+import { useUser } from '../../../mocks/user';
+import { useCreateDrain } from '../../../mocks/drains';
+
+describe('drains add', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    client.nonInteractive = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('drains', 'add', '--help');
+      const exitCodePromise = drains(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'drains:add',
+        },
+      ]);
+    });
+  });
+
+  it('errors listing all missing required flags in non-interactive mode', async () => {
+    client.nonInteractive = true;
+    client.setArgv('drains', 'add', '--name', 'my-drain');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Missing required flags: --type, --endpoint'
+    );
+  });
+
+  it('creates an HTTP drain with the full flag surface', async () => {
+    const recorder = useCreateDrain();
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'prod-logs',
+      '--type',
+      'log',
+      '--endpoint',
+      'https://logs.example.com/ingest',
+      '--encoding',
+      'ndjson',
+      '--compression',
+      'gzip',
+      '--header',
+      'Authorization: Bearer sk_add_no_leak',
+      '--header',
+      'X-Env: prod',
+      '--secret',
+      'whsec_add_no_leak',
+      '--project',
+      'prj_1',
+      '--project',
+      'prj_2',
+      '--sampling',
+      '0.25',
+      '--environment',
+      'production'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    expect(recorder.body).toEqual({
+      name: 'prod-logs',
+      projects: 'some',
+      projectIds: ['prj_1', 'prj_2'],
+      schemas: { log: { version: 'v1' } },
+      delivery: {
+        type: 'http',
+        endpoint: 'https://logs.example.com/ingest',
+        encoding: 'ndjson',
+        compression: 'gzip',
+        headers: {
+          Authorization: 'Bearer sk_add_no_leak',
+          'X-Env': 'prod',
+        },
+        secret: 'whsec_add_no_leak',
+      },
+      sampling: [{ type: 'log', rate: 0.25, env: 'production' }],
+    });
+
+    await expect(client.stderr).toOutput('created');
+
+    const combined =
+      client.stdout.getFullOutput() + client.stderr.getFullOutput();
+    expect(combined).toContain('drn_new');
+    expect(combined).not.toContain('whsec_add_no_leak');
+    expect(combined).not.toContain('sk_add_no_leak');
+  });
+
+  it('defaults to json encoding and all projects', async () => {
+    const recorder = useCreateDrain();
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'minimal',
+      '--type',
+      'trace',
+      '--endpoint',
+      'https://traces.example.com'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    expect(recorder.body).toEqual({
+      name: 'minimal',
+      projects: 'all',
+      schemas: { trace: { version: 'v1' } },
+      delivery: {
+        type: 'http',
+        endpoint: 'https://traces.example.com',
+        encoding: 'json',
+        headers: {},
+      },
+    });
+  });
+
+  it('outputs the created drain as redacted JSON', async () => {
+    useCreateDrain();
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'prod-logs',
+      '--type',
+      'log',
+      '--endpoint',
+      'https://logs.example.com/ingest',
+      '--header',
+      'Authorization: Bearer sk_add_no_leak',
+      '--secret',
+      'whsec_add_no_leak',
+      '--json'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).not.toContain('whsec_add_no_leak');
+    expect(stdout).not.toContain('sk_add_no_leak');
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.id).toEqual('drn_new');
+    expect(parsed.name).toEqual('prod-logs');
+    expect('secret' in parsed.delivery).toBe(false);
+    expect(parsed.delivery.headers.Authorization).toBeNull();
+  });
+
+  it('prompts for missing required values in TTY mode', async () => {
+    const recorder = useCreateDrain();
+    client.input.text = vi
+      .fn()
+      .mockResolvedValueOnce('prompted-drain')
+      .mockResolvedValueOnce('https://logs.example.com');
+    client.input.select = vi.fn().mockResolvedValue('log');
+
+    client.setArgv('drains', 'add');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.input.text).toHaveBeenCalledTimes(2);
+    expect(client.input.select).toHaveBeenCalledTimes(1);
+    expect(recorder.body?.name).toEqual('prompted-drain');
+    expect(recorder.body?.schemas).toEqual({ log: { version: 'v1' } });
+    expect(recorder.body?.delivery.endpoint).toEqual(
+      'https://logs.example.com'
+    );
+  });
+
+  it('rejects an invalid --type', async () => {
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'x',
+      '--type',
+      'metrics',
+      '--endpoint',
+      'https://logs.example.com'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid --type value');
+  });
+
+  it('rejects an invalid --endpoint', async () => {
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'x',
+      '--type',
+      'log',
+      '--endpoint',
+      'not-a-url'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('must be a valid HTTP(S) URL');
+  });
+
+  it('rejects an out-of-range --sampling', async () => {
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'x',
+      '--type',
+      'log',
+      '--endpoint',
+      'https://logs.example.com',
+      '--sampling',
+      '1.5'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('between 0 and 1');
+  });
+
+  it('rejects --environment without --sampling', async () => {
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'x',
+      '--type',
+      'log',
+      '--endpoint',
+      'https://logs.example.com',
+      '--environment',
+      'production'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'The --environment flag requires --sampling.'
+    );
+  });
+
+  it('rejects a malformed --header', async () => {
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'x',
+      '--type',
+      'log',
+      '--endpoint',
+      'https://logs.example.com',
+      '--header',
+      'no-colon-here'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(`Couldn't parse header`);
+  });
+
+  it('surfaces the plan/permission error on 403', async () => {
+    client.scenario.post('/v1/drains', (_req, res) => {
+      res.status(403).json({
+        error: {
+          code: 'forbidden',
+          message: 'Drains are not available for this team.',
+        },
+      });
+    });
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'x',
+      '--type',
+      'log',
+      '--endpoint',
+      'https://logs.example.com'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Drains are not available for this team.'
+    );
+  });
+
+  it('maps a 400 validation error', async () => {
+    client.scenario.post('/v1/drains', (_req, res) => {
+      res.status(400).json({
+        error: {
+          code: 'bad_request',
+          message: 'A drain with this name already exists.',
+        },
+      });
+    });
+    client.setArgv(
+      'drains',
+      'add',
+      '--name',
+      'x',
+      '--type',
+      'log',
+      '--endpoint',
+      'https://logs.example.com'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'A drain with this name already exists.'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/drains/rm.test.ts
+++ b/packages/cli/test/unit/commands/drains/rm.test.ts
@@ -1,0 +1,95 @@
+import { describe, beforeEach, afterEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import drains from '../../../../src/commands/drains';
+import { useUser } from '../../../mocks/user';
+import { useDrains } from '../../../mocks/drains';
+
+describe('drains rm', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    client.nonInteractive = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('drains', 'rm', '--help');
+      const exitCodePromise = drains(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'drains:rm',
+        },
+      ]);
+    });
+  });
+
+  it('errors when no id is passed', async () => {
+    client.setArgv('drains', 'rm');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Please provide a drain id');
+  });
+
+  it('removes the drain with --yes', async () => {
+    useDrains();
+    client.setArgv('drains', 'rm', 'drn_1', '--yes');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('removed');
+  });
+
+  it('asks for confirmation and removes on yes', async () => {
+    useDrains();
+    client.setArgv('drains', 'rm', 'drn_1');
+    const exitCodePromise = drains(client);
+
+    await expect(client.stderr).toOutput(
+      'The following drain will be removed permanently'
+    );
+    client.stdin.write('y\n');
+
+    await expect(exitCodePromise).resolves.toEqual(0);
+  });
+
+  it('does nothing when the user declines', async () => {
+    useDrains();
+    client.setArgv('drains', 'rm', 'drn_1');
+    const exitCodePromise = drains(client);
+
+    await expect(client.stderr).toOutput('Are you sure?');
+    client.stdin.write('n\n');
+
+    await expect(exitCodePromise).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('User canceled.');
+  });
+
+  it('removes the drain and reports JSON with --format json', async () => {
+    useDrains();
+    client.setArgv('drains', 'rm', 'drn_1', '--yes', '--format', 'json');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed).toEqual({ removed: true, id: 'drn_1' });
+  });
+
+  it('requires --yes in non-interactive mode', async () => {
+    useDrains();
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as () => never);
+    client.nonInteractive = true;
+    client.setArgv('drains', 'rm', 'drn_1');
+
+    await expect(drains(client)).rejects.toThrow('exit:1');
+    const payload = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(payload.reason).toBe('confirmation_required');
+    expect(payload.next?.[0]?.command).toContain('--yes');
+  });
+});

--- a/packages/cli/test/unit/commands/drains/status.test.ts
+++ b/packages/cli/test/unit/commands/drains/status.test.ts
@@ -1,0 +1,95 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import drains from '../../../../src/commands/drains';
+import { useUser } from '../../../mocks/user';
+import { defaultDrain } from '../../../mocks/drains';
+
+describe('drains pause / resume', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  it('pauses a drain', async () => {
+    let patched: { status?: string } = {};
+    client.scenario.get('/v1/drains/drn_1', (_req, res) =>
+      res.json(defaultDrain)
+    );
+    client.scenario.patch('/v1/drains/drn_1', (req, res) => {
+      patched = req.body;
+      res.json({ ...defaultDrain, status: 'disabled' });
+    });
+
+    client.setArgv('drains', 'pause', 'drn_1');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+    expect(patched.status).toEqual('disabled');
+    await expect(client.stderr).toOutput('paused');
+  });
+
+  it('resumes a drain', async () => {
+    let patched: { status?: string } = {};
+    client.scenario.patch('/v1/drains/drn_1', (req, res) => {
+      patched = req.body;
+      res.json({ ...defaultDrain, status: 'enabled' });
+    });
+
+    client.setArgv('drains', 'resume', 'drn_1');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+    expect(patched.status).toEqual('enabled');
+    await expect(client.stderr).toOutput('resumed');
+  });
+
+  it('reports the new status as JSON', async () => {
+    client.scenario.patch('/v1/drains/drn_1', (_req, res) =>
+      res.json({ ...defaultDrain, status: 'disabled' })
+    );
+    client.setArgv('drains', 'pause', 'drn_1', '--json');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed).toEqual({ id: 'drn_1', status: 'disabled' });
+  });
+
+  it('reports the new status with --format json', async () => {
+    client.scenario.patch('/v1/drains/drn_1', (_req, res) =>
+      res.json({ ...defaultDrain, status: 'enabled' })
+    );
+    client.setArgv('drains', 'resume', 'drn_1', '--format', 'json');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed).toEqual({ id: 'drn_1', status: 'enabled' });
+  });
+
+  it('rejects an invalid --format value', async () => {
+    client.setArgv('drains', 'pause', 'drn_1', '--format', 'yaml');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid output format');
+  });
+
+  it('cannot resume a drain that Vercel disabled', async () => {
+    client.scenario.patch('/v1/drains/drn_1', (_req, res) => {
+      res.status(400).json({
+        error: {
+          code: 'drain_enable_not_allowed',
+          message: 'disabled by vercel',
+        },
+      });
+    });
+    client.setArgv('drains', 'resume', 'drn_1');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput("can't be resumed");
+  });
+
+  it('errors when no id is passed', async () => {
+    client.setArgv('drains', 'pause');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Please provide a drain id');
+  });
+});

--- a/packages/cli/test/unit/commands/drains/test.test.ts
+++ b/packages/cli/test/unit/commands/drains/test.test.ts
@@ -1,0 +1,158 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import drains from '../../../../src/commands/drains';
+import { useUser } from '../../../mocks/user';
+import { defaultDrain, useDrains, useTestDrain } from '../../../mocks/drains';
+
+describe('drains test', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('drains', 'test', '--help');
+      const exitCodePromise = drains(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'drains:test',
+        },
+      ]);
+    });
+  });
+
+  it('errors when no id is passed', async () => {
+    client.setArgv('drains', 'test');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Please provide a drain id');
+  });
+
+  it('sends the drain configuration to the validation endpoint', async () => {
+    useDrains();
+    const recorder = useTestDrain();
+    client.setArgv('drains', 'test', 'drn_1');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    expect(recorder.body).toEqual({
+      schemas: { log: { version: 'v1' } },
+      delivery: {
+        type: 'http',
+        endpoint: 'https://logs.example.com',
+        encoding: 'ndjson',
+        headers: { Authorization: 'Bearer sk_do_not_leak' },
+        secret: 'whsec_do_not_leak',
+      },
+    });
+
+    await expect(client.stderr).toOutput('Test event delivered');
+
+    const combined =
+      client.stdout.getFullOutput() + client.stderr.getFullOutput();
+    expect(combined).not.toContain('whsec_do_not_leak');
+    expect(combined).not.toContain('sk_do_not_leak');
+  });
+
+  it('omits integration-managed placeholder secrets', async () => {
+    useDrains([
+      {
+        ...defaultDrain,
+        delivery: {
+          ...defaultDrain.delivery,
+          type: 'http',
+          endpoint: 'https://logs.example.com',
+          encoding: 'ndjson',
+          headers: {},
+          secret: { kind: 'INTEGRATION_SECRET' },
+        },
+      },
+    ]);
+    const recorder = useTestDrain();
+    client.setArgv('drains', 'test', 'drn_1');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+    expect(recorder.body?.delivery).not.toHaveProperty('secret');
+  });
+
+  it('reports a failed sample delivery and exits 1', async () => {
+    useDrains();
+    useTestDrain({
+      status: 'error',
+      error: 'connection refused',
+      endpoint: 'https://logs.example.com',
+    });
+    client.setArgv('drains', 'test', 'drn_1');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Test delivery failed: connection refused'
+    );
+  });
+
+  it('reports the result as JSON on success', async () => {
+    useDrains();
+    useTestDrain();
+    client.setArgv('drains', 'test', 'drn_1', '--json');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed).toEqual({ id: 'drn_1', passed: true });
+  });
+
+  it('reports the result as JSON on failure and exits 1', async () => {
+    useDrains();
+    useTestDrain({
+      status: 'error',
+      error: 'connection refused',
+      endpoint: 'https://logs.example.com',
+    });
+    client.setArgv('drains', 'test', 'drn_1', '--json');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).not.toContain('whsec_do_not_leak');
+    expect(stdout).not.toContain('sk_do_not_leak');
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({
+      id: 'drn_1',
+      passed: false,
+      error: 'connection refused',
+      endpoint: 'https://logs.example.com',
+    });
+  });
+
+  it('rejects unsupported delivery types', async () => {
+    useDrains([
+      {
+        ...defaultDrain,
+        id: 'drn_ch',
+        delivery: {
+          type: 'clickhouse',
+          endpoint: 'https://ch.example.com',
+          table: 'logs',
+        },
+      },
+    ]);
+    client.setArgv('drains', 'test', 'drn_ch');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput("Can't test a clickhouse drain");
+  });
+
+  it('maps a 404 to a not-found message', async () => {
+    client.scenario.get('/v1/drains/drn_missing', (_req, res) => {
+      res.status(404).json({ error: { code: 'not_found', message: 'nope' } });
+    });
+    client.setArgv('drains', 'test', 'drn_missing');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Drain not found.');
+  });
+});

--- a/packages/cli/test/unit/commands/drains/update.test.ts
+++ b/packages/cli/test/unit/commands/drains/update.test.ts
@@ -1,0 +1,216 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import drains from '../../../../src/commands/drains';
+import { useUser } from '../../../mocks/user';
+import { defaultDrain } from '../../../mocks/drains';
+import type { UpdateDrainRequestBody } from '../../../../src/util/drains/types';
+
+function useUpdatableDrain(drain = defaultDrain) {
+  const recorder: { body?: UpdateDrainRequestBody } = {};
+  client.scenario.get(`/v1/drains/${drain.id}`, (_req, res) => {
+    res.json(drain);
+  });
+  client.scenario.patch(`/v1/drains/${drain.id}`, (req, res) => {
+    recorder.body = req.body as UpdateDrainRequestBody;
+    const { projects: _projects, ...rest } = recorder.body;
+    res.json({ ...drain, ...rest });
+  });
+  return recorder;
+}
+
+describe('drains update', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('drains', 'update', '--help');
+      const exitCodePromise = drains(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'drains:update',
+        },
+      ]);
+    });
+  });
+
+  it('errors when no id is passed', async () => {
+    client.setArgv('drains', 'update');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Please provide a drain id');
+  });
+
+  it('errors when no change flag is passed', async () => {
+    client.setArgv('drains', 'update', 'drn_1');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Provide at least one flag to update');
+  });
+
+  it('renames a drain sending only the name', async () => {
+    const recorder = useUpdatableDrain();
+    client.setArgv('drains', 'update', 'drn_1', '--name', 'staging-logs');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    expect(recorder.body).toEqual({ name: 'staging-logs' });
+    await expect(client.stderr).toOutput('updated');
+  });
+
+  it('merges a new endpoint into the full delivery object', async () => {
+    const recorder = useUpdatableDrain();
+    client.setArgv(
+      'drains',
+      'update',
+      'drn_1',
+      '--endpoint',
+      'https://logs.example.com/v2'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    expect(recorder.body).toEqual({
+      delivery: {
+        type: 'http',
+        endpoint: 'https://logs.example.com/v2',
+        encoding: 'ndjson',
+        headers: { Authorization: 'Bearer sk_do_not_leak' },
+        secret: 'whsec_do_not_leak',
+      },
+    });
+
+    const combined =
+      client.stdout.getFullOutput() + client.stderr.getFullOutput();
+    expect(combined).not.toContain('whsec_do_not_leak');
+    expect(combined).not.toContain('sk_do_not_leak');
+  });
+
+  it('replaces the header set and secret when passed', async () => {
+    const recorder = useUpdatableDrain();
+    client.setArgv(
+      'drains',
+      'update',
+      'drn_1',
+      '--header',
+      'X-New: value',
+      '--secret',
+      'whsec_new_no_leak'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    expect(recorder.body?.delivery).toEqual({
+      type: 'http',
+      endpoint: 'https://logs.example.com',
+      encoding: 'ndjson',
+      headers: { 'X-New': 'value' },
+      secret: 'whsec_new_no_leak',
+    });
+
+    const combined =
+      client.stdout.getFullOutput() + client.stderr.getFullOutput();
+    expect(combined).not.toContain('whsec_new_no_leak');
+    expect(combined).not.toContain('whsec_do_not_leak');
+  });
+
+  it('updates project scoping and sampling with the drain schema type', async () => {
+    const recorder = useUpdatableDrain();
+    client.setArgv(
+      'drains',
+      'update',
+      'drn_1',
+      '--project',
+      'prj_9',
+      '--sampling',
+      '0.5',
+      '--environment',
+      'preview'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    expect(recorder.body).toEqual({
+      projects: 'some',
+      projectIds: ['prj_9'],
+      sampling: [{ type: 'log', rate: 0.5, env: 'preview' }],
+    });
+  });
+
+  it('rejects delivery updates for non-http drains', async () => {
+    useUpdatableDrain({
+      ...defaultDrain,
+      id: 'drn_ch',
+      delivery: {
+        type: 'clickhouse',
+        endpoint: 'https://ch.example.com',
+        table: 'logs',
+      },
+    });
+    client.setArgv(
+      'drains',
+      'update',
+      'drn_ch',
+      '--endpoint',
+      'https://logs.example.com'
+    );
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      "Can't update delivery settings of a clickhouse drain"
+    );
+  });
+
+  it('still allows renaming a non-http drain', async () => {
+    const recorder = useUpdatableDrain({
+      ...defaultDrain,
+      id: 'drn_ch',
+      delivery: {
+        type: 'clickhouse',
+        endpoint: 'https://ch.example.com',
+        table: 'logs',
+      },
+    });
+    client.setArgv('drains', 'update', 'drn_ch', '--name', 'renamed');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+    expect(recorder.body).toEqual({ name: 'renamed' });
+  });
+
+  it('outputs the updated drain as redacted JSON', async () => {
+    useUpdatableDrain();
+    client.setArgv('drains', 'update', 'drn_1', '--name', 'renamed', '--json');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(0);
+
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).not.toContain('whsec_do_not_leak');
+    expect(stdout).not.toContain('sk_do_not_leak');
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.name).toEqual('renamed');
+    expect('secret' in parsed.delivery).toBe(false);
+    expect(parsed.delivery.headers.Authorization).toBeNull();
+  });
+
+  it('rejects an invalid --encoding', async () => {
+    client.setArgv('drains', 'update', 'drn_1', '--encoding', 'xml');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid --encoding value');
+  });
+
+  it('maps a 404 to a not-found message', async () => {
+    client.scenario.get('/v1/drains/drn_missing', (_req, res) => {
+      res.status(404).json({ error: { code: 'not_found', message: 'nope' } });
+    });
+    client.setArgv('drains', 'update', 'drn_missing', '--name', 'x');
+    const exitCode = await drains(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Drain not found.');
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #17429 (drains read commands) 

- `drains add` creates an HTTP-delivery drain (`--name`, `--type log|trace|analytics|speed_insights|ai_gateway|audit_log|connect`, `--endpoint`, plus `--encoding`, `--compression`, repeatable `--header`, `--secret`, repeatable `--project`, `--sampling`, `--environment`). In a TTY, missing required values are prompted; non-interactive errors list all missing flags at once.
- `drains update <id>` edits name, delivery settings, project scoping, and sampling. Delivery is replaced wholesale by the PATCH API, so the CLI fetches the drain and merges partial delivery edits; `--header` replaces the full header set.
- `drains test <id>` re-sends the drain's own schemas + delivery to the public validation endpoint (`POST /v1/drains/test`) and exits 1 if the sample delivery fails. Supported for http/otlphttp/s3 deliveries.
- `drains rm <id>` deletes with a confirmation prompt (skippable via `--yes`; non-interactive mode emits a structured action-required payload). `drains pause|resume <id>` toggle delivery via the status field.
- Secrets and header values never appear in output, JSON, or telemetry.

## Notes

- `add` creates HTTP-delivery drains only; `otlphttp`/`s3` creation is a possible follow-up (S3 delivery is Enterprise audit-log-only per the docs). Schema version is pinned per the public docs schema table.
- `update` on a drain with an integration-managed secret omits the placeholder from the merged delivery (it can't be re-sent).