### PR TITLE
[CLI] Add dns update subcommand

### DIFF
--- a/.changeset/dns-update.md
+++ b/.changeset/dns-update.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel dns update <id>` to edit an existing DNS record in place

--- a/packages/cli/src/commands/dns/command.ts
+++ b/packages/cli/src/commands/dns/command.ts
@@ -86,6 +86,121 @@ export const inspectSubcommand = {
   ],
 } as const;
 
+export const updateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Update an existing DNS record using its ID',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'name',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+      description: "New name of the DNS record ('@' refers to the domain)",
+    },
+    {
+      name: 'type',
+      shorthand: null,
+      type: String,
+      argument: 'TYPE',
+      deprecated: false,
+      description:
+        'New type of the DNS record (A, AAAA, ALIAS, CAA, CNAME, MX, SRV, TXT)',
+    },
+    {
+      name: 'value',
+      shorthand: null,
+      type: String,
+      argument: 'VALUE',
+      deprecated: false,
+      description: 'New value of the DNS record',
+    },
+    {
+      name: 'ttl',
+      shorthand: null,
+      type: Number,
+      argument: 'SECONDS',
+      deprecated: false,
+      description: 'New Time to live (TTL) of the DNS record, in seconds',
+    },
+    {
+      name: 'mx-priority',
+      shorthand: null,
+      type: Number,
+      argument: 'PRIORITY',
+      deprecated: false,
+      description: 'New priority of the MX record',
+    },
+    {
+      name: 'srv-priority',
+      shorthand: null,
+      type: Number,
+      argument: 'PRIORITY',
+      deprecated: false,
+      description: 'New priority of the SRV record',
+    },
+    {
+      name: 'srv-weight',
+      shorthand: null,
+      type: Number,
+      argument: 'WEIGHT',
+      deprecated: false,
+      description: 'New weight of the SRV record',
+    },
+    {
+      name: 'srv-port',
+      shorthand: null,
+      type: Number,
+      argument: 'PORT',
+      deprecated: false,
+      description: 'New port of the SRV record',
+    },
+    {
+      name: 'srv-target',
+      shorthand: null,
+      type: String,
+      argument: 'TARGET',
+      deprecated: false,
+      description: 'New target of the SRV record',
+    },
+    {
+      name: 'comment',
+      shorthand: null,
+      type: String,
+      argument: 'TEXT',
+      deprecated: false,
+      description: 'A comment to add context on what this DNS record is for',
+    },
+    formatOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'Update the value of an A record',
+      value: `${packageName} dns update rec_1a2b3c4d5e6f --value 198.51.100.100`,
+    },
+    {
+      name: 'Update the name and TTL of a record',
+      value: `${packageName} dns update rec_1a2b3c4d5e6f --name api --ttl 300`,
+    },
+    {
+      name: 'Update an MX record priority',
+      value: `${packageName} dns update rec_1a2b3c4d5e6f --mx-priority 10`,
+    },
+    {
+      name: 'Update an SRV record',
+      value: `${packageName} dns update rec_1a2b3c4d5e6f --srv-priority 10 --srv-weight 0 --srv-port 389 --srv-target zeit.party`,
+    },
+  ],
+} as const;
+
 export const removeSubcommand = {
   name: 'remove',
   aliases: ['rm'],
@@ -116,6 +231,7 @@ export const dnsCommand = {
     inspectSubcommand,
     listSubcommand,
     removeSubcommand,
+    updateSubcommand,
   ],
   options: [],
   examples: [

--- a/packages/cli/src/commands/dns/index.ts
+++ b/packages/cli/src/commands/dns/index.ts
@@ -6,6 +6,7 @@ import importZone from './import';
 import inspect from './inspect';
 import ls from './ls';
 import rm from './rm';
+import update from './update';
 import {
   addSubcommand,
   dnsCommand,
@@ -13,6 +14,7 @@ import {
   inspectSubcommand,
   listSubcommand,
   removeSubcommand,
+  updateSubcommand,
 } from './command';
 import { type Command, help } from '../help';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -27,6 +29,7 @@ const COMMAND_CONFIG = {
   inspect: getCommandAliases(inspectSubcommand),
   ls: getCommandAliases(listSubcommand),
   rm: getCommandAliases(removeSubcommand),
+  update: getCommandAliases(updateSubcommand),
 };
 
 export default async function dns(client: Client) {
@@ -101,6 +104,14 @@ export default async function dns(client: Client) {
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
+    case 'update':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('dns', subcommandOriginal);
+        printHelp(updateSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandUpdate(subcommandOriginal);
+      return update(client, args);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('dns', subcommandOriginal);

--- a/packages/cli/src/commands/dns/update.ts
+++ b/packages/cli/src/commands/dns/update.ts
@@ -1,0 +1,161 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import updateDNSRecord, {
+  type UpdateDNSRecordData,
+} from '../../util/dns/update-dns-record';
+import { handleDNSRecordError } from '../../util/dns/error';
+import { DnsUpdateTelemetryClient } from '../../util/telemetry/commands/dns/update';
+import { updateSubcommand } from './command';
+
+const SRV_FLAGS = [
+  '--srv-priority',
+  '--srv-weight',
+  '--srv-port',
+  '--srv-target',
+] as const;
+
+export default async function update(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new DnsUpdateTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(updateSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  if (args.length !== 1) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        `${getCommandName('dns update <id> [options]')}`
+      )}`
+    );
+    return 1;
+  }
+
+  const [recordId] = args;
+
+  telemetry.trackCliArgumentId(recordId);
+  telemetry.trackCliOptionName(flags['--name']);
+  telemetry.trackCliOptionType(flags['--type']);
+  telemetry.trackCliOptionValue(flags['--value']);
+  telemetry.trackCliOptionTtl(flags['--ttl']);
+  telemetry.trackCliOptionMxPriority(flags['--mx-priority']);
+  telemetry.trackCliOptionSrvPriority(flags['--srv-priority']);
+  telemetry.trackCliOptionSrvWeight(flags['--srv-weight']);
+  telemetry.trackCliOptionSrvPort(flags['--srv-port']);
+  telemetry.trackCliOptionSrvTarget(flags['--srv-target']);
+  telemetry.trackCliOptionComment(flags['--comment']);
+  telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliFlagJson(flags['--json']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const numericFlags = [
+    '--ttl',
+    '--mx-priority',
+    '--srv-priority',
+    '--srv-weight',
+    '--srv-port',
+  ] as const;
+  for (const flagName of numericFlags) {
+    const value = flags[flagName];
+    if (value !== undefined && Number.isNaN(value)) {
+      output.error(`The ${flagName} option must be a number.`);
+      return 1;
+    }
+  }
+
+  const data: UpdateDNSRecordData = {};
+
+  const name = flags['--name'];
+  if (name !== undefined) {
+    data.name = name === '@' ? '' : name;
+  }
+  if (flags['--type'] !== undefined) {
+    data.type = flags['--type'];
+  }
+  if (flags['--value'] !== undefined) {
+    data.value = flags['--value'];
+  }
+  if (flags['--ttl'] !== undefined) {
+    data.ttl = flags['--ttl'];
+  }
+  if (flags['--mx-priority'] !== undefined) {
+    data.mxPriority = flags['--mx-priority'];
+  }
+  if (flags['--comment'] !== undefined) {
+    data.comment = flags['--comment'];
+  }
+
+  const srvFlagsProvided = SRV_FLAGS.filter(
+    flagName => flags[flagName] !== undefined
+  );
+  if (srvFlagsProvided.length > 0) {
+    if (srvFlagsProvided.length !== SRV_FLAGS.length) {
+      output.error(
+        `Updating an SRV record requires all of ${SRV_FLAGS.join(', ')}.`
+      );
+      return 1;
+    }
+    data.srv = {
+      priority: flags['--srv-priority']!,
+      weight: flags['--srv-weight']!,
+      port: flags['--srv-port']!,
+      target: flags['--srv-target']!,
+    };
+  }
+
+  if (Object.keys(data).length === 0) {
+    output.error(
+      `Provide at least one field to update. See ${chalk.cyan(
+        `${getCommandName('dns update --help')}`
+      )} for available options.`
+    );
+    return 1;
+  }
+
+  const updateStamp = stamp();
+
+  let record;
+  try {
+    record = await updateDNSRecord(client, recordId, data);
+  } catch (err) {
+    return handleDNSRecordError(err);
+  }
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify(record, null, 2)}\n`);
+    return 0;
+  }
+
+  const { contextName } = await getScope(client);
+  output.success(
+    `DNS record ${chalk.gray(`${record.id}`)} of domain ${chalk.bold(
+      record.domain
+    )} updated under ${chalk.bold(contextName)} ${chalk.gray(updateStamp())}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/util/dns/update-dns-record.ts
+++ b/packages/cli/src/util/dns/update-dns-record.ts
@@ -1,0 +1,42 @@
+import type { DNSRecord } from '@vercel-internals/types';
+import type Client from '../client';
+
+export interface UpdateDNSRecordData {
+  name?: string;
+  type?: string;
+  value?: string;
+  ttl?: number;
+  mxPriority?: number;
+  srv?: {
+    priority: number;
+    weight: number;
+    port: number;
+    target: string;
+  };
+  comment?: string;
+}
+
+export type UpdatedDNSRecord = Pick<
+  DNSRecord,
+  'id' | 'name' | 'value' | 'creator' | 'domain'
+> & {
+  type: 'record' | 'record-sys';
+  recordType: string;
+  ttl?: number;
+  comment?: string;
+  createdAt?: number | null;
+};
+
+export default async function updateDNSRecord(
+  client: Client,
+  recordId: string,
+  data: UpdateDNSRecordData
+): Promise<UpdatedDNSRecord> {
+  return client.fetch<UpdatedDNSRecord>(
+    `/v1/domains/records/${encodeURIComponent(recordId)}`,
+    {
+      method: 'PATCH',
+      body: data,
+    }
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/dns/index.ts
+++ b/packages/cli/src/util/telemetry/commands/dns/index.ts
@@ -34,6 +34,13 @@ export class DnsTelemetryClient
     });
   }
 
