### PR TITLE
[CLI] Add project members remove subcommand

### DIFF
--- a/.changeset/project-members-remove.md
+++ b/.changeset/project-members-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project members remove` to remove a member from a project (resolves email/username/uid via the project members listing, with `--yes` to skip confirmation)

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -404,10 +404,17 @@ export const membersAddFlags = [
   memberRoleOption,
 ] as const;
 
+/** Flags for `vercel project members remove` / `rm`. */
+export const membersRemoveFlags = [
+  formatOption,
+  jsonOption,
+  yesOption,
+] as const;
+
 export const membersSubcommand = {
   name: 'members',
   aliases: ['member'],
-  description: 'List or add project members for a project',
+  description: 'List, add, or remove project members for a project',
   arguments: [
     {
       name: 'name',
@@ -432,6 +439,7 @@ export const membersSubcommand = {
       deprecated: false,
     },
     memberRoleOption,
+    yesOption,
   ],
   examples: [
     {
@@ -445,6 +453,10 @@ export const membersSubcommand = {
     {
       name: 'Add a member to a project by email with a role',
       value: `${packageName} project members add my-project user@example.com --role PROJECT_VIEWER`,
+    },
+    {
+      name: 'Remove a member from a project',
+      value: `${packageName} project members remove my-project user@example.com --yes`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -157,7 +157,11 @@ export default async function main(client: Client) {
         return printHelp(membersSubcommand);
       }
       telemetry.trackCliSubcommandMembers(
-        args[0] === 'add' ? 'members add' : subcommandOriginal
+        args[0] === 'add'
+          ? 'members add'
+          : args[0] === 'remove' || args[0] === 'rm'
+            ? 'members remove'
+            : subcommandOriginal
       );
       exitCode = await members(client, args);
       break;

--- a/packages/cli/src/commands/project/members-remove.ts
+++ b/packages/cli/src/commands/project/members-remove.ts
@@ -1,0 +1,254 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import {
+  buildCommandWithYes,
+  buildCommandWithGlobalFlags,
+  exitWithNonInteractiveError,
+  outputActionRequired,
+  outputAgentError,
+} from '../../util/agent-output';
+import {
+  AGENT_ACTION,
+  AGENT_REASON,
+  AGENT_STATUS,
+} from '../../util/agent-output-constants';
+import { membersRemoveFlags } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import output from '../../output-manager';
+import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
+import { ProjectTelemetryClient } from '../../util/telemetry/commands/project';
+
+interface ProjectMember {
+  uid: string;
+  username?: string;
+  email?: string;
+  name?: string;
+}
+
+interface ProjectMembersResponse {
+  members?: ProjectMember[];
+}
+
+/** Finds the member whose uid, username, or email matches `identifier`. */
+function findMember(
+  members: ProjectMember[],
+  identifier: string
+): ProjectMember | undefined {
+  const needle = identifier.toLowerCase();
+  return members.find(
+    m =>
+      m.uid === identifier ||
+      m.username?.toLowerCase() === needle ||
+      m.email?.toLowerCase() === needle
+  );
+}
+
+export async function membersRemove(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new ProjectTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification([...membersRemoveFlags]);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: error instanceof Error ? error.message : String(error),
+        },
+        1
+      );
+    }
+    printError(error);
+    return 1;
+  }
+
+  if (parsedArgs.args.length !== 2) {
+    const cmd = buildCommandWithGlobalFlags(
+      client.argv,
+      'project members remove <project> <member> --yes'
+    );
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message:
+            'Invalid number of arguments. Usage: `vercel project members remove <project> <member>`',
+          next: [
+            {
+              command: cmd,
+              when: 'Remove a member from a project (replace <project> and <member>)',
+            },
+          ],
+        },
+        1
+      );
+    }
+    output.error(
+      'Invalid number of arguments. Usage: `vercel project members remove <project> <member>`'
+    );
+    return 1;
+  }
+
+  const [projectNameOrId, member] = parsedArgs.args;
+  telemetry.trackCliArgumentProject(projectNameOrId);
+  telemetry.trackCliArgumentMember(member);
+  telemetry.trackCliFlagYes(parsedArgs.flags['--yes']);
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: formatResult.error,
+        },
+        1
+      );
+    }
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput || Boolean(client.nonInteractive);
+  const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
+
+  let project;
+  let target: ProjectMember | undefined;
+  try {
+    project = await getProjectByCwdOrLink({
+      client,
+      commandName: 'project members remove',
+      projectNameOrId,
+      forReadOnlyCommand: true,
+    });
+
+    const query = new URLSearchParams({ search: member, limit: '100' });
+    const result = await client.fetch<ProjectMembersResponse>(
+      `/v1/projects/${encodeURIComponent(project.id)}/members?${query.toString()}`
+    );
+    target = findMember(result.members ?? [], member);
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'members' });
+    printError(err);
+    return 1;
+  }
+
+  if (!target) {
+    const message = `${member} is not a member of ${project.name}.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.NOT_FOUND,
+          message,
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                `project members ${project.name}`
+              ),
+              when: 'List current members to find the right identifier',
+            },
+          ],
+        },
+        1
+      );
+    }
+    output.error(message);
+    return 1;
+  }
+
+  const memberLabel = target.username || target.email || target.uid;
+
+  if (client.nonInteractive && !skipConfirmation) {
+    outputActionRequired(
+      client,
+      {
+        status: AGENT_STATUS.ACTION_REQUIRED,
+        reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+        action: AGENT_ACTION.CONFIRMATION_REQUIRED,
+        message: `In non-interactive mode --yes is required to remove ${memberLabel} from ${project.name}.`,
+        next: [
+          {
+            command: buildCommandWithYes(client.argv),
+            when: 'to confirm removal',
+          },
+        ],
+      },
+      1
+    );
+    return 1;
+  }
+
+  if (!skipConfirmation) {
+    const confirmed = await client.input.confirm(
+      `Remove ${chalk.bold(memberLabel)} from ${chalk.bold(project.name)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled.');
+      return 0;
+    }
+  }
+
+  try {
+    const result = await client.fetch<Record<string, unknown>>(
+      `/v1/projects/${encodeURIComponent(project.id)}/members/${encodeURIComponent(target.uid)}`,
+      { method: 'DELETE' }
+    );
+
+    if (asJson) {
+      if (client.nonInteractive) {
+        client.stdout.write(
+          `${JSON.stringify(
+            {
+              status: AGENT_STATUS.OK,
+              projectId: project.id,
+              projectName: project.name,
+              uid: target.uid,
+              result,
+              message: `Removed ${memberLabel} from ${project.name}.`,
+              next: [
+                {
+                  command: buildCommandWithGlobalFlags(
+                    client.argv,
+                    `project members ${project.name}`
+                  ),
+                  when: 'List remaining members',
+                },
+              ],
+            },
+            null,
+            2
+          )}\n`
+        );
+      } else {
+        client.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      }
+      return 0;
+    }
+
+    output.log(`Removed ${memberLabel} from ${project.name}.`);
+    return 0;
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'members' });
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/project/members.ts
+++ b/packages/cli/src/commands/project/members.ts
@@ -13,6 +13,7 @@ import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
 import { membersAdd } from './members-add';
+import { membersRemove } from './members-remove';
 
 interface ProjectMember {
   uid: string;
@@ -34,6 +35,10 @@ export default async function members(
 ): Promise<number> {
   if (argv[0] === 'add') {
     return membersAdd(client, argv.slice(1));
+  }
+
+  if (argv[0] === 'remove' || argv[0] === 'rm') {
+    return membersRemove(client, argv.slice(1));
   }
 
   let parsedArgs;

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -111,6 +111,13 @@ export class ProjectTelemetryClient
     }
   }
 
+  /** `--yes` confirmation-skip flag for `members remove`. */
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+
   trackCliSubcommandAccessGroups(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'access-groups',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5703,6 +5703,7 @@ exports[`help command > project help output snapshots > project help column widt
                                    …
                                    …
                                    …
+                                   …
                                    a
                                    …
   access-groups   [name]           …
@@ -5827,7 +5828,8 @@ exports[`help command > project help output snapshots > project help column widt
   inspect         [name]           Displays information related to a project
   list                             Show all projects in the selected scope  
                                    (default)                                
-  members         [name]           List or add project members for a project
+  members         [name]           List, add, or remove project members for 
+                                   a project                                
   access-groups   [name]           List access groups for a project         
   protection      [action] [name]  Show or toggle deployment protection     
                                    settings for a project                   
@@ -5875,7 +5877,7 @@ exports[`help command > project help output snapshots > project help column widt
                                    /v2/projects/.../checks)                                                         
   inspect         [name]           Displays information related to a project                                        
   list                             Show all projects in the selected scope (default)                                
-  members         [name]           List or add project members for a project                                        
+  members         [name]           List, add, or remove project members for a project                               
   access-groups   [name]           List access groups for a project                                                 
   protection      [action] [name]  Show or toggle deployment protection settings for a project                      
   web-analytics   [name]           Enable Web Analytics for a project                                               

--- a/packages/cli/test/unit/commands/project/members.test.ts
+++ b/packages/cli/test/unit/commands/project/members.test.ts
@@ -260,4 +260,140 @@ describe('project members', () => {
       await expect(client.stderr).toOutput('Invalid number of arguments.');
     });
   });
