### PR TITLE
[CLI] Add target remove subcommand

### DIFF
--- a/.changeset/target-remove.md
+++ b/.changeset/target-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel target remove <name-or-id>` to delete a custom environment

--- a/packages/cli/src/commands/target/command.ts
+++ b/packages/cli/src/commands/target/command.ts
@@ -172,6 +172,36 @@ export const updateSubcommand = {
   ],
 } as const;
 
+export const removeSubcommand = {
+  name: 'remove',
+  aliases: ['rm'],
+  description: 'Remove a custom environment from the current Project',
+  arguments: [
+    {
+      name: 'name',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'delete-unassigned-env-vars',
+      shorthand: null,
+      type: Boolean,
+      description:
+        'Also delete environment variables that are not assigned to any environment',
+      deprecated: false,
+    },
+    projectOption,
+    yesOption,
+  ],
+  examples: [
+    {
+      name: 'Remove a custom environment',
+      value: `${packageName} target remove staging`,
+    },
+  ],
+} as const;
+
 export const targetCommand = {
   name: 'target',
   aliases: ['targets'],
@@ -182,6 +212,7 @@ export const targetCommand = {
     inspectSubcommand,
     addSubcommand,
     updateSubcommand,
+    removeSubcommand,
   ],
   options: [],
   examples: [],

--- a/packages/cli/src/commands/target/index.ts
+++ b/packages/cli/src/commands/target/index.ts
@@ -6,10 +6,12 @@ import list from './list';
 import inspect from './inspect';
 import add from './add';
 import update from './update';
+import rm from './rm';
 import {
   addSubcommand,
   inspectSubcommand,
   listSubcommand,
+  removeSubcommand,
   targetCommand,
   updateSubcommand,
 } from './command';
@@ -24,6 +26,7 @@ const COMMAND_CONFIG = {
   inspect: getCommandAliases(inspectSubcommand),
   add: getCommandAliases(addSubcommand),
   update: getCommandAliases(updateSubcommand),
+  rm: getCommandAliases(removeSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -97,6 +100,15 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandUpdate(subcommand);
       return await update(client, args);
+    case 'rm':
+    case 'remove':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('target', 'remove');
+        printHelp(removeSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRemove(subcommand);
+      return await rm(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(targetCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/target/rm.ts
+++ b/packages/cli/src/commands/target/rm.ts
@@ -1,0 +1,152 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import { removeSubcommand, targetCommand } from './command';
+import { ensureLink } from '../../util/link/ensure-link';
+import { formatProject } from '../../util/projects/format-project';
+import { STANDARD_ENVIRONMENTS } from '../../util/target/standard-environments';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { isAPIError } from '../../util/errors-ts';
+import {
+  outputActionRequired,
+  buildCommandWithYes,
+} from '../../util/agent-output';
+import { TargetRemoveTelemetryClient } from '../../util/telemetry/commands/target/remove';
+import type Client from '../../util/client';
+
+export default async function rm(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const { cwd } = client;
+
+  const telemetry = new TargetRemoveTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(removeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  if (args.length !== 1) {
+    output.error(
+      `Invalid number of arguments. Usage: ${getCommandName(
+        'target remove <name>'
+      )}`
+    );
+    return 2;
+  }
+
+  const [nameOrId] = args;
+  const deleteUnassignedEnvVars = !!flags['--delete-unassigned-env-vars'];
+  const projectName = flags['--project'];
+
+  telemetry.trackCliArgumentName(nameOrId);
+  telemetry.trackCliFlagDeleteUnassignedEnvVars(
+    flags['--delete-unassigned-env-vars']
+  );
+  telemetry.trackCliOptionProject(projectName);
+  telemetry.trackCliFlagYes(flags['--yes']);
+
+  if (
+    STANDARD_ENVIRONMENTS.includes(
+      nameOrId as (typeof STANDARD_ENVIRONMENTS)[number]
+    )
+  ) {
+    output.error(
+      `${chalk.bold(
+        nameOrId
+      )} is a built-in environment and cannot be removed as a custom environment.`
+    );
+    return 1;
+  }
+
+  const autoConfirm = !!flags['--yes'];
+  const link = await ensureLink(targetCommand.name, client, cwd, {
+    autoConfirm,
+    projectName,
+    failIfNotFound: Boolean(projectName),
+  });
+  if (typeof link === 'number') {
+    return link;
+  }
+
+  const projectSlugLink = formatProject(link.org.slug, link.project.name);
+
+  if (!autoConfirm) {
+    if (client.nonInteractive) {
+      outputActionRequired(
+        client,
+        {
+          status: 'action_required',
+          reason: 'confirmation_required',
+          message: `Removing custom environment ${nameOrId} from ${link.org.slug}/${link.project.name}. Use --yes to confirm.`,
+          next: [{ command: buildCommandWithYes(client.argv) }],
+        },
+        1
+      );
+    }
+    const confirmed = await client.input.confirm(
+      `Removing custom environment ${chalk.bold(
+        nameOrId
+      )} from Project ${chalk.bold(link.project.name)}. Are you sure?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  output.spinner(
+    `Removing custom environment ${chalk.bold(nameOrId)} from ${projectSlugLink}`
+  );
+
+  const url = `/projects/${encodeURIComponent(
+    link.project.id
+  )}/custom-environments/${encodeURIComponent(nameOrId)}`;
+
+  try {
+    await client.fetch(url, {
+      method: 'DELETE',
+      accountId: link.org.id,
+      body: deleteUnassignedEnvVars
+        ? { deleteUnassignedEnvironmentVariables: true }
+        : {},
+    });
+  } catch (error) {
+    output.stopSpinner();
+    if (isAPIError(error) && error.status === 404) {
+      output.error(
+        `Custom environment ${chalk.bold(
+          nameOrId
+        )} was not found under ${projectSlugLink}.`
+      );
+      return 1;
+    }
+    if (isAPIError(error) && error.status === 400) {
+      output.error(error.serverMessage || 'The request was invalid.');
+      return 1;
+    }
+    printError(error);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  output.log(
+    `Removed custom environment ${chalk.bold(nameOrId)} from ${projectSlugLink}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/target/index.ts
+++ b/packages/cli/src/util/telemetry/commands/target/index.ts
@@ -33,4 +33,11 @@ export class TargetTelemetryClient
       value: subcommandActual,
     });
   }
+
+  trackCliSubcommandRemove(subcommandActual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: subcommandActual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/target/remove.ts
+++ b/packages/cli/src/util/telemetry/commands/target/remove.ts
@@ -1,0 +1,29 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { removeSubcommand } from '../../../../commands/target/command';
+
+export class TargetRemoveTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof removeSubcommand>
+{
+  trackCliArgumentName(name: string | undefined) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagDeleteUnassignedEnvVars(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('delete-unassigned-env-vars');
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -7013,6 +7013,10 @@ exports[`help command > target help output snapshots > target help column width 
                  environment on 
                  the current    
                  Project        
+  remove   name  Remove a custom
+                 environment    
+                 from the       
+                 current Project
 
 
   Global Options:
@@ -7078,6 +7082,7 @@ exports[`help command > target help output snapshots > target help column width 
   inspect  name  Show a custom environment in full                      
   add      name  Add a new custom environment to the current Project    
   update   name  Update a custom environment on the current Project     
+  remove   name  Remove a custom environment from the current Project   
 
 
   Global Options:
@@ -7111,6 +7116,7 @@ exports[`help command > target help output snapshots > target help column width 
   inspect  name  Show a custom environment in full                                                              
   add      name  Add a new custom environment to the current Project                                            
   update   name  Update a custom environment on the current Project                                             
+  remove   name  Remove a custom environment from the current Project                                           
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/target/remove.test.ts
+++ b/packages/cli/test/unit/commands/target/remove.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, beforeEach, afterEach, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import target from '../../../../src/commands/target';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+
+interface DeleteState {
+  called: boolean;
+  body: Record<string, unknown> | undefined;
+}
+
+function useDeleteCustomEnvironment(): DeleteState {
+  const state: DeleteState = { called: false, body: undefined };
+  client.scenario.delete(
+    '/projects/static/custom-environments/:idOrSlug',
+    (req, res) => {
+      state.called = true;
+      state.body = req.body;
+      res.status(200).json({
+        id: 'env_ph1tjPP20xp8VAuiFsYt4rhRYGys',
+        slug: req.params.idOrSlug,
+        type: 'preview',
+        description: '',
+        domains: [],
+        createdAt: 1717176506341,
+        updatedAt: 1717176506341,
+      });
+    }
+  );
+  return state;
+}
+
+describe('target remove', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+      accountId: 'team_dummy',
+    });
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.stderr.isTTY = false;
+  });
+
+  afterEach(() => {
+    client.nonInteractive = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('target', 'remove', '--help');
+      const exitCodePromise = target(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'target:remove',
+        },
+      ]);
+    });
+  });
+
+  describe('usage errors', () => {
+    it('errors with exit code 2 when no name is passed', async () => {
+      client.setArgv('target', 'remove');
+      const exitCode = await target(client);
+      expect(exitCode).toEqual(2);
+      await expect(client.stderr).toOutput('Invalid number of arguments');
+    });
+  });
+
+  it('rejects a built-in environment name without calling the API', async () => {
+    const state = useDeleteCustomEnvironment();
+    client.setArgv('target', 'remove', 'production', '--yes');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(1);
+    expect(state.called).toBe(false);
+    await expect(client.stderr).toOutput('built-in environment');
+  });
+
+  it('removes a custom environment with --yes and tracks telemetry', async () => {
+    const state = useDeleteCustomEnvironment();
+    client.setArgv('target', 'remove', 'staging', '--yes');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+    expect(state.called).toBe(true);
+
+    await expect(client.stderr).toOutput('Removed custom environment');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:remove',
+        value: 'remove',
+      },
+      {
+        key: 'argument:name',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'flag:yes',
+        value: 'TRUE',
+      },
+    ]);
+  });
+
+  it('tracks the rm alias as subcommand:remove', async () => {
+    useDeleteCustomEnvironment();
+    client.setArgv('target', 'rm', 'staging', '--yes');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:remove',
+        value: 'rm',
+      },
+      {
+        key: 'argument:name',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'flag:yes',
+        value: 'TRUE',
+      },
+    ]);
+  });
+
+  it('sends deleteUnassignedEnvironmentVariables when the flag is set', async () => {
+    const state = useDeleteCustomEnvironment();
+    client.setArgv(
+      'target',
+      'remove',
+      'staging',
+      '--delete-unassigned-env-vars',
+      '--yes'
+    );
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+    expect(state.body).toEqual({ deleteUnassignedEnvironmentVariables: true });
+  });
+
+  it('asks for confirmation and removes when accepted', async () => {
+    const state = useDeleteCustomEnvironment();
+    const confirmMock = vi.fn().mockResolvedValue(true);
+    client.input.confirm = confirmMock;
+    client.setArgv('target', 'remove', 'staging');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+    expect(confirmMock).toHaveBeenCalled();
+    expect(state.called).toBe(true);
+  });
+
+  it('does not call the API when the confirmation is declined', async () => {
+    const state = useDeleteCustomEnvironment();
+    const confirmMock = vi.fn().mockResolvedValue(false);
+    client.input.confirm = confirmMock;
+    client.setArgv('target', 'remove', 'staging');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+    expect(confirmMock).toHaveBeenCalled();
+    expect(state.called).toBe(false);
+    await expect(client.stderr).toOutput('Canceled');
+  });
+
+  it('outputs confirmation_required and does not call the API in non-interactive mode', async () => {
+    const state = useDeleteCustomEnvironment();
+    client.nonInteractive = true;
+
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: number) => {
+        throw new Error(`process.exit(${code})`);
+      });
+
+    client.setArgv('target', 'remove', 'staging', '--non-interactive');
+
+    await expect(target(client)).rejects.toThrow('process.exit(1)');
+
+    const payload = JSON.parse(client.stdout.getFullOutput());
+    expect(payload.status).toBe('action_required');
+    expect(payload.reason).toBe('confirmation_required');
+    expect(payload.next[0].command).toContain('--yes');
+    expect(state.called).toBe(false);
+
+    exitSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `vercel target remove <name-or-id>` (alias `rm`) to delete a custom environment from the linked Project.

## Notes
- Endpoint: `DELETE /projects/:idOrName/custom-environments/:environmentSlugOrId`. The optional `--delete-unassigned-env-vars` flag maps to the DELETE body's `deleteUnassignedEnvironmentVariables`.
- In a TTY, prompts to confirm (default No), naming the environment and Project; `--yes` skips the prompt.
- In non-interactive mode without `--yes`, emits an `action_required` payload with `reason: confirmation_required` (and a `--yes` next command) to stdout and exits 1 without calling the API. A unit test asserts the DELETE is not fired on both the non-interactive and declined-prompt paths.
- Built-in targets (`production`/`preview`/`development`) are rejected before any API call, since they are not custom environments.
- Telemetry redacts the user-provided name; the `--yes` and `--delete-unassigned-env-vars` flags and `rm` alias are tracked.
- Stacked on #17466 (target update) → #17459 (target add) → #17458 (target inspect).