### PR TITLE
[CLI] Add project web-analytics disable

### DIFF
--- a/.changeset/web-analytics-disable.md
+++ b/.changeset/web-analytics-disable.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project web-analytics disable` to turn off Web Analytics for a project

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -614,25 +614,27 @@ export const accessGroupsSubcommand = {
 export const webAnalyticsSubcommand = {
   name: 'web-analytics',
   aliases: [],
-  description: 'Enable Web Analytics for a project',
+  description: 'Enable or disable Web Analytics for a project',
   arguments: [
-    {
-      name: 'name',
-      required: false,
-    },
+    { name: 'action', required: false },
+    { name: 'name', required: false },
   ],
   options: [formatOption, jsonOption],
   examples: [
     {
-      name: 'Enable Web Analytics for the linked project',
+      name: 'Enable Web Analytics for the linked project (omitting the action defaults to enable)',
       value: `${packageName} project web-analytics`,
     },
     {
       name: 'Enable Web Analytics for a named project',
-      value: `${packageName} project web-analytics my-project`,
+      value: `${packageName} project web-analytics enable my-project`,
     },
     {
-      name: 'Confirm enablement as JSON (non-interactive / agents)',
+      name: 'Disable Web Analytics for a named project',
+      value: `${packageName} project web-analytics disable my-project`,
+    },
+    {
+      name: 'Confirm the result as JSON (non-interactive / agents)',
       value: `${packageName} project web-analytics --json`,
     },
   ],

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -186,7 +186,13 @@ export default async function main(client: Client) {
         telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(webAnalyticsSubcommand);
       }
-      telemetry.trackCliSubcommandWebAnalytics(subcommandOriginal);
+      telemetry.trackCliSubcommandWebAnalytics(
+        args[0] === 'enable'
+          ? 'web-analytics enable'
+          : args[0] === 'disable'
+            ? 'web-analytics disable'
+            : subcommandOriginal
+      );
       exitCode = await webAnalytics(client, args);
       break;
     case 'speedInsights':

--- a/packages/cli/src/commands/project/web-analytics.ts
+++ b/packages/cli/src/commands/project/web-analytics.ts
@@ -15,6 +15,13 @@ interface ToggleResponse {
   value: boolean;
 }
 
+const WEB_ANALYTICS_ACTIONS = ['enable', 'disable'] as const;
+type WebAnalyticsAction = (typeof WEB_ANALYTICS_ACTIONS)[number];
+
+function isWebAnalyticsAction(v: string | undefined): v is WebAnalyticsAction {
+  return !!v && (WEB_ANALYTICS_ACTIONS as readonly string[]).includes(v);
+}
+
 export default async function webAnalytics(
   client: Client,
   argv: string[]
@@ -41,9 +48,22 @@ export default async function webAnalytics(
     return 1;
   }
 
-  if (parsedArgs.args.length > 1) {
+  const actionArg = parsedArgs.args[0];
+  const action = isWebAnalyticsAction(actionArg) ? actionArg : undefined;
+  // Back-compat: with no explicit action, the first argument is the project
+  // name and the command enables Web Analytics, exactly as before.
+  const projectNameOrId = action ? parsedArgs.args[1] : parsedArgs.args[0];
+  const enable = action !== 'disable';
+
+  if (!action && parsedArgs.args.length > 1) {
     output.error(
       'Invalid number of arguments. Usage: `vercel project web-analytics [name]`'
+    );
+    return 2;
+  }
+  if (action && parsedArgs.args.length > 2) {
+    output.error(
+      `Invalid number of arguments. Usage: \`vercel project web-analytics ${action} [name]\``
     );
     return 2;
   }
