### PR TITLE
[CLI] Add access-group command with read subcommands: list and inspect

### DIFF
--- a/.changeset/access-group-command.md
+++ b/.changeset/access-group-command.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel access-group` to list and inspect team Access Groups

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -5,6 +5,7 @@
  */
 
 // Non-priority commands - bundled together
+export { default as accessGroup } from './commands/access-group';
 export { default as agent } from './commands/agent';
 export { default as agentRuns } from './commands/agent-runs';
 export { default as activity } from './commands/activity';

--- a/packages/cli/src/commands/access-group/command.ts
+++ b/packages/cli/src/commands/access-group/command.ts
@@ -1,0 +1,55 @@
+import { packageName } from '../../util/pkg-name';
+import { formatOption, jsonOption } from '../../util/arg-common';
+
+export const listSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List the access groups on the current team',
+  default: true,
+  arguments: [],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'List all access groups on the current team',
+      value: `${packageName} access-group ls`,
+    },
+  ],
+} as const;
+
+export const inspectSubcommand = {
+  name: 'inspect',
+  aliases: [],
+  description: 'Show an access group in full',
+  arguments: [
+    {
+      name: 'idOrName',
+      required: true,
+    },
+  ],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Show an access group by id or name',
+      value: `${packageName} access-group inspect my-access-group`,
+    },
+  ],
+} as const;
+
+export const accessGroupCommand = {
+  name: 'access-group',
+  aliases: ['access-groups'],
+  description: 'Manage team Access Groups and their members and projects',
+  arguments: [],
+  subcommands: [listSubcommand, inspectSubcommand],
+  options: [],
+  examples: [
+    {
+      name: 'List all access groups on the current team',
+      value: `${packageName} access-group ls`,
+    },
+    {
+      name: 'Show an access group by id or name',
+      value: `${packageName} access-group inspect ag_1a2b3c4d5e6f`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/access-group/index.ts
+++ b/packages/cli/src/commands/access-group/index.ts
@@ -1,0 +1,83 @@
+import { parseArguments } from '../../util/get-args';
+import getSubcommand from '../../util/get-subcommand';
+import { printError } from '../../util/error';
+import inspect from './inspect';
+import ls from './ls';
+import {
+  accessGroupCommand,
+  inspectSubcommand,
+  listSubcommand,
+} from './command';
+import { type Command, help } from '../help';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { AccessGroupTelemetryClient } from '../../util/telemetry/commands/access-group';
+import type Client from '../../util/client';
+import { getCommandAliases } from '..';
+
+const COMMAND_CONFIG = {
+  inspect: getCommandAliases(inspectSubcommand),
+  ls: getCommandAliases(listSubcommand),
+};
+
+export default async function accessGroup(client: Client) {
+  const { telemetryEventStore } = client;
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(accessGroupCommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const telemetry = new AccessGroupTelemetryClient({
+    opts: {
+      store: telemetryEventStore,
+    },
+  });
+
+  const { subcommand, subcommandOriginal, args } = getSubcommand(
+    parsedArgs.args.slice(1),
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('access-group', subcommand);
+    output.print(help(accessGroupCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        parent: accessGroupCommand,
+        columns: client.stderr.columns,
+      })
+    );
+  }
+
+  switch (subcommand) {
+    case 'inspect':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group', subcommandOriginal);
+        printHelp(inspectSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandInspect(subcommandOriginal);
+      return inspect(client, args);
+    default:
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group', subcommandOriginal);
+        printHelp(listSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return ls(client, args);
+  }
+}

--- a/packages/cli/src/commands/access-group/inspect.ts
+++ b/packages/cli/src/commands/access-group/inspect.ts
@@ -1,0 +1,76 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { validateJsonOutput } from '../../util/output-format';
+import { AccessGroupTelemetryClient } from '../../util/telemetry/commands/access-group';
+import getAccessGroup from '../../util/access-group/get-access-group';
+import { formatAccessGroupDetails } from '../../util/access-group/format';
+import { handleAccessGroupError } from '../../util/access-group/error';
+import { inspectSubcommand } from './command';
+
+export default async function inspect(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AccessGroupTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(inspectSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  const idOrName = parsedArgs.args[0];
+  if (!idOrName) {
+    output.error(
+      `Please provide an access group id or name. See ${getCommandName(
+        'access-group inspect <idOrName>'
+      )}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentIdOrName(idOrName);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  let accessGroup;
+  try {
+    accessGroup = await getAccessGroup(client, idOrName);
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify(accessGroup, null, 2)}\n`);
+    return 0;
+  }
+
+  const { contextName } = await getScope(client);
+  output.log(
+    `Access group ${chalk.bold(accessGroup.name)} (${
+      accessGroup.accessGroupId
+    }) under ${chalk.bold(contextName)}`
+  );
+  client.stdout.write(formatAccessGroupDetails(accessGroup));
+
+  return 0;
+}

--- a/packages/cli/src/commands/access-group/ls.ts
+++ b/packages/cli/src/commands/access-group/ls.ts
@@ -1,0 +1,69 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { validateJsonOutput } from '../../util/output-format';
+import { AccessGroupTelemetryClient } from '../../util/telemetry/commands/access-group';
+import getAccessGroups from '../../util/access-group/get-access-groups';
+import { formatAccessGroupsTable } from '../../util/access-group/format';
+import { handleAccessGroupError } from '../../util/access-group/error';
+import { listSubcommand } from './command';
+
+export default async function ls(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AccessGroupTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(listSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  telemetry.trackCliOptionFormat(flags['--format']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const lsStamp = stamp();
+
+  let accessGroups;
+  try {
+    accessGroups = await getAccessGroups(client);
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify({ accessGroups }, null, 2)}\n`);
+    return 0;
+  }
+
+  const { contextName } = await getScope(client);
+  output.log(
+    `${
+      accessGroups.length > 0 ? 'Access groups' : 'No access groups'
+    } found under ${chalk.bold(contextName)} ${lsStamp()}`
+  );
+
+  if (accessGroups.length > 0) {
+    client.stdout.write(formatAccessGroupsTable(accessGroups));
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,3 +1,4 @@
+import { accessGroupCommand } from './access-group/command';
 import { agentCommand } from './agent/command';
 import { agentRunsCommand } from './agent-runs/command';
 import { activityCommand } from './activity/command';
@@ -67,6 +68,7 @@ import type { Command } from './help';
 import output from '../output-manager';
 
 const commandsStructs = [
+  accessGroupCommand,
   agentCommand,
   agentRunsCommand,
   aiGatewayCommand,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -960,6 +960,11 @@ const main = async () => {
           break;
 
         // Non-priority commands - loaded from bulk bundle
+        case 'access-group':
+        case 'access-groups':
+          telemetry.trackCliCommandAccessGroup(userSuppliedSubCommand);
+          func = (await import('./commands-bulk.js')).accessGroup;
+          break;
         case 'agent':
           telemetry.trackCliCommandAgent(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).agent;

--- a/packages/cli/src/util/access-group/error.ts
+++ b/packages/cli/src/util/access-group/error.ts
@@ -1,0 +1,30 @@
+import { isAPIError } from '../errors-ts';
+import { printError } from '../error';
+import output from '../../output-manager';
+
+export function handleAccessGroupError(err: unknown): number {
+  if (isAPIError(err)) {
+    switch (err.status) {
+      case 404:
+        output.error('Access group not found.');
+        return 1;
+      case 400:
+        output.error(err.serverMessage || 'The request was invalid.');
+        return 1;
+      case 403:
+        output.error(
+          err.serverMessage ||
+            'You do not have permission to manage access groups on this team.'
+        );
+        return 1;
+      case 429:
+        output.error(
+          err.serverMessage || 'Too many requests. Try again shortly.'
+        );
+        return 1;
+    }
+  }
+
+  printError(err);
+  return 1;
+}

--- a/packages/cli/src/util/access-group/format.ts
+++ b/packages/cli/src/util/access-group/format.ts
@@ -1,0 +1,59 @@
+import chalk from 'chalk';
+import ms from 'ms';
+import table from '../output/table';
+import { formatDateWithoutTime } from '../format-date';
+import type { AccessGroup } from './types';
+
+function age(createdAt: string): string {
+  const created = Number(createdAt);
+  if (!Number.isFinite(created) || created <= 0) {
+    return chalk.gray('—');
+  }
+  return chalk.gray(ms(Date.now() - created));
+}
+
+function list(values: string[] | undefined): string {
+  return values && values.length > 0 ? values.join(', ') : '—';
+}
+
+export function formatAccessGroupsTable(accessGroups: AccessGroup[]): string {
+  return `${table(
+    [
+      ['id', 'name', 'members', 'projects', 'age'].map(header =>
+        chalk.dim(header)
+      ),
+      ...accessGroups.map(accessGroup => [
+        accessGroup.accessGroupId,
+        accessGroup.name,
+        String(accessGroup.membersCount ?? 0),
+        String(accessGroup.projectsCount ?? 0),
+        age(accessGroup.createdAt),
+      ]),
+    ],
+    { align: ['l', 'l', 'r', 'r', 'r'], hsep: 2 }
+  ).replace(/^(.*)/gm, '  $1')}\n`;
+}
+
+export function formatAccessGroupDetails(accessGroup: AccessGroup): string {
+  const rows: string[][] = [
+    ['Name', accessGroup.name],
+    ['ID', accessGroup.accessGroupId],
+    ['Members', String(accessGroup.membersCount ?? 0)],
+    ['Projects', String(accessGroup.projectsCount ?? 0)],
+    ['Team roles', list(accessGroup.teamRoles)],
+    ['Team permissions', list(accessGroup.teamPermissions)],
+  ];
+
+  if (accessGroup.entitlements && accessGroup.entitlements.length > 0) {
+    rows.push(['Entitlements', accessGroup.entitlements.join(', ')]);
+  }
+
+  if (accessGroup.isDsyncManaged) {
+    rows.push(['Directory synced', 'yes']);
+  }
+
+  rows.push(['Created', formatDateWithoutTime(Number(accessGroup.createdAt))]);
+  rows.push(['Updated', formatDateWithoutTime(Number(accessGroup.updatedAt))]);
+
+  return `${table(rows, { align: ['l', 'l'], hsep: 2 }).replace(/^(.*)/gm, '  $1')}\n`;
+}

--- a/packages/cli/src/util/access-group/get-access-group.ts
+++ b/packages/cli/src/util/access-group/get-access-group.ts
@@ -1,0 +1,11 @@
+import type Client from '../client';
+import type { AccessGroup } from './types';
+
+export default async function getAccessGroup(
+  client: Client,
+  idOrName: string
+): Promise<AccessGroup> {
+  return client.fetch<AccessGroup>(
+    `/v1/access-groups/${encodeURIComponent(idOrName)}`
+  );
+}

--- a/packages/cli/src/util/access-group/get-access-groups.ts
+++ b/packages/cli/src/util/access-group/get-access-groups.ts
@@ -1,0 +1,25 @@
+import type Client from '../client';
+import type { AccessGroup, ListAccessGroupsResponse } from './types';
+
+// Pages through the public list endpoint so the CLI returns every access group
+// on the team, not just the first page.
+export default async function getAccessGroups(
+  client: Client
+): Promise<AccessGroup[]> {
+  const accessGroups: AccessGroup[] = [];
+  let next: string | undefined;
+
+  do {
+    const query = new URLSearchParams({ limit: '100' });
+    if (next) {
+      query.set('next', next);
+    }
+    const response = await client.fetch<ListAccessGroupsResponse>(
+      `/v1/access-groups?${query.toString()}`
+    );
+    accessGroups.push(...(response.accessGroups ?? []));
+    next = response.pagination?.next ?? undefined;
+  } while (next);
+
+  return accessGroups;
+}

--- a/packages/cli/src/util/access-group/types.ts
+++ b/packages/cli/src/util/access-group/types.ts
@@ -1,0 +1,30 @@
+// Wire shapes for the public Access Groups API (v1). Mirrors the AccessGroup
+// DTO returned by the read/list endpoints. Timestamps are unix-ms encoded as
+// strings.
+export interface AccessGroup {
+  accessGroupId: string;
+  name: string;
+  teamId: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt?: string;
+  membersCount: number;
+  projectsCount: number;
+  teamRoles?: string[];
+  teamPermissions?: string[];
+  // Sideloaded by the read endpoint (and the list endpoint when requested):
+  entitlements?: string[];
+  isDsyncManaged?: boolean;
+  // Present only when the list is scoped to a project.
+  role?: string;
+}
+
+export interface AccessGroupsPagination {
+  count?: number;
+  next?: string | null;
+}
+
+export interface ListAccessGroupsResponse {
+  accessGroups: AccessGroup[];
+  pagination?: AccessGroupsPagination;
+}

--- a/packages/cli/src/util/telemetry/commands/access-group/index.ts
+++ b/packages/cli/src/util/telemetry/commands/access-group/index.ts
@@ -1,0 +1,31 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { accessGroupCommand } from '../../../../commands/access-group/command';
+
+export class AccessGroupTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof accessGroupCommand>
+{
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: actual,
+    });
+  }
+
+  trackCliArgumentIdOrName(idOrName: string | undefined) {
+    if (idOrName) {
+      this.trackCliArgument({
+        arg: 'idOrName',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -12,6 +12,13 @@ export class RootTelemetryClient extends TelemetryClient {
     }
   }
 
+  trackCliCommandAccessGroup(actual: string) {
+    this.trackCliCommand({
+      command: 'access-group',
+      value: actual,
+    });
+  }
+
   trackCliCommandAgent(actual: string) {
     this.trackCliCommand({
       command: 'agent',

--- a/packages/cli/test/mocks/access-group.ts
+++ b/packages/cli/test/mocks/access-group.ts
@@ -1,0 +1,44 @@
+import { client } from './client';
+import type { AccessGroup } from '../../src/util/access-group/types';
+
+export const defaultAccessGroup: AccessGroup = {
+  accessGroupId: 'ag_1',
+  name: 'engineering',
+  teamId: 'team_dummy',
+  createdAt: '1600000000000',
+  updatedAt: '1600000000000',
+  membersCount: 3,
+  projectsCount: 2,
+  teamRoles: ['DEVELOPER'],
+  teamPermissions: ['CreateProject'],
+};
+
+// Registers the happy-path list/read routes. Error cases register their own
+// handlers instead of calling this.
+export function useAccessGroups(
+  accessGroups: AccessGroup[] = [defaultAccessGroup]
+) {
+  client.scenario.get('/v1/access-groups', (_req, res) => {
+    res.json({
+      accessGroups,
+      pagination: { count: accessGroups.length, next: null },
+    });
+  });
+
+  for (const accessGroup of accessGroups) {
+    client.scenario.get(
+      `/v1/access-groups/${accessGroup.accessGroupId}`,
+      (_req, res) => {
+        res.json(accessGroup);
+      }
+    );
+    client.scenario.get(
+      `/v1/access-groups/${accessGroup.name}`,
+      (_req, res) => {
+        res.json(accessGroup);
+      }
+    );
+  }
+
+  return accessGroups;
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1,5 +1,238 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`help command > access-group help output snapshots > access-group help column width 40 1`] = `
+"
+  ▲ vercel access-group [command]
+
+  Manage team Access Groups and their   
+  members and projects                  
+
+  Commands:
+
+  list               List the   
+                     access     
+                     groups on  
+                     the current
+                     team       
+                     (default)  
+  inspect  idOrName  Show an    
+                     access     
+                     group in   
+                     full       
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the  
+                              current   
+                              working   
+                              directory 
+                              for a     
+                              single run
+                              of a      
+                              command   
+  -d,  --debug                Debug mode
+                              (default  
+                              off)      
+  -Q,  --global-config <DIR>  Path to   
+                              the global
+                              \`.vercel\` 
+                              directory 
+  -h,  --help                 Output    
+                              usage     
+                              informati…
+  -A,  --local-config <FILE>  Path to   
+                              the local 
+                              \`vercel.j…
+                              file      
+       --no-color             No color  
+                              mode      
+                              (default  
+                              off)      
+       --non-interactive      Run       
+                              without   
+                              interacti…
+                              prompts;  
+                              when an   
+                              agent is  
+                              detected  
+                              this is   
+                              the       
+                              default   
+  -S,  --scope                Set a     
+                              custom    
+                              scope     
+  -t,  --token <TOKEN>        Login     
+                              token     
+  -v,  --version              Output the
+                              version   
+                              number    
+
+
+  Examples:
+
+  - List all access groups on the current team
+
+    $ vercel access-group ls
+
+  - Show an access group by id or name
+
+    $ vercel access-group inspect ag_1a2b3c4d5e6f
+
+"
+`;
+
+exports[`help command > access-group help output snapshots > access-group help column width 80 1`] = `
+"
+  ▲ vercel access-group [command]
+
+  Manage team Access Groups and their members and projects                      
+
+  Commands:
+
+  list               List the access groups on the current team         
+                     (default)                                          
+  inspect  idOrName  Show an access group in full                       
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single   
+                              run of a command                                  
+  -d,  --debug                Debug mode (default off)                          
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory            
+  -h,  --help                 Output usage information                          
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file              
+       --no-color             No color mode (default off)                       
+       --non-interactive      Run without interactive prompts; when an agent is 
+                              detected this is the default                      
+  -S,  --scope                Set a custom scope                                
+  -t,  --token <TOKEN>        Login token                                       
+  -v,  --version              Output the version number                         
+
+
+  Examples:
+
+  - List all access groups on the current team
+
+    $ vercel access-group ls
+
+  - Show an access group by id or name
+
+    $ vercel access-group inspect ag_1a2b3c4d5e6f
+
+"
+`;
+
+exports[`help command > access-group help output snapshots > access-group help column width 120 1`] = `
+"
+  ▲ vercel access-group [command]
+
+  Manage team Access Groups and their members and projects                                                              
+
+  Commands:
+
+  list               List the access groups on the current team (default)                                       
+  inspect  idOrName  Show an access group in full                                                               
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - List all access groups on the current team
+
+    $ vercel access-group ls
+
+  - Show an access group by id or name
+
+    $ vercel access-group inspect ag_1a2b3c4d5e6f
+
+"
+`;
+
+exports[`help command > access-group help output snapshots > access-group inspect help output snapshots > access-group inspect help column width 120 1`] = `
+"
+  ▲ vercel access-group inspect idOrName [options]
+
+  Show an access group in full                                                                                          
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Show an access group by id or name
+
+    $ vercel access-group inspect my-access-group
+
+"
+`;
+
+exports[`help command > access-group help output snapshots > access-group list help output snapshots > access-group list help column width 120 1`] = `
+"
+  ▲ vercel access-group list [options]
+
+  List the access groups on the current team                                                                            
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - List all access groups on the current team
+
+    $ vercel access-group ls
+
+"
+`;
+
 exports[`help command > alias help output snapshots > alias help column width 40 1`] = `
 "
   ▲ vercel alias [command]

--- a/packages/cli/test/unit/commands/access-group/index.test.ts
+++ b/packages/cli/test/unit/commands/access-group/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+import { useAccessGroups } from '../../../mocks/access-group';
+
+describe('access-group', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  it('prints help and exits 2 for the bare command with --help', async () => {
+    client.setArgv('access-group', '--help');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(2);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'flag:help',
+        value: 'access-group',
+      },
+    ]);
+  });
+
+  it('defaults to the list subcommand when none is given', async () => {
+    useAccessGroups();
+    client.setArgv('access-group');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Access groups found under');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:list',
+        value: 'default',
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/access-group/inspect.test.ts
+++ b/packages/cli/test/unit/commands/access-group/inspect.test.ts
@@ -1,0 +1,80 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+import { useAccessGroups } from '../../../mocks/access-group';
+
+describe('access-group inspect', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('access-group', 'inspect', '--help');
+      const exitCodePromise = accessGroup(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'access-group:inspect',
+        },
+      ]);
+    });
+  });
+
+  it('errors when no id or name is passed', async () => {
+    client.setArgv('access-group', 'inspect');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Please provide an access group id or name'
+    );
+  });
+
+  it('shows the access group by name and redacts the identifier in telemetry', async () => {
+    useAccessGroups();
+    client.setArgv('access-group', 'inspect', 'engineering');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+
+    const output =
+      client.stdout.getFullOutput() + client.stderr.getFullOutput();
+    expect(output).toContain('engineering');
+    expect(output).toContain('ag_1');
+    expect(output).toContain('DEVELOPER');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:inspect',
+        value: 'inspect',
+      },
+      {
+        key: 'argument:idOrName',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('outputs JSON on stdout', async () => {
+    useAccessGroups();
+    client.setArgv('access-group', 'inspect', 'ag_1', '--json');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.accessGroupId).toEqual('ag_1');
+    expect(parsed.name).toEqual('engineering');
+  });
+
+  it('maps a 404 to a not-found message', async () => {
+    client.scenario.get('/v1/access-groups/ag_missing', (_req, res) => {
+      res.status(404).json({ error: { code: 'not_found', message: 'nope' } });
+    });
+    client.setArgv('access-group', 'inspect', 'ag_missing');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Access group not found.');
+  });
+});

--- a/packages/cli/test/unit/commands/access-group/ls.test.ts
+++ b/packages/cli/test/unit/commands/access-group/ls.test.ts
@@ -1,0 +1,113 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+import {
+  useAccessGroups,
+  defaultAccessGroup,
+} from '../../../mocks/access-group';
+
+describe('access-group ls', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('access-group', 'ls', '--help');
+      const exitCodePromise = accessGroup(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'access-group:ls',
+        },
+      ]);
+    });
+  });
+
+  it('lists the access groups on the team', async () => {
+    useAccessGroups();
+    client.setArgv('access-group', 'ls');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+
+    await expect(client.stderr).toOutput('Access groups found under');
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).toContain('engineering');
+    expect(stdout).toContain('ag_1');
+  });
+
+  it('handles an empty list', async () => {
+    useAccessGroups([]);
+    client.setArgv('access-group', 'ls');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('No access groups found under');
+  });
+
+  it('outputs JSON on stdout without human prose', async () => {
+    useAccessGroups();
+    client.setArgv('access-group', 'ls', '--json');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+
+    const stdout = client.stdout.getFullOutput();
+    const parsed = JSON.parse(stdout);
+    expect(parsed.accessGroups).toHaveLength(1);
+    expect(parsed.accessGroups[0].name).toEqual('engineering');
+  });
+
+  it('paginates across cursors', async () => {
+    let call = 0;
+    client.scenario.get('/v1/access-groups', (req, res) => {
+      call += 1;
+      if (call === 1) {
+        res.json({
+          accessGroups: [defaultAccessGroup],
+          pagination: { count: 1, next: 'cursor2' },
+        });
+      } else {
+        expect(req.query.next).toEqual('cursor2');
+        res.json({
+          accessGroups: [
+            { ...defaultAccessGroup, accessGroupId: 'ag_2', name: 'design' },
+          ],
+          pagination: { count: 1, next: null },
+        });
+      }
+    });
+    client.setArgv('access-group', 'ls', '--json');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+
+    const parsed = JSON.parse(client.stdout.getFullOutput());
+    expect(parsed.accessGroups).toHaveLength(2);
+    expect(call).toEqual(2);
+  });
+
+  it('surfaces the permission error on 403', async () => {
+    client.scenario.get('/v1/access-groups', (_req, res) => {
+      res.status(403).json({
+        error: {
+          code: 'forbidden',
+          message: 'Access groups are not available for this team.',
+        },
+      });
+    });
+    client.setArgv('access-group', 'ls');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Access groups are not available for this team.'
+    );
+  });
+
+  it('rejects an invalid --format value', async () => {
+    client.setArgv('access-group', 'ls', '--format', 'yaml');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid output format');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -5,6 +5,7 @@ import {
   outputArrayToString,
 } from '../../../src/commands/help';
 import { deployCommand } from '../../../src/commands/deploy/command';
+import * as accessGroup from '../../../src/commands/access-group/command';
 import * as alias from '../../../src/commands/alias/command';
 import { bisectCommand } from '../../../src/commands/bisect/command';
 import * as certs from '../../../src/commands/certs/command';
@@ -89,6 +90,44 @@ describe('help command', () => {
     });
     it('deploy help column width 120', () => {
       expect(help(deployCommand, { columns: 120 })).toMatchSnapshot();
+    });
+  });
+
+  describe('access-group help output snapshots', () => {
+    it('access-group help column width 40', () => {
+      expect(
+        help(accessGroup.accessGroupCommand, { columns: 40 })
+      ).toMatchSnapshot();
+    });
+    it('access-group help column width 80', () => {
+      expect(
+        help(accessGroup.accessGroupCommand, { columns: 80 })
+      ).toMatchSnapshot();
+    });
+    it('access-group help column width 120', () => {
+      expect(
+        help(accessGroup.accessGroupCommand, { columns: 120 })
+      ).toMatchSnapshot();
+    });
+    describe('access-group list help output snapshots', () => {
+      it('access-group list help column width 120', () => {
+        expect(
+          help(accessGroup.listSubcommand, {
+            columns: 120,
+            parent: accessGroup.accessGroupCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
+    describe('access-group inspect help output snapshots', () => {
+      it('access-group inspect help column width 120', () => {
+        expect(
+          help(accessGroup.inspectSubcommand, {
+            columns: 120,
+            parent: accessGroup.accessGroupCommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -4,6 +4,8 @@ describe('index', () => {
   it('outputs a map of what aliases our commands use', () => {
     expect(commands).toEqual(
       new Map([
+        ['access-group', 'access-group'],
+        ['access-groups', 'access-group'],
         ['agent', 'agent'],
         ['agent-runs', 'agent-runs'],
         ['ai-gateway', 'ai-gateway'],


### PR DESCRIPTION
## Summary
- Adds a new top-level `vercel access-group` command family (alias `access-groups`) with read subcommands `list` (team access groups) and `inspect <idOrName>` (full details incl. member/project counts, team roles/permissions, entitlements, directory-sync status).
- Human output plus `--json`/`--format json` machine output on stdout; paginates the list endpoint so all access groups are returned.

## Notes
- Endpoints (public v1): `GET /v1/access-groups` (list, paginated via `next` cursor) and `GET /v1/access-groups/:idOrName` (inspect). No secrets are present in access-group payloads, so JSON is emitted as-returned.
- New-top-level-command wiring: `src/commands-bulk.ts`, `src/commands/index.ts` (registry), `src/index.ts` (dispatch + telemetry), `src/util/telemetry/root.ts` (root telemetry), and `test/unit/commands/index.test.ts` (alias map). Modeled on the `drains` family (#17429).
- Output-flag convention: `--format`/`--json` via shared `formatOption`/`jsonOption` and `validateJsonOutput`, matching the newest family (drains).
- Telemetry redacts the `idOrName` argument; subcommand/format enums are recorded verbatim.
- Help snapshots added for `access-group` and its subcommands. The pre-existing `connex` width-120 snapshot failure is unrelated and left untouched.
- Stack: #17460 (read) → #17464 (add/update) → #17476 (remove) → #17470 (members list) → #17488 (members add) → #17478 (members remove) → #17474 (projects list) → #17493 (projects add) → #17480 (projects update/remove).