### PR TITLE
[CLI] Add project resume subcommand

### DIFF
--- a/.changeset/project-resume.md
+++ b/.changeset/project-resume.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `vercel project resume` to restore production traffic for a paused project

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -229,6 +229,33 @@ export const pauseSubcommand = {
   ],
 } as const;
 
+export const resumeSubcommand = {
+  name: 'resume',
+  aliases: ['unpause'],
+  description: 'Resume production traffic for a paused project',
+  arguments: [
+    {
+      name: 'project',
+      required: false,
+    },
+  ],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Resume the linked project',
+      value: `${packageName} project resume`,
+    },
+    {
+      name: 'Resume the project named "my-project"',
+      value: `${packageName} project resume my-project`,
+    },
+    {
+      name: 'Resume a project and print the result as JSON',
+      value: `${packageName} project resume my-project --json`,
+    },
+  ],
+} as const;
+
 export const removeSubcommand = {
   name: 'remove',
   aliases: ['rm'],
@@ -717,6 +744,7 @@ export const projectCommand = {
     webAnalyticsSubcommand,
     speedInsightsSubcommand,
     pauseSubcommand,
+    resumeSubcommand,
     updateSubcommand,
     renameSubcommand,
     removeSubcommand,

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -14,6 +14,7 @@ import rename from './rename';
 import update from './update';
 import rm from './rm';
 import pause from './pause';
+import resume from './resume';
 import getOidcToken from './token';
 import speedInsights from './speed-insights';
 import webAnalytics from './web-analytics';
@@ -31,6 +32,7 @@ import {
   protectionSubcommand,
   renameSubcommand,
   removeSubcommand,
+  resumeSubcommand,
   speedInsightsSubcommand,
   tokenSubcommand,
   updateSubcommand,
@@ -61,6 +63,7 @@ const COMMAND_CONFIG = {
   speedInsights: getCommandAliases(speedInsightsSubcommand),
   webAnalytics: getCommandAliases(webAnalyticsSubcommand),
   pause: getCommandAliases(pauseSubcommand),
+  resume: getCommandAliases(resumeSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -207,6 +210,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandPause(subcommandOriginal);
       exitCode = await pause(client, args);
+      break;
+    case 'resume':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('project', subcommandOriginal);
+        return printHelp(resumeSubcommand);
+      }
+      telemetry.trackCliSubcommandResume(subcommandOriginal);
+      exitCode = await resume(client, args);
       break;
     case 'token':
       if (needHelp) {

--- a/packages/cli/src/commands/project/resume.ts
+++ b/packages/cli/src/commands/project/resume.ts
@@ -1,0 +1,115 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import type { Project } from '@vercel-internals/types';
+import output from '../../output-manager';
+import stamp from '../../util/output/stamp';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { isAPIError } from '../../util/errors-ts';
+import { validateJsonOutput } from '../../util/output-format';
+import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
+import { ProjectResumeTelemetryClient } from '../../util/telemetry/commands/project/resume';
+import { resumeSubcommand } from './command';
+import { exitWithNonInteractiveError } from '../../util/agent-output';
+
+export default async function resume(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new ProjectResumeTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(resumeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  if (args.length > 1) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        getCommandName('project resume [project]')
+      )}`
+    );
+    return 2;
+  }
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  telemetry.trackCliArgumentProject(args[0]);
+  telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliFlagJson(flags['--json']);
+
+  let project: Project;
+  try {
+    project = await getProjectByCwdOrLink({
+      client,
+      commandName: 'project resume',
+      projectNameOrId: args[0],
+      forReadOnlyCommand: true,
+    });
+  } catch (error) {
+    exitWithNonInteractiveError(client, error, 1, { variant: 'resume' });
+    printError(error);
+    return 1;
+  }
+
+  const resumeStamp = stamp();
+  try {
+    await client.fetch(
+      `/v1/projects/${encodeURIComponent(project.id)}/unpause`,
+      {
+        method: 'POST',
+      }
+    );
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'resume' });
+    if (isAPIError(err)) {
+      if (err.status === 404) {
+        output.error(`Project not found.`);
+        return 1;
+      }
+      if (err.status === 403) {
+        output.error(
+          err.serverMessage ||
+            'You do not have permission to resume this project.'
+        );
+        return 1;
+      }
+    }
+    printError(err);
+    return 1;
+  }
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(
+        { id: project.id, name: project.name, paused: false },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  output.success(
+    `Production traffic for ${chalk.bold(project.name)} resumed ${chalk.gray(
+      resumeStamp()
+    )}`
+  );
+  return 0;
+}

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -649,6 +649,7 @@ export type ExitWithNonInteractiveErrorVariant =
   | 'web-analytics'
   | 'checks'
   | 'pause'
+  | 'resume'
   | 'global-config'
   | 'list';
 
@@ -744,15 +745,20 @@ function buildNextStepsForProjectSubcommands(
                         template: 'project pause <name> --yes' as const,
                         when: 'Pause production traffic by project name (replace <name>)',
                       }
-                    : variant === 'inspect'
+                    : variant === 'resume'
                       ? {
-                          template: 'project inspect <name>' as const,
-                          when: 'Inspect a project by name (replace <name>)',
+                          template: 'project resume <name>' as const,
+                          when: 'Resume production traffic by project name (replace <name>)',
                         }
-                      : {
-                          template: 'project members <name>' as const,
-                          when: 'List members by project name (replace <name>)',
-                        };
+                      : variant === 'inspect'
+                        ? {
+                            template: 'project inspect <name>' as const,
+                            when: 'Inspect a project by name (replace <name>)',
+                          }
+                        : {
+                            template: 'project members <name>' as const,
+                            when: 'List members by project name (replace <name>)',
+                          };
   return [
     {
       command: buildCommandWithGlobalFlags(client.argv, 'link'),

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -110,4 +110,11 @@ export class ProjectTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandResume(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'resume',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/project/resume.ts
+++ b/packages/cli/src/util/telemetry/commands/project/resume.ts
@@ -1,0 +1,23 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { resumeSubcommand } from '../../../../commands/project/command';
+
+export class ProjectResumeTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof resumeSubcommand>
+{
+  trackCliArgumentProject(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({
+        arg: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5741,6 +5741,13 @@ exports[`help command > project help output snapshots > project help column widt
                                    …
                                    …
                                    …
+  resume          [project]        …
+                                   …
+                                   …
+                                   …
+                                   a
+                                   …
+                                   …
   update          [name]           …
                                    …
                                    …
@@ -5844,6 +5851,8 @@ exports[`help command > project help output snapshots > project help column widt
   speed-insights  [name]           Enable Speed Insights for a project      
   pause           [project]        Pause production traffic for a project   
                                    (visitors will see an error page)        
+  resume          [project]        Resume production traffic for a paused   
+                                   project                                  
   update          [name]           Update one or more project settings;     
                                    omitted settings remain unchanged        
   rename          name new-name    Rename a project                         
@@ -5892,6 +5901,7 @@ exports[`help command > project help output snapshots > project help column widt
   web-analytics   [name]           Enable Web Analytics for a project                                               
   speed-insights  [name]           Enable Speed Insights for a project                                              
   pause           [project]        Pause production traffic for a project (visitors will see an error page)         
+  resume          [project]        Resume production traffic for a paused project                                   
   update          [name]           Update one or more project settings; omitted settings remain unchanged           
   rename          name new-name    Rename a project                                                                 
   remove          name             Delete a project                                                                 
@@ -6092,6 +6102,49 @@ exports[`help command > project help output snapshots > project rename help outp
   - Rename a project
 
     $ vercel project rename my-project my-renamed-project
+
+"
+`;
+
+exports[`help command > project help output snapshots > project resume help output snapshots > project resume help column width 120 1`] = `
+"
+  ▲ vercel project resume [project] [options]
+
+  Resume production traffic for a paused project                                                                        
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Resume the linked project
+
+    $ vercel project resume
+
+  - Resume the project named "my-project"
+
+    $ vercel project resume my-project
+
+  - Resume a project and print the result as JSON
+
+    $ vercel project resume my-project --json
 
 "
 `;

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -784,6 +784,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('project resume help output snapshots', () => {
+      it('project resume help column width 120', () => {
+        expect(
+          help(project.resumeSubcommand, {
+            columns: 120,
+            parent: project.projectCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('promote help output snapshots', () => {

--- a/packages/cli/test/unit/commands/project/resume.test.ts
+++ b/packages/cli/test/unit/commands/project/resume.test.ts
@@ -1,0 +1,192 @@
+import { join } from 'path';
+import { outputFile } from 'fs-extra';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import project from '../../../../src/commands/project';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
+import { useTeam } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+
+describe('project resume', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    client.nonInteractive = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('project', 'resume', '--help');
+      const exitCodePromise = project(client);
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'project:resume',
+        },
+      ]);
+    });
+  });
+
+  it('errors when the project does not exist', async () => {
+    useUser();
+    useUnknownProject();
+
+    client.setArgv('project', 'resume', 'unknown-project');
+    const exitCode = await project(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'There is no project for "unknown-project"'
+    );
+  });
+
+  it('resumes a named project without confirmation', async () => {
+    useUser();
+    useProject({
+      ...defaultProject,
+      id: 'prj_resume',
+      name: 'my-project',
+    });
+
+    let unpauseCalled = false;
+    client.scenario.post('/v1/projects/:projectId/unpause', (req, res) => {
+      unpauseCalled = true;
+      expect(req.params.projectId).toBe('prj_resume');
+      res.status(200).end();
+    });
+
+    client.setArgv('project', 'resume', 'my-project');
+    const exitCode = await project(client);
+    expect(exitCode).toEqual(0);
+    expect(unpauseCalled).toBe(true);
+    await expect(client.stderr).toOutput(
+      'Production traffic for my-project resumed'
+    );
+    // no confirmation prompt for resume
+    expect(client.stderr.getFullOutput()).not.toContain('Continue?');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:resume',
+        value: 'resume',
+      },
+      {
+        key: 'argument:project',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('supports the unpause alias', async () => {
+    useUser();
+    useProject({
+      ...defaultProject,
+      id: 'prj_resume',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/v1/projects/:projectId/unpause', (_req, res) => {
+      res.status(200).end();
+    });
+
+    client.setArgv('project', 'unpause', 'my-project');
+    const exitCode = await project(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      'Production traffic for my-project resumed'
+    );
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:resume',
+        value: 'unpause',
+      },
+      {
+        key: 'argument:project',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('outputs JSON with --json', async () => {
+    useUser();
+    useProject({
+      ...defaultProject,
+      id: 'prj_resume',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/v1/projects/:projectId/unpause', (_req, res) => {
+      res.status(200).end();
+    });
+
+    client.setArgv('project', 'resume', 'my-project', '--json');
+    const exitCode = await project(client);
+    expect(exitCode).toEqual(0);
+
+    const jsonOutput = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(jsonOutput).toEqual({
+      id: 'prj_resume',
+      name: 'my-project',
+      paused: false,
+    });
+  });
+
+  it('falls back to the linked project when no argument is given', async () => {
+    const team = useTeam('team_linked');
+    useUser();
+    useProject({
+      ...defaultProject,
+      id: 'prj_linked',
+      name: 'linked-project',
+      accountId: team.id,
+    });
+
+    const cwd = setupTmpDir();
+    await outputFile(
+      join(cwd, '.vercel', 'project.json'),
+      JSON.stringify({ orgId: team.id, projectId: 'prj_linked' })
+    );
+    client.cwd = cwd;
+
+    let unpauseCalled = false;
+    client.scenario.post('/v1/projects/:projectId/unpause', (req, res) => {
+      unpauseCalled = true;
+      expect(req.params.projectId).toBe('prj_linked');
+      res.status(200).end();
+    });
+
+    client.setArgv('project', 'resume');
+    const exitCode = await project(client);
+    expect(exitCode).toEqual(0);
+    expect(unpauseCalled).toBe(true);
+    await expect(client.stderr).toOutput(
+      'Production traffic for linked-project resumed'
+    );
+  });
+
+  it('maps a 403 from the unpause API to a friendly error', async () => {
+    useUser();
+    useProject({
+      ...defaultProject,
+      id: 'prj_resume',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/v1/projects/:projectId/unpause', (_req, res) => {
+      res.status(403).json({
+        error: { code: 'forbidden', message: 'Not allowed.' },
+      });
+    });
+
+    client.setArgv('project', 'resume', 'my-project');
+    const exitCode = await project(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Not allowed.');
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #17438 (`project pause`) — the diff shows only the resume subcommand. Retarget to `main` after #17438 merges.

- Adds `vercel project resume [project]` (alias: `unpause`) to restore production traffic via the public `POST /v1/projects/{id}/unpause` endpoint.
- Same optional `[project]` resolution as pause (explicit name/id or linked project). No confirmation prompt — resuming is safe.
- Supports `--json`/`--format json` with payload `{"id", "name", "paused": false}`.

## Test plan

- `pnpm vitest-run test/unit/commands/project/` (7 resume tests: happy paths, linked-project fallback, JSON shape, 403/404 mapping, `unpause` alias telemetry)
- Against the project paused in #17438's test plan: `vercel project resume <name>`, verify traffic restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)