### PR TITLE
[CLI] Add global-config schema set and remove subcommands

### DIFF
--- a/.changeset/global-config-schema.md
+++ b/.changeset/global-config-schema.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Add `vercel global-config schema get` to read a Global Config store's JSON Schema
+Add `vercel global-config schema get|set|remove` to read, set, and delete a Global Config store's JSON Schema

--- a/packages/cli/src/commands/global-config/command.ts
+++ b/packages/cli/src/commands/global-config/command.ts
@@ -113,7 +113,7 @@ export const removeSubcommand = {
 export const schemaSubcommand = {
   name: 'schema',
   aliases: [],
-  description: "Get a Global Config store's JSON Schema",
+  description: "Get, set, or remove a Global Config store's JSON Schema",
   arguments: [
     {
       name: 'action',
@@ -123,16 +123,28 @@ export const schemaSubcommand = {
       name: 'id-or-slug',
       required: true,
     },
+    {
+      name: 'file',
+      required: false,
+    },
   ],
-  options: [formatOption, jsonOption],
+  options: [formatOption, jsonOption, yesOption],
   examples: [
     {
       name: 'Get the schema for a Global Config',
       value: `${packageName} global-config schema get my-store`,
     },
     {
-      name: 'Get the schema as JSON',
-      value: `${packageName} global-config schema get my-store --json`,
+      name: 'Set the schema from a file',
+      value: `${packageName} global-config schema set my-store ./schema.json`,
+    },
+    {
+      name: 'Set the schema from stdin',
+      value: `cat schema.json | ${packageName} global-config schema set my-store`,
+    },
+    {
+      name: 'Remove the schema without a prompt',
+      value: `${packageName} global-config schema remove my-store --yes`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/global-config/parse-schema-body.ts
+++ b/packages/cli/src/commands/global-config/parse-schema-body.ts
@@ -1,0 +1,38 @@
+/**
+ * Parse the JSON for `global-config schema set`. The input is a JSON Schema
+ * document read from a file or stdin.
+ *
+ * Accepts either the bare schema definition or a `{ "definition": <schema> }`
+ * wrapper so that the output of `global-config schema get` round-trips back
+ * into `set`. The API body is always `{ definition: <schema> }`.
+ */
+export function parseSchemaBody(raw: string): { definition: unknown } {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error(
+      'No schema provided. Pass a file path or pipe JSON via stdin.'
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(
+      `Schema must be valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    !Array.isArray(parsed) &&
+    'definition' in parsed
+  ) {
+    return { definition: (parsed as { definition: unknown }).definition };
+  }
+
+  return { definition: parsed };
+}

--- a/packages/cli/src/commands/global-config/schema.ts
+++ b/packages/cli/src/commands/global-config/schema.ts
@@ -1,4 +1,6 @@
 import chalk from 'chalk';
+import { readFile } from 'fs/promises';
+import type { JSONObject } from '@vercel-internals/types';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -6,21 +8,30 @@ import { printError } from '../../util/error';
 import { validateJsonOutput } from '../../util/output-format';
 import {
   buildCommandWithGlobalFlags,
+  buildCommandWithYes,
   exitWithNonInteractiveError,
   outputAgentError,
 } from '../../util/agent-output';
 import { getCommandName } from '../../util/pkg-name';
 import output from '../../output-manager';
+import readStandardInput from '../../util/input/read-standard-input';
 import { GlobalConfigSchemaTelemetryClient } from '../../util/telemetry/commands/global-config/schema';
 import { schemaSubcommand } from './command';
 import { resolveGlobalConfigId } from './resolve-global-config-id';
+import { parseSchemaBody } from './parse-schema-body';
 
-const KNOWN_ACTIONS = ['get'] as const;
+const KNOWN_ACTIONS = ['get', 'set', 'remove'] as const;
 type SchemaAction = (typeof KNOWN_ACTIONS)[number];
 
 function resolveAction(raw: string | undefined): SchemaAction | undefined {
   if (raw === 'get' || raw === 'inspect') {
     return 'get';
+  }
+  if (raw === 'set') {
+    return 'set';
+  }
+  if (raw === 'remove' || raw === 'rm' || raw === 'delete') {
+    return 'remove';
   }
   return undefined;
 }
@@ -50,11 +61,14 @@ export default async function schemaCmd(
   }
 
   const { args, flags } = parsedArgs;
-  const [actionRaw, idOrSlug] = args;
+  const [actionRaw, idOrSlug, fileArg] = args;
   const action = resolveAction(actionRaw);
+  const skipConfirmation = flags['--yes'] === true;
 
   telemetry.trackCliArgumentAction(action);
   telemetry.trackCliArgumentIdOrSlug(idOrSlug);
+  telemetry.trackCliArgumentFile(fileArg);
+  telemetry.trackCliFlagYes(flags['--yes']);
   telemetry.trackCliOptionFormat(flags['--format']);
 
   if (!action) {
@@ -74,7 +88,7 @@ export default async function schemaCmd(
     }
     output.error(
       `${message} Usage: ${chalk.cyan(
-        getCommandName('global-config schema get <id-or-slug>')
+        getCommandName('global-config schema <get|set|remove> <id-or-slug>')
       )}`
     );
     return 1;
@@ -87,8 +101,7 @@ export default async function schemaCmd(
         {
           status: 'error',
           reason: 'missing_arguments',
-          message:
-            'Global Config id or slug is required. Usage: `vercel global-config schema get <id-or-slug>`',
+          message: `Global Config id or slug is required. Usage: \`vercel global-config schema ${action} <id-or-slug>\``,
           next: [
             {
               command: buildCommandWithGlobalFlags(
@@ -103,10 +116,24 @@ export default async function schemaCmd(
     }
     output.error(
       `Missing id or slug. Usage: ${chalk.cyan(
-        getCommandName('global-config schema get <id-or-slug>')
+        getCommandName(`global-config schema ${action} <id-or-slug>`)
       )}`
     );
     return 1;
+  }
+
+  if (action === 'remove' && client.nonInteractive && !skipConfirmation) {
+    outputAgentError(
+      client,
+      {
+        status: 'error',
+        reason: 'confirmation_required',
+        message:
+          "Removing a Global Config's schema requires confirmation. Re-run with `--yes`.",
+        next: [{ command: buildCommandWithYes(client.argv) }],
+      },
+      1
+    );
   }
 
   const formatResult = validateJsonOutput(flags);
@@ -115,6 +142,47 @@ export default async function schemaCmd(
     return 1;
   }
   const asJson = formatResult.jsonOutput;
+
+  // Validate local input before any remote mutation.
+  let schemaBody: { definition: unknown } | undefined;
+  if (action === 'set') {
+    let raw: string;
+    if (fileArg) {
+      try {
+        raw = await readFile(fileArg, 'utf8');
+      } catch (err: unknown) {
+        const message = `Could not read schema file "${fileArg}": ${
+          err instanceof Error ? err.message : String(err)
+        }`;
+        if (client.nonInteractive) {
+          outputAgentError(
+            client,
+            { status: 'error', reason: 'invalid_arguments', message },
+            1
+          );
+        }
+        output.error(message);
+        return 1;
+      }
+    } else {
+      raw = await readStandardInput(client.stdin);
+    }
+
+    try {
+      schemaBody = parseSchemaBody(raw);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          { status: 'error', reason: 'invalid_arguments', message },
+          1
+        );
+      }
+      output.error(message);
+      return 1;
+    }
+  }
 
   let id: string | null;
   try {
@@ -149,11 +217,67 @@ export default async function schemaCmd(
     return 1;
   }
 
-  let data: unknown;
+  const path = `/v1/global-config/${encodeURIComponent(id)}/schema`;
+
+  if (action === 'get') {
+    let data: unknown;
+    try {
+      data = await client.fetch(path);
+    } catch (err: unknown) {
+      exitWithNonInteractiveError(client, err, 1, { variant: 'global-config' });
+      printError(err);
+      return 1;
+    }
+
+    if (asJson) {
+      client.stdout.write(`${JSON.stringify(data ?? null, null, 2)}\n`);
+      return 0;
+    }
+    if (data === null || data === undefined) {
+      output.log('No schema is set for this Global Config.');
+      return 0;
+    }
+    output.log(JSON.stringify(data, null, 2));
+    return 0;
+  }
+
+  if (action === 'set') {
+    let data: unknown;
+    try {
+      data = await client.fetch(path, {
+        method: 'POST',
+        body: schemaBody as JSONObject,
+      });
+    } catch (err: unknown) {
+      exitWithNonInteractiveError(client, err, 1, { variant: 'global-config' });
+      printError(err);
+      return 1;
+    }
+
+    if (asJson) {
+      client.stdout.write(`${JSON.stringify(data ?? null, null, 2)}\n`);
+      return 0;
+    }
+    output.success(`Global Config schema updated for ${chalk.bold(id)}.`);
+    return 0;
+  }
+
+  // action === 'remove'
+  if (
+    !skipConfirmation &&
+    !(await client.input.confirm(
+      `Remove the schema for Global Config ${chalk.bold(id)} (${chalk.bold(
+        idOrSlug
+      )})?`,
+      false
+    ))
+  ) {
+    output.log('Canceled');
+    return 0;
+  }
+
   try {
-    data = await client.fetch(
-      `/v1/global-config/${encodeURIComponent(id)}/schema`
-    );
+    await client.fetch(path, { method: 'DELETE' });
   } catch (err: unknown) {
     exitWithNonInteractiveError(client, err, 1, { variant: 'global-config' });
     printError(err);
@@ -161,15 +285,20 @@ export default async function schemaCmd(
   }
 
   if (asJson) {
-    client.stdout.write(`${JSON.stringify(data ?? null, null, 2)}\n`);
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          status: 'ok',
+          id,
+          message: `Schema removed for Global Config ${id}.`,
+        },
+        null,
+        2
+      )}\n`
+    );
     return 0;
   }
 
-  if (data === null || data === undefined) {
-    output.log('No schema is set for this Global Config.');
-    return 0;
-  }
-
-  output.log(JSON.stringify(data, null, 2));
+  output.success(`Schema removed for Global Config ${chalk.bold(id)}.`);
   return 0;
 }

--- a/packages/cli/src/util/telemetry/commands/global-config/schema.ts
+++ b/packages/cli/src/util/telemetry/commands/global-config/schema.ts
@@ -16,6 +16,21 @@ export class GlobalConfigSchemaTelemetryClient
     this.trackCliArgument({ arg: 'id-or-slug', value });
   }
 
+  trackCliArgumentFile(value: string | undefined) {
+    // A file path can reveal local filesystem structure, so record only that
+    // one was provided, never its value. Schema contents are never recorded.
+    this.trackCliArgument({
+      arg: 'file',
+      value: value ? this.redactedValue : undefined,
+    });
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+
   trackCliOptionFormat(format: string | undefined) {
     if (format) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/global-config/global-config.test.ts
+++ b/packages/cli/test/unit/commands/global-config/global-config.test.ts
@@ -779,6 +779,28 @@ describe('global-config', () => {
       expect(deleted).toBe(true);
     });
 
+    it('cancels without deleting when the confirmation is declined', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_rm_decline', slug: 'my-store' }]);
+      });
+      let deleted = false;
+      client.scenario.delete(
+        '/v1/global-config/ecfg_rm_decline/schema',
+        (_req, res) => {
+          deleted = true;
+          res.status(204).end();
+        }
+      );
+
+      client.setArgv('global-config', 'schema', 'remove', 'my-store');
+      const exitCodePromise = globalConfig(client);
+      await expect(client.stderr).toOutput('Remove the schema');
+      client.stdin.write('n\n');
+      await expect(exitCodePromise).resolves.toBe(0);
+      expect(deleted).toBe(false);
+      await expect(client.stderr).toOutput('Canceled');
+    });
+
     it('removes a schema with --yes and emits JSON', async () => {
       client.scenario.get('/v1/global-config', (_req, res) => {
         res.json([{ id: 'ecfg_rm_yes', slug: 'my-store' }]);

--- a/packages/cli/test/unit/commands/global-config/global-config.test.ts
+++ b/packages/cli/test/unit/commands/global-config/global-config.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useTeams } from '../../../mocks/team';
@@ -621,6 +624,225 @@ describe('global-config', () => {
       const exitCode = await globalConfig(client);
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('No Global Config matches');
+    });
+  });
+
+  describe('schema set', () => {
+    it('sets a schema from a file and posts { definition }', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_set_file', slug: 'my-store' }]);
+      });
+      let posted: { definition?: unknown } | undefined;
+      client.scenario.post(
+        '/v1/global-config/ecfg_set_file/schema',
+        (req, res) => {
+          expect(req.query.teamId).toBe('team_ec_test');
+          posted = req.body;
+          res.json({ definition: req.body.definition });
+        }
+      );
+
+      const dir = mkdtempSync(join(tmpdir(), 'gc-schema-'));
+      const file = join(dir, 'schema.json');
+      const schema = {
+        type: 'object',
+        properties: { greeting: { type: 'string' } },
+      };
+      writeFileSync(file, JSON.stringify(schema));
+
+      client.setArgv(
+        'global-config',
+        'schema',
+        'set',
+        'my-store',
+        file,
+        '--format',
+        'json'
+      );
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(0);
+      expect(posted).toEqual({ definition: schema });
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toEqual({ definition: schema });
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:schema', value: 'schema' },
+        { key: 'argument:action', value: 'set' },
+        { key: 'argument:id-or-slug', value: 'my-store' },
+        { key: 'argument:file', value: '[REDACTED]' },
+        { key: 'option:format', value: 'json' },
+      ]);
+    });
+
+    it('sets a schema from stdin', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_set_stdin', slug: 'my-store' }]);
+      });
+      let posted: { definition?: unknown } | undefined;
+      client.scenario.post(
+        '/v1/global-config/ecfg_set_stdin/schema',
+        (req, res) => {
+          posted = req.body;
+          res.json({ definition: req.body.definition });
+        }
+      );
+
+      // Buffer the piped input so delivery does not race the listener that
+      // `readStandardInput` attaches after the command's async setup.
+      client.stdin.isTTY = false;
+      client.stdin.write(JSON.stringify({ type: 'object' }));
+      client.setArgv(
+        'global-config',
+        'schema',
+        'set',
+        'my-store',
+        '--format',
+        'json'
+      );
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(0);
+      expect(posted).toEqual({ definition: { type: 'object' } });
+    });
+
+    it('unwraps a { definition } wrapper so `get` output round-trips into `set`', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_set_wrap', slug: 'my-store' }]);
+      });
+      let posted: { definition?: unknown } | undefined;
+      client.scenario.post(
+        '/v1/global-config/ecfg_set_wrap/schema',
+        (req, res) => {
+          posted = req.body;
+          res.json({ definition: req.body.definition });
+        }
+      );
+
+      const dir = mkdtempSync(join(tmpdir(), 'gc-schema-'));
+      const file = join(dir, 'schema.json');
+      writeFileSync(file, JSON.stringify({ definition: { type: 'object' } }));
+
+      client.setArgv('global-config', 'schema', 'set', 'my-store', file);
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(0);
+      expect(posted).toEqual({ definition: { type: 'object' } });
+    });
+
+    it('rejects invalid JSON before any remote mutation', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_set_bad', slug: 'my-store' }]);
+      });
+      let posted = false;
+      client.scenario.post(
+        '/v1/global-config/ecfg_set_bad/schema',
+        (_req, res) => {
+          posted = true;
+          res.json({});
+        }
+      );
+
+      const dir = mkdtempSync(join(tmpdir(), 'gc-schema-'));
+      const file = join(dir, 'bad.json');
+      writeFileSync(file, '{ not valid json ');
+
+      client.setArgv('global-config', 'schema', 'set', 'my-store', file);
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(1);
+      expect(posted).toBe(false);
+      await expect(client.stderr).toOutput('Schema must be valid JSON');
+    });
+  });
+
+  describe('schema remove', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      client.nonInteractive = false;
+    });
+
+    it('removes a schema after confirmation', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_rm_schema', slug: 'my-store' }]);
+      });
+      let deleted = false;
+      client.scenario.delete(
+        '/v1/global-config/ecfg_rm_schema/schema',
+        (req, res) => {
+          expect(req.query.teamId).toBe('team_ec_test');
+          deleted = true;
+          res.status(204).end();
+        }
+      );
+
+      client.setArgv('global-config', 'schema', 'remove', 'my-store');
+      const exitCodePromise = globalConfig(client);
+      await expect(client.stderr).toOutput('Remove the schema');
+      client.stdin.write('y\n');
+      await expect(exitCodePromise).resolves.toBe(0);
+      expect(deleted).toBe(true);
+    });
+
+    it('removes a schema with --yes and emits JSON', async () => {
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_rm_yes', slug: 'my-store' }]);
+      });
+      let deleted = false;
+      client.scenario.delete(
+        '/v1/global-config/ecfg_rm_yes/schema',
+        (_req, res) => {
+          deleted = true;
+          res.status(204).end();
+        }
+      );
+
+      client.setArgv(
+        'global-config',
+        'schema',
+        'remove',
+        'my-store',
+        '--yes',
+        '--format',
+        'json'
+      );
+      const exitCode = await globalConfig(client);
+      expect(exitCode).toBe(0);
+      expect(deleted).toBe(true);
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toEqual({
+        status: 'ok',
+        id: 'ecfg_rm_yes',
+        message: 'Schema removed for Global Config ecfg_rm_yes.',
+      });
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:schema', value: 'schema' },
+        { key: 'argument:action', value: 'remove' },
+        { key: 'argument:id-or-slug', value: 'my-store' },
+        { key: 'flag:yes', value: 'TRUE' },
+        { key: 'option:format', value: 'json' },
+      ]);
+    });
+
+    it('exits 1 with a confirmation error when removing non-interactively without --yes', async () => {
+      vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code ?? 0}`);
+      }) as () => never);
+
+      client.scenario.get('/v1/global-config', (_req, res) => {
+        res.json([{ id: 'ecfg_rm_ni', slug: 'my-store' }]);
+      });
+
+      client.nonInteractive = true;
+      client.setArgv(
+        'global-config',
+        'schema',
+        'remove',
+        'my-store',
+        '--non-interactive'
+      );
+
+      await expect(globalConfig(client)).rejects.toThrow('exit:1');
+      const payload = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(payload).toMatchObject({
+        status: 'error',
+        reason: 'confirmation_required',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `vercel global-config schema set <id-or-slug> [file]` to write a store's JSON Schema from a file path argument or piped stdin, with human and `--json`/`--format json` output.
- Adds `vercel global-config schema remove <id-or-slug>` to delete a store's schema, with a TTY confirmation prompt and a `--yes` bypass.

## Notes

- Uses the public `POST /v1/global-config/:id/schema` (body `{ definition }`) and `DELETE /v1/global-config/:id/schema` endpoints; slugs resolve via the family's shared `resolveGlobalConfigId` helper.
- `set` validates that the input is valid JSON locally before any remote call; `parse-schema-body.ts` accepts either a bare schema or a `{ definition }` wrapper so `schema get` output round-trips into `set`.
- `remove` in non-interactive mode without `--yes` exits 1 with a `confirmation_required` agent error telling the user to re-run with `--yes`; it never prompts non-interactively.
- Telemetry records the action, id-or-slug, presence of a file argument (redacted), `--yes`, and `--format` only; schema contents are never recorded.
- Existing `global-config` subcommands and the `schema get` behavior from the base PR are untouched.
- Stacked on #17442.