### PR TITLE
[CLI] Add policy flags to teams update

### DIFF
--- a/.changeset/teams-update-policies.md
+++ b/.changeset/teams-update-policies.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add policy flags to `vercel teams update`

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -221,6 +221,46 @@ export const updateSubcommand = {
         'Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic',
       deprecated: false,
     },
+    {
+      name: 'require-verified-commits',
+      shorthand: null,
+      type: String,
+      description:
+        'Require signed and verified commits before deployments: one of on or off',
+      deprecated: false,
+    },
+    {
+      name: 'sensitive-env-policy',
+      shorthand: null,
+      type: String,
+      description:
+        'Policy for creating Environment Variables as sensitive: one of on, off, or default',
+      deprecated: false,
+    },
+    {
+      name: 'ip-visibility',
+      shorthand: null,
+      type: String,
+      description:
+        'Show or hide IP addresses in Monitoring queries: one of on or off',
+      deprecated: false,
+    },
+    {
+      name: 'git-source-policy',
+      shorthand: null,
+      type: String,
+      description:
+        'Deployment policy git-source rules as a JSON array, or null to clear them',
+      deprecated: false,
+    },
+    {
+      name: 'deployment-source-policy',
+      shorthand: null,
+      type: String,
+      description:
+        'Deployment policy deployment-source rules as a JSON array, or null to clear them',
+      deprecated: false,
+    },
     yesOption,
   ],
   examples: [
@@ -235,6 +275,14 @@ export const updateSubcommand = {
     {
       name: 'Update a specific team by slug',
       value: `${packageName} teams update acme --default-build-machine enhanced`,
+    },
+    {
+      name: 'Require verified commits and sensitive Environment Variables',
+      value: `${packageName} teams update --require-verified-commits on --sensitive-env-policy on`,
+    },
+    {
+      name: 'Restrict deployment sources to git and CLI',
+      value: `${packageName} teams update --deployment-source-policy '[{"enabled":true,"environments":[{"type":"system","target":"production"}],"sources":["git","cli"]}]'`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/teams/update.ts
+++ b/packages/cli/src/commands/teams/update.ts
@@ -6,6 +6,7 @@ import output from '../../output-manager';
 import getScope from '../../util/get-scope';
 import getTeams from '../../util/teams/get-teams';
 import updateTeam, {
+  type DeploymentPolicyRules,
   type TeamUpdatePayload,
 } from '../../util/teams/update-team';
 import { parseArguments } from '../../util/get-args';
@@ -24,7 +25,7 @@ import {
 import { updateSubcommand } from './command';
 import { TeamsUpdateTelemetryClient } from '../../util/telemetry/commands/teams/update';
 
-const TOOLBAR_VALUES = ['on', 'off', 'default'] as const;
+const ON_OFF_DEFAULT_VALUES = ['on', 'off', 'default'] as const;
 const BUILD_MACHINE_VALUES = [
   'basic',
   'standard',
@@ -32,8 +33,53 @@ const BUILD_MACHINE_VALUES = [
   'turbo',
   'elastic',
 ] as const;
+const ON_OFF_VALUES = ['on', 'off'] as const;
+type OnOff = (typeof ON_OFF_VALUES)[number];
 
 const validateSlug = (value: string) => /^[a-z]+[a-z0-9_-]*$/.test(value);
+
+/** Sentinel returned by parsePolicyRules for values that fail validation. */
+const INVALID_POLICY = Symbol('invalid-policy');
+
+/**
+ * Parses a deployment-policy flag value: the literal `null` clears the rule
+ * list; otherwise the value must be a JSON array whose entries are objects
+ * with `enabled`, `environments`, and `sources`. Rule internals (environment
+ * scopes, source enums) are validated by the API.
+ */
+function parsePolicyRules(
+  value: string
+): DeploymentPolicyRules | typeof INVALID_POLICY {
+  const trimmed = value.trim();
+  if (trimmed === 'null') {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return INVALID_POLICY;
+  }
+  if (parsed === null) {
+    return null;
+  }
+  if (!Array.isArray(parsed)) {
+    return INVALID_POLICY;
+  }
+  for (const rule of parsed) {
+    if (
+      typeof rule !== 'object' ||
+      rule === null ||
+      Array.isArray(rule) ||
+      typeof rule.enabled !== 'boolean' ||
+      !Array.isArray(rule.environments) ||
+      !Array.isArray(rule.sources)
+    ) {
+      return INVALID_POLICY;
+    }
+  }
+  return parsed as DeploymentPolicyRules;
+}
 
 export default async function update(
   client: Client,
@@ -71,6 +117,11 @@ export default async function update(
   const previewSuffixFlag = flags['--preview-suffix'];
   const toolbarFlag = flags['--toolbar'];
   const buildMachineFlag = flags['--default-build-machine'];
+  const verifiedCommitsFlag = flags['--require-verified-commits'];
+  const sensitiveEnvPolicyFlag = flags['--sensitive-env-policy'];
+  const ipVisibilityFlag = flags['--ip-visibility'];
+  const gitSourcePolicyFlag = flags['--git-source-policy'];
+  const deploymentSourcePolicyFlag = flags['--deployment-source-policy'];
   const yes = Boolean(flags['--yes']);
 
   telemetry.trackCliArgumentTeamSlug(teamSlugArg);
@@ -79,6 +130,11 @@ export default async function update(
   telemetry.trackCliOptionPreviewSuffix(previewSuffixFlag);
   telemetry.trackCliOptionToolbar(toolbarFlag);
   telemetry.trackCliOptionDefaultBuildMachine(buildMachineFlag);
+  telemetry.trackCliOptionRequireVerifiedCommits(verifiedCommitsFlag);
+  telemetry.trackCliOptionSensitiveEnvPolicy(sensitiveEnvPolicyFlag);
+  telemetry.trackCliOptionIpVisibility(ipVisibilityFlag);
+  telemetry.trackCliOptionGitSourcePolicy(gitSourcePolicyFlag);
+  telemetry.trackCliOptionDeploymentSourcePolicy(deploymentSourcePolicyFlag);
   telemetry.trackCliFlagYes(yes);
 
   if (args.length > 1) {
@@ -134,11 +190,11 @@ export default async function update(
   }
 
   if (toolbarFlag !== undefined) {
-    if (!TOOLBAR_VALUES.includes(toolbarFlag as (typeof TOOLBAR_VALUES)[number])) {
+    if (!ON_OFF_DEFAULT_VALUES.includes(toolbarFlag as (typeof ON_OFF_DEFAULT_VALUES)[number])) {
       return invalidValue(
         client,
         'invalid_toolbar',
-        `Invalid ${param('--toolbar')}: must be one of ${TOOLBAR_VALUES.join(', ')}`
+        `Invalid ${param('--toolbar')}: must be one of ${ON_OFF_DEFAULT_VALUES.join(', ')}`
       );
     }
     payload.enablePreviewFeedback = toolbarFlag;
@@ -159,6 +215,81 @@ export default async function update(
     }
     payload.resourceConfig = { buildMachine: { default: buildMachineFlag } };
     changes.push(['Build Machine', buildMachineFlag]);
+  }
+
+  if (verifiedCommitsFlag !== undefined) {
+    if (!ON_OFF_VALUES.includes(verifiedCommitsFlag as OnOff)) {
+      return invalidValue(
+        client,
+        'invalid_require_verified_commits',
+        `Invalid ${param('--require-verified-commits')}: must be one of ${ON_OFF_VALUES.join(', ')}`
+      );
+    }
+    payload.requireVerifiedCommits = verifiedCommitsFlag === 'on';
+    changes.push(['Verified Commits', verifiedCommitsFlag]);
+  }
+
+  if (sensitiveEnvPolicyFlag !== undefined) {
+    if (!ON_OFF_DEFAULT_VALUES.includes(sensitiveEnvPolicyFlag as (typeof ON_OFF_DEFAULT_VALUES)[number])) {
+      return invalidValue(
+        client,
+        'invalid_sensitive_env_policy',
+        `Invalid ${param('--sensitive-env-policy')}: must be one of ${ON_OFF_DEFAULT_VALUES.join(', ')}`
+      );
+    }
+    payload.sensitiveEnvironmentVariablePolicy = sensitiveEnvPolicyFlag;
+    changes.push(['Sensitive Env Policy', sensitiveEnvPolicyFlag]);
+  }
+
+  if (ipVisibilityFlag !== undefined) {
+    if (!ON_OFF_VALUES.includes(ipVisibilityFlag as OnOff)) {
+      return invalidValue(
+        client,
+        'invalid_ip_visibility',
+        `Invalid ${param('--ip-visibility')}: must be one of ${ON_OFF_VALUES.join(', ')}`
+      );
+    }
+    // The API field is inverted: `hideIpAddresses: true` hides them.
+    payload.hideIpAddresses = ipVisibilityFlag === 'off';
+    changes.push(['IP Visibility', ipVisibilityFlag]);
+  }
+
+  if (gitSourcePolicyFlag !== undefined) {
+    const rules = parsePolicyRules(gitSourcePolicyFlag);
+    if (rules === INVALID_POLICY) {
+      return invalidValue(
+        client,
+        'invalid_git_source_policy',
+        `Invalid ${param('--git-source-policy')}: must be a JSON array of rules (each with enabled, environments, and sources) or null`
+      );
+    }
+    payload.deploymentPolicy = {
+      ...payload.deploymentPolicy,
+      gitSources: rules,
+    };
+    changes.push([
+      'Git Sources',
+      rules === null ? '(cleared)' : `${rules.length} rule${rules.length === 1 ? '' : 's'}`,
+    ]);
+  }
+
+  if (deploymentSourcePolicyFlag !== undefined) {
+    const rules = parsePolicyRules(deploymentSourcePolicyFlag);
+    if (rules === INVALID_POLICY) {
+      return invalidValue(
+        client,
+        'invalid_deployment_source_policy',
+        `Invalid ${param('--deployment-source-policy')}: must be a JSON array of rules (each with enabled, environments, and sources) or null`
+      );
+    }
+    payload.deploymentPolicy = {
+      ...payload.deploymentPolicy,
+      deploymentSources: rules,
+    };
+    changes.push([
+      'Deploy Sources',
+      rules === null ? '(cleared)' : `${rules.length} rule${rules.length === 1 ? '' : 's'}`,
+    ]);
   }
 
   if (Object.keys(payload).length === 0) {

--- a/packages/cli/src/util/teams/update-team.ts
+++ b/packages/cli/src/util/teams/update-team.ts
@@ -1,5 +1,13 @@
-import type { Team } from '@vercel-internals/types';
+import type { JSONArray, Team } from '@vercel-internals/types';
 import type Client from '../client';
+
+/**
+ * One deployment-policy rule list: a JSON array of rule objects, or `null`
+ * to clear all rules of that type. The CLI validates that each entry is an
+ * object with `enabled`, `environments`, and `sources`; rule internals are
+ * validated by the API.
+ */
+export type DeploymentPolicyRules = JSONArray | null;
 
 /**
  * Sparse PATCH payload for `PATCH /teams/:id`. Only fields explicitly set by
@@ -14,6 +22,13 @@ export type TeamUpdatePayload = {
     buildMachine: {
       default: string;
     };
+  };
+  requireVerifiedCommits?: boolean;
+  sensitiveEnvironmentVariablePolicy?: string;
+  hideIpAddresses?: boolean;
+  deploymentPolicy?: {
+    gitSources?: DeploymentPolicyRules;
+    deploymentSources?: DeploymentPolicyRules;
   };
 };
 

--- a/packages/cli/src/util/telemetry/commands/teams/update.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/update.ts
@@ -2,7 +2,7 @@ import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { updateSubcommand } from '../../../../commands/teams/command';
 
-const TOOLBAR_VALUES = ['on', 'off', 'default'];
+const ON_OFF_DEFAULT_VALUES = ['on', 'off', 'default'];
 const BUILD_MACHINE_VALUES = [
   'basic',
   'standard',
@@ -10,6 +10,7 @@ const BUILD_MACHINE_VALUES = [
   'turbo',
   'elastic',
 ];
+const ON_OFF_VALUES = ['on', 'off'];
 
 export class TeamsUpdateTelemetryClient
   extends TelemetryClient
@@ -55,7 +56,7 @@ export class TeamsUpdateTelemetryClient
     if (value !== undefined) {
       this.trackCliOption({
         option: 'toolbar',
-        value: TOOLBAR_VALUES.includes(value) ? value : this.redactedValue,
+        value: ON_OFF_DEFAULT_VALUES.includes(value) ? value : this.redactedValue,
       });
     }
   }
@@ -67,6 +68,51 @@ export class TeamsUpdateTelemetryClient
         value: BUILD_MACHINE_VALUES.includes(value)
           ? value
           : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionRequireVerifiedCommits(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'require-verified-commits',
+        value: ON_OFF_VALUES.includes(value) ? value : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSensitiveEnvPolicy(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'sensitive-env-policy',
+        value: ON_OFF_DEFAULT_VALUES.includes(value) ? value : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionIpVisibility(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'ip-visibility',
+        value: ON_OFF_VALUES.includes(value) ? value : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionGitSourcePolicy(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'git-source-policy',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDeploymentSourcePolicy(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'deployment-source-policy',
+        value: this.redactedValue,
       });
     }
   }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -7471,12 +7471,17 @@ exports[`help command > teams help output snapshots > teams update help output s
 
   Options:
 
-       --default-build-machine  Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic    
-       --name                   New display name for the team                                                                
-       --preview-suffix         Domain suffix for preview deployment URLs; pass an empty string to clear it                  
-       --slug                   New URL slug for the team; this changes the team URL                                         
-       --toolbar                Vercel Toolbar on preview deployments: one of on, off, or default                            
-  -y,  --yes                    Accept default value for all prompts                                                         
+       --default-build-machine     Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic 
+       --deployment-source-policy  Deployment policy deployment-source rules as a JSON array, or null to clear them          
+       --git-source-policy         Deployment policy git-source rules as a JSON array, or null to clear them                 
+       --ip-visibility             Show or hide IP addresses in Monitoring queries: one of on or off                         
+       --name                      New display name for the team                                                             
+       --preview-suffix            Domain suffix for preview deployment URLs; pass an empty string to clear it               
+       --require-verified-commits  Require signed and verified commits before deployments: one of on or off                  
+       --sensitive-env-policy      Policy for creating Environment Variables as sensitive: one of on, off, or default        
+       --slug                      New URL slug for the team; this changes the team URL                                      
+       --toolbar                   Vercel Toolbar on preview deployments: one of on, off, or default                         
+  -y,  --yes                       Accept default value for all prompts                                                      
 
 
   Global Options:
@@ -7506,6 +7511,14 @@ exports[`help command > teams help output snapshots > teams update help output s
   - Update a specific team by slug
 
     $ vercel teams update acme --default-build-machine enhanced
+
+  - Require verified commits and sensitive Environment Variables
+
+    $ vercel teams update --require-verified-commits on --sensitive-env-policy on
+
+  - Restrict deployment sources to git and CLI
+
+    $ vercel teams update --deployment-source-policy '[{"enabled":true,"environments":[{"type":"system","target":"production"}],"sources":["git","cli"]}]'
 
 "
 `;

--- a/packages/cli/test/unit/commands/teams/update.test.ts
+++ b/packages/cli/test/unit/commands/teams/update.test.ts
@@ -269,4 +269,143 @@ describe('teams update', () => {
       exitSpy.mockRestore();
     });
   });
+
+  describe('policy flags', () => {
+    it('maps --require-verified-commits and --sensitive-env-policy', async () => {
+      let patchBody: Record<string, unknown> | undefined;
+      client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+        patchBody = req.body as Record<string, unknown>;
+        return res.json(team);
+      });
+
+      client.setArgv(
+        'teams',
+        'update',
+        '--require-verified-commits',
+        'on',
+        '--sensitive-env-policy',
+        'default'
+      );
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({
+        requireVerifiedCommits: true,
+        sensitiveEnvironmentVariablePolicy: 'default',
+      });
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:update', value: 'update' },
+        { key: 'option:require-verified-commits', value: 'on' },
+        { key: 'option:sensitive-env-policy', value: 'default' },
+      ]);
+    });
+
+    it('inverts --ip-visibility into hideIpAddresses', async () => {
+      let patchBody: Record<string, unknown> | undefined;
+      client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+        patchBody = req.body as Record<string, unknown>;
+        return res.json(team);
+      });
+
+      client.setArgv('teams', 'update', '--ip-visibility', 'off');
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({ hideIpAddresses: true });
+    });
+
+    it('sends deploymentPolicy rules from JSON policy flags', async () => {
+      let patchBody: Record<string, unknown> | undefined;
+      client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+        patchBody = req.body as Record<string, unknown>;
+        return res.json(team);
+      });
+
+      const rule = {
+        enabled: true,
+        environments: [{ type: 'system', target: 'production' }],
+        sources: ['git', 'cli'],
+      };
+      client.setArgv(
+        'teams',
+        'update',
+        '--deployment-source-policy',
+        JSON.stringify([rule]),
+        '--git-source-policy',
+        'null'
+      );
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({
+        deploymentPolicy: {
+          gitSources: null,
+          deploymentSources: [rule],
+        },
+      });
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:update', value: 'update' },
+        { key: 'option:git-source-policy', value: '[REDACTED]' },
+        { key: 'option:deployment-source-policy', value: '[REDACTED]' },
+      ]);
+    });
+
+    it('rejects malformed policy JSON before calling the API', async () => {
+      let called = false;
+      client.scenario.patch(`/teams/${team.id}`, (_req, res) => {
+        called = true;
+        return res.json(team);
+      });
+
+      client.setArgv('teams', 'update', '--git-source-policy', '{not json');
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(1);
+      expect(called).toBe(false);
+      await expect(client.stderr).toOutput('must be a JSON array of rules');
+    });
+
+    it('rejects policy rules missing required fields', async () => {
+      client.setArgv(
+        'teams',
+        'update',
+        '--deployment-source-policy',
+        JSON.stringify([{ enabled: true }])
+      );
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('must be a JSON array of rules');
+    });
+
+    it('rejects an invalid --require-verified-commits value', async () => {
+      client.setArgv('teams', 'update', '--require-verified-commits', 'yes');
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('must be one of on, off');
+    });
+
+    it('outputs error JSON for invalid --ip-visibility in non-interactive mode', async () => {
+      client.nonInteractive = true;
+      const logSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined as unknown as void);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.setArgv('teams', 'update', '--ip-visibility', 'visible');
+      await expect(teams(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('invalid_ip_visibility');
+
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/teams/update.test.ts
+++ b/packages/cli/test/unit/commands/teams/update.test.ts
@@ -329,6 +329,34 @@ describe('teams update', () => {
       expect(patchBody).toEqual({ hideIpAddresses: true });
     });
 
+    it('maps --ip-visibility on to hideIpAddresses false', async () => {
+      let patchBody: Record<string, unknown> | undefined;
+      client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+        patchBody = req.body as Record<string, unknown>;
+        return res.json(team);
+      });
+
+      client.setArgv('teams', 'update', '--ip-visibility', 'on');
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({ hideIpAddresses: false });
+    });
+
+    it('maps --require-verified-commits off to false', async () => {
+      let patchBody: Record<string, unknown> | undefined;
+      client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+        patchBody = req.body as Record<string, unknown>;
+        return res.json(team);
+      });
+
+      client.setArgv('teams', 'update', '--require-verified-commits', 'off');
+      const exitCode = await teams(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({ requireVerifiedCommits: false });
+    });
+
     it('sends deploymentPolicy rules from JSON policy flags', async () => {
       let patchBody: Record<string, unknown> | undefined;
       client.scenario.patch(`/teams/${team.id}`, (req, res) => {


### PR DESCRIPTION
## Summary

- Adds team-policy flags to `vercel teams update`: `--require-verified-commits` (on/off), `--sensitive-env-policy` (on/off/default), `--ip-visibility` (on/off), `--git-source-policy` (JSON rules or null), and `--deployment-source-policy` (JSON rules or null).

## Notes

- Uses the same public `PATCH /teams/:id` endpoint and sparse-patch behavior as the base PRs.
- Flag → field mapping: `--require-verified-commits` → `requireVerifiedCommits` (boolean), `--sensitive-env-policy` → `sensitiveEnvironmentVariablePolicy`, `--ip-visibility` → `hideIpAddresses` (inverted: on shows IPs), `--git-source-policy` → `deploymentPolicy.gitSources`, `--deployment-source-policy` → `deploymentPolicy.deploymentSources`.
- The two policy flags take the raw JSON rule array from the endpoint schema (or the literal `null` to clear); the CLI validates JSON shape (array of objects with `enabled`, `environments`, `sources`) locally and leaves rule internals to the API.
- `--require-2fa` was dropped: the underlying `mfaEnforced` field is marked private in the endpoint schema.
- Telemetry records enum values only; JSON policy values are `[REDACTED]`.
- Top of a 3-PR stack: #17448 (identity flags, base main) ← #17452 (general settings flags) ← this PR (base: add-teams-update-general).

🤖 Generated with [Claude Code](https://claude.com/claude-code)