### PR TITLE
[CLI] Add general settings flags to teams update

### DIFF
--- a/.changeset/teams-update-general.md
+++ b/.changeset/teams-update-general.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add general settings flags (--preview-suffix, --toolbar, --default-build-machine) to `vercel teams update`

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -197,6 +197,30 @@ export const updateSubcommand = {
       description: 'New URL slug for the team; this changes the team URL',
       deprecated: false,
     },
+    {
+      name: 'preview-suffix',
+      shorthand: null,
+      type: String,
+      description:
+        'Domain suffix for preview deployment URLs; pass an empty string to clear it',
+      deprecated: false,
+    },
+    {
+      name: 'toolbar',
+      shorthand: null,
+      type: String,
+      description:
+        'Vercel Toolbar on preview deployments: one of on, off, or default',
+      deprecated: false,
+    },
+    {
+      name: 'default-build-machine',
+      shorthand: null,
+      type: String,
+      description:
+        'Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic',
+      deprecated: false,
+    },
     yesOption,
   ],
   examples: [
@@ -210,7 +234,7 @@ export const updateSubcommand = {
     },
     {
       name: 'Update a specific team by slug',
-      value: `${packageName} teams update acme --name "Acme Corp"`,
+      value: `${packageName} teams update acme --default-build-machine enhanced`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/teams/update.ts
+++ b/packages/cli/src/commands/teams/update.ts
@@ -24,6 +24,15 @@ import {
 import { updateSubcommand } from './command';
 import { TeamsUpdateTelemetryClient } from '../../util/telemetry/commands/teams/update';
 
+const TOOLBAR_VALUES = ['on', 'off', 'default'] as const;
+const BUILD_MACHINE_VALUES = [
+  'basic',
+  'standard',
+  'enhanced',
+  'turbo',
+  'elastic',
+] as const;
+
 const validateSlug = (value: string) => /^[a-z]+[a-z0-9_-]*$/.test(value);
 
 export default async function update(
@@ -59,11 +68,17 @@ export default async function update(
 
   const nameFlag = flags['--name'];
   const slugFlag = flags['--slug'];
+  const previewSuffixFlag = flags['--preview-suffix'];
+  const toolbarFlag = flags['--toolbar'];
+  const buildMachineFlag = flags['--default-build-machine'];
   const yes = Boolean(flags['--yes']);
 
   telemetry.trackCliArgumentTeamSlug(teamSlugArg);
   telemetry.trackCliOptionName(nameFlag);
   telemetry.trackCliOptionSlug(slugFlag);
+  telemetry.trackCliOptionPreviewSuffix(previewSuffixFlag);
+  telemetry.trackCliOptionToolbar(toolbarFlag);
+  telemetry.trackCliOptionDefaultBuildMachine(buildMachineFlag);
   telemetry.trackCliFlagYes(yes);
 
   if (args.length > 1) {
@@ -110,6 +125,40 @@ export default async function update(
     }
     payload.slug = slug;
     changes.push(['Slug', slug]);
+  }
+
+  if (previewSuffixFlag !== undefined) {
+    const suffix = previewSuffixFlag.trim();
+    payload.previewDeploymentSuffix = suffix === '' ? null : suffix;
+    changes.push(['Preview Suffix', suffix === '' ? '(cleared)' : suffix]);
+  }
+
+  if (toolbarFlag !== undefined) {
+    if (!TOOLBAR_VALUES.includes(toolbarFlag as (typeof TOOLBAR_VALUES)[number])) {
+      return invalidValue(
+        client,
+        'invalid_toolbar',
+        `Invalid ${param('--toolbar')}: must be one of ${TOOLBAR_VALUES.join(', ')}`
+      );
+    }
+    payload.enablePreviewFeedback = toolbarFlag;
+    changes.push(['Toolbar', toolbarFlag]);
+  }
+
+  if (buildMachineFlag !== undefined) {
+    if (
+      !BUILD_MACHINE_VALUES.includes(
+        buildMachineFlag as (typeof BUILD_MACHINE_VALUES)[number]
+      )
+    ) {
+      return invalidValue(
+        client,
+        'invalid_default_build_machine',
+        `Invalid ${param('--default-build-machine')}: must be one of ${BUILD_MACHINE_VALUES.join(', ')}`
+      );
+    }
+    payload.resourceConfig = { buildMachine: { default: buildMachineFlag } };
+    changes.push(['Build Machine', buildMachineFlag]);
   }
 
   if (Object.keys(payload).length === 0) {

--- a/packages/cli/src/util/teams/update-team.ts
+++ b/packages/cli/src/util/teams/update-team.ts
@@ -8,6 +8,13 @@ import type Client from '../client';
 export type TeamUpdatePayload = {
   name?: string;
   slug?: string;
+  previewDeploymentSuffix?: string | null;
+  enablePreviewFeedback?: string;
+  resourceConfig?: {
+    buildMachine: {
+      default: string;
+    };
+  };
 };
 
 export default async function updateTeam(

--- a/packages/cli/src/util/telemetry/commands/teams/update.ts
+++ b/packages/cli/src/util/telemetry/commands/teams/update.ts
@@ -2,6 +2,15 @@ import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { updateSubcommand } from '../../../../commands/teams/command';
 
+const TOOLBAR_VALUES = ['on', 'off', 'default'];
+const BUILD_MACHINE_VALUES = [
+  'basic',
+  'standard',
+  'enhanced',
+  'turbo',
+  'elastic',
+];
+
 export class TeamsUpdateTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof updateSubcommand>
@@ -29,6 +38,35 @@ export class TeamsUpdateTelemetryClient
       this.trackCliOption({
         option: 'slug',
         value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionPreviewSuffix(suffix: string | undefined) {
+    if (suffix !== undefined) {
+      this.trackCliOption({
+        option: 'preview-suffix',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionToolbar(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'toolbar',
+        value: TOOLBAR_VALUES.includes(value) ? value : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDefaultBuildMachine(value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'default-build-machine',
+        value: BUILD_MACHINE_VALUES.includes(value)
+          ? value
+          : this.redactedValue,
       });
     }
   }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -7471,9 +7471,12 @@ exports[`help command > teams help output snapshots > teams update help output s
 
   Options:
 
-       --name  New display name for the team                                                                             
-       --slug  New URL slug for the team; this changes the team URL                                                      
-  -y,  --yes   Accept default value for all prompts                                                                      
+       --default-build-machine  Default build machine for new builds: one of basic, standard, enhanced, turbo, or elastic    
+       --name                   New display name for the team                                                                
+       --preview-suffix         Domain suffix for preview deployment URLs; pass an empty string to clear it                  
+       --slug                   New URL slug for the team; this changes the team URL                                         
+       --toolbar                Vercel Toolbar on preview deployments: one of on, off, or default                            
+  -y,  --yes                    Accept default value for all prompts                                                         
 
 
   Global Options:
@@ -7502,7 +7505,7 @@ exports[`help command > teams help output snapshots > teams update help output s
 
   - Update a specific team by slug
 
-    $ vercel teams update acme --name "Acme Corp"
+    $ vercel teams update acme --default-build-machine enhanced
 
 "
 `;

--- a/packages/cli/test/unit/commands/teams/update.test.ts
+++ b/packages/cli/test/unit/commands/teams/update.test.ts
@@ -83,6 +83,20 @@ describe('teams update', () => {
     ]);
   });
 
+  it('forwards a non-empty preview suffix in the request body', async () => {
+    let patchBody: Record<string, unknown> | undefined;
+    client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+      patchBody = req.body as Record<string, unknown>;
+      return res.json(team);
+    });
+
+    client.setArgv('teams', 'update', '--preview-suffix', 'example.dev');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(patchBody).toEqual({ previewDeploymentSuffix: 'example.dev' });
+  });
+
   it('clears the preview suffix when passed an empty string', async () => {
     let patchBody: Record<string, unknown> | undefined;
     client.scenario.patch(`/teams/${team.id}`, (req, res) => {

--- a/packages/cli/test/unit/commands/teams/update.test.ts
+++ b/packages/cli/test/unit/commands/teams/update.test.ts
@@ -53,6 +53,65 @@ describe('teams update', () => {
     ]);
   });
 
+  it('updates multiple settings in one call and records enum telemetry', async () => {
+    let patchBody: Record<string, unknown> | undefined;
+    client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+      patchBody = req.body as Record<string, unknown>;
+      return res.json(team);
+    });
+
+    client.setArgv(
+      'teams',
+      'update',
+      '--toolbar',
+      'on',
+      '--default-build-machine',
+      'enhanced'
+    );
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(patchBody).toEqual({
+      enablePreviewFeedback: 'on',
+      resourceConfig: { buildMachine: { default: 'enhanced' } },
+    });
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:update', value: 'update' },
+      { key: 'option:toolbar', value: 'on' },
+      { key: 'option:default-build-machine', value: 'enhanced' },
+    ]);
+  });
+
+  it('clears the preview suffix when passed an empty string', async () => {
+    let patchBody: Record<string, unknown> | undefined;
+    client.scenario.patch(`/teams/${team.id}`, (req, res) => {
+      patchBody = req.body as Record<string, unknown>;
+      return res.json(team);
+    });
+
+    client.setArgv('teams', 'update', '--preview-suffix', '');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(0);
+    expect(patchBody).toEqual({ previewDeploymentSuffix: null });
+  });
+
+  it('rejects an invalid --toolbar value before calling the API', async () => {
+    let called = false;
+    client.scenario.patch(`/teams/${team.id}`, (_req, res) => {
+      called = true;
+      return res.json(team);
+    });
+
+    client.setArgv('teams', 'update', '--toolbar', 'bogus');
+    const exitCode = await teams(client);
+
+    expect(exitCode).toBe(1);
+    expect(called).toBe(false);
+    await expect(client.stderr).toOutput('must be one of on, off, default');
+  });
+
   it('errors when no settings are provided', async () => {
     client.setArgv('teams', 'update');
     const exitCode = await teams(client);
@@ -189,5 +248,25 @@ describe('teams update', () => {
       exitSpy.mockRestore();
     });
 
+    it('outputs error JSON for an invalid enum value', async () => {
+      client.nonInteractive = true;
+      const logSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined as unknown as void);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as () => never);
+
+      client.setArgv('teams', 'update', '--default-build-machine', 'nope');
+      await expect(teams(client)).rejects.toThrow('exit');
+
+      const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(payload.status).toBe('error');
+      expect(payload.reason).toBe('invalid_default_build_machine');
+      expect(payload.message).toContain('default-build-machine');
+
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds general settings flags to `vercel teams update`: `--preview-suffix`, `--toolbar` (on/off/default), and `--default-build-machine` (basic/standard/enhanced/turbo/elastic).

## Notes

- Uses the same public `PATCH /teams/:id` endpoint and sparse-patch behavior as the base PR.
- Flag → field mapping: `--preview-suffix` → `previewDeploymentSuffix` (empty string clears via `null`), `--toolbar` → `enablePreviewFeedback`, `--default-build-machine` → `resourceConfig.buildMachine.default`; enum values match the endpoint schema verbatim.
- Values are validated locally before the remote call; telemetry records enum values only, free-text suffix is `[REDACTED]`.
- Identity flags (`--name`, `--slug`) and their confirmation flow are unchanged from the base PR.
- Stacked on #17448 (base: add-teams-update); stacked follow-up (policy flags): #17449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)