### PR TITLE
[CLI] Add teams update subcommand

### DIFF
--- a/.changeset/teams-update.md
+++ b/.changeset/teams-update.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel teams update` to change team settings

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -4,6 +4,7 @@ import {
   jsonOption,
   limitOption,
   nextOption,
+  yesOption,
 } from '../../util/arg-common';
 
 export const requestSubcommand = {
@@ -171,6 +172,73 @@ export const membersSubcommand = {
   ],
 } as const;
 
+export const updateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Update settings for a team',
+  arguments: [
+    {
+      name: 'team-slug',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'name',
+      shorthand: null,
+      type: String,
+      description: 'New display name for the team',
+      deprecated: false,
+    },
+    {
+      name: 'slug',
+      shorthand: null,
+      type: String,
+      description: 'New URL slug for the team; this changes the team URL',
+      deprecated: false,
+    },
+    {
+      name: 'preview-suffix',
+      shorthand: null,
+      type: String,
+      description:
+        'Domain suffix for preview deployment URLs; pass an empty string to clear it',
+      deprecated: false,
+    },
+    {
+      name: 'toolbar',
+      shorthand: null,
+      type: String,
+      description:
+        'Vercel Toolbar on preview deployments: one of on, off, or default',
+      deprecated: false,
+    },
+    {
+      name: 'default-build-machine',
+      shorthand: null,
+      type: String,
+      description:
+        'Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic',
+      deprecated: false,
+    },
+    yesOption,
+  ],
+  examples: [
+    {
+      name: 'Rename the current team',
+      value: `${packageName} teams update --name "Acme Corp"`,
+    },
+    {
+      name: 'Change the team URL slug (asks for confirmation)',
+      value: `${packageName} teams update --slug acme`,
+    },
+    {
+      name: 'Update a specific team by slug',
+      value: `${packageName} teams update acme --default-build-machine enhanced`,
+    },
+  ],
+} as const;
+
 export const teamsCommand = {
   name: 'teams',
   aliases: ['switch', 'team'],
@@ -184,6 +252,7 @@ export const teamsCommand = {
     switchSubcommand,
     ssoSubcommand,
     membersSubcommand,
+    updateSubcommand,
   ],
   options: [],
   examples: [],

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -197,30 +197,6 @@ export const updateSubcommand = {
       description: 'New URL slug for the team; this changes the team URL',
       deprecated: false,
     },
-    {
-      name: 'preview-suffix',
-      shorthand: null,
-      type: String,
-      description:
-        'Domain suffix for preview deployment URLs; pass an empty string to clear it',
-      deprecated: false,
-    },
-    {
-      name: 'toolbar',
-      shorthand: null,
-      type: String,
-      description:
-        'Vercel Toolbar on preview deployments: one of on, off, or default',
-      deprecated: false,
-    },
-    {
-      name: 'default-build-machine',
-      shorthand: null,
-      type: String,
-      description:
-        'Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic',
-      deprecated: false,
-    },
     yesOption,
   ],
   examples: [
@@ -234,7 +210,7 @@ export const updateSubcommand = {
     },
     {
       name: 'Update a specific team by slug',
-      value: `${packageName} teams update acme --default-build-machine enhanced`,
+      value: `${packageName} teams update acme --name "Acme Corp"`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/teams/index.ts
+++ b/packages/cli/src/commands/teams/index.ts
@@ -5,6 +5,7 @@ import invite from './invite';
 import request from './request';
 import members from './members';
 import sso from './sso';
+import update from './update';
 import { parseArguments } from '../../util/get-args';
 import {
   addSubcommand,
@@ -15,6 +16,7 @@ import {
   ssoSubcommand,
   switchSubcommand,
   teamsCommand,
+  updateSubcommand,
 } from './command';
 import { type Command, help } from '../help';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -35,6 +37,7 @@ const COMMAND_CONFIG = {
   request: ['request', 'access-request'],
   sso: ['sso'],
   members: ['members', 'member'],
+  update: ['update'],
 };
 
 export default async function teams(client: Client) {
@@ -153,6 +156,15 @@ export default async function teams(client: Client) {
       telemetry.trackCliSubcommandMembers(subcommandOriginal);
       return members(client, args);
     }
+    case 'update': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('teams', subcommandOriginal);
+        printHelp(updateSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandUpdate(subcommandOriginal);
+      return update(client, args);
+    }
     default: {
       const fallback = await tryOpenApiFallback(
         client,
@@ -163,7 +175,7 @@ export default async function teams(client: Client) {
         return fallback;
       }
       output.error(
-        'Please specify a valid subcommand: add | ls | switch | invite | request | sso | members'
+        'Please specify a valid subcommand: add | ls | switch | invite | request | sso | members | update'
       );
       output.print(help(teamsCommand, { columns: client.stderr.columns }));
       return 2;

--- a/packages/cli/src/commands/teams/update.ts
+++ b/packages/cli/src/commands/teams/update.ts
@@ -1,0 +1,319 @@
+import chalk from 'chalk';
+import stripAnsi from 'strip-ansi';
+import type Client from '../../util/client';
+import type { Team } from '@vercel-internals/types';
+import output from '../../output-manager';
+import getScope from '../../util/get-scope';
+import getTeams from '../../util/teams/get-teams';
+import updateTeam, {
+  type TeamUpdatePayload,
+} from '../../util/teams/update-team';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { isAPIError } from '../../util/errors-ts';
+import param from '../../util/output/param';
+import { getCommandName } from '../../util/pkg-name';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import {
+  buildCommandWithYes,
+  outputActionRequired,
+  outputAgentError,
+  withGlobalFlags,
+} from '../../util/agent-output';
+import { updateSubcommand } from './command';
+import { TeamsUpdateTelemetryClient } from '../../util/telemetry/commands/teams/update';
+
+const TOOLBAR_VALUES = ['on', 'off', 'default'] as const;
+const BUILD_MACHINE_VALUES = [
+  'basic',
+  'standard',
+  'enhanced',
+  'turbo',
+  'elastic',
+] as const;
+
+const validateSlug = (value: string) => /^[a-z]+[a-z0-9_-]*$/.test(value);
+
+export default async function update(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new TeamsUpdateTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(updateSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'invalid_arguments',
+          message: error instanceof Error ? error.message : String(error),
+        },
+        1
+      );
+    }
+    printError(error);
+    return 1;
+  }
+
+  const { flags, args } = parsedArgs;
+  const [teamSlugArg] = args;
+
+  const nameFlag = flags['--name'];
+  const slugFlag = flags['--slug'];
+  const previewSuffixFlag = flags['--preview-suffix'];
+  const toolbarFlag = flags['--toolbar'];
+  const buildMachineFlag = flags['--default-build-machine'];
+  const yes = Boolean(flags['--yes']);
+
+  telemetry.trackCliArgumentTeamSlug(teamSlugArg);
+  telemetry.trackCliOptionName(nameFlag);
+  telemetry.trackCliOptionSlug(slugFlag);
+  telemetry.trackCliOptionPreviewSuffix(previewSuffixFlag);
+  telemetry.trackCliOptionToolbar(toolbarFlag);
+  telemetry.trackCliOptionDefaultBuildMachine(buildMachineFlag);
+  telemetry.trackCliFlagYes(yes);
+
+  if (args.length > 1) {
+    const msg = `Too many arguments. Usage: ${getCommandName(
+      'teams update [team-slug]'
+    )}`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        { status: 'error', reason: 'invalid_arguments', message: msg },
+        1
+      );
+    }
+    output.error(msg);
+    return 1;
+  }
+
+  // Build the sparse PATCH payload, validating every value locally before any
+  // remote call. `changes` mirrors the payload for the human result block.
+  const payload: TeamUpdatePayload = {};
+  const changes: Array<[string, string]> = [];
+
+  if (nameFlag !== undefined) {
+    const name = nameFlag.trim();
+    if (!name) {
+      return invalidValue(
+        client,
+        'invalid_name',
+        `Invalid ${param('--name')}: value cannot be empty`
+      );
+    }
+    payload.name = name;
+    changes.push(['Name', name]);
+  }
+
+  if (slugFlag !== undefined) {
+    const slug = slugFlag.trim().toLowerCase();
+    if (!validateSlug(slug)) {
+      return invalidValue(
+        client,
+        'invalid_slug',
+        `Invalid ${param('--slug')}: must start with a letter and contain only lowercase letters, numbers, hyphens, and underscores (e.g. ${param('acme')})`
+      );
+    }
+    payload.slug = slug;
+    changes.push(['Slug', slug]);
+  }
+
+  if (previewSuffixFlag !== undefined) {
+    const suffix = previewSuffixFlag.trim();
+    payload.previewDeploymentSuffix = suffix === '' ? null : suffix;
+    changes.push(['Preview Suffix', suffix === '' ? '(cleared)' : suffix]);
+  }
+
+  if (toolbarFlag !== undefined) {
+    if (!TOOLBAR_VALUES.includes(toolbarFlag as (typeof TOOLBAR_VALUES)[number])) {
+      return invalidValue(
+        client,
+        'invalid_toolbar',
+        `Invalid ${param('--toolbar')}: must be one of ${TOOLBAR_VALUES.join(', ')}`
+      );
+    }
+    payload.enablePreviewFeedback = toolbarFlag;
+    changes.push(['Toolbar', toolbarFlag]);
+  }
+
+  if (buildMachineFlag !== undefined) {
+    if (
+      !BUILD_MACHINE_VALUES.includes(
+        buildMachineFlag as (typeof BUILD_MACHINE_VALUES)[number]
+      )
+    ) {
+      return invalidValue(
+        client,
+        'invalid_default_build_machine',
+        `Invalid ${param('--default-build-machine')}: must be one of ${BUILD_MACHINE_VALUES.join(', ')}`
+      );
+    }
+    payload.resourceConfig = { buildMachine: { default: buildMachineFlag } };
+    changes.push(['Build Machine', buildMachineFlag]);
+  }
+
+  if (Object.keys(payload).length === 0) {
+    const msg = `No settings to update. Provide at least one option, e.g. ${param('--name')}. See ${getCommandName('teams update --help')}.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        { status: 'error', reason: 'missing_arguments', message: msg },
+        1
+      );
+    }
+    output.error(msg);
+    return 1;
+  }
+
+  // Resolve the target team: the positional slug when provided, otherwise the
+  // currently selected scope's team.
+  const team = await resolveTeam(client, teamSlugArg);
+  if (!team) {
+    return 1;
+  }
+
+  // Changing the slug changes the team URL, so confirm it explicitly.
+  if (payload.slug !== undefined && payload.slug !== team.slug) {
+    if (client.nonInteractive) {
+      if (!yes) {
+        outputActionRequired(
+          client,
+          {
+            status: 'action_required',
+            reason: 'confirmation_required',
+            action: 'confirmation_required',
+            message: `Changing the team URL from ${team.slug} to ${payload.slug} requires confirmation. Re-run with --yes.`,
+            userActionRequired: true,
+            next: [{ command: buildCommandWithYes(client.argv) }],
+          },
+          1
+        );
+        output.error(
+          `Confirmation required to change the team URL. Re-run with ${param('--yes')}.`
+        );
+        return 1;
+      }
+    } else if (!yes) {
+      const confirmed = await client.input.confirm(
+        `Change the team URL from ${chalk.bold(
+          `vercel.com/${team.slug}`
+        )} to ${chalk.bold(`vercel.com/${payload.slug}`)}?`,
+        false
+      );
+      if (!confirmed) {
+        output.log('Canceled. No changes made.');
+        return 0;
+      }
+    }
+  }
+
+  output.spinner(`Updating team ${chalk.bold(team.slug)}`);
+  let updated: Team;
+  try {
+    updated = await updateTeam(client, team.id, payload);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    return handleUpdateError(client, err);
+  }
+  output.stopSpinner();
+
+  const slug = updated.slug ?? team.slug;
+  printAlignedLabel('Updated', `${updated.name} (${slug})`, { gutter: '✓' });
+  for (const [label, value] of changes) {
+    printAlignedLabel(label, value);
+  }
+
+  return 0;
+}
+
+function invalidValue(
+  client: Client,
+  reason: string,
+  message: string
+): number {
+  // `message` may contain ANSI from param(); strip it for the JSON payload.
+  const plain = stripAnsi(message);
+  if (client.nonInteractive) {
+    outputAgentError(client, { status: 'error', reason, message: plain }, 1);
+  }
+  output.error(message);
+  return 1;
+}
+
+async function resolveTeam(
+  client: Client,
+  teamSlugArg: string | undefined
+): Promise<Team | null> {
+  if (teamSlugArg) {
+    const teams = await getTeams(client);
+    const match = teams.find(team => team.slug === teamSlugArg);
+    if (!match) {
+      const msg = `You do not have access to a team with the slug "${teamSlugArg}".`;
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: 'scope_not_accessible',
+            message: msg,
+            next: [{ command: withGlobalFlags(client, 'teams list') }],
+          },
+          1
+        );
+      }
+      output.error(msg);
+      output.log(`Run ${getCommandName('teams list')} to see your teams.`);
+      return null;
+    }
+    return match;
+  }
+
+  const { team } = await getScope(client);
+  if (!team) {
+    const msg =
+      'No team is selected. Pass a team slug or run `vercel teams switch`.';
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'missing_scope',
+          message: msg,
+          next: [{ command: withGlobalFlags(client, 'teams list') }],
+        },
+        1
+      );
+    }
+    output.error(msg);
+    return null;
+  }
+  return team;
+}
+
+function handleUpdateError(client: Client, err: unknown): number {
+  if (isAPIError(err)) {
+    const message = err.serverMessage || err.message || 'Failed to update team.';
+    if (client.nonInteractive) {
+      const reason =
+        err.status === 403
+          ? 'permission_denied'
+          : err.status === 400
+            ? 'invalid_arguments'
+            : 'api_error';
+      outputAgentError(client, { status: 'error', reason, message }, 1);
+    }
+    output.error(message);
+    return 1;
+  }
+  printError(err);
+  return 1;
+}