+
+  describe('remove', () => {
+    function useMembersList(members: unknown[]) {
+      client.scenario.get('/v1/projects/:idOrName/members', (_req, res) => {
+        res.json({ members, pagination: {} });
+      });
+    }
+
+    it('removes a member by uid after resolving via the members listing', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+      useMembersList([
+        { uid: 'user_1', username: 'octocat', email: 'octocat@example.com' },
+      ]);
+
+      let deletedUid: string | undefined;
+      client.scenario.delete(
+        '/v1/projects/:idOrName/members/:uid',
+        (req, res) => {
+          expect(req.params.idOrName).toBe('prj_123');
+          deletedUid = req.params.uid;
+          res.json({ id: 'prj_123' });
+        }
+      );
+
+      client.setArgv(
+        'project',
+        'members',
+        'remove',
+        'my-project',
+        'octocat@example.com',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(deletedUid).toBe('user_1');
+      await expect(client.stderr).toOutput('Removed octocat from my-project.');
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:members', value: 'members remove' },
+        { key: 'argument:project', value: '[REDACTED]' },
+        { key: 'argument:member', value: '[REDACTED]' },
+        { key: 'flag:yes', value: 'TRUE' },
+      ]);
+    });
+
+    it('removes a member after interactive confirmation', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+      useMembersList([{ uid: 'user_1', username: 'octocat' }]);
+      client.scenario.delete(
+        '/v1/projects/:idOrName/members/:uid',
+        (_req, res) => {
+          res.json({ id: 'prj_123' });
+        }
+      );
+
+      client.setArgv('project', 'members', 'remove', 'my-project', 'octocat');
+      const pending = project(client);
+      await expect(client.stderr).toOutput('Remove');
+      client.stdin.write('y\n');
+      const exitCode = await pending;
+      expect(exitCode).toBe(0);
+    });
+
+    it('errors when the member is not part of the project', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+      useMembersList([{ uid: 'user_1', username: 'octocat' }]);
+
+      client.setArgv(
+        'project',
+        'members',
+        'remove',
+        'my-project',
+        'nobody@example.com',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('is not a member of my-project.');
+    });
+
+    it('errors when arguments are missing', async () => {
+      client.setArgv('project', 'members', 'remove', 'my-project');
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid number of arguments.');
+    });
+
+    describe('--non-interactive', () => {
+      afterEach(() => {
+        vi.restoreAllMocks();
+        client.nonInteractive = false;
+      });
+
+      it('requires --yes and outputs confirmation_required JSON', async () => {
+        useProject({
+          ...defaultProject,
+          id: 'prj_123',
+          name: 'my-project',
+        });
+        useMembersList([{ uid: 'user_1', username: 'octocat' }]);
+
+        vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+          throw new Error(`exit:${code ?? 0}`);
+        }) as () => never);
+
+        client.nonInteractive = true;
+        client.setArgv(
+          'project',
+          'members',
+          'remove',
+          'my-project',
+          'octocat',
+          '--non-interactive'
+        );
+
+        await expect(project(client)).rejects.toThrow('exit:1');
+
+        const payload = JSON.parse(client.stdout.getFullOutput().trim());
+        expect(payload).toMatchObject({
+          status: 'action_required',
+          reason: 'confirmation_required',
+        });
+      });
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/project/members.test.ts
+++ b/packages/cli/test/unit/commands/project/members.test.ts
@@ -337,6 +337,70 @@ describe('project members', () => {
       expect(exitCode).toBe(0);
     });
 