@@ -59,7 +79,7 @@ export default async function webAnalytics(
     const project = await getProjectByCwdOrLink({
       client,
       commandName: 'project web-analytics',
-      projectNameOrId: parsedArgs.args[0],
+      projectNameOrId,
       forReadOnlyCommand: true,
     });
 
@@ -69,7 +89,7 @@ export default async function webAnalytics(
       {
         method: 'POST',
         json: true,
-        body: { value: true },
+        body: { value: enable },
       }
     );
 
@@ -88,7 +108,11 @@ export default async function webAnalytics(
       return 0;
     }
 
-    output.log(`Web Analytics is enabled for ${project.name}.`);
+    output.log(
+      result.value
+        ? `Web Analytics is enabled for ${project.name}.`
+        : `Web Analytics is disabled for ${project.name}.`
+    );
     return 0;
   } catch (err: unknown) {
     exitWithNonInteractiveError(client, err, 1, {

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5717,7 +5717,9 @@ exports[`help command > project help output snapshots > project help column widt
                                    …
                                    a
                                    …
-  web-analytics   [name]           …
+  web-analytics   [action] [name]  …
+                                   …
+                                   …
                                    …
                                    …
                                    …
@@ -5814,28 +5816,30 @@ exports[`help command > project help output snapshots > project help column widt
 
   Commands:
 
-  add             name             Add a new project                        
-  access-summary  [name]           Show member counts by team role for      
-                                   project access (requires access groups   
-                                   entitlement)                             
-  checks          [name]           List, add, or remove deployment checks   
-                                   for a project (GET/POST/DELETE           
-                                   /v2/projects/.../checks)                 
-  inspect         [name]           Displays information related to a project
-  list                             Show all projects in the selected scope  
-                                   (default)                                
-  members         [name]           List project members for a project       
-  access-groups   [name]           List access groups for a project         
-  protection      [action] [name]  Show or toggle deployment protection     
-                                   settings for a project                   
-  web-analytics   [name]           Enable Web Analytics for a project       
-  speed-insights  [name]           Enable Speed Insights for a project      
-  update          [name]           Update one or more project settings;     
-                                   omitted settings remain unchanged        
-  rename          name new-name    Rename a project                         
-  remove          name             Delete a project                         
-  token           [name]           Get a development OIDC token for a       
-                                   project                                  
+  add             name             Add a new project                     
+  access-summary  [name]           Show member counts by team role for   
+                                   project access (requires access groups
+                                   entitlement)                          
+  checks          [name]           List, add, or remove deployment checks
+                                   for a project (GET/POST/DELETE        
+                                   /v2/projects/.../checks)              
+  inspect         [name]           Displays information related to a     
+                                   project                               
+  list                             Show all projects in the selected     
+                                   scope (default)                       
+  members         [name]           List project members for a project    
+  access-groups   [name]           List access groups for a project      
+  protection      [action] [name]  Show or toggle deployment protection  
+                                   settings for a project                
+  web-analytics   [action] [name]  Enable or disable Web Analytics for a 
+                                   project                               
+  speed-insights  [name]           Enable Speed Insights for a project   
+  update          [name]           Update one or more project settings;  
+                                   omitted settings remain unchanged     
+  rename          name new-name    Rename a project                      
+  remove          name             Delete a project                      
+  token           [name]           Get a development OIDC token for a    
+                                   project                               
 
 
   Global Options:
@@ -5865,22 +5869,22 @@ exports[`help command > project help output snapshots > project help column widt
 
   Commands:
 
-  add             name             Add a new project                                                                
-  access-summary  [name]           Show member counts by team role for project access (requires access groups       
-                                   entitlement)                                                                     
-  checks          [name]           List, add, or remove deployment checks for a project (GET/POST/DELETE            
-                                   /v2/projects/.../checks)                                                         
-  inspect         [name]           Displays information related to a project                                        
-  list                             Show all projects in the selected scope (default)                                
-  members         [name]           List project members for a project                                               
-  access-groups   [name]           List access groups for a project                                                 
-  protection      [action] [name]  Show or toggle deployment protection settings for a project                      
-  web-analytics   [name]           Enable Web Analytics for a project                                               
-  speed-insights  [name]           Enable Speed Insights for a project                                              
-  update          [name]           Update one or more project settings; omitted settings remain unchanged           
-  rename          name new-name    Rename a project                                                                 
-  remove          name             Delete a project                                                                 
-  token           [name]           Get a development OIDC token for a project                                       
+  add             name             Add a new project                                                             
+  access-summary  [name]           Show member counts by team role for project access (requires access groups    
+                                   entitlement)                                                                  
+  checks          [name]           List, add, or remove deployment checks for a project (GET/POST/DELETE         
+                                   /v2/projects/.../checks)                                                      
+  inspect         [name]           Displays information related to a project                                     
+  list                             Show all projects in the selected scope (default)                             
+  members         [name]           List project members for a project                                            
+  access-groups   [name]           List access groups for a project                                              
+  protection      [action] [name]  Show or toggle deployment protection settings for a project                   
+  web-analytics   [action] [name]  Enable or disable Web Analytics for a project                                 
+  speed-insights  [name]           Enable Speed Insights for a project                                           
+  update          [name]           Update one or more project settings; omitted settings remain unchanged        
+  rename          name new-name    Rename a project                                                              
+  remove          name             Delete a project                                                              
+  token           [name]           Get a development OIDC token for a project                                    
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/project/web-analytics.test.ts
+++ b/packages/cli/test/unit/commands/project/web-analytics.test.ts
@@ -186,6 +186,37 @@ describe('project web-analytics', () => {
     expect(exitCode).toBe(1);
   });
 
+  it('targets a project literally named "disable" by its project ID', async () => {
+    // A bare `disable` argument is always the action word (see the linked
+    // project test above), so a project named "disable" or "enable" must be
+    // targeted by its project ID instead.
+    useProject({
+      ...defaultProject,
+      id: 'prj_shadowed_123',
+      name: 'disable',
+    });
+
+    client.scenario.post('/web/insights/toggle', (req, res) => {
+      expect(req.query.projectId).toBe('prj_shadowed_123');
+      expect(req.body).toEqual({ value: false });
+      res.json({ value: false });
+    });
+
+    client.setArgv('project', 'web-analytics', 'disable', 'prj_shadowed_123');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Web Analytics is disabled');
+  });
+
+  it('returns 2 when the action form is given too many arguments', async () => {
+    client.setArgv('project', 'web-analytics', 'enable', 'a', 'b');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput(
+      'Invalid number of arguments. Usage: `vercel project web-analytics enable [name]`'
+    );
+  });
+
   describe('--non-interactive', () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/packages/cli/test/unit/commands/project/web-analytics.test.ts
+++ b/packages/cli/test/unit/commands/project/web-analytics.test.ts
@@ -1,10 +1,14 @@
 import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { outputFile } from 'fs-extra';
 import { client } from '../../../mocks/client';
 import project from '../../../../src/commands/project';
 import { defaultProject, useProject } from '../../../mocks/project';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
 
 describe('project web-analytics', () => {
   it('enables Web Analytics for a named project', async () => {
@@ -59,6 +63,127 @@ describe('project web-analytics', () => {
       projectId: 'prj_123',
       projectName: 'my-project',
     });
+  });
+
+  it('disables Web Analytics for a named project', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/web/insights/toggle', (req, res) => {
+      expect(req.query.projectId).toBe('prj_123');
+      expect(req.body).toEqual({ value: false });
+      res.json({ value: false });
+    });
+
+    client.setArgv('project', 'web-analytics', 'disable', 'my-project');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Web Analytics is disabled');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:web-analytics',
+        value: 'web-analytics disable',
+      },
+    ]);
+  });
+
+  it('enables Web Analytics with an explicit enable action', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/web/insights/toggle', (req, res) => {
+      expect(req.body).toEqual({ value: true });
+      res.json({ value: true });
+    });
+
+    client.setArgv('project', 'web-analytics', 'enable', 'my-project');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Web Analytics is enabled');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:web-analytics',
+        value: 'web-analytics enable',
+      },
+    ]);
+  });
+
+  it('outputs JSON with enabled=false when disabling', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/web/insights/toggle', (_req, res) => {
+      res.json({ value: false });
+    });
+
+    client.setArgv(
+      'project',
+      'web-analytics',
+      'disable',
+      'my-project',
+      '--format',
+      'json'
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+
+    const jsonOutput = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(jsonOutput).toEqual({
+      enabled: false,
+      projectId: 'prj_123',
+      projectName: 'my-project',
+    });
+  });
+
+  it('disables Web Analytics for the linked project when no name is given', async () => {
+    useUser();
+    useTeam('team_dummy');
+    const cwd = setupTmpDir();
+    const prevCwd = client.cwd;
+    client.cwd = cwd;
+    const projectId = basename(cwd);
+    useProject({
+      ...defaultProject,
+      id: projectId,
+      name: projectId,
+      accountId: 'team_dummy',
+    });
+    await outputFile(
+      join(cwd, '.vercel', 'project.json'),
+      JSON.stringify({ projectId, orgId: 'team_dummy' })
+    );
+
+    let receivedProjectId: string | undefined;
+    client.scenario.post('/web/insights/toggle', (req, res) => {
+      receivedProjectId = req.query.projectId as string;
+      expect(req.body).toEqual({ value: false });
+      res.json({ value: false });
+    });
+
+    try {
+      client.setArgv('project', 'web-analytics', 'disable');
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(receivedProjectId).toBe(projectId);
+      await expect(client.stderr).toOutput('Web Analytics is disabled');
+    } finally {
+      client.cwd = prevCwd;
+    }
+  });
+
+  it('returns 1 when the named project is not found', async () => {
+    client.setArgv('project', 'web-analytics', 'disable', 'missing-project');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(1);
   });
 
   describe('--non-interactive', () => {


### PR DESCRIPTION
## Summary

- Adds `vercel project web-analytics disable [name]` to turn off Web Analytics, alongside an explicit `enable` action, while keeping the existing `vercel project web-analytics [name]` invocation working exactly as before (defaults to enable).
- Human output prints a clear result line (`Web Analytics is enabled/disabled for <name>.`) and `--json`/`--format json` returns `{ enabled, projectId, projectName }` reflecting the resulting state.
- Adds `web-analytics enable` / `web-analytics disable` telemetry values and unit tests (disable success, explicit enable, disable JSON, linked-project resolution, project-not-found, action-word precedence, action arg-count), plus updated `project` help snapshots.

## Notes

- Uses the same public endpoint as the enable path (`POST /web/insights/toggle`), sending `{ value: false }` to disable and `{ value: true }` to enable — the same value the dashboard's disable action uses.
- Back-compat: with no action word the first arg is still the project name and the command enables, so existing args/flags/output/exit codes are unchanged; the equivalence is documented in the help examples.
- Caveat: `enable`/`disable` as the first argument are always treated as action words (consistent with `project protection`), so a project literally named `enable` or `disable` must be targeted by its project ID (e.g. `vercel project web-analytics disable prj_...`); pinned by test.
- Untouched: enable-only behavior, the `/web/insights/toggle` request shape, other `project` subcommands, and non-interactive/agent error payloads.