### PR TITLE
[CLI] Add firewall restore subcommand

### DIFF
--- a/.changeset/firewall-restore.md
+++ b/.changeset/firewall-restore.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel firewall restore <config-version>` to restore a previously published firewall configuration version

--- a/packages/cli/src/commands/firewall/command.ts
+++ b/packages/cli/src/commands/firewall/command.ts
@@ -87,6 +87,25 @@ export const discardSubcommand = {
   ],
 } as const;
 
+export const restoreSubcommand = {
+  name: 'restore',
+  aliases: [],
+  description:
+    'Restore a previously published firewall configuration version, making it live in production',
+  arguments: [{ name: 'config-version', required: true }],
+  options: [projectOption, yesOption],
+  examples: [
+    {
+      name: 'Restore a previously published configuration version',
+      value: `${packageName} firewall restore 42`,
+    },
+    {
+      name: 'Restore without confirmation',
+      value: `${packageName} firewall restore 42 --yes`,
+    },
+  ],
+} as const;
+
 // System Bypass subcommands
 export const systemBypassListSubcommand = {
   name: 'list',
@@ -947,6 +966,7 @@ export const firewallCommand = {
     diffSubcommand,
     publishSubcommand,
     discardSubcommand,
+    restoreSubcommand,
     ipBlocksSubcommand,
     rulesSubcommand,
     systemBypassSubcommand,

--- a/packages/cli/src/commands/firewall/index.ts
+++ b/packages/cli/src/commands/firewall/index.ts
@@ -8,6 +8,7 @@ import overview from './overview';
 import diff from './diff';
 import publish from './publish';
 import discard from './discard';
+import restore from './restore';
 import systemBypass from './system-bypass';
 import attackMode from './attack-mode';
 import systemMitigations from './system-mitigations';
@@ -19,6 +20,7 @@ import {
   diffSubcommand,
   publishSubcommand,
   discardSubcommand,
+  restoreSubcommand,
   rulesSubcommand,
   ipBlocksSubcommand,
   systemBypassSubcommand,
@@ -37,6 +39,7 @@ const COMMAND_CONFIG = {
   diff: getCommandAliases(diffSubcommand),
   publish: getCommandAliases(publishSubcommand),
   discard: getCommandAliases(discardSubcommand),
+  restore: getCommandAliases(restoreSubcommand),
   'ip-blocks': getCommandAliases(ipBlocksSubcommand),
   'system-bypass': getCommandAliases(systemBypassSubcommand),
   'attack-mode': getCommandAliases(attackModeSubcommand),
@@ -121,6 +124,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandDiscard(subcommandOriginal);
       return discard(client, args);
+    case 'restore':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('firewall', subcommandOriginal);
+        printHelp(restoreSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRestore(subcommandOriginal);
+      return restore(client, args);
     case 'rules': {
       telemetry.trackCliSubcommandRules(subcommandOriginal);
       const nestedArgs = needHelp ? [...args, '--help'] : args;

--- a/packages/cli/src/commands/firewall/restore.ts
+++ b/packages/cli/src/commands/firewall/restore.ts
@@ -1,0 +1,174 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { requireProjectContext } from '../../util/projects/require-project-context';
+import output from '../../output-manager';
+import { restoreSubcommand } from './command';
+import { parseSubcommandArgs, confirmAction, withGlobalFlags } from './shared';
+import getFirewallConfig from '../../util/firewall/get-firewall-config';
+import activateFirewallConfig from '../../util/firewall/activate-firewall-config';
+import formatDate from '../../util/format-date';
+import stamp from '../../util/output/stamp';
+import { outputAgentError } from '../../util/agent-output';
+
+export default async function restore(client: Client, argv: string[]) {
+  const parsed = await parseSubcommandArgs(argv, restoreSubcommand, client);
+  if (typeof parsed === 'number') return parsed;
+
+  const configVersion = parsed.args[0];
+
+  // Validate the version argument locally before any remote calls.
+  if (!configVersion) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'missing_arguments',
+          message: 'A configuration version is required.',
+          next: [
+            {
+              command: withGlobalFlags(
+                client,
+                'firewall restore <config-version>'
+              ),
+              when: 'replace <config-version>',
+            },
+          ],
+        },
+        1
+      );
+      return 1;
+    }
+    output.error(
+      `A configuration version is required. Usage: ${withGlobalFlags(client, 'firewall restore <config-version>')}`
+    );
+    return 1;
+  }
+
+  if (!/^\d+$/.test(configVersion) || Number(configVersion) < 1) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'invalid_arguments',
+          message: `Invalid configuration version "${configVersion}". Expected a positive integer.`,
+          next: [
+            {
+              command: withGlobalFlags(
+                client,
+                'firewall restore <config-version>'
+              ),
+              when: 'provide a valid version number',
+            },
+          ],
+        },
+        1
+      );
+      return 1;
+    }
+    output.error(
+      `Invalid configuration version "${configVersion}". Expected a positive integer.`
+    );
+    return 1;
+  }
+
+  const link = await requireProjectContext(
+    client,
+    'firewall',
+    parsed.flags['--project']
+  );
+  if (typeof link === 'number') return link;
+
+  const { project, org } = link;
+  const teamId = org.type === 'team' ? org.id : undefined;
+
+  output.spinner(
+    `Fetching configuration version ${chalk.bold(configVersion)} for ${chalk.bold(project.name)}`
+  );
+
+  let config;
+  try {
+    config = await getFirewallConfig(client, project.id, configVersion, {
+      teamId,
+    });
+  } catch (e: unknown) {
+    output.stopSpinner();
+    const error = e as { status?: number; message?: string };
+    const notFound = error.status === 404;
+    const msg = notFound
+      ? `Firewall configuration version ${configVersion} was not found for ${chalk.bold(project.name)}.`
+      : error.message || 'Failed to fetch firewall configuration';
+    if (client.nonInteractive) {
+      outputAgentError(client, {
+        status: 'error',
+        reason: notFound ? 'not_found' : 'api_error',
+        message: msg,
+        next: [{ command: withGlobalFlags(client, 'firewall overview') }],
+      });
+      process.exit(1);
+      return 1;
+    }
+    output.error(msg);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  output.print(
+    `\n${chalk.bold(`Restore firewall configuration version ${configVersion}`)}\n`
+  );
+  if (config.updatedAt) {
+    output.print(`  Published ${formatDate(config.updatedAt)}\n`);
+  }
+  output.print('\n');
+
+  const confirmed = await confirmAction(
+    client,
+    parsed.flags['--yes'],
+    `Restore version ${configVersion} to production?`,
+    `This will replace the active firewall configuration for ${chalk.bold(project.name)}.`
+  );
+
+  if (!confirmed) {
+    output.log('Canceled');
+    return 0;
+  }
+
+  const updateStamp = stamp();
+  output.spinner('Restoring configuration to production');
+
+  try {
+    await activateFirewallConfig(client, project.id, configVersion, {
+      teamId,
+    });
+  } catch (e: unknown) {
+    const error = e as { message?: string };
+    const msg = error.message || 'Failed to restore firewall configuration';
+    if (client.nonInteractive) {
+      outputAgentError(client, {
+        status: 'error',
+        reason: 'api_error',
+        message: msg,
+        next: [
+          {
+            command: withGlobalFlags(
+              client,
+              `firewall restore ${configVersion} --yes`
+            ),
+          },
+        ],
+      });
+      process.exit(1);
+      return 1;
+    }
+    output.error(msg);
+    return 1;
+  }
+
+  output.log(
+    `${chalk.cyan('Success!')} Firewall configuration version ${configVersion} restored to production ${chalk.gray(updateStamp())}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/util/firewall/get-firewall-config.ts
+++ b/packages/cli/src/util/firewall/get-firewall-config.ts
@@ -1,0 +1,22 @@
+import type Client from '../client';
+import type { FirewallConfigResponse } from './types';
+
+interface GetFirewallConfigOptions {
+  teamId?: string;
+}
+
+export default async function getFirewallConfig(
+  client: Client,
+  projectId: string,
+  configVersion: string,
+  options: GetFirewallConfigOptions = {}
+): Promise<FirewallConfigResponse> {
+  const { teamId } = options;
+
+  const query = new URLSearchParams();
+  query.set('projectId', projectId);
+  if (teamId) query.set('teamId', teamId);
+
+  const url = `/v1/security/firewall/config/${configVersion}?${query.toString()}`;
+  return client.fetch<FirewallConfigResponse>(url);
+}

