### PR TITLE
[CLI] Add teams members remove subcommand

### DIFF
--- a/.changeset/teams-members-remove.md
+++ b/.changeset/teams-members-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel teams members remove <member>` to remove a member from the currently scoped team.

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -4,6 +4,7 @@ import {
   jsonOption,
   limitOption,
   nextOption,
+  yesOption,
 } from '../../util/arg-common';
 
 // Team roles accepted by the public API's `PATCH /v1/teams/{teamId}/members/{uid}`
@@ -196,13 +197,36 @@ export const updateMemberSubcommand = {
   ],
 } as const;
 
+export const removeMemberSubcommand = {
+  name: 'remove',
+  aliases: ['rm'],
+  description: 'Remove a member from the currently scoped team',
+  arguments: [
+    {
+      name: 'member',
+      required: true,
+    },
+  ],
+  options: [yesOption],
+  examples: [
+    {
+      name: 'Remove a member by email',
+      value: `${packageName} teams members remove user@example.com`,
+    },
+    {
+      name: 'Remove a member by username without confirmation',
+      value: `${packageName} teams members remove my-username --yes`,
+    },
+  ],
+} as const;
+
 export const membersSubcommand = {
   name: 'members',
   aliases: ['member'],
   description: 'List and manage members for the currently scoped team',
   arguments: [],
   options: [nextOption, limitOption, formatOption, jsonOption],
-  subcommands: [updateMemberSubcommand],
+  subcommands: [updateMemberSubcommand, removeMemberSubcommand],
   examples: [
     {
       name: 'List team members',
@@ -219,6 +243,10 @@ export const membersSubcommand = {
     {
       name: "Update a member's role",
       value: `${packageName} teams members update user@example.com --role MEMBER`,
+    },
+    {
+      name: 'Remove a member',
+      value: `${packageName} teams members remove user@example.com`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/teams/members-remove.ts
+++ b/packages/cli/src/commands/teams/members-remove.ts
@@ -1,0 +1,137 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import {
+  buildCommandWithGlobalFlags,
+  outputAgentError,
+} from '../../util/agent-output';
+import { getCommandName } from '../../util/pkg-name';
+import getScope from '../../util/get-scope';
+import {
+  findTeamMember,
+  memberIdentifier,
+} from '../../util/teams/find-team-member';
+import { removeMemberSubcommand } from './command';
+import type { TeamsMembersTelemetryClient } from '../../util/telemetry/commands/teams/members';
+
+const usage = getCommandName('teams members remove <member>');
+
+export default async function membersRemove(
+  client: Client,
+  argv: string[],
+  telemetry: TeamsMembersTelemetryClient
+): Promise<number> {
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    removeMemberSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'invalid_arguments',
+          message: error instanceof Error ? error.message : String(error),
+        },
+        1
+      );
+    }
+    printError(error);
+    return 1;
+  }
+
+  const { args } = parsedArgs;
+  const memberArg = args[0];
+  const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
+
+  telemetry.trackCliArgumentMember(memberArg);
+  telemetry.trackCliFlagYes(parsedArgs.flags['--yes']);
+
+  if (args.length !== 1 || !memberArg) {
+    output.error(`Invalid number of arguments. Usage: ${usage}`);
+    return 1;
+  }
+
+  const { team, contextName } = await getScope(client);
+  if (!team) {
+    output.error(
+      'Team scope is required. Run `vercel teams switch <slug>` or pass `--scope`.'
+    );
+    return 1;
+  }
+  const teamName = team.name || team.slug || contextName;
+
+  output.spinner('Resolving member');
+  let member;
+  try {
+    member = await findTeamMember(client, team.id, memberArg);
+  } finally {
+    output.stopSpinner();
+  }
+
+  if (!member) {
+    output.error(
+      `No member matching "${memberArg}" found in ${chalk.bold(teamName)}.`
+    );
+    output.log(`Run ${getCommandName('teams members')} to list team members.`);
+    return 1;
+  }
+
+  const identity = memberIdentifier(member);
+
+  if (!skipConfirmation) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'confirmation_required',
+          message: `Removing a team member requires confirmation. Re-run with \`--yes\` to remove ${identity} from ${teamName}.`,
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                `teams members remove ${memberArg} --yes`
+              ),
+              when: 'to remove the member without an interactive prompt',
+            },
+          ],
+        },
+        1
+      );
+      output.error(
+        `Confirmation required to remove a team member. Re-run with \`--yes\`.`
+      );
+      return 1;
+    }
+
+    output.log(
+      `The member ${chalk.bold(identity)} will be removed from ${chalk.bold(
+        teamName
+      )}.`
+    );
+    const confirmed = await client.input.confirm(
+      `${chalk.bold.red('Are you sure?')}`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  await client.fetch(`/v1/teams/${team.id}/members/${member.uid}`, {
+    method: 'DELETE',
+  });
+
+  output.success(
+    `Removed ${chalk.bold(identity)} from ${chalk.bold(teamName)}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/teams/members.ts
+++ b/packages/cli/src/commands/teams/members.ts
@@ -5,7 +5,11 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { outputAgentError } from '../../util/agent-output';
-import { membersSubcommand, updateMemberSubcommand } from './command';
+import {
+  membersSubcommand,
+  updateMemberSubcommand,
+  removeMemberSubcommand,
+} from './command';
 import { validateJsonOutput } from '../../util/output-format';
 import { packageName } from '../../util/pkg-name';
 import getCommandFlags from '../../util/get-command-flags';
@@ -16,6 +20,7 @@ import getSubcommand from '../../util/get-subcommand';
 import { getCommandAliases } from '..';
 import { TeamsMembersTelemetryClient } from '../../util/telemetry/commands/teams/members';
 import membersUpdate from './members-update';
+import membersRemove from './members-remove';
 
 interface TeamMember {
   uid: string;
@@ -35,6 +40,7 @@ interface TeamMembersResponse {
 
 const COMMAND_CONFIG = {
   update: getCommandAliases(updateMemberSubcommand),
+  remove: getCommandAliases(removeMemberSubcommand),
 };
 
 export default async function members(
@@ -56,6 +62,9 @@ export default async function members(
     case 'update':
       telemetry.trackCliSubcommandUpdate(subcommandOriginal);
       return membersUpdate(client, args, telemetry);
+    case 'remove':
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
+      return membersRemove(client, args, telemetry);
     default:
       return membersList(client, argv);
   }

--- a/packages/cli/src/util/telemetry/commands/teams/members.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/members.ts
@@ -10,6 +10,15 @@ export class TeamsMembersTelemetryClient extends TelemetryClient {
     }
   }
 
+  trackCliSubcommandRemove(actual: string) {
+    if (actual) {
+      this.trackCliSubcommand({
+        subcommand: 'remove',
+        value: actual,
+      });
+    }
+  }
+
   trackCliArgumentMember(member: string | undefined) {
     if (member) {
       this.trackCliArgument({
@@ -27,6 +36,12 @@ export class TeamsMembersTelemetryClient extends TelemetryClient {
         option: 'role',
         value: role,
       });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
     }
   }
 }

--- a/packages/cli/test/unit/commands/teams/members-remove.test.ts
+++ b/packages/cli/test/unit/commands/teams/members-remove.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import teams from '../../../../src/commands/teams';
+
+function useMembers(teamId: string) {
+  client.scenario.get(`/v2/teams/${teamId}/members`, (_req, res) => {
+    res.json({
+      members: [
+        {
+          uid: 'user_ada',
+          email: 'ada@example.com',
+          username: 'ada',
+          role: 'MEMBER',
+        },
+      ],
+      pagination: { count: 1, next: null, prev: null },
+    });
+  });
+}
+
+describe('teams members remove', () => {
+  it('removes a member with --yes (no prompt)', async () => {
+    useUser();
+    const team = useTeam('team_123');
+    client.config.currentTeam = 'team_123';
+    useMembers('team_123');
+
+    let deleted = false;
+    client.scenario.delete(
+      '/v1/teams/team_123/members/user_ada',
+      (_req, res) => {
+        deleted = true;
+        res.json({ id: 'team_123' });
+      }
+    );
+
+    client.setArgv('teams', 'members', 'remove', 'ada@example.com', '--yes');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(deleted).toBe(true);
+    await expect(client.stderr).toOutput(`Removed ada from ${team.name}`);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:members', value: 'members' },
+      { key: 'subcommand:remove', value: 'remove' },
+      { key: 'argument:member', value: '[REDACTED]' },
+      { key: 'flag:yes', value: 'TRUE' },
+    ]);
+  });
+
+  it('prompts for confirmation in a TTY and removes on yes', async () => {
+    useUser();
+    const team = useTeam('team_123');
+    client.config.currentTeam = 'team_123';
+    useMembers('team_123');
+
+    let deleted = false;
+    client.scenario.delete(
+      '/v1/teams/team_123/members/user_ada',
+      (_req, res) => {
+        deleted = true;
+        res.json({ id: 'team_123' });
+      }
+    );
+
+    client.setArgv('teams', 'members', 'remove', 'ada');
+    const exitCodePromise = teams(client);
+
+    await expect(client.stderr).toOutput(
+      `The member ada will be removed from ${team.name}.`
+    );
+    client.stdin.write('y\n');
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode).toBe(0);
+    expect(deleted).toBe(true);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:members', value: 'members' },
+      { key: 'subcommand:remove', value: 'remove' },
+      { key: 'argument:member', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('exits in non-interactive mode without --yes', async () => {
+    useUser();
+    useTeam('team_123');
+    client.config.currentTeam = 'team_123';
+    useMembers('team_123');
+    client.nonInteractive = true;
+
+    let deleted = false;
+    client.scenario.delete(
+      '/v1/teams/team_123/members/user_ada',
+      (_req, res) => {
+        deleted = true;
+        res.json({ id: 'team_123' });
+      }
+    );
+
+    vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('exit');
+    }) as () => never);
+
+    client.setArgv('teams', 'members', 'remove', 'ada@example.com');
+
+    await expect(teams(client)).rejects.toThrow('exit');
+    expect(deleted).toBe(false);
+
+    const payload = JSON.parse(client.stdout.getFullOutput());
+    expect(payload).toMatchObject({
+      status: 'error',
+      reason: 'confirmation_required',
+      message: expect.stringMatching(/--yes/),
+      next: expect.arrayContaining([
+        expect.objectContaining({
+          command: expect.stringContaining('--yes'),
+        }),
+      ]),
+    });
+  });
+
+  it('supports the rm alias', async () => {
+    useUser();
+    useTeam('team_123');
+    client.config.currentTeam = 'team_123';
+    useMembers('team_123');
+
+    client.scenario.delete(
+      '/v1/teams/team_123/members/user_ada',
+      (_req, res) => {
+        res.json({ id: 'team_123' });
+      }
+    );
+
+    client.setArgv('teams', 'members', 'rm', 'ada@example.com', '--yes');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:members', value: 'members' },
+      { key: 'subcommand:remove', value: 'rm' },
+      { key: 'argument:member', value: '[REDACTED]' },
+      { key: 'flag:yes', value: 'TRUE' },
+    ]);
+  });
+
+  it('errors when the member cannot be found', async () => {
+    useUser();
+    useTeam('team_123');
+    client.config.currentTeam = 'team_123';
+    useMembers('team_123');
+
+    client.setArgv('teams', 'members', 'remove', 'nobody@example.com', '--yes');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput(
+      'No member matching "nobody@example.com"'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/teams/members-remove.test.ts
+++ b/packages/cli/test/unit/commands/teams/members-remove.test.ts
@@ -85,6 +85,36 @@ describe('teams members remove', () => {
     ]);
   });
 
+  it('cancels without removing when the prompt is declined', async () => {
+    useUser();
+    const team = useTeam('team_123');
+    client.config.currentTeam = 'team_123';
+    useMembers('team_123');
+
+    let deleted = false;
+    client.scenario.delete(
+      '/v1/teams/team_123/members/user_ada',
+      (_req, res) => {
+        deleted = true;
+        res.json({ id: 'team_123' });
+      }
+    );
+
+    client.setArgv('teams', 'members', 'remove', 'ada');
+    const exitCodePromise = teams(client);
+
+    await expect(client.stderr).toOutput(
+      `The member ada will be removed from ${team.name}.`
+    );
+    client.stdin.write('n\n');
+
+    await expect(client.stderr).toOutput('Canceled');
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode).toBe(0);
+    expect(deleted).toBe(false);
+  });
+
   it('exits in non-interactive mode without --yes', async () => {
     useUser();
     useTeam('team_123');


### PR DESCRIPTION
## Summary

- Adds `vercel teams members remove <member>` (alias `rm`) to remove a member from the currently scoped team.
- Prompts for confirmation in a TTY (naming the member and team) and supports `--yes` to skip the prompt.
- Adds telemetry, unit tests, and a changeset (patch bump for `vercel`).

## Notes

- Uses the public endpoint `DELETE /v1/teams/{teamId}/members/{uid}`.
- `<member>` accepts email, username, or uid; it is resolved via the member-resolution helper from the stacked base PR (paging the public `/v2/teams/{teamId}/members` listing) before any mutation.
- Non-interactive mode without `--yes` exits 1 with a machine-readable `confirmation_required` payload and a `--yes` retry command; it never prompts.
- Team scope resolves via `getScope`, matching existing `teams` command behavior.
- Telemetry records the `--yes` flag but redacts the member argument (`[REDACTED]`); emails and usernames are never recorded.
- Stacked on #17446 (`teams members update`); the `update` subcommand, members listing, and all other `teams` subcommands are untouched.