--- a/packages/cli/src/commands/teams/update.ts
+++ b/packages/cli/src/commands/teams/update.ts
@@ -24,15 +24,6 @@ import {
 import { updateSubcommand } from './command';
 import { TeamsUpdateTelemetryClient } from '../../util/telemetry/commands/teams/update';
 
-const TOOLBAR_VALUES = ['on', 'off', 'default'] as const;
-const BUILD_MACHINE_VALUES = [
-  'basic',
-  'standard',
-  'enhanced',
-  'turbo',
-  'elastic',
-] as const;
-
 const validateSlug = (value: string) => /^[a-z]+[a-z0-9_-]*$/.test(value);
 
 export default async function update(
@@ -68,17 +59,11 @@ export default async function update(
 
   const nameFlag = flags['--name'];
   const slugFlag = flags['--slug'];
-  const previewSuffixFlag = flags['--preview-suffix'];
-  const toolbarFlag = flags['--toolbar'];
-  const buildMachineFlag = flags['--default-build-machine'];
   const yes = Boolean(flags['--yes']);
 
   telemetry.trackCliArgumentTeamSlug(teamSlugArg);
   telemetry.trackCliOptionName(nameFlag);
   telemetry.trackCliOptionSlug(slugFlag);
-  telemetry.trackCliOptionPreviewSuffix(previewSuffixFlag);
-  telemetry.trackCliOptionToolbar(toolbarFlag);
-  telemetry.trackCliOptionDefaultBuildMachine(buildMachineFlag);
   telemetry.trackCliFlagYes(yes);
 
   if (args.length > 1) {
@@ -125,40 +110,6 @@ export default async function update(
     }
     payload.slug = slug;
     changes.push(['Slug', slug]);
-  }
-
-  if (previewSuffixFlag !== undefined) {
-    const suffix = previewSuffixFlag.trim();
-    payload.previewDeploymentSuffix = suffix === '' ? null : suffix;
-    changes.push(['Preview Suffix', suffix === '' ? '(cleared)' : suffix]);
-  }
-
-  if (toolbarFlag !== undefined) {
-    if (!TOOLBAR_VALUES.includes(toolbarFlag as (typeof TOOLBAR_VALUES)[number])) {
-      return invalidValue(
-        client,
-        'invalid_toolbar',
-        `Invalid ${param('--toolbar')}: must be one of ${TOOLBAR_VALUES.join(', ')}`
-      );
-    }
-    payload.enablePreviewFeedback = toolbarFlag;
-    changes.push(['Toolbar', toolbarFlag]);
-  }
-
-  if (buildMachineFlag !== undefined) {
-    if (
-      !BUILD_MACHINE_VALUES.includes(
-        buildMachineFlag as (typeof BUILD_MACHINE_VALUES)[number]
-      )
-    ) {
-      return invalidValue(
-        client,
-        'invalid_default_build_machine',
-        `Invalid ${param('--default-build-machine')}: must be one of ${BUILD_MACHINE_VALUES.join(', ')}`
-      );
-    }
-    payload.resourceConfig = { buildMachine: { default: buildMachineFlag } };
-    changes.push(['Build Machine', buildMachineFlag]);
   }
 
   if (Object.keys(payload).length === 0) {

--- a/packages/cli/src/util/teams/update-team.ts
+++ b/packages/cli/src/util/teams/update-team.ts
@@ -1,0 +1,38 @@
+import type { Team } from '@vercel-internals/types';
+import type Client from '../client';
+
+/**
+ * Sparse PATCH payload for `PATCH /teams/:id`. Only fields explicitly set by
+ * the caller are sent; the endpoint leaves omitted fields untouched.
+ */
+export type TeamUpdatePayload = {
+  name?: string;
+  slug?: string;
+  previewDeploymentSuffix?: string | null;
+  enablePreviewFeedback?: string;
+  resourceConfig?: {
+    buildMachine: {
+      default: string;
+    };
+  };
+};
+
+export default async function updateTeam(
+  client: Client,
+  teamId: string,
+  payload: TeamUpdatePayload
+): Promise<Team> {
+  const body = await client.fetch<Team>(
+    `/teams/${encodeURIComponent(teamId)}`,
+    {
+      method: 'PATCH',
+      body: payload,
+    }
+  );
+  // fetch() returns a Response when the body is not application/json; PATCH
+  // /teams should always return the updated Team as JSON.
+  if (body && typeof body === 'object' && 'ok' in body) {
+    throw new Error('PATCH /teams returned a non-JSON response');
+  }
+  return body as Team;
+}

--- a/packages/cli/src/util/teams/update-team.ts
+++ b/packages/cli/src/util/teams/update-team.ts
@@ -8,13 +8,6 @@ import type Client from '../client';
 export type TeamUpdatePayload = {
   name?: string;
   slug?: string;
-  previewDeploymentSuffix?: string | null;
-  enablePreviewFeedback?: string;
-  resourceConfig?: {
-    buildMachine: {
-      default: string;
-    };
-  };
 };
 
 export default async function updateTeam(

--- a/packages/cli/src/util/telemetry/commands/teams/index.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/index.ts
@@ -68,4 +68,13 @@ export class TeamsTelemetryClient
       });
     }
   }
+
+  trackCliSubcommandUpdate(actual?: string) {
+    if (actual) {
+      this.trackCliSubcommand({
+        subcommand: 'update',
+        value: actual,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/teams/update.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/update.ts
@@ -2,15 +2,6 @@ import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { updateSubcommand } from '../../../../commands/teams/command';
 
-const TOOLBAR_VALUES = ['on', 'off', 'default'];
-const BUILD_MACHINE_VALUES = [
-  'basic',
-  'standard',
-  'enhanced',
-  'turbo',
-  'elastic',
-];
-
 export class TeamsUpdateTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof updateSubcommand>
@@ -38,35 +29,6 @@ export class TeamsUpdateTelemetryClient
       this.trackCliOption({
         option: 'slug',
         value: this.redactedValue,
-      });
-    }
-  }
-
-  trackCliOptionPreviewSuffix(suffix: string | undefined) {
-    if (suffix !== undefined) {
-      this.trackCliOption({
-        option: 'preview-suffix',
-        value: this.redactedValue,
-      });
-    }
-  }
-
-  trackCliOptionToolbar(value: string | undefined) {
-    if (value !== undefined) {
-      this.trackCliOption({
-        option: 'toolbar',
-        value: TOOLBAR_VALUES.includes(value) ? value : this.redactedValue,
-      });
-    }
-  }
-
-  trackCliOptionDefaultBuildMachine(value: string | undefined) {
-    if (value !== undefined) {
-      this.trackCliOption({
-        option: 'default-build-machine',
-        value: BUILD_MACHINE_VALUES.includes(value)
-          ? value
-          : this.redactedValue,
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/teams/update.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/update.ts
@@ -1,0 +1,79 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { updateSubcommand } from '../../../../commands/teams/command';
+
+const TOOLBAR_VALUES = ['on', 'off', 'default'];
+const BUILD_MACHINE_VALUES = [
+  'basic',
+  'standard',
+  'enhanced',
+  'turbo',
+  'elastic',
+];
+
+export class TeamsUpdateTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof updateSubcommand>
+{
+  trackCliArgumentTeamSlug(slug: string | undefined) {
+    if (slug) {
+      this.trackCliArgument({
+        arg: 'team-slug',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionName(name: string | undefined) {
+    if (name !== undefined) {
+      this.trackCliOption({
+        option: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSlug(slug: string | undefined) {
+    if (slug !== undefined) {
+      this.trackCliOption({
+        option: 'slug',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionPreviewSuffix(suffix: string | undefined) {
+    if (suffix !== undefined) {
+      this.trackCliOption({
+        option: 'preview-suffix',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionToolbar(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'toolbar',
+        value: TOOLBAR_VALUES.includes(value) ? value : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDefaultBuildMachine(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'default-build-machine',
+        value: BUILD_MACHINE_VALUES.includes(value)
+          ? value
+          : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -7471,12 +7471,9 @@ exports[`help command > teams help output snapshots > teams update help output s
 
   Options:
 
-       --default-build-machine  Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic    
-       --name                   New display name for the team                                                                
-       --preview-suffix         Domain suffix for preview deployment URLs; pass an empty string to clear it                  
-       --slug                   New URL slug for the team; this changes the team URL                                         
-       --toolbar                Vercel Toolbar on preview deployments: one of on, off, or default                            
-  -y,  --yes                    Accept default value for all prompts                                                         
+       --name  New display name for the team                                                                             
+       --slug  New URL slug for the team; this changes the team URL                                                      
+  -y,  --yes   Accept default value for all prompts                                                                      
 
 
   Global Options:
@@ -7505,7 +7502,7 @@ exports[`help command > teams help output snapshots > teams update help output s
 
   - Update a specific team by slug
 
-    $ vercel teams update acme --default-build-machine enhanced
+    $ vercel teams update acme --name "Acme Corp"
 
 "
 `;

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -7197,38 +7197,47 @@ exports[`help command > teams help output snapshots > teams help column width 40
 
   Commands:
 
-  add                Create a   
-                     new team   
-  invite   email     Invite a   
-                     new member 
-                     to a team  
-  list               Show all   
-                     teams that 
-                     you're a   
-                     member of  
-  request  [userId]  Show       
-                     join-reque…
-                     status for 
-                     the current
-                     team       
-                     (defaults  
-                     to the     
-                     authentica…
-                     user)      
-  switch   [name]    Switch to a
-                     different  
-                     team       
-  sso                Show SAML /
-                     SSO        
-                     configurat…
-                     for the    
-                     current    
-                     team       
-  members            List       
-                     members for
-                     the        
-                     currently  
-                     scoped team
+  add                   Create a 
+                        new team 
+  invite   email        Invite a 
+                        new      
+                        member to
+                        a team   
+  list                  Show all 
+                        teams    
+                        that     
+                        you're a 
+                        member of
+  request  [userId]     Show     
+                        join-req…
+                        status   
+                        for the  
+                        current  
+                        team     
+                        (defaults
+                        to the   
+                        authenti…
+                        user)    
+  switch   [name]       Switch to
+                        a        
+                        different
+                        team     
+  sso                   Show SAML
+                        / SSO    
+                        configur…
+                        for the  
+                        current  
+                        team     
+  members               List     
+                        members  
+                        for the  
+                        currently
+                        scoped   
+                        team     
+  update   [team-slug]  Update   
+                        settings 
+                        for a    
+                        team     
 
 
   Global Options:
@@ -7290,14 +7299,16 @@ exports[`help command > teams help output snapshots > teams help column width 80
 
   Commands:
 
-  add                Create a new team                                  
-  invite   email     Invite a new member to a team                      
-  list               Show all teams that you're a member of             
-  request  [userId]  Show join-request status for the current team      
-                     (defaults to the authenticated user)               
-  switch   [name]    Switch to a different team                         
-  sso                Show SAML / SSO configuration for the current team 
-  members            List members for the currently scoped team         
+  add                   Create a new team                                
+  invite   email        Invite a new member to a team                    
+  list                  Show all teams that you're a member of           
+  request  [userId]     Show join-request status for the current team    
+                        (defaults to the authenticated user)             
+  switch   [name]       Switch to a different team                       
+  sso                   Show SAML / SSO configuration for the current    
+                        team                                             
+  members               List members for the currently scoped team       
+  update   [team-slug]  Update settings for a team                       
 
 
   Global Options:
@@ -7327,13 +7338,14 @@ exports[`help command > teams help output snapshots > teams help column width 12
 
   Commands:
 
-  add                Create a new team                                                                          
-  invite   email     Invite a new member to a team                                                              
-  list               Show all teams that you're a member of                                                     
-  request  [userId]  Show join-request status for the current team (defaults to the authenticated user)         
-  switch   [name]    Switch to a different team                                                                 
-  sso                Show SAML / SSO configuration for the current team                                         
-  members            List members for the currently scoped team                                                 
+  add                   Create a new team                                                                        
+  invite   email        Invite a new member to a team                                                            
+  list                  Show all teams that you're a member of                                                   
+  request  [userId]     Show join-request status for the current team (defaults to the authenticated user)       
+  switch   [name]       Switch to a different team                                                               
+  sso                   Show SAML / SSO configuration for the current team                                       
+  members               List members for the currently scoped team                                               
+  update   [team-slug]  Update settings for a team                                                               
 
 
   Global Options:
@@ -7447,6 +7459,53 @@ exports[`help command > teams help output snapshots > teams switch help output s
   - Switch to a team. If your team's url is 'vercel.com/name', then 'name' is the slug. If the slug is omitted, you can choose interactively
 
     $ vercel teams switch <slug>
+
+"
+`;
+
+exports[`help command > teams help output snapshots > teams update help output snapshots > teams update help column width 120 1`] = `
+"
+  ▲ vercel teams update [team-slug] [options]
+
+  Update settings for a team                                                                                            
+
+  Options:
+
+       --default-build-machine  Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic    
+       --name                   New display name for the team                                                                
+       --preview-suffix         Domain suffix for preview deployment URLs; pass an empty string to clear it                  
+       --slug                   New URL slug for the team; this changes the team URL                                         
+       --toolbar                Vercel Toolbar on preview deployments: one of on, off, or default                            
+  -y,  --yes                    Accept default value for all prompts                                                         
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Rename the current team
+
+    $ vercel teams update --name "Acme Corp"
+
+  - Change the team URL slug (asks for confirmation)
+
+    $ vercel teams update --slug acme
+
+  - Update a specific team by slug
+
+    $ vercel teams update acme --default-build-machine enhanced
 
 "
 `;

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -930,6 +930,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('teams update help output snapshots', () => {
+      it('teams update help column width 120', () => {
+        expect(
+          help(teams.updateSubcommand, {
+            columns: 120,
+            parent: teams.teamsCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('telemetry help output snapshots', () => {

--- a/packages/cli/test/unit/commands/teams/update.test.ts
+++ b/packages/cli/test/unit/commands/teams/update.test.ts
@@ -53,65 +53,6 @@ describe('teams update', () => {
     ]);
   });
 
-  it('updates multiple settings in one call and records enum telemetry', async () => {
-    let patchBody: Record<string, unknown> | undefined;
-    client.scenario.patch(`/teams/${team.id}`, (req, res) => {
-      patchBody = req.body as Record<string, unknown>;
-      return res.json(team);
-    });
-
-    client.setArgv(
-      'teams',
-      'update',
-      '--toolbar',
-      'on',
-      '--default-build-machine',
-      'enhanced'
-    );
-    const exitCode = await teams(client);
-
-    expect(exitCode).toBe(0);
-    expect(patchBody).toEqual({
-      enablePreviewFeedback: 'on',
-      resourceConfig: { buildMachine: { default: 'enhanced' } },
-    });
-
-    expect(client.telemetryEventStore).toHaveTelemetryEvents([
-      { key: 'subcommand:update', value: 'update' },
-      { key: 'option:toolbar', value: 'on' },
-      { key: 'option:default-build-machine', value: 'enhanced' },
-    ]);
-  });
-
-  it('clears the preview suffix when passed an empty string', async () => {
-    let patchBody: Record<string, unknown> | undefined;
-    client.scenario.patch(`/teams/${team.id}`, (req, res) => {
-      patchBody = req.body as Record<string, unknown>;
-      return res.json(team);
-    });
-
-    client.setArgv('teams', 'update', '--preview-suffix', '');
-    const exitCode = await teams(client);
-
-    expect(exitCode).toBe(0);
-    expect(patchBody).toEqual({ previewDeploymentSuffix: null });
-  });
-
-  it('rejects an invalid --toolbar value before calling the API', async () => {
-    let called = false;
-    client.scenario.patch(`/teams/${team.id}`, (_req, res) => {
-      called = true;
-      return res.json(team);
-    });
-
-    client.setArgv('teams', 'update', '--toolbar', 'bogus');
-    const exitCode = await teams(client);
-
-    expect(exitCode).toBe(1);
-    expect(called).toBe(false);
-    await expect(client.stderr).toOutput('must be one of on, off, default');
-  });
-
   it('errors when no settings are provided', async () => {
     client.setArgv('teams', 'update');
     const exitCode = await teams(client);
@@ -248,25 +189,5 @@ describe('teams update', () => {
       exitSpy.mockRestore();
     });
 
-    it('outputs error JSON for an invalid enum value', async () => {
-      client.nonInteractive = true;
-      const logSpy = vi
-        .spyOn(console, 'log')
-        .mockImplementation(() => undefined as unknown as void);
-      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('exit');
-      }) as () => never);
-
-      client.setArgv('teams', 'update', '--default-build-machine', 'nope');
-      await expect(teams(client)).rejects.toThrow('exit');
-
-      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
-      expect(payload.status).toBe('error');
-      expect(payload.reason).toBe('invalid_default_build_machine');
-      expect(payload.message).toContain('default-build-machine');
-
-      logSpy.mockRestore();
-      exitSpy.mockRestore();
-    });
   });
 });

--- a/packages/cli/test/unit/commands/teams/update.test.ts
+++ b/packages/cli/test/unit/commands/teams/update.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import teams from '../../../../src/commands/teams';
+import { useUser } from '../../../mocks/user';
+import { createTeam, useTeams } from '../../../mocks/team';
+
+describe('teams update', () => {
+  const currentTeamId = 'team_123';
+  const team = createTeam(currentTeamId, 'team-slug', 'My Team');
+
+  beforeEach(() => {
+    useUser();
+    useTeams(team.id);
+    client.config = {
+      currentTeam: currentTeamId,
+    };
+    client.nonInteractive = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('teams', 'update', '--help');
+      const exitCodePromise = teams(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `teams:update`,
+        },
+      ]);
+    });
+  });
+
+  it('updates the current team name with a sparse patch', async () => {
+    let patchBody: Record<string, unknown> | undefined;
+    client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+      patchBody = req.body as Record<string, unknown>;
+      return res.json({ ...team, name: 'New Name' });
+    });
+
+    client.setArgv('teams', 'update', '--name', 'New Name');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(patchBody).toEqual({ name: 'New Name' });
+    await expect(client.stderr).toOutput('Updated');
+    await expect(client.stderr).toOutput('New Name');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:update', value: 'update' },
+      { key: 'option:name', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('updates multiple settings in one call and records enum telemetry', async () => {
+    let patchBody: Record<string, unknown> | undefined;
+    client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+      patchBody = req.body as Record<string, unknown>;
+      return res.json(team);
+    });
+
+    client.setArgv(
+      'teams',
+      'update',
+      '--toolbar',
+      'on',
+      '--default-build-machine',
+      'enhanced'
+    );
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(patchBody).toEqual({
+      enablePreviewFeedback: 'on',
+      resourceConfig: { buildMachine: { default: 'enhanced' } },
+    });
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:update', value: 'update' },
+      { key: 'option:toolbar', value: 'on' },
+      { key: 'option:default-build-machine', value: 'enhanced' },
+    ]);
+  });
+
+  it('clears the preview suffix when passed an empty string', async () => {
+    let patchBody: Record<string, unknown> | undefined;
+    client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+      patchBody = req.body as Record<string, unknown>;
+      return res.json(team);
+    });
+
+    client.setArgv('teams', 'update', '--preview-suffix', '');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(patchBody).toEqual({ previewDeploymentSuffix: null });
+  });
+
+  it('rejects an invalid --toolbar value before calling the API', async () => {
+    let called = false;
+    client.scenario.patch(`/teams/${team.id}`, (_req, res) => {
+      called = true;
+      return res.json(team);
+    });
+
+    client.setArgv('teams', 'update', '--toolbar', 'bogus');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(1);
+    expect(called).toBe(false);
+    await expect(client.stderr).toOutput('must be one of on, off, default');
+  });
+
+  it('errors when no settings are provided', async () => {
+    client.setArgv('teams', 'update');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput('No settings to update');
+  });
+
+  it('targets a team by slug positional argument', async () => {
+    const other = createTeam('team_other', 'other-co', 'Other Co');
+    let patchedId: string | undefined;
+    client.scenario.patch(`/teams/${other.id}`, (req, res) => {
+      patchedId = other.id;
+      return res.json({ ...other, name: 'Renamed' });
+    });
+
+    client.setArgv('teams', 'update', 'other-co', '--name', 'Renamed');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(patchedId).toBe('team_other');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:update', value: 'update' },
+      { key: 'argument:team-slug', value: '[REDACTED]' },
+      { key: 'option:name', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('errors for an unknown team slug', async () => {
+    client.setArgv('teams', 'update', 'nope', '--name', 'X');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(1);
+    await expect(client.stderr).toOutput('do not have access');
+  });
+
+  describe('--slug confirmation', () => {
+    it('asks for confirmation and applies the change when accepted', async () => {
+      let patchBody: Record<string, unknown> | undefined;
+      client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+        patchBody = req.body as Record<string, unknown>;
+        return res.json({ ...team, slug: 'new-slug' });
+      });
+
+      client.setArgv('teams', 'update', '--slug', 'new-slug');
+      const exitCodePromise = teams(client);
+
+      await expect(client.stderr).toOutput('Change the team URL');
+      client.stdin.write('y\n');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+      expect(patchBody).toEqual({ slug: 'new-slug' });
+    });
+
+    it('cancels without changes when declined', async () => {
+      let called = false;
+      client.scenario.patch(`/teams/${team.id}`, (_req, res) => {
+        called = true;
+        return res.json(team);
+      });
+
+      client.setArgv('teams', 'update', '--slug', 'new-slug');
+      const exitCodePromise = teams(client);
+
+      await expect(client.stderr).toOutput('Change the team URL');
+      client.stdin.write('n\n');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+      expect(called).toBe(false);
+      await expect(client.stderr).toOutput('Canceled');
+    });
+
+    it('skips the prompt when --yes is passed', async () => {
+      let patchBody: Record<string, unknown> | undefined;
+      client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+        patchBody = req.body as Record<string, unknown>;
+        return res.json({ ...team, slug: 'new-slug' });
+      });
+
+      client.setArgv('teams', 'update', '--slug', 'new-slug', '--yes');
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({ slug: 'new-slug' });
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:update', value: 'update' },
+        { key: 'option:slug', value: '[REDACTED]' },
+        { key: 'flag:yes', value: 'TRUE' },
+      ]);
+    });
+  });
+
+  describe('non-interactive mode', () => {
+    it('requires --yes to change the slug', async () => {
+      client.nonInteractive = true;
+      const logSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined as unknown as void);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.setArgv('teams', 'update', '--slug', 'new-slug');
+      await expect(teams(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(payload.status).toBe('action_required');
+      expect(payload.reason).toBe('confirmation_required');
+      expect(payload.next[0].command).toContain('--yes');
+
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    it('outputs error JSON when no settings are provided', async () => {
+      client.nonInteractive = true;
+      const logSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined as unknown as void);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.setArgv('teams', 'update');
+      await expect(teams(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('missing_arguments');
+
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    it('outputs error JSON for an invalid enum value', async () => {
+      client.nonInteractive = true;
+      const logSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined as unknown as void);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.setArgv('teams', 'update', '--default-build-machine', 'nope');
+      await expect(teams(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('invalid_default_build_machine');
+      expect(payload.message).toContain('default-build-machine');
+
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `vercel teams update [team-slug]` to change team settings, defaulting to the current scope's team when the slug is omitted.
- Flags in this PR: `--name`, `--slug`, plus `--yes`.
- `--slug` changes the team URL, so it asks for confirmation in a TTY (old → new) and requires `--yes` non-interactively.

## Notes

- Uses the public `PATCH /teams/:id` endpoint; only fields whose flags were explicitly provided are sent (sparse patch), and at least one flag is required.
- Flag → field mapping: `--name` → `name`, `--slug` → `slug`.
- All values are validated locally before the remote call; telemetry records flag presence only (free-text values are `[REDACTED]`).
- `--avatar` is out of scope (file upload) and left as a follow-up.
- Existing `teams add|ls|switch|invite|request|sso|members` behavior is untouched.
- Bottom of a 3-PR stack; stacked follow-ups: #17452 (general settings flags: `--preview-suffix`, `--toolbar`, `--default-build-machine`), #17449 (policy flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)