### PR TITLE
[CLI] Add global-config schema get subcommand

### DIFF
--- a/.changeset/global-config-schema.md
+++ b/.changeset/global-config-schema.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel global-config schema get` to read a Global Config store's JSON Schema

--- a/packages/cli/src/commands/global-config/command.ts
+++ b/packages/cli/src/commands/global-config/command.ts
@@ -110,6 +110,33 @@ export const removeSubcommand = {
   examples: [],
 } as const;
 
+export const schemaSubcommand = {
+  name: 'schema',
+  aliases: [],
+  description: "Get a Global Config store's JSON Schema",
+  arguments: [
+    {
+      name: 'action',
+      required: true,
+    },
+    {
+      name: 'id-or-slug',
+      required: true,
+    },
+  ],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Get the schema for a Global Config',
+      value: `${packageName} global-config schema get my-store`,
+    },
+    {
+      name: 'Get the schema as JSON',
+      value: `${packageName} global-config schema get my-store --json`,
+    },
+  ],
+} as const;
+
 export const itemsSubcommand = {
   name: 'items',
   aliases: [],
@@ -249,6 +276,7 @@ export const globalConfigCommand = {
     getSubcommand,
     updateSubcommand,
     removeSubcommand,
+    schemaSubcommand,
     itemsSubcommand,
     tokensSubcommand,
     backupsSubcommand,

--- a/packages/cli/src/commands/global-config/index.ts
+++ b/packages/cli/src/commands/global-config/index.ts
@@ -7,6 +7,7 @@ import addCmd from './add';
 import getCmd from './get';
 import updateCmd from './update';
 import removeCmd from './remove';
+import schemaCmd from './schema';
 import itemsCmd from './items';
 import tokensCmd from './tokens';
 import backupsCmd from './backups';
@@ -17,6 +18,7 @@ import {
   getSubcommand as getSubcommandDef,
   updateSubcommand,
   removeSubcommand,
+  schemaSubcommand,
   itemsSubcommand,
   tokensSubcommand,
   backupsSubcommand,
@@ -33,6 +35,7 @@ const COMMAND_CONFIG = {
   get: ['get', 'inspect'],
   update: ['update'],
   remove: ['remove', 'rm', 'delete'],
+  schema: ['schema'],
   items: ['items'],
   tokens: ['tokens'],
   backups: ['backups'],
@@ -119,6 +122,13 @@ export default async function main(client: Client): Promise<number> {
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return removeCmd(client, args);
+    case 'schema':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('global-config', subcommandOriginal);
+        return printHelp(schemaSubcommand);
+      }
+      telemetry.trackCliSubcommandSchema(subcommandOriginal);
+      return schemaCmd(client, args);
     case 'items':
       if (needHelp) {
         telemetry.trackCliFlagHelp('global-config', subcommandOriginal);

--- a/packages/cli/src/commands/global-config/schema.ts
+++ b/packages/cli/src/commands/global-config/schema.ts
@@ -1,0 +1,175 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { validateJsonOutput } from '../../util/output-format';
+import {
+  buildCommandWithGlobalFlags,
+  exitWithNonInteractiveError,
+  outputAgentError,
+} from '../../util/agent-output';
+import { getCommandName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { GlobalConfigSchemaTelemetryClient } from '../../util/telemetry/commands/global-config/schema';
+import { schemaSubcommand } from './command';
+import { resolveGlobalConfigId } from './resolve-global-config-id';
+
+const KNOWN_ACTIONS = ['get'] as const;
+type SchemaAction = (typeof KNOWN_ACTIONS)[number];
+
+function resolveAction(raw: string | undefined): SchemaAction | undefined {
+  if (raw === 'get' || raw === 'inspect') {
+    return 'get';
+  }
+  return undefined;
+}
+
+export default async function schemaCmd(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new GlobalConfigSchemaTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(
+      argv,
+      getFlagsSpecification(schemaSubcommand.options)
+    );
+  } catch (error) {
+    if (client.nonInteractive) {
+      exitWithNonInteractiveError(client, error, 1, {
+        variant: 'global-config',
+      });
+    }
+    printError(error);
+    return 1;
+  }
+
+  const { args, flags } = parsedArgs;
+  const [actionRaw, idOrSlug] = args;
+  const action = resolveAction(actionRaw);
+
+  telemetry.trackCliArgumentAction(action);
+  telemetry.trackCliArgumentIdOrSlug(idOrSlug);
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  if (!action) {
+    const message = `Unknown action "${actionRaw ?? ''}". Supported: ${KNOWN_ACTIONS.join(
+      ', '
+    )}.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'invalid_arguments',
+          message,
+        },
+        1
+      );
+    }
+    output.error(
+      `${message} Usage: ${chalk.cyan(
+        getCommandName('global-config schema get <id-or-slug>')
+      )}`
+    );
+    return 1;
+  }
+
+  if (!idOrSlug) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'missing_arguments',
+          message:
+            'Global Config id or slug is required. Usage: `vercel global-config schema get <id-or-slug>`',
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                'global-config list'
+              ),
+            },
+          ],
+        },
+        1
+      );
+    }
+    output.error(
+      `Missing id or slug. Usage: ${chalk.cyan(
+        getCommandName('global-config schema get <id-or-slug>')
+      )}`
+    );
+    return 1;
+  }
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  let id: string | null;
+  try {
+    id = await resolveGlobalConfigId(client, idOrSlug);
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'global-config' });
+    printError(err);
+    return 1;
+  }
+
+  if (!id) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'not_found',
+          message: `No Global Config matches "${idOrSlug}" in the current team.`,
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                'global-config list'
+              ),
+            },
+          ],
+        },
+        1
+      );
+    }
+    output.error(`No Global Config matches "${idOrSlug}" in the current team.`);
+    return 1;
+  }
+
+  let data: unknown;
+  try {
+    data = await client.fetch(
+      `/v1/global-config/${encodeURIComponent(id)}/schema`
+    );
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'global-config' });
+    printError(err);
+    return 1;
+  }
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify(data ?? null, null, 2)}\n`);
+    return 0;
+  }
+
+  if (data === null || data === undefined) {
+    output.log('No schema is set for this Global Config.');
+    return 0;
+  }
+
+  output.log(JSON.stringify(data, null, 2));
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/global-config/index.ts
+++ b/packages/cli/src/util/telemetry/commands/global-config/index.ts
@@ -26,6 +26,10 @@ export class GlobalConfigTelemetryClient
     this.trackCliSubcommand({ subcommand: 'remove', value: actual });
   }
 
+  trackCliSubcommandSchema(actual: string) {
+    this.trackCliSubcommand({ subcommand: 'schema', value: actual });
+  }
+
   trackCliSubcommandItems(actual: string) {
     this.trackCliSubcommand({ subcommand: 'items', value: actual });
   }

--- a/packages/cli/src/util/telemetry/commands/global-config/schema.ts
+++ b/packages/cli/src/util/telemetry/commands/global-config/schema.ts
@@ -1,0 +1,33 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { schemaSubcommand } from '../../../../commands/global-config/command';
+
+export class GlobalConfigSchemaTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof schemaSubcommand>
+{
+  trackCliArgumentAction(value: string | undefined) {
+    // Only known actions are recorded; unknown input is dropped so we never
+    // capture arbitrary user-supplied strings.
+    this.trackCliArgument({ arg: 'action', value });
+  }
+
+  trackCliArgumentIdOrSlug(value: string | undefined) {
+    this.trackCliArgument({ arg: 'id-or-slug', value });
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/global-config/global-config.test.ts
+++ b/packages/cli/test/unit/commands/global-config/global-config.test.ts
@@ -523,6 +523,107 @@ describe('global-config', () => {
     await expect(client.stderr).toOutput('`--patch` must be');
   });
 
+  describe('schema get', () => {
+    it('gets a schema in human output', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_schema_get', slug: 'my-store' }]);
+      });
+      client.scenario.get(
+        '/v1/global-config/ecfg_schema_get/schema',
+        (req, res) => {
+          expect(req.query.teamId).toBe('team_ec_test');
+          res.json({
+            definition: {
+              type: 'object',
+              properties: { greeting: { type: 'string' } },
+            },
+          });
+        }
+      );
+
+      client.setArgv('global-config', 'schema', 'get', 'my-store');
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(0);
+      const out = client.stderr.getFullOutput();
+      expect(out).toContain('greeting');
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:schema', value: 'schema' },
+        { key: 'argument:action', value: 'get' },
+        { key: 'argument:id-or-slug', value: 'my-store' },
+      ]);
+    });
+
+    it('gets a schema as pure JSON on stdout', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_schema_json', slug: 'my-store' }]);
+      });
+      client.scenario.get(
+        '/v1/global-config/ecfg_schema_json/schema',
+        (req, res) => {
+          expect(req.query.teamId).toBe('team_ec_test');
+          res.json({ definition: { type: 'object' } });
+        }
+      );
+
+      client.setArgv(
+        'global-config',
+        'schema',
+        'get',
+        'my-store',
+        '--format',
+        'json'
+      );
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(0);
+      const raw = client.stdout.getFullOutput();
+      // stdout must be parseable JSON with no human prose mixed in
+      const out = JSON.parse(raw.trim());
+      expect(out).toEqual({ definition: { type: 'object' } });
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:schema', value: 'schema' },
+        { key: 'argument:action', value: 'get' },
+        { key: 'argument:id-or-slug', value: 'my-store' },
+        { key: 'option:format', value: 'json' },
+      ]);
+    });
+
+    it('reports when no schema is set (human) and emits null (JSON)', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_schema_none', slug: 'my-store' }]);
+      });
+      client.scenario.get(
+        '/v1/global-config/ecfg_schema_none/schema',
+        (_req, res) => {
+          res.json(null);
+        }
+      );
+
+      client.setArgv('global-config', 'schema', 'get', 'my-store', '--json');
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toBeNull();
+    });
+
+    it('errors on an unknown action', async () => {
+      client.setArgv('global-config', 'schema', 'bogus', 'my-store');
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Unknown action');
+    });
+
+    it('errors when the store cannot be resolved', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([]);
+      });
+
+      client.setArgv('global-config', 'schema', 'get', 'missing-store');
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('No Global Config matches');
+    });
+  });
+
   describe('linked project scope', () => {
     it('uses the linked project team instead of the globally configured team', async () => {
       // Globally we are scoped to a different team. The linked project's


### PR DESCRIPTION
## Summary

- Adds `vercel global-config schema get <id-or-slug>` to read a Global Config store's JSON Schema, with human and `--json`/`--format json` output.

## Notes

- Uses the public `GET /v1/global-config/:id/schema` endpoint; resolves slugs to ids via the family's shared `resolveGlobalConfigId` helper.
- Machine-readable output is pure JSON on stdout; when no schema is set the endpoint returns `null`, printed as `null` in JSON mode and a short message in human mode.
- Telemetry records the action, id-or-slug, and `--format` only; schema contents are never recorded.
- Existing `global-config list|add|get|update|remove|items|tokens|backups` behavior is untouched.
- Stacked follow-up (schema set|remove) will target this branch.