### PR TITLE
[CLI] Add project speed-insights disable

### DIFF
--- a/.changeset/speed-insights-disable.md
+++ b/.changeset/speed-insights-disable.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project speed-insights disable` to turn off Speed Insights

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -641,12 +641,10 @@ export const webAnalyticsSubcommand = {
 export const speedInsightsSubcommand = {
   name: 'speed-insights',
   aliases: [],
-  description: 'Enable Speed Insights for a project',
+  description: 'Enable or disable Speed Insights for a project',
   arguments: [
-    {
-      name: 'name',
-      required: false,
-    },
+    { name: 'action', required: false },
+    { name: 'name', required: false },
   ],
   options: [formatOption, jsonOption],
   examples: [
@@ -656,7 +654,11 @@ export const speedInsightsSubcommand = {
     },
     {
       name: 'Enable Speed Insights for a named project',
-      value: `${packageName} project speed-insights my-project`,
+      value: `${packageName} project speed-insights enable my-project`,
+    },
+    {
+      name: 'Disable Speed Insights for a named project',
+      value: `${packageName} project speed-insights disable my-project`,
     },
     {
       name: 'Confirm enablement as JSON (non-interactive / agents)',

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -194,7 +194,13 @@ export default async function main(client: Client) {
         telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(speedInsightsSubcommand);
       }
-      telemetry.trackCliSubcommandSpeedInsights(subcommandOriginal);
+      telemetry.trackCliSubcommandSpeedInsights(
+        args[0] === 'enable'
+          ? 'speed-insights enable'
+          : args[0] === 'disable'
+            ? 'speed-insights disable'
+            : subcommandOriginal
+      );
       exitCode = await speedInsights(client, args);
       break;
     case 'token':

--- a/packages/cli/src/commands/project/speed-insights.ts
+++ b/packages/cli/src/commands/project/speed-insights.ts
@@ -15,6 +15,15 @@ interface ToggleResponse {
   value: boolean;
 }
 
+const SPEED_INSIGHTS_ACTIONS = ['enable', 'disable'] as const;
+type SpeedInsightsAction = (typeof SPEED_INSIGHTS_ACTIONS)[number];
+
+function isSpeedInsightsAction(
+  v: string | undefined
+): v is SpeedInsightsAction {
+  return !!v && (SPEED_INSIGHTS_ACTIONS as readonly string[]).includes(v);
+}
+
 export default async function speedInsights(
   client: Client,
   argv: string[]
@@ -41,9 +50,16 @@ export default async function speedInsights(
     return 1;
   }
 
-  if (parsedArgs.args.length > 1) {
+  const actionArg = parsedArgs.args[0];
+  const action = isSpeedInsightsAction(actionArg) ? actionArg : undefined;
+  const projectNameOrId = action ? parsedArgs.args[1] : parsedArgs.args[0];
+
+  const maxArgs = action ? 2 : 1;
+  if (parsedArgs.args.length > maxArgs) {
     output.error(
-      'Invalid number of arguments. Usage: `vercel project speed-insights [name]`'
+      `Invalid number of arguments. Usage: \`vercel project speed-insights ${
+        action ? `${action} ` : ''
+      }[name]\``
     );
     return 2;
   }
@@ -55,11 +71,13 @@ export default async function speedInsights(
   }
   const asJson = formatResult.jsonOutput;
 