+    it('does not delete when the confirmation is declined', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+      useMembersList([{ uid: 'user_1', username: 'octocat' }]);
+
+      let deleted = false;
+      client.scenario.delete(
+        '/v1/projects/:idOrName/members/:uid',
+        (_req, res) => {
+          deleted = true;
+          res.json({ id: 'prj_123' });
+        }
+      );
+
+      client.setArgv('project', 'members', 'remove', 'my-project', 'octocat');
+      const pending = project(client);
+      await expect(client.stderr).toOutput('Remove');
+      client.stdin.write('n\n');
+      const exitCode = await pending;
+      expect(exitCode).toBe(0);
+      await expect(client.stderr).toOutput('Canceled.');
+      expect(deleted).toBe(false);
+    });
+
+    it('supports the rm alias and tracks members remove telemetry', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+      });
+      useMembersList([{ uid: 'user_1', username: 'octocat' }]);
+
+      let deleted = false;
+      client.scenario.delete(
+        '/v1/projects/:idOrName/members/:uid',
+        (req, res) => {
+          deleted = true;
+          expect(req.params.uid).toBe('user_1');
+          res.json({ id: 'prj_123' });
+        }
+      );
+
+      client.setArgv(
+        'project',
+        'members',
+        'rm',
+        'my-project',
+        'octocat',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(deleted).toBe(true);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:members', value: 'members remove' },
+        { key: 'argument:project', value: '[REDACTED]' },
+        { key: 'argument:member', value: '[REDACTED]' },
+        { key: 'flag:yes', value: 'TRUE' },
+      ]);
+    });
+
     it('errors when the member is not part of the project', async () => {
       useProject({
         ...defaultProject,


### PR DESCRIPTION
## Summary

- Adds `vercel project members remove <project> <member>` (alias `rm`) to remove a member from a project, with human and `--json`/`--format json` output.
- Resolves `<member>` (email, username, or uid) against the project members listing the CLI already uses, then deletes by resolved `uid`.
- Prompts for TTY confirmation naming the member and project; `--yes` skips it, and non-interactive without `--yes` exits 1 with a `confirmation_required` action payload.
- Adds telemetry for the `members remove` subcommand, the project/member arguments (redacted), and the `--yes` flag.

## Notes

- Endpoints used: `GET /v1/projects/:idOrName/members` (member resolution, queried with `search` + `limit=100`) and `DELETE /v1/projects/:idOrName/members/:uid` (removal; the delete endpoint takes a uid, hence the listing lookup).
- A member not found in the project's listing fails with a `not_found` error before any delete; project resolution follows the existing project-command name/id pattern.
- Existing `project members` list and `project members add` behavior is untouched; `remove`/`rm` is routed as a pseudo-subcommand like `project checks remove`.
- Stacked on #17456 (`members add`), mirroring #17437 → #17440.