### PR TITLE
[CLI] Add project members add subcommand

### DIFF
--- a/.changeset/project-members-manage.md
+++ b/.changeset/project-members-manage.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project members add` to add a member to a project by email, username, or user id with a role

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -379,10 +379,35 @@ export const accessSummarySubcommand = {
   ],
 } as const;
 
+/** Project roles accepted by the add-member API (`POST /v1/projects/:id/members`). */
+export const PROJECT_MEMBER_ROLES = [
+  'ADMIN',
+  'PROJECT_DEVELOPER',
+  'PROJECT_VIEWER',
+  'PROJECT_GUEST',
+] as const;
+
+/** `--role` for `project members add` (request body role, verbatim API enum). */
+const memberRoleOption = {
+  name: 'role',
+  shorthand: null,
+  type: String,
+  argument: 'ROLE',
+  description: `Project role when adding a member: ${PROJECT_MEMBER_ROLES.join(', ')}`,
+  deprecated: false,
+} as const;
+
+/** Flags for `vercel project members add` (also merged into `members` help). */
+export const membersAddFlags = [
+  formatOption,
+  jsonOption,
+  memberRoleOption,
+] as const;
+
 export const membersSubcommand = {
   name: 'members',
   aliases: ['member'],
-  description: 'List project members for a project',
+  description: 'List or add project members for a project',
   arguments: [
     {
       name: 'name',
@@ -406,6 +431,7 @@ export const membersSubcommand = {
       description: 'Limit number of project members returned (1-100)',
       deprecated: false,
     },
+    memberRoleOption,
   ],
   examples: [
     {
@@ -415,6 +441,10 @@ export const membersSubcommand = {
     {
       name: 'List members for a named project as JSON',
       value: `${packageName} project members my-project --json`,
+    },
+    {
+      name: 'Add a member to a project by email with a role',
+      value: `${packageName} project members add my-project user@example.com --role PROJECT_VIEWER`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -156,7 +156,9 @@ export default async function main(client: Client) {
         telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(membersSubcommand);
       }
-      telemetry.trackCliSubcommandMembers(subcommandOriginal);
+      telemetry.trackCliSubcommandMembers(
+        args[0] === 'add' ? 'members add' : subcommandOriginal
+      );
       exitCode = await members(client, args);
       break;
     case 'accessGroups':

--- a/packages/cli/src/commands/project/members-add.ts
+++ b/packages/cli/src/commands/project/members-add.ts
@@ -1,0 +1,208 @@
+import type { JSONObject } from '@vercel-internals/types';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import {
+  buildCommandWithGlobalFlags,
+  exitWithNonInteractiveError,
+  outputAgentError,
+} from '../../util/agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import { membersAddFlags, PROJECT_MEMBER_ROLES } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import { email as emailRegex } from '../../util/input/regexes';
+import output from '../../output-manager';
+import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
+import { ProjectTelemetryClient } from '../../util/telemetry/commands/project';
+
+/**
+ * Maps a single member identifier to the correct `POST /members` body field.
+ *
+ * The public add-member endpoint accepts exactly one of `uid`, `username`, or
+ * `email` (JSON Schema `oneOf`) and resolves the user server-side. We classify
+ * by shape: an email address, otherwise an opaque Vercel user id (a long
+ * alphanumeric token with no separators), otherwise a username.
+ */
+function memberToBodyField(member: string): JSONObject {
+  if (emailRegex.test(member)) {
+    return { email: member };
+  }
+  if (/^[A-Za-z0-9]{24,}$/.test(member)) {
+    return { uid: member };
+  }
+  return { username: member };
+}
+
+export async function membersAdd(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new ProjectTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification([...membersAddFlags]);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: error instanceof Error ? error.message : String(error),
+        },
+        1
+      );
+    }
+    printError(error);
+    return 1;
+  }
+
+  if (parsedArgs.args.length !== 2) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message:
+          'Invalid number of arguments. Usage: `vercel project members add <project> <member> --role <role>`',
+        hint: `Valid roles: ${PROJECT_MEMBER_ROLES.join(', ')}`,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'project members add <project> <member> --role PROJECT_VIEWER'
+            ),
+            when: 'Add a member to a project (replace <project> and <member>)',
+          },
+        ],
+      },
+      1
+    );
+    output.error(
+      'Invalid number of arguments. Usage: `vercel project members add <project> <member> --role <role>`'
+    );
+    return 1;
+  }
+
+  const [projectNameOrId, member] = parsedArgs.args;
+  telemetry.trackCliArgumentProject(projectNameOrId);
+  telemetry.trackCliArgumentMember(member);
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: formatResult.error,
+        },
+        1
+      );
+    }
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || Boolean(client.nonInteractive);
+
+  const roleRaw = parsedArgs.flags['--role'];
+  telemetry.trackCliOptionRole(
+    typeof roleRaw === 'string' ? roleRaw.trim().toUpperCase() : undefined
+  );
+  if (typeof roleRaw !== 'string' || !roleRaw.trim()) {
+    const message = `\`--role\` is required. Valid roles: ${PROJECT_MEMBER_ROLES.join(', ')}`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.MISSING_ARGUMENTS,
+          message,
+        },
+        1
+      );
+    }
+    output.error(message);
+    return 1;
+  }
+  const role = roleRaw.trim().toUpperCase();
+  if (!(PROJECT_MEMBER_ROLES as readonly string[]).includes(role)) {
+    const message = `\`--role\` must be one of: ${PROJECT_MEMBER_ROLES.join(', ')}`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message,
+        },
+        1
+      );
+    }
+    output.error(message);
+    return 1;
+  }
+
+  const body: JSONObject = { ...memberToBodyField(member), role };
+
+  try {
+    const project = await getProjectByCwdOrLink({
+      client,
+      commandName: 'project members add',
+      projectNameOrId,
+      forReadOnlyCommand: true,
+    });
+
+    const result = await client.fetch<JSONObject>(
+      `/v1/projects/${encodeURIComponent(project.id)}/members`,
+      {
+        method: 'POST',
+        body,
+      }
+    );
+
+    if (asJson) {
+      if (client.nonInteractive) {
+        client.stdout.write(
+          `${JSON.stringify(
+            {
+              status: AGENT_STATUS.OK,
+              projectId: project.id,
+              projectName: project.name,
+              role,
+              result,
+              message: `Added ${member} to ${project.name} as ${role}.`,
+              next: [
+                {
+                  command: buildCommandWithGlobalFlags(
+                    client.argv,
+                    `project members ${project.name}`
+                  ),
+                  when: 'List members for this project',
+                },
+              ],
+            },
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        client.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      }
+      return 0;
+    }
+
+    output.log(`Added ${member} to ${project.name} as ${role}.`);
+    return 0;
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'members' });
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/project/members.ts
+++ b/packages/cli/src/commands/project/members.ts
@@ -12,6 +12,7 @@ import { membersSubcommand } from './command';
 import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
+import { membersAdd } from './members-add';
 
 interface ProjectMember {
   uid: string;
@@ -31,6 +32,10 @@ export default async function members(
   client: Client,
   argv: string[]
 ): Promise<number> {
+  if (argv[0] === 'add') {
+    return membersAdd(client, argv.slice(1));
+  }
+
   let parsedArgs;
   const flagsSpecification = getFlagsSpecification(membersSubcommand.options);
   try {

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -1,6 +1,9 @@
 import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
-import type { projectCommand } from '../../../../commands/project/command';
+import {
+  PROJECT_MEMBER_ROLES,
+  type projectCommand,
+} from '../../../../commands/project/command';
 
 export class ProjectTelemetryClient
   extends TelemetryClient
@@ -74,6 +77,38 @@ export class ProjectTelemetryClient
       subcommand: 'members',
       value: actual,
     });
+  }
+
+  /** Project name/id argument for `members add`/`members remove` (redacted). */
+  trackCliArgumentProject(project: string | undefined) {
+    if (project) {
+      this.trackCliArgument({
+        arg: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  /** Member identifier (email/username/uid) for `members add`/`remove` (redacted). */
+  trackCliArgumentMember(member: string | undefined) {
+    if (member) {
+      this.trackCliArgument({
+        arg: 'member',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  /** Records the `--role` value verbatim when it is a known enum, else redacts. */
+  trackCliOptionRole(role: string | undefined) {
+    if (role) {
+      this.trackCliOption({
+        option: 'role',
+        value: (PROJECT_MEMBER_ROLES as readonly string[]).includes(role)
+          ? role
+          : this.redactedValue,
+      });
+    }
   }
 
   trackCliSubcommandAccessGroups(actual: string) {

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -849,7 +849,8 @@ exports[`help command > connex help output snapshots > connex create subcommand 
        --icon <PATH>             Path to a PNG or JPEG image to use as the connector icon (uploaded to Vercel)               
        --json                    Output as JSON                                                                              
   -n,  --name <NAME>             Name of the connector                                                                       
-       --trigger-event <EVENT>   Webhook event to receive. Repeatable.                                                       
+       --trigger-event <EVENT>   Webhook event to receive. Repeatable. Requires --triggers and replaces the provider's       
+                                 default events.                                                                             
        --triggers                Enable webhook triggers for this connector                                                  
 
 
@@ -5700,6 +5701,8 @@ exports[`help command > project help output snapshots > project help column widt
                                    …
                                    …
                                    …
+                                   …
+                                   …
                                    a
                                    …
   access-groups   [name]           …
@@ -5824,7 +5827,7 @@ exports[`help command > project help output snapshots > project help column widt
   inspect         [name]           Displays information related to a project
   list                             Show all projects in the selected scope  
                                    (default)                                
-  members         [name]           List project members for a project       
+  members         [name]           List or add project members for a project
   access-groups   [name]           List access groups for a project         
   protection      [action] [name]  Show or toggle deployment protection     
                                    settings for a project                   
@@ -5872,7 +5875,7 @@ exports[`help command > project help output snapshots > project help column widt
                                    /v2/projects/.../checks)                                                         
   inspect         [name]           Displays information related to a project                                        
   list                             Show all projects in the selected scope (default)                                
-  members         [name]           List project members for a project                                               
+  members         [name]           List or add project members for a project                                        
   access-groups   [name]           List access groups for a project                                                 
   protection      [action] [name]  Show or toggle deployment protection settings for a project                      
   web-analytics   [name]           Enable Web Analytics for a project                                               

--- a/packages/cli/test/unit/commands/project/members.test.ts
+++ b/packages/cli/test/unit/commands/project/members.test.ts
@@ -226,6 +226,12 @@ describe('project members', () => {
         name: 'my-project',
       });
 
+      let posted = false;
+      client.scenario.post('/v1/projects/:idOrName/members', (_req, res) => {
+        posted = true;
+        res.json({ id: 'prj_123' });
+      });
+
       client.setArgv(
         'project',
         'members',
@@ -238,6 +244,7 @@ describe('project members', () => {
       const exitCode = await project(client);
       expect(exitCode).toBe(1);
       await expect(client.stderr).toOutput('`--role` must be one of:');
+      expect(posted).toBe(false);
     });
 
     it('requires a role', async () => {

--- a/packages/cli/test/unit/commands/project/members.test.ts
+++ b/packages/cli/test/unit/commands/project/members.test.ts
@@ -150,4 +150,114 @@ describe('project members', () => {
       }
     });
   });
+
+  describe('add', () => {
+    it('adds a member by email and sends the expected request body', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+
+      let received: Record<string, unknown> | undefined;
+      client.scenario.post('/v1/projects/:idOrName/members', (req, res) => {
+        expect(req.params.idOrName).toBe('prj_123');
+        received = req.body;
+        res.json({ id: 'prj_123' });
+      });
+
+      client.setArgv(
+        'project',
+        'members',
+        'add',
+        'my-project',
+        'user@example.com',
+        '--role',
+        'PROJECT_VIEWER'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(received).toEqual({
+        email: 'user@example.com',
+        role: 'PROJECT_VIEWER',
+      });
+      await expect(client.stderr).toOutput(
+        'Added user@example.com to my-project as PROJECT_VIEWER.'
+      );
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:members', value: 'members add' },
+        { key: 'argument:project', value: '[REDACTED]' },
+        { key: 'argument:member', value: '[REDACTED]' },
+        { key: 'option:role', value: 'PROJECT_VIEWER' },
+      ]);
+    });
+
+    it('sends a username field for a non-email, non-uid identifier', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+
+      let received: Record<string, unknown> | undefined;
+      client.scenario.post('/v1/projects/:idOrName/members', (_req, res) => {
+        received = _req.body;
+        res.json({ id: 'prj_123' });
+      });
+
+      client.setArgv(
+        'project',
+        'members',
+        'add',
+        'my-project',
+        'octocat',
+        '--role',
+        'admin'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(received).toEqual({ username: 'octocat', role: 'ADMIN' });
+    });
+
+    it('rejects an invalid role without calling the API', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+
+      client.setArgv(
+        'project',
+        'members',
+        'add',
+        'my-project',
+        'user@example.com',
+        '--role',
+        'OWNER'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('`--role` must be one of:');
+    });
+
+    it('requires a role', async () => {
+      client.setArgv(
+        'project',
+        'members',
+        'add',
+        'my-project',
+        'user@example.com'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('`--role` is required.');
+    });
+
+    it('errors when arguments are missing', async () => {
+      client.setArgv('project', 'members', 'add', 'my-project');
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid number of arguments.');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `vercel project members add <project> <member> --role <role>` to add a member to a project, with human and `--json`/`--format json` output.
- Classifies `<member>` into the request body field the public add-member endpoint accepts: an email address maps to `email`, an opaque Vercel user id maps to `uid`, otherwise `username`.
- Validates `--role` (case-insensitively) against the verbatim API enum and sends the canonical uppercase value; a missing or invalid role fails locally before any request.
- Adds telemetry for the `members add` subcommand, the `--role` option (recorded verbatim only for known enum values), and the project/member arguments (redacted).

## Notes

- Endpoint used: `POST /v1/projects/:idOrName/members`. Role enum source: the add-member handler schema (`ADMIN`, `PROJECT_DEVELOPER`, `PROJECT_VIEWER`, `PROJECT_GUEST`); `role` is required with no default, so the CLI requires `--role`.
- `<member>` field selection mirrors the endpoint's `oneOf` (uid/username/email); the server resolves the user, so a misclassified identifier fails with the API's `not_a_member` error rather than silently doing the wrong thing.
- Existing `project members` list behavior (args, flags, table/JSON output, exit codes) is untouched; `add` is routed as a pseudo-subcommand like `project checks add`.
- Stacked follow-up (`members remove`): add-project-members-remove.