+  const value = action !== 'disable';
+
   try {
     const project = await getProjectByCwdOrLink({
       client,
       commandName: 'project speed-insights',
-      projectNameOrId: parsedArgs.args[0],
+      projectNameOrId,
       forReadOnlyCommand: true,
     });
 
@@ -69,7 +87,7 @@ export default async function speedInsights(
       {
         method: 'POST',
         json: true,
-        body: { value: true },
+        body: { value },
       }
     );
 
@@ -88,7 +106,9 @@ export default async function speedInsights(
       return 0;
     }
 
-    output.log(`Speed Insights is enabled for ${project.name}.`);
+    output.log(
+      `Speed Insights is ${result.value ? 'enabled' : 'disabled'} for ${project.name}.`
+    );
     return 0;
   } catch (err: unknown) {
     exitWithNonInteractiveError(client, err, 1, {

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5723,7 +5723,9 @@ exports[`help command > project help output snapshots > project help column widt
                                    …
                                    a
                                    …
-  speed-insights  [name]           …
+  speed-insights  [action] [name]  …
+                                   …
+                                   …
                                    …
                                    …
                                    …
@@ -5814,28 +5816,30 @@ exports[`help command > project help output snapshots > project help column widt
 
   Commands:
 
-  add             name             Add a new project                        
-  access-summary  [name]           Show member counts by team role for      
-                                   project access (requires access groups   
-                                   entitlement)                             
-  checks          [name]           List, add, or remove deployment checks   
-                                   for a project (GET/POST/DELETE           
-                                   /v2/projects/.../checks)                 
-  inspect         [name]           Displays information related to a project
-  list                             Show all projects in the selected scope  
-                                   (default)                                
-  members         [name]           List project members for a project       
-  access-groups   [name]           List access groups for a project         
-  protection      [action] [name]  Show or toggle deployment protection     
-                                   settings for a project                   
-  web-analytics   [name]           Enable Web Analytics for a project       
-  speed-insights  [name]           Enable Speed Insights for a project      
-  update          [name]           Update one or more project settings;     
-                                   omitted settings remain unchanged        
-  rename          name new-name    Rename a project                         
-  remove          name             Delete a project                         
-  token           [name]           Get a development OIDC token for a       
-                                   project                                  
+  add             name             Add a new project                    
+  access-summary  [name]           Show member counts by team role for  
+                                   project access (requires access      
+                                   groups entitlement)                  
+  checks          [name]           List, add, or remove deployment      
+                                   checks for a project (GET/POST/DELETE
+                                   /v2/projects/.../checks)             
+  inspect         [name]           Displays information related to a    
+                                   project                              
+  list                             Show all projects in the selected    
+                                   scope (default)                      
+  members         [name]           List project members for a project   
+  access-groups   [name]           List access groups for a project     
+  protection      [action] [name]  Show or toggle deployment protection 
+                                   settings for a project               
+  web-analytics   [name]           Enable Web Analytics for a project   
+  speed-insights  [action] [name]  Enable or disable Speed Insights for 
+                                   a project                            
+  update          [name]           Update one or more project settings; 
+                                   omitted settings remain unchanged    
+  rename          name new-name    Rename a project                     
+  remove          name             Delete a project                     
+  token           [name]           Get a development OIDC token for a   
+                                   project                              
 
 
   Global Options:
@@ -5865,22 +5869,22 @@ exports[`help command > project help output snapshots > project help column widt
 
   Commands:
 
-  add             name             Add a new project                                                                
-  access-summary  [name]           Show member counts by team role for project access (requires access groups       
-                                   entitlement)                                                                     
-  checks          [name]           List, add, or remove deployment checks for a project (GET/POST/DELETE            
-                                   /v2/projects/.../checks)                                                         
-  inspect         [name]           Displays information related to a project                                        
-  list                             Show all projects in the selected scope (default)                                
-  members         [name]           List project members for a project                                               
-  access-groups   [name]           List access groups for a project                                                 
-  protection      [action] [name]  Show or toggle deployment protection settings for a project                      
-  web-analytics   [name]           Enable Web Analytics for a project                                               
-  speed-insights  [name]           Enable Speed Insights for a project                                              
-  update          [name]           Update one or more project settings; omitted settings remain unchanged           
-  rename          name new-name    Rename a project                                                                 
-  remove          name             Delete a project                                                                 
-  token           [name]           Get a development OIDC token for a project                                       
+  add             name             Add a new project                                                            
+  access-summary  [name]           Show member counts by team role for project access (requires access groups   
+                                   entitlement)                                                                 
+  checks          [name]           List, add, or remove deployment checks for a project (GET/POST/DELETE        
+                                   /v2/projects/.../checks)                                                     
+  inspect         [name]           Displays information related to a project                                    
+  list                             Show all projects in the selected scope (default)                            
+  members         [name]           List project members for a project                                           
+  access-groups   [name]           List access groups for a project                                             
+  protection      [action] [name]  Show or toggle deployment protection settings for a project                  
+  web-analytics   [name]           Enable Web Analytics for a project                                           
+  speed-insights  [action] [name]  Enable or disable Speed Insights for a project                               
+  update          [name]           Update one or more project settings; omitted settings remain unchanged       
+  rename          name new-name    Rename a project                                                             
+  remove          name             Delete a project                                                             
+  token           [name]           Get a development OIDC token for a project                                   
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/project/speed-insights.test.ts
+++ b/packages/cli/test/unit/commands/project/speed-insights.test.ts
@@ -1,10 +1,18 @@
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { outputFile } from 'fs-extra';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../../mocks/client';
 import project from '../../../../src/commands/project';
-import { defaultProject, useProject } from '../../../mocks/project';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../../mocks/project';
+import { useTeam } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
 
 describe('project speed-insights', () => {
   it('enables Speed Insights for a named project', async () => {
@@ -30,6 +38,139 @@ describe('project speed-insights', () => {
         value: 'speed-insights',
       },
     ]);
+  });
+
+  it('enables Speed Insights with the explicit `enable` action', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/speed-insights/toggle', (req, res) => {
+      expect(req.query.projectId).toBe('prj_123');
+      expect(req.body).toEqual({ value: true });
+      res.json({ value: true });
+    });
+
+    client.setArgv('project', 'speed-insights', 'enable', 'my-project');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Speed Insights is enabled');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:speed-insights',
+        value: 'speed-insights enable',
+      },
+    ]);
+  });
+
+  it('disables Speed Insights for a named project', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/speed-insights/toggle', (req, res) => {
+      expect(req.query.projectId).toBe('prj_123');
+      expect(req.body).toEqual({ value: false });
+      res.json({ value: false });
+    });
+
+    client.setArgv('project', 'speed-insights', 'disable', 'my-project');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+    await expect(client.stderr).toOutput('Speed Insights is disabled');
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:speed-insights',
+        value: 'speed-insights disable',
+      },
+    ]);
+  });
+
+  it('outputs JSON when disabling with --format json', async () => {
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+
+    client.scenario.post('/speed-insights/toggle', (req, res) => {
+      expect(req.body).toEqual({ value: false });
+      res.json({ value: false });
+    });
+
+    client.setArgv(
+      'project',
+      'speed-insights',
+      'disable',
+      'my-project',
+      '--format',
+      'json'
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(0);
+
+    const jsonOutput = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(jsonOutput).toEqual({
+      enabled: false,
+      projectId: 'prj_123',
+      projectName: 'my-project',
+    });
+  });
+
+  it('disables Speed Insights for the linked project', async () => {
+    const team = useTeam('team_linked');
+    useUser();
+    useProject({
+      ...defaultProject,
+      id: 'prj_linked',
+      name: 'linked-project',
+      accountId: team.id,
+    });
+
+    const cwd = setupTmpDir();
+    await outputFile(
+      join(cwd, '.vercel', 'project.json'),
+      JSON.stringify({ orgId: team.id, projectId: 'prj_linked' })
+    );
+    const prevCwd = client.cwd;
+    client.cwd = cwd;
+
+    let requestQuery: unknown;
+    let requestBody: unknown;
+    client.scenario.post('/speed-insights/toggle', (req, res) => {
+      requestQuery = req.query;
+      requestBody = req.body;
+      res.json({ value: false });
+    });
+
+    client.setArgv('project', 'speed-insights', 'disable');
+    try {
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(requestQuery).toMatchObject({ projectId: 'prj_linked' });
+      expect(requestBody).toEqual({ value: false });
+      await expect(client.stderr).toOutput('Speed Insights is disabled');
+    } finally {
+      client.cwd = prevCwd;
+    }
+  });
+
+  it('returns 1 when the project is not found', async () => {
+    useUser();
+    useProject({
+      ...defaultProject,
+      id: 'prj_123',
+      name: 'my-project',
+    });
+    useUnknownProject();
+
+    client.setArgv('project', 'speed-insights', 'disable', 'does-not-exist');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(1);
   });
 
   it('outputs JSON with --format json', async () => {

--- a/packages/cli/test/unit/commands/project/speed-insights.test.ts
+++ b/packages/cli/test/unit/commands/project/speed-insights.test.ts
@@ -159,6 +159,24 @@ describe('project speed-insights', () => {
     }
   });
 
+  it('returns 2 when an action is passed with too many arguments', async () => {
+    client.setArgv('project', 'speed-insights', 'enable', 'a', 'b');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput(
+      'Invalid number of arguments. Usage: `vercel project speed-insights enable [name]`'
+    );
+  });
+
+  it('returns 2 when too many arguments are passed without an action', async () => {
+    client.setArgv('project', 'speed-insights', 'a', 'b');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput(
+      'Invalid number of arguments. Usage: `vercel project speed-insights [name]`'
+    );
+  });
+
   it('returns 1 when the project is not found', async () => {
     useUser();
     useProject({


### PR DESCRIPTION
## Summary

- Add `vercel project speed-insights disable [name]` to turn Speed Insights off, alongside an explicit `enable` action.
- Bare `vercel project speed-insights [name]` still enables (backward compatible: unchanged args, flags, JSON shape, output, and exit codes).
- Human output now reflects the resolved state ("enabled"/"disabled"); JSON keeps `{ enabled, projectId, projectName }`.
- Telemetry records `speed-insights enable` / `speed-insights disable` when an action is passed, mirroring the `protection` family.
- Unit tests for enable (bare + explicit action), disable success, JSON, linked-project resolution, request assertions, project-not-found, and telemetry; regenerated project help snapshots.

## Notes

- Uses the same public `POST /speed-insights/toggle` endpoint as enable, sending `{ value: false }` to disable (the value the dashboard sends).
- Backward-compatible: the first arg is treated as an action only when it is exactly `enable` or `disable`; otherwise it is the project name, so existing invocations are unchanged.
- Untouched: the toggle endpoint, `web-analytics`, and all other `project` subcommands.