+  trackCliSubcommandUpdate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandList(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'list',

--- a/packages/cli/src/util/telemetry/commands/dns/update.ts
+++ b/packages/cli/src/util/telemetry/commands/dns/update.ts
@@ -1,0 +1,127 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { updateSubcommand } from '../../../../commands/dns/command';
+
+const ALLOWED_RECORD_TYPES = [
+  'A',
+  'AAAA',
+  'ALIAS',
+  'CAA',
+  'CNAME',
+  'MX',
+  'SRV',
+  'TXT',
+];
+
+export class DnsUpdateTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof updateSubcommand>
+{
+  trackCliArgumentId(recordId: string | undefined) {
+    if (recordId) {
+      this.trackCliArgument({
+        arg: 'id',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionName(name: string | undefined) {
+    if (name !== undefined) {
+      this.trackCliOption({
+        option: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionType(type: string | undefined) {
+    if (type) {
+      const allowedType = ALLOWED_RECORD_TYPES.includes(type)
+        ? type
+        : this.redactedValue;
+      this.trackCliOption({
+        option: 'type',
+        value: allowedType,
+      });
+    }
+  }
+
+  trackCliOptionValue(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'value',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionTtl(ttl: number | undefined) {
+    if (ttl !== undefined) {
+      this.trackCliOption({
+        option: 'ttl',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionMxPriority(mxPriority: number | undefined) {
+    if (mxPriority !== undefined) {
+      this.trackCliOption({
+        option: 'mx-priority',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSrvPriority(srvPriority: number | undefined) {
+    if (srvPriority !== undefined) {
+      this.trackCliOption({
+        option: 'srv-priority',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSrvWeight(srvWeight: number | undefined) {
+    if (srvWeight !== undefined) {
+      this.trackCliOption({
+        option: 'srv-weight',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSrvPort(srvPort: number | undefined) {
+    if (srvPort !== undefined) {
+      this.trackCliOption({
+        option: 'srv-port',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSrvTarget(srvTarget: string | undefined) {
+    if (srvTarget) {
+      this.trackCliOption({
+        option: 'srv-target',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionComment(comment: string | undefined) {
+    if (comment !== undefined) {
+      this.trackCliOption({
+        option: 'comment',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1762,6 +1762,14 @@ exports[`help command > dns help output snapshots > dns help column width 40 1`]
                             using
                             its  
                             ID   
+  update   id               Upda…
+                            an   
+                            exis…
+                            DNS  
+                            reco…
+                            using
+                            its  
+                            ID   
 
 
   Global Options:
@@ -1863,6 +1871,7 @@ exports[`help command > dns help output snapshots > dns help column width 80 1`]
                             records, or omit the argument to list records
                             across every domain on the scope (default)   
   remove   id               Remove a DNS entry using its ID              
+  update   id               Update an existing DNS record using its ID   
 
 
   Global Options:
@@ -1930,6 +1939,7 @@ exports[`help command > dns help output snapshots > dns help column width 120 1`
   list     [domain]         List DNS entries. Pass a domain to list its records, or omit the argument to list    
                             records across every domain on the scope (default)                                   
   remove   id               Remove a DNS entry using its ID                                                      
+  update   id               Update an existing DNS record using its ID                                           
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/dns/update.test.ts
+++ b/packages/cli/test/unit/commands/dns/update.test.ts
@@ -1,0 +1,268 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import dns from '../../../../src/commands/dns';
+import { useUser } from '../../../mocks/user';
+
+const UPDATED_RECORD = {
+  id: 'rec_123',
+  name: 'www',
+  type: 'record',
+  recordType: 'A',
+  value: '9.9.9.9',
+  creator: 'user_abc',
+  domain: 'example.com',
+  ttl: 300,
+  createdAt: 1729878610745,
+};
+
+function usePatchRecord(recordId: string) {
+  const received: { body?: unknown } = {};
+  client.scenario.patch(`/v1/domains/records/${recordId}`, (req, res) => {
+    received.body = req.body;
+    res.json({ ...UPDATED_RECORD, id: recordId });
+  });
+  return received;
+}
+
+describe('dns update', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('dns', 'update', '--help');
+      const exitCodePromise = dns(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'dns:update',
+        },
+      ]);
+    });
+  });
+
+  describe('missing arguments', () => {
+    it('errors when no record id is passed', async () => {
+      client.setArgv('dns', 'update');
+      const exitCode = await dns(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid number of arguments');
+    });
+
+    it('errors when more than one argument is passed', async () => {
+      client.setArgv('dns', 'update', 'rec_123', 'extra');
+      const exitCode = await dns(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid number of arguments');
+    });
+  });
+
+  it('errors when no fields are provided', async () => {
+    client.setArgv('dns', 'update', 'rec_123');
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Provide at least one field to update'
+    );
+  });
+
+  it('updates a record and tracks telemetry', async () => {
+    usePatchRecord('rec_123');
+    client.setArgv('dns', 'update', 'rec_123', '--value', '9.9.9.9');
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(0);
+
+    await expect(client.stderr).toOutput(
+      'Success! DNS record rec_123 of domain example.com updated'
+    );
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:update',
+        value: 'update',
+      },
+      {
+        key: 'argument:id',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:value',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('sends only the provided fields in the request body', async () => {
+    const received = usePatchRecord('rec_123');
+    client.setArgv(
+      'dns',
+      'update',
+      'rec_123',
+      '--value',
+      '9.9.9.9',
+      '--ttl',
+      '300'
+    );
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(0);
+
+    expect(received.body).toEqual({
+      value: '9.9.9.9',
+      ttl: 300,
+    });
+  });
+
+  it('sends every supported field when provided', async () => {
+    const received = usePatchRecord('rec_mx');
+    client.setArgv(
+      'dns',
+      'update',
+      'rec_mx',
+      '--name',
+      '@',
+      '--type',
+      'MX',
+      '--value',
+      'mail.example.com',
+      '--ttl',
+      '60',
+      '--mx-priority',
+      '10',
+      '--comment',
+      'mail exchanger'
+    );
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(0);
+
+    expect(received.body).toEqual({
+      name: '',
+      type: 'MX',
+      value: 'mail.example.com',
+      ttl: 60,
+      mxPriority: 10,
+      comment: 'mail exchanger',
+    });
+  });
+
+  it('sends the srv object when all srv flags are provided', async () => {
+    const received = usePatchRecord('rec_srv');
+    client.setArgv(
+      'dns',
+      'update',
+      'rec_srv',
+      '--srv-priority',
+      '10',
+      '--srv-weight',
+      '0',
+      '--srv-port',
+      '389',
+      '--srv-target',
+      'zeit.party'
+    );
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(0);
+
+    expect(received.body).toEqual({
+      srv: {
+        priority: 10,
+        weight: 0,
+        port: 389,
+        target: 'zeit.party',
+      },
+    });
+  });
+
+  it('errors when only some srv flags are provided', async () => {
+    client.setArgv('dns', 'update', 'rec_srv', '--srv-port', '389');
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Updating an SRV record requires all of'
+    );
+  });
+
+  it('errors when --ttl is not a number', async () => {
+    client.setArgv('dns', 'update', 'rec_123', '--ttl', 'abc');
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('--ttl option must be a number');
+  });
+
+  it('outputs the updated record as JSON with --json', async () => {
+    usePatchRecord('rec_123');
+    client.setArgv('dns', 'update', 'rec_123', '--value', '9.9.9.9', '--json');
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.id).toEqual('rec_123');
+    expect(parsed.recordType).toEqual('A');
+    expect(parsed.value).toEqual('9.9.9.9');
+    expect(parsed.domain).toEqual('example.com');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:update',
+        value: 'update',
+      },
+      {
+        key: 'argument:id',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:value',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'flag:json',
+        value: 'TRUE',
+      },
+    ]);
+  });
+
+  it('maps a 404 to a not-found message', async () => {
+    client.scenario.patch('/v1/domains/records/rec_missing', (_req, res) => {
+      res.status(404).json({ error: { code: 'not_found', message: 'nope' } });
+    });
+    client.setArgv('dns', 'update', 'rec_missing', '--value', '9.9.9.9');
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('DNS record not found');
+  });
+
+  it('maps a 403 to a permission message', async () => {
+    client.scenario.patch('/v1/domains/records/rec_403', (_req, res) => {
+      res.status(403).json({ error: { code: 'forbidden', message: 'nope' } });
+    });
+    client.setArgv('dns', 'update', 'rec_403', '--value', '9.9.9.9');
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput("You don't have permission");
+  });
+
+  it('surfaces the API message for a 400', async () => {
+    client.scenario.patch('/v1/domains/records/rec_400', (_req, res) => {
+      res.status(400).json({
+        error: { code: 'invalid_ttl', message: 'TTL must be at least 60' },
+      });
+    });
+    client.setArgv('dns', 'update', 'rec_400', '--ttl', '1');
+    const exitCode = await dns(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('TTL must be at least 60');
+  });
+
+  describe('errors', () => {
+    it('rejects unknown flags', async () => {
+      client.setArgv('dns', 'update', 'rec_123', '--unknown');
+      const exitCode = await dns(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: unknown or unexpected option: --unknown'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #17437 (`dns inspect`) — the diff shows only the update subcommand. Retarget to `main` after #17437 merges.

- Adds `vercel dns update <record-id>` to edit an existing record in place via the public `PATCH /v1/domains/records/{recordId}` endpoint — no more delete + recreate.
- Flags: `--name`, `--type`, `--value`, `--ttl`, `--mx-priority`, `--srv-priority|--srv-weight|--srv-port|--srv-target`, `--comment`. Only the fields you pass are sent (asserted in tests against the mock's received body).
- SRV updates require all four `--srv-*` flags (the API requires the full object); partial SRV input errors locally before any mutation.

## Test plan

- `pnpm vitest-run test/unit/commands/dns/` (15 update tests: happy paths, JSON shape, no-flags error, partial-SRV validation, NaN validation, 404/403 mapping, PATCH body assertions)
- Against a real domain: `vercel dns update <id> --ttl 300`, `--name`/`--value` edits, `--json` variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)