### PR TITLE
[CLI] Add rollback describe subcommand

### DIFF
--- a/.changeset/rollback-describe.md
+++ b/.changeset/rollback-describe.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel rollback describe` to edit the description attached to a rollback

--- a/packages/cli/src/commands/rollback/command.ts
+++ b/packages/cli/src/commands/rollback/command.ts
@@ -10,6 +10,15 @@ const timeoutOption = {
   deprecated: false,
 } as const;
 
+const descriptionOption = {
+  name: 'description',
+  description: 'The reason for the rollback',
+  argument: 'TEXT',
+  shorthand: null,
+  type: String,
+  deprecated: false,
+} as const;
+
 export const statusSubcommand = {
   name: 'status',
   aliases: [],
@@ -33,6 +42,25 @@ export const statusSubcommand = {
   ],
 } as const;
 
+export const describeSubcommand = {
+  name: 'describe',
+  aliases: [],
+  description: 'Edit the description attached to an existing rollback',
+  arguments: [
+    {
+      name: 'url|deploymentId',
+      required: true,
+    },
+  ],
+  options: [descriptionOption],
+  examples: [
+    {
+      name: 'Edit the description attached to a rollback',
+      value: `${packageName} rollback describe <deployment id/url> --description "Reverting checkout regression"`,
+    },
+  ],
+} as const;
+
 export const rollbackCommand = {
   name: 'rollback',
   aliases: [],
@@ -43,7 +71,7 @@ export const rollbackCommand = {
       required: true,
     },
   ],
-  subcommands: [statusSubcommand],
+  subcommands: [statusSubcommand, describeSubcommand],
   options: [timeoutOption, yesOption],
   examples: [
     {

--- a/packages/cli/src/commands/rollback/describe.ts
+++ b/packages/cli/src/commands/rollback/describe.ts
@@ -1,0 +1,106 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import getProjectByDeployment from '../../util/projects/get-project-by-deployment';
+import { RollbackDescribeTelemetryClient } from '../../util/telemetry/commands/rollback/describe';
+import { describeSubcommand } from './command';
+import output from '../../output-manager';
+
+// Mirrors the API schema for the rollback description body.
+const MAX_DESCRIPTION_LENGTH = 250;
+
+/**
+ * Edits the description attached to an existing rollback.
+ * @param {Client} client - The Vercel client instance
+ * @param {string[]} argv - The subcommand arguments (after `rollback describe`)
+ * @returns {Promise<number>} Resolves an exit code; 0 on success
+ */
+export default async function describe(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new RollbackDescribeTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(describeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  const deployId = args[0];
+  const description = flags['--description'];
+
+  telemetry.trackCliArgumentUrlOrDeploymentId(deployId);
+  telemetry.trackCliOptionDescription(description);
+
+  if (!deployId) {
+    output.error(
+      `Missing deployment id or url. Usage: ${chalk.cyan(
+        getCommandName(
+          'rollback describe <deployment id/url> --description <text>'
+        )
+      )}`
+    );
+    return 1;
+  }
+
+  if (description === undefined) {
+    output.error(
+      `The ${chalk.cyan('--description')} option is required. Usage: ${chalk.cyan(
+        getCommandName(
+          'rollback describe <deployment id/url> --description <text>'
+        )
+      )}`
+    );
+    return 1;
+  }
+
+  const trimmedDescription = description.trim();
+  if (trimmedDescription.length === 0) {
+    output.error("The rollback description can't be empty.");
+    return 1;
+  }
+
+  if (trimmedDescription.length > MAX_DESCRIPTION_LENGTH) {
+    output.error(
+      `The rollback description must be ${MAX_DESCRIPTION_LENGTH} characters or fewer.`
+    );
+    return 1;
+  }
+
+  const { deployment, project } = await getProjectByDeployment({
+    client,
+    deployId,
+  });
+
+  try {
+    output.spinner('Updating rollback description…');
+    await client.fetch(
+      `/v10/projects/${project.id}/rollback/${deployment.id}/update-description`,
+      {
+        body: { description: trimmedDescription },
+        method: 'PATCH',
+      }
+    );
+  } finally {
+    output.stopSpinner();
+  }
+
+  output.log(
+    `Updated rollback description for ${chalk.bold(deployment.url)} (${
+      deployment.id
+    })`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/rollback/index.ts
+++ b/packages/cli/src/commands/rollback/index.ts
@@ -6,8 +6,13 @@ import { isErrnoException } from '@vercel/error-utils';
 import ms from 'ms';
 import requestRollback from './request-rollback';
 import rollbackStatus from './status';
+import describe from './describe';
 import { help } from '../help';
-import { rollbackCommand, statusSubcommand } from './command';
+import {
+  describeSubcommand,
+  rollbackCommand,
+  statusSubcommand,
+} from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { RollbackTelemetryClient } from '../../util/telemetry/commands/rollback';
 import output from '../../output-manager';
@@ -23,8 +28,21 @@ export default async (client: Client): Promise<number> => {
   try {
     parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
   } catch (error) {
-    printError(error);
-    return 1;
+    // the `describe` subcommand has options the parent parser does not know
+    // about; re-parse permissively so they reach the subcommand parser, and
+    // keep the original strict error for every other path
+    try {
+      parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+        permissive: true,
+      });
+    } catch (permissiveError) {
+      printError(permissiveError);
+      return 1;
+    }
+    if (parsedArgs.args[1] !== 'describe') {
+      printError(error);
+      return 1;
+    }
   }
 
   const telemetry = new RollbackTelemetryClient({
@@ -78,6 +96,21 @@ export default async (client: Client): Promise<number> => {
         project,
         timeout,
       });
+    }
+
+    if (actionOrDeployId === 'describe') {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('rollback', 'describe');
+        output.print(
+          help(describeSubcommand, {
+            columns: client.stderr.columns,
+            parent: rollbackCommand,
+          })
+        );
+        return 2;
+      }
+      telemetry.trackCliSubcommandDescribe(actionOrDeployId);
+      return await describe(client, parsedArgs.args.slice(2));
     }
 
     return await requestRollback({

--- a/packages/cli/src/util/telemetry/commands/rollback/describe.ts
+++ b/packages/cli/src/util/telemetry/commands/rollback/describe.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { describeSubcommand } from '../../../../commands/rollback/command';
+
+export class RollbackDescribeTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof describeSubcommand>
+{
+  trackCliArgumentUrlOrDeploymentId(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({
+        arg: 'urlOrDeploymentId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDescription(description: string | undefined) {
+    if (description) {
+      this.trackCliOption({
+        option: 'description',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/rollback/index.ts
+++ b/packages/cli/src/util/telemetry/commands/rollback/index.ts
@@ -22,6 +22,13 @@ export class RollbackTelemetryClient
     });
   }
 
+  trackCliSubcommandDescribe(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'describe',
+      value: actual,
+    });
+  }
+
   trackCliOptionTimeout(time: string | undefined) {
     if (time) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -6798,11 +6798,22 @@ exports[`help command > rollback help output snapshots > rollback help column wi
 
   Commands:
 
-  status  [project]  Show the   
-                     status of  
-                     any current
-                     pending    
-                     rollbacks  
+  status    [project]         S…
+                              t…
+                              s…
+                              of
+                              a…
+                              c…
+                              p…
+                              r…
+  describe  url|deploymentId  E…
+                              t…
+                              d…
+                              a…
+                              to
+                              an
+                              e…
+                              r…
 
 
   Options:
@@ -6879,7 +6890,10 @@ exports[`help command > rollback help output snapshots > rollback help column wi
 
   Commands:
 
-  status  [project]  Show the status of any current pending rollbacks   
+  status    [project]         Show the status of any current pending    
+                              rollbacks                                 
+  describe  url|deploymentId  Edit the description attached to an       
+                              existing rollback                         
 
 
   Options:
@@ -6921,7 +6935,8 @@ exports[`help command > rollback help output snapshots > rollback help column wi
 
   Commands:
 
-  status  [project]  Show the status of any current pending rollbacks                                           
+  status    [project]         Show the status of any current pending rollbacks                                  
+  describe  url|deploymentId  Edit the description attached to an existing rollback                             
 
 
   Options:

--- a/packages/cli/test/unit/commands/rollback/describe.test.ts
+++ b/packages/cli/test/unit/commands/rollback/describe.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import chalk from 'chalk';
+import type { Request, Response } from 'express';
+import { client } from '../../../mocks/client';
+import { defaultProject, useProject } from '../../../mocks/project';
+import rollback from '../../../../src/commands/rollback';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import { useDeployment } from '../../../mocks/deployment';
+import { useTeams } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+describe('rollback describe', () => {
+  it('should update the rollback description by deployment id', async () => {
+    const { cwd, previousDeployment, getLastBody } = initDescribeTest();
+    client.cwd = cwd;
+    client.setArgv(
+      'rollback',
+      'describe',
+      previousDeployment.id,
+      '--description',
+      'Reverting checkout regression'
+    );
+    const exitCodePromise = rollback(client);
+
+    await expect(client.stderr).toOutput(
+      `Updated rollback description for ${chalk.bold(previousDeployment.url)} (${
+        previousDeployment.id
+      })`
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "rollback describe"').toEqual(0);
+    expect(getLastBody()).toEqual({
+      description: 'Reverting checkout regression',
+    });
+  });
+
+  it('should error if --description is missing', async () => {
+    const { cwd, previousDeployment } = initDescribeTest();
+    client.cwd = cwd;
+    client.setArgv('rollback', 'describe', previousDeployment.id);
+    const exitCodePromise = rollback(client);
+
+    await expect(client.stderr).toOutput(
+      'Error: The --description option is required.'
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "rollback describe"').toEqual(1);
+  });
+
+  it('should error if --description is empty', async () => {
+    const { cwd, previousDeployment } = initDescribeTest();
+    client.cwd = cwd;
+    client.setArgv(
+      'rollback',
+      'describe',
+      previousDeployment.id,
+      '--description',
+      '   '
+    );
+    const exitCodePromise = rollback(client);
+
+    await expect(client.stderr).toOutput(
+      "Error: The rollback description can't be empty."
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "rollback describe"').toEqual(1);
+  });
+
+  it('should error if --description exceeds the maximum length', async () => {
+    const { cwd, previousDeployment } = initDescribeTest();
+    client.cwd = cwd;
+    client.setArgv(
+      'rollback',
+      'describe',
+      previousDeployment.id,
+      '--description',
+      'a'.repeat(251)
+    );
+    const exitCodePromise = rollback(client);
+
+    await expect(client.stderr).toOutput(
+      'Error: The rollback description must be 250 characters or fewer.'
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "rollback describe"').toEqual(1);
+  });
+
+  it('should error if an unknown option is used', async () => {
+    const { cwd, previousDeployment } = initDescribeTest();
+    client.cwd = cwd;
+    client.setArgv(
+      'rollback',
+      'describe',
+      previousDeployment.id,
+      '--description',
+      'text',
+      '--bogus'
+    );
+    const exitCodePromise = rollback(client);
+
+    await expect(client.stderr).toOutput(
+      'Error: unknown or unexpected option: --bogus'
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "rollback describe"').toEqual(1);
+  });
+
+  it('should error if deployment not found', async () => {
+    const { cwd } = initDescribeTest();
+    client.cwd = cwd;
+    client.setArgv('rollback', 'describe', 'foo', '--description', 'text');
+    const exitCodePromise = rollback(client);
+
+    await expect(client.stderr).toOutput(
+      'Error: Can\'t find the deployment "foo" under the context'
+    );
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "rollback describe"').toEqual(1);
+  });
+
+  describe('telemetry', () => {
+    it('tracks usage', async () => {
+      const { cwd, previousDeployment } = initDescribeTest();
+      client.cwd = cwd;
+      client.setArgv(
+        'rollback',
+        'describe',
+        previousDeployment.id,
+        '--description',
+        'Reverting checkout regression'
+      );
+      const exitCode = await rollback(client);
+      expect(exitCode, 'exit code for "rollback describe"').toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:describe',
+          value: 'describe',
+        },
+        {
+          key: 'argument:urlOrDeploymentId',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'option:description',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+});
+
+function initDescribeTest() {
+  const cwd = setupUnitFixture('commands/rollback/simple-next-site');
+  const user = useUser();
+  useTeams('team_dummy');
+  const { project } = useProject({
+    ...defaultProject,
+    id: 'vercel-rollback',
+    name: 'vercel-rollback',
+  });
+
+  const previousDeployment = useDeployment({ creator: user, project });
+
+  let lastBody: unknown;
+  client.scenario.patch(
+    '/:version/projects/:project/rollback/:id/update-description',
+    (req: Request, res: Response) => {
+      const { id } = req.params;
+      if (previousDeployment.id !== id) {
+        res.statusCode = 404;
+        res.json({
+          error: { code: 'not_found', message: 'Deployment not found', id },
+        });
+        return;
+      }
+      lastBody = req.body;
+      res.statusCode = 200;
+      res.end();
+    }
+  );
+
+  return {
+    cwd,
+    project,
+    previousDeployment,
+    getLastBody: () => lastBody,
+  };
+}

--- a/packages/cli/test/unit/commands/rollback/index.test.ts
+++ b/packages/cli/test/unit/commands/rollback/index.test.ts
@@ -42,6 +42,19 @@ describe('rollback', () => {
     });
   });
 
+  it('should error if an unknown option is used', async () => {
+    const { cwd, previousDeployment } = initRollbackTest();
+    client.cwd = cwd;
+    client.setArgv('rollback', previousDeployment.id, '--bogus');
+    const exitCodePromise = rollback(client);
+
+    await expect(client.stderr).toOutput(
+      'Error: unknown or unexpected option: --bogus'
+    );
+    const exitCode = await exitCodePromise;
+    expect(exitCode, 'exit code for "rollback"').toEqual(1);
+  });
+
   it('should error if timeout is invalid', async () => {
     const { cwd } = initRollbackTest();
     client.cwd = cwd;


### PR DESCRIPTION
## Summary

- Adds `vercel rollback describe <deployment id/url> --description <text>` to edit the description attached to an existing rollback, with local validation (required, non-empty, max 250 characters per the API schema) before the remote call.

## Notes

- Uses the public `PATCH /v10/projects/:projectId/rollback/:deploymentId/update-description` endpoint (the same one the dashboard uses).
- No confirmation prompt: this is low-risk metadata editing, consistent with other metadata-edit commands.
- The deployment argument accepts an id or URL and is resolved with the same helper the rollback request path uses; the description is redacted in telemetry.
- Existing `rollback <deployment>` and `rollback status` behavior is untouched, including strict flag parsing (locked by a new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)