--- a/packages/cli/src/util/telemetry/commands/firewall/index.ts
+++ b/packages/cli/src/util/telemetry/commands/firewall/index.ts
@@ -34,6 +34,13 @@ export class FirewallTelemetryClient
     });
   }
 
+  trackCliSubcommandRestore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'restore',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandRules(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'rules',

--- a/packages/cli/test/mocks/firewall.ts
+++ b/packages/cli/test/mocks/firewall.ts
@@ -197,6 +197,24 @@ export function useListFirewallConfigs(
   });
 }
 
+export function useGetFirewallConfig(
+  config: FirewallConfigResponse | null = null,
+  statusCode = 404
+) {
+  client.scenario.get(
+    '/v1/security/firewall/config/:version',
+    (req: any, res: any) => {
+      if (!config) {
+        res.status(statusCode).json({
+          error: { code: 'not_found', message: 'Config not found' },
+        });
+        return;
+      }
+      res.json({ ...config, version: Number(req.params.version) });
+    }
+  );
+}
+
 export function useGetBypass(bypass: BypassRule[] = []) {
   client.scenario.get('/v1/security/firewall/bypass', (_req: any, res: any) => {
     const response: BypassListResponse = {

--- a/packages/cli/test/unit/commands/firewall/restore.test.ts
+++ b/packages/cli/test/unit/commands/firewall/restore.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import firewall from '../../../../src/commands/firewall';
+import { useUser } from '../../../mocks/user';
+import {
+  useGetFirewallConfig,
+  useActivateConfig,
+  capturedRequests,
+  createConfig,
+} from '../../../mocks/firewall';
+import { useProject, defaultProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+
+describe('firewall restore', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'firewall-test-project',
+      name: 'firewall-test',
+    });
+    const cwd = setupUnitFixture('commands/firewall');
+    client.cwd = cwd;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('firewall', 'restore', '--help');
+      const exitCode = await firewall(client);
+      expect(exitCode).toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'firewall:restore',
+        },
+      ]);
+    });
+  });
+
+  it('should error when no version is provided', async () => {
+    client.setArgv('firewall', 'restore');
+    const exitCodePromise = firewall(client);
+    await expect(client.stderr).toOutput(
+      'A configuration version is required.'
+    );
+    expect(await exitCodePromise).toEqual(1);
+  });
+
+  it('should error when version is not a positive integer', async () => {
+    client.setArgv('firewall', 'restore', 'abc', '--yes');
+    const exitCodePromise = firewall(client);
+    await expect(client.stderr).toOutput('Invalid configuration version "abc"');
+    expect(await exitCodePromise).toEqual(1);
+  });
+
+  it('should error when the version is not found', async () => {
+    useGetFirewallConfig(null);
+
+    client.setArgv('firewall', 'restore', '999', '--yes');
+    const exitCodePromise = firewall(client);
+    await expect(client.stderr).toOutput(
+      'Firewall configuration version 999 was not found'
+    );
+    expect(await exitCodePromise).toEqual(1);
+    expect(capturedRequests.activate).toBeUndefined();
+  });
+
+  it('should restore a version with --yes', async () => {
+    useGetFirewallConfig(createConfig({ version: 5 }));
+    useActivateConfig();
+
+    client.setArgv('firewall', 'restore', '5', '--yes');
+    const exitCodePromise = firewall(client);
+    await expect(client.stderr).toOutput('restored to production');
+    expect(await exitCodePromise).toEqual(0);
+    expect(capturedRequests.activate).toEqual({ version: '5' });
+  });
+
+  it('should show what will be restored before confirming', async () => {
+    useGetFirewallConfig(createConfig({ version: 7 }));
+    useActivateConfig();
+
+    client.setArgv('firewall', 'restore', '7', '--yes');
+    const exitCodePromise = firewall(client);
+    await expect(client.stderr).toOutput(
+      'Restore firewall configuration version 7'
+    );
+    expect(await exitCodePromise).toEqual(0);
+  });
+
+  it('should cancel when the user declines the confirmation', async () => {
+    useGetFirewallConfig(createConfig({ version: 5 }));
+    useActivateConfig();
+
+    client.setArgv('firewall', 'restore', '5');
+    const exitCodePromise = firewall(client);
+    await expect(client.stderr).toOutput('Restore version 5 to production?');
+    client.stdin.write('n\n');
+    await expect(client.stderr).toOutput('Canceled');
+    expect(await exitCodePromise).toEqual(0);
+    expect(capturedRequests.activate).toBeUndefined();
+  });
+
+  it('should restore when the user accepts the confirmation', async () => {
+    useGetFirewallConfig(createConfig({ version: 5 }));
+    useActivateConfig();
+
+    client.setArgv('firewall', 'restore', '5');
+    const exitCodePromise = firewall(client);
+    await expect(client.stderr).toOutput('Restore version 5 to production?');
+    client.stdin.write('y\n');
+    await expect(client.stderr).toOutput('restored to production');
+    expect(await exitCodePromise).toEqual(0);
+    expect(capturedRequests.activate).toEqual({ version: '5' });
+  });
+
+  it('should error in non-interactive mode without --yes', async () => {
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as () => never);
+    client.nonInteractive = true;
+    useGetFirewallConfig(createConfig({ version: 5 }));
+    useActivateConfig();
+
+    client.setArgv('firewall', 'restore', '5');
+    await expect(firewall(client)).rejects.toThrow('exit:1');
+
+    const payload = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(payload.status).toBe('error');
+    expect(payload.reason).toBe('confirmation_required');
+    expect(payload.next?.[0]?.command).toContain('firewall restore 5 --yes');
+    expect(capturedRequests.activate).toBeUndefined();
+  });
+
+  it('tracks subcommand telemetry', async () => {
+    useGetFirewallConfig(createConfig({ version: 5 }));
+    useActivateConfig();
+
+    client.setArgv('firewall', 'restore', '5', '--yes');
+    const exitCodePromise = firewall(client);
+    await expect(client.stderr).toOutput('restored to production');
+    expect(await exitCodePromise).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:restore',
+        value: 'restore',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `vercel firewall restore <config-version>` to restore a previously published firewall configuration version, making it live in production for the linked project.
- Validates the version argument locally (positive integer) before any remote call, fetches the target version to show what will be restored, confirms in TTY (default No), and requires `--yes` to skip; non-interactive without `--yes` exits 1 with a `confirmation_required` agent payload.
- Adds `restore` telemetry (`subcommand:restore`), a `getFirewallConfig` helper, unit tests, and a changeset.

## Notes
- Uses the public activate endpoint `POST /v1/security/firewall/config/:configVersion/activate` (via the existing `activateFirewallConfig` helper) to promote the chosen version, and `GET /v1/security/firewall/config/:configVersion` (new `getFirewallConfig` helper) to validate existence and read metadata before confirming.
- A missing version → `not_found`; other API failures → `api_error`; invalid/missing argument → `invalid_arguments`/`missing_arguments`, mirroring the firewall family's error and agent-output conventions.
- Follows the `publish`/`discard` family patterns for project linking, scope resolution, spinners, and success copy; no existing firewall subcommands or their behavior are changed.
- `firewall restore --help` renders correctly and the subcommand appears in `firewall --help`; help.test.ts is unaffected (firewall is not snapshotted there).