### PR TITLE
[CLI] Add target inspect subcommand

### DIFF
--- a/.changeset/target-inspect.md
+++ b/.changeset/target-inspect.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel target inspect <name-or-id>` to show a single custom environment in full

--- a/packages/cli/src/commands/target/command.ts
+++ b/packages/cli/src/commands/target/command.ts
@@ -29,12 +29,44 @@ export const listSubcommand = {
   ],
 } as const;
 
+export const inspectSubcommand = {
+  name: 'inspect',
+  aliases: [],
+  description: 'Show a custom environment in full',
+  arguments: [
+    {
+      name: 'name',
+      required: true,
+    },
+  ],
+  options: [
+    formatOption,
+    jsonOption,
+    projectOption,
+    {
+      ...yesOption,
+      description:
+        'Skip confirmation when linking is required (e.g. in non-interactive mode)',
+    },
+  ],
+  examples: [
+    {
+      name: 'Show a custom environment in full',
+      value: `${packageName} target inspect my-environment`,
+    },
+    {
+      name: 'Show a custom environment as JSON',
+      value: `${packageName} target inspect my-environment --json`,
+    },
+  ],
+} as const;
+
 export const targetCommand = {
   name: 'target',
   aliases: ['targets'],
   description: 'Manage your Vercel Project\'s "targets" (custom environments).',
   arguments: [],
-  subcommands: [listSubcommand],
+  subcommands: [listSubcommand, inspectSubcommand],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/target/index.ts
+++ b/packages/cli/src/commands/target/index.ts
@@ -3,7 +3,8 @@ import { parseArguments } from '../../util/get-args';
 import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import { type Command, help } from '../help';
 import list from './list';
-import { listSubcommand, targetCommand } from './command';
+import inspect from './inspect';
+import { inspectSubcommand, listSubcommand, targetCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import output from '../../output-manager';
@@ -12,6 +13,7 @@ import { getCommandAliases } from '..';
 
 const COMMAND_CONFIG = {
   ls: getCommandAliases(listSubcommand),
+  inspect: getCommandAliases(inspectSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -61,6 +63,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandList(subcommand);
       return await list(client, args);
+    case 'inspect':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('target', 'inspect');
+        printHelp(inspectSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandInspect(subcommand);
+      return await inspect(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(targetCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/target/inspect.ts
+++ b/packages/cli/src/commands/target/inspect.ts
@@ -1,0 +1,181 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import { inspectSubcommand, targetCommand } from './command';
+import { ensureLink } from '../../util/link/ensure-link';
+import { formatProject } from '../../util/projects/format-project';
+import { formatEnvironment } from '../../util/target/format-environment';
+import { validateJsonOutput } from '../../util/output-format';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import formatDate from '../../util/format-date';
+import table from '../../util/output/table';
+import { isAPIError } from '../../util/errors-ts';
+import { TargetInspectTelemetryClient } from '../../util/telemetry/commands/target/inspect';
+import type Client from '../../util/client';
+import type {
+  CustomEnvironment,
+  CustomEnvironmentBranchMatcher,
+} from '@vercel-internals/types';
+
+function formatBranchMatcher(
+  branchMatcher?: CustomEnvironmentBranchMatcher
+): string {
+  if (branchMatcher?.type === 'equals') {
+    return `equals ${branchMatcher.pattern}`;
+  } else if (branchMatcher?.type === 'startsWith') {
+    return `starts with ${branchMatcher.pattern}`;
+  } else if (branchMatcher?.type === 'endsWith') {
+    return `ends with ${branchMatcher.pattern}`;
+  }
+  return chalk.dim('No branch configuration');
+}
+
+export default async function inspect(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const { cwd } = client;
+
+  const telemetry = new TargetInspectTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(inspectSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  if (args.length !== 1) {
+    output.error(
+      `Invalid number of arguments. Usage: ${getCommandName(
+        'target inspect <name>'
+      )}`
+    );
+    return 2;
+  }
+
+  const [nameOrId] = args;
+  telemetry.trackCliArgumentName(nameOrId);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+  telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliFlagJson(flags['--json']);
+
+  const projectName = flags['--project'];
+  telemetry.trackCliOptionProject(projectName);
+
+  const autoConfirm = !!flags['--yes'];
+  telemetry.trackCliFlagYes(flags['--yes']);
+
+  const link = await ensureLink(targetCommand.name, client, cwd, {
+    autoConfirm,
+    projectName,
+    failIfNotFound: Boolean(projectName),
+  });
+  if (typeof link === 'number') {
+    return link;
+  }
+
+  const projectSlugLink = formatProject(link.org.slug, link.project.name);
+
+  output.spinner(
+    `Fetching custom environment ${chalk.bold(nameOrId)} for ${projectSlugLink}`
+  );
+
+  const url = `/projects/${encodeURIComponent(
+    link.project.id
+  )}/custom-environments/${encodeURIComponent(nameOrId)}`;
+
+  let environment: CustomEnvironment;
+  try {
+    environment = (await client.fetch(url, {
+      method: 'GET',
+      accountId: link.org.id,
+    })) as CustomEnvironment;
+  } catch (error) {
+    output.stopSpinner();
+    if (isAPIError(error) && error.status === 404) {
+      output.error(
+        `Custom environment ${chalk.bold(
+          nameOrId
+        )} was not found under ${projectSlugLink}.`
+      );
+      return 1;
+    }
+    printError(error);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          id: environment.id,
+          slug: environment.slug,
+          type: environment.type,
+          description: environment.description,
+          branchMatcher: environment.branchMatcher,
+          domains: environment.domains,
+          createdAt: environment.createdAt,
+          updatedAt: environment.updatedAt,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  output.log(
+    `Custom environment ${formatEnvironment(
+      link.org.slug,
+      link.project.name,
+      environment
+    )} under ${projectSlugLink}`
+  );
+  client.stdout.write(formatEnvironmentDetails(environment));
+
+  return 0;
+}
+
+function formatEnvironmentDetails(environment: CustomEnvironment): string {
+  const rows: string[][] = [
+    ['ID', environment.id],
+    ['Name', environment.slug],
+    ['Type', environment.type],
+    ['Branch Matcher', formatBranchMatcher(environment.branchMatcher)],
+  ];
+
+  if (environment.description) {
+    rows.push(['Description', environment.description]);
+  }
+
+  const domains = (environment.domains ?? [])
+    .map(domain => (domain as { name?: string }).name)
+    .filter((name): name is string => Boolean(name));
+  rows.push(['Domains', domains.length ? domains.join(', ') : chalk.dim('-')]);
+
+  rows.push(['Created', formatDate(environment.createdAt)]);
+  rows.push(['Updated', formatDate(environment.updatedAt)]);
+
+  return `${table(rows, { align: ['l', 'l'], hsep: 2 }).replace(
+    /^(.*)/gm,
+    '  $1'
+  )}\n`;
+}

--- a/packages/cli/src/util/telemetry/commands/target/index.ts
+++ b/packages/cli/src/util/telemetry/commands/target/index.ts
@@ -12,4 +12,11 @@ export class TargetTelemetryClient
       value: subcommandActual,
     });
   }
+
+  trackCliSubcommandInspect(subcommandActual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: subcommandActual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/target/inspect.ts
+++ b/packages/cli/src/util/telemetry/commands/target/inspect.ts
@@ -1,0 +1,29 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { inspectSubcommand } from '../../../../commands/target/command';
+
+export class TargetInspectTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof inspectSubcommand>
+{
+  trackCliArgumentName(name: string | undefined) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -6998,9 +6998,12 @@ exports[`help command > target help output snapshots > target help column width 
 
   Commands:
 
-  list    List targets defined  
-          for the current       
-          Project               
+  list           List targets   
+                 defined for the
+                 current Project
+  inspect  name  Show a custom  
+                 environment in 
+                 full           
 
 
   Global Options:
@@ -7062,7 +7065,8 @@ exports[`help command > target help output snapshots > target help column width 
 
   Commands:
 
-  list    List targets defined for the current Project                  
+  list           List targets defined for the current Project           
+  inspect  name  Show a custom environment in full                      
 
 
   Global Options:
@@ -7092,7 +7096,8 @@ exports[`help command > target help output snapshots > target help column width 
 
   Commands:
 
-  list    List targets defined for the current Project                                                          
+  list           List targets defined for the current Project                                                   
+  inspect  name  Show a custom environment in full                                                              
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/target/inspect.test.ts
+++ b/packages/cli/test/unit/commands/target/inspect.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, beforeEach, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import target from '../../../../src/commands/target';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+
+const CUSTOM_ENVIRONMENT = {
+  id: 'env_ph1tjPP20xp8VAuiFsYt4rhRYGys',
+  slug: 'staging',
+  type: 'preview',
+  description: 'staging environment',
+  branchMatcher: {
+    type: 'startsWith',
+    pattern: 'staging',
+  },
+  domains: [{ name: 'staging.example.com' }],
+  createdAt: 1717176506341,
+  updatedAt: 1717176506341,
+};
+
+function useCustomEnvironment() {
+  client.scenario.get(
+    '/projects/static/custom-environments/:idOrSlug',
+    (req, res) => {
+      const { idOrSlug } = req.params;
+      if (
+        idOrSlug === CUSTOM_ENVIRONMENT.slug ||
+        idOrSlug === CUSTOM_ENVIRONMENT.id
+      ) {
+        res.json(CUSTOM_ENVIRONMENT);
+        return;
+      }
+      res.status(404).send();
+    }
+  );
+}
+
+describe('target inspect', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+      accountId: 'team_dummy',
+    });
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.stderr.isTTY = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('target', 'inspect', '--help');
+      const exitCodePromise = target(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'target:inspect',
+        },
+      ]);
+    });
+  });
+
+  describe('missing arguments', () => {
+    it('errors with exit code 2 when no arguments are passed', async () => {
+      client.setArgv('target', 'inspect');
+      const exitCode = await target(client);
+      expect(exitCode).toEqual(2);
+      await expect(client.stderr).toOutput('Invalid number of arguments');
+    });
+
+    it('errors with exit code 2 when too many arguments are passed', async () => {
+      client.setArgv('target', 'inspect', 'staging', 'extra');
+      const exitCode = await target(client);
+      expect(exitCode).toEqual(2);
+      await expect(client.stderr).toOutput('Invalid number of arguments');
+    });
+  });
+
+  it('shows the custom environment in full and tracks telemetry', async () => {
+    useCustomEnvironment();
+    client.setArgv('target', 'inspect', 'staging');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).toContain('env_ph1tjPP20xp8VAuiFsYt4rhRYGys');
+    expect(stdout).toContain('staging');
+    expect(stdout).toContain('preview');
+    expect(stdout).toContain('starts with staging');
+    expect(stdout).toContain('staging.example.com');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:inspect',
+        value: 'inspect',
+      },
+      {
+        key: 'argument:name',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('resolves a custom environment by id', async () => {
+    useCustomEnvironment();
+    client.setArgv('target', 'inspect', 'env_ph1tjPP20xp8VAuiFsYt4rhRYGys');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+    expect(client.stdout.getFullOutput()).toContain('staging');
+  });
+
+  it('outputs the custom environment as JSON with --json', async () => {
+    useCustomEnvironment();
+    client.setArgv('target', 'inspect', 'staging', '--json');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.id).toEqual('env_ph1tjPP20xp8VAuiFsYt4rhRYGys');
+    expect(parsed.slug).toEqual('staging');
+    expect(parsed.type).toEqual('preview');
+    expect(parsed.branchMatcher).toEqual({
+      type: 'startsWith',
+      pattern: 'staging',
+    });
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:inspect',
+        value: 'inspect',
+      },
+      {
+        key: 'argument:name',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'flag:json',
+        value: 'TRUE',
+      },
+    ]);
+  });
+
+  it('supports --format json', async () => {
+    useCustomEnvironment();
+    client.setArgv('target', 'inspect', 'staging', '--format', 'json');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.slug).toEqual('staging');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:inspect',
+        value: 'inspect',
+      },
+      {
+        key: 'argument:name',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:format',
+        value: 'json',
+      },
+    ]);
+  });
+
+  it('errors when the custom environment is not found', async () => {
+    useCustomEnvironment();
+    client.setArgv('target', 'inspect', 'does-not-exist');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('was not found');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `vercel target inspect <name-or-id>` to show a single custom environment in full (id, name, type, branch matcher, domains, description, created/updated), with human and `--json`/`--format json` output.

## Notes
- Reads the public get-one endpoint `GET /projects/:idOrName/custom-environments/:environmentSlugOrId`; the argument accepts either the environment slug/name or its id.
- Resolves the linked project via the target family's existing `ensureLink` pattern (respects `--project` and `--yes`).
- Existing `target ls` behavior is untouched.
- Stacked follow-ups: #17459 (target add) → #17466 (target update) → #17462 (target remove).