### PR TITLE
[CLI] Add target update subcommand

### DIFF
--- a/.changeset/target-update.md
+++ b/.changeset/target-update.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel target update <name-or-id>` to update a custom environment

--- a/packages/cli/src/commands/target/command.ts
+++ b/packages/cli/src/commands/target/command.ts
@@ -131,12 +131,58 @@ export const addSubcommand = {
   ],
 } as const;
 
+export const updateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Update a custom environment on the current Project',
+  arguments: [
+    {
+      name: 'name',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'slug',
+      shorthand: null,
+      type: String,
+      argument: 'SLUG',
+      description: 'New name (slug) for the custom environment',
+      deprecated: false,
+    },
+    descriptionOption,
+    branchMatcherTypeOption,
+    branchMatcherPatternOption,
+    projectOption,
+    {
+      ...yesOption,
+      description:
+        'Skip confirmation when linking is required (e.g. in non-interactive mode)',
+    },
+  ],
+  examples: [
+    {
+      name: "Update a custom environment's branch matcher",
+      value: `${packageName} target update staging --branch-matcher-type equals --branch-matcher-pattern staging`,
+    },
+    {
+      name: 'Rename a custom environment',
+      value: `${packageName} target update staging --slug preprod`,
+    },
+  ],
+} as const;
+
 export const targetCommand = {
   name: 'target',
   aliases: ['targets'],
   description: 'Manage your Vercel Project\'s "targets" (custom environments).',
   arguments: [],
-  subcommands: [listSubcommand, inspectSubcommand, addSubcommand],
+  subcommands: [
+    listSubcommand,
+    inspectSubcommand,
+    addSubcommand,
+    updateSubcommand,
+  ],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/target/index.ts
+++ b/packages/cli/src/commands/target/index.ts
@@ -5,11 +5,13 @@ import { type Command, help } from '../help';
 import list from './list';
 import inspect from './inspect';
 import add from './add';
+import update from './update';
 import {
   addSubcommand,
   inspectSubcommand,
   listSubcommand,
   targetCommand,
+  updateSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
@@ -21,6 +23,7 @@ const COMMAND_CONFIG = {
   ls: getCommandAliases(listSubcommand),
   inspect: getCommandAliases(inspectSubcommand),
   add: getCommandAliases(addSubcommand),
+  update: getCommandAliases(updateSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -86,6 +89,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandAdd(subcommand);
       return await add(client, args);
+    case 'update':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('target', 'update');
+        printHelp(updateSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandUpdate(subcommand);
+      return await update(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(targetCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/target/update.ts
+++ b/packages/cli/src/commands/target/update.ts
@@ -1,0 +1,177 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import { targetCommand, updateSubcommand } from './command';
+import { ensureLink } from '../../util/link/ensure-link';
+import { formatProject } from '../../util/projects/format-project';
+import { formatEnvironment } from '../../util/target/format-environment';
+import { STANDARD_ENVIRONMENTS } from '../../util/target/standard-environments';
+import { parseBranchMatcher } from '../../util/target/parse-branch-matcher';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { isAPIError } from '../../util/errors-ts';
+import { TargetUpdateTelemetryClient } from '../../util/telemetry/commands/target/update';
+import type Client from '../../util/client';
+import type { CustomEnvironment } from '@vercel-internals/types';
+
+// Type alias (not interface) so it satisfies the client's JSONObject body type.
+type UpdateCustomEnvironmentBody = {
+  slug?: string;
+  description?: string;
+  branchMatcher?: { type: string; pattern: string };
+};
+
+export default async function update(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const { cwd } = client;
+
+  const telemetry = new TargetUpdateTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(updateSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  if (args.length !== 1) {
+    output.error(
+      `Invalid number of arguments. Usage: ${getCommandName(
+        'target update <name>'
+      )}`
+    );
+    return 2;
+  }
+
+  const [nameOrId] = args;
+  const slug = flags['--slug'];
+  const description = flags['--description'];
+  const branchMatcherType = flags['--branch-matcher-type'];
+  const branchMatcherPattern = flags['--branch-matcher-pattern'];
+  const projectName = flags['--project'];
+
+  telemetry.trackCliArgumentName(nameOrId);
+  telemetry.trackCliOptionSlug(slug);
+  telemetry.trackCliOptionDescription(description);
+  telemetry.trackCliOptionBranchMatcherType(branchMatcherType);
+  telemetry.trackCliOptionBranchMatcherPattern(branchMatcherPattern);
+  telemetry.trackCliOptionProject(projectName);
+  telemetry.trackCliFlagYes(flags['--yes']);
+
+  const hasBranchMatcherFlag =
+    branchMatcherType !== undefined || branchMatcherPattern !== undefined;
+  if (
+    slug === undefined &&
+    description === undefined &&
+    !hasBranchMatcherFlag
+  ) {
+    output.error(
+      `No changes provided. Pass at least one of ${chalk.bold(
+        '--slug'
+      )}, ${chalk.bold('--description')}, or ${chalk.bold(
+        '--branch-matcher-type'
+      )} with ${chalk.bold('--branch-matcher-pattern')}.`
+    );
+    return 2;
+  }
+
+  if (
+    STANDARD_ENVIRONMENTS.includes(
+      nameOrId as (typeof STANDARD_ENVIRONMENTS)[number]
+    )
+  ) {
+    output.error(
+      `${chalk.bold(
+        nameOrId
+      )} is a built-in environment and cannot be updated as a custom environment.`
+    );
+    return 1;
+  }
+
+  const matcherResult = parseBranchMatcher(
+    branchMatcherType,
+    branchMatcherPattern
+  );
+  if (!matcherResult.valid) {
+    output.error(matcherResult.error);
+    return 1;
+  }
+
+  const autoConfirm = !!flags['--yes'];
+  const link = await ensureLink(targetCommand.name, client, cwd, {
+    autoConfirm,
+    projectName,
+    failIfNotFound: Boolean(projectName),
+  });
+  if (typeof link === 'number') {
+    return link;
+  }
+
+  const projectSlugLink = formatProject(link.org.slug, link.project.name);
+
+  const body: UpdateCustomEnvironmentBody = {};
+  if (slug !== undefined) {
+    body.slug = slug;
+  }
+  if (description !== undefined) {
+    body.description = description;
+  }
+  if (matcherResult.branchMatcher) {
+    body.branchMatcher = matcherResult.branchMatcher;
+  }
+
+  output.spinner(
+    `Updating custom environment ${chalk.bold(nameOrId)} for ${projectSlugLink}`
+  );
+
+  const url = `/projects/${encodeURIComponent(
+    link.project.id
+  )}/custom-environments/${encodeURIComponent(nameOrId)}`;
+
+  let environment: CustomEnvironment;
+  try {
+    environment = (await client.fetch(url, {
+      method: 'PATCH',
+      accountId: link.org.id,
+      body,
+    })) as CustomEnvironment;
+  } catch (error) {
+    output.stopSpinner();
+    if (isAPIError(error) && error.status === 404) {
+      output.error(
+        `Custom environment ${chalk.bold(
+          nameOrId
+        )} was not found under ${projectSlugLink}.`
+      );
+      return 1;
+    }
+    if (isAPIError(error) && error.status === 400) {
+      output.error(error.serverMessage || 'The request was invalid.');
+      return 1;
+    }
+    printError(error);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  output.log(
+    `Updated custom environment ${formatEnvironment(
+      link.org.slug,
+      link.project.name,
+      environment
+    )} under ${projectSlugLink}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/target/index.ts
+++ b/packages/cli/src/util/telemetry/commands/target/index.ts
@@ -26,4 +26,11 @@ export class TargetTelemetryClient
       value: subcommandActual,
     });
   }
+
+  trackCliSubcommandUpdate(subcommandActual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update',
+      value: subcommandActual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/target/update.ts
+++ b/packages/cli/src/util/telemetry/commands/target/update.ts
@@ -1,0 +1,61 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { updateSubcommand } from '../../../../commands/target/command';
+
+const BRANCH_MATCHER_TYPES = ['equals', 'startsWith', 'endsWith'];
+
+export class TargetUpdateTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof updateSubcommand>
+{
+  trackCliArgumentName(name: string | undefined) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSlug(slug: string | undefined) {
+    if (slug) {
+      this.trackCliOption({
+        option: 'slug',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDescription(description: string | undefined) {
+    if (description) {
+      this.trackCliOption({
+        option: 'description',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionBranchMatcherType(type: string | undefined) {
+    if (type) {
+      this.trackCliOption({
+        option: 'branch-matcher-type',
+        value: BRANCH_MATCHER_TYPES.includes(type) ? type : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionBranchMatcherPattern(pattern: string | undefined) {
+    if (pattern) {
+      this.trackCliOption({
+        option: 'branch-matcher-pattern',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -7009,6 +7009,10 @@ exports[`help command > target help output snapshots > target help column width 
                  environment to 
                  the current    
                  Project        
+  update   name  Update a custom
+                 environment on 
+                 the current    
+                 Project        
 
 
   Global Options:
@@ -7073,6 +7077,7 @@ exports[`help command > target help output snapshots > target help column width 
   list           List targets defined for the current Project           
   inspect  name  Show a custom environment in full                      
   add      name  Add a new custom environment to the current Project    
+  update   name  Update a custom environment on the current Project     
 
 
   Global Options:
@@ -7105,6 +7110,7 @@ exports[`help command > target help output snapshots > target help column width 
   list           List targets defined for the current Project                                                   
   inspect  name  Show a custom environment in full                                                              
   add      name  Add a new custom environment to the current Project                                            
+  update   name  Update a custom environment on the current Project                                             
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/target/update.test.ts
+++ b/packages/cli/test/unit/commands/target/update.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, beforeEach, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import target from '../../../../src/commands/target';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+
+interface PatchState {
+  called: boolean;
+  body: Record<string, unknown> | undefined;
+  notFound: boolean;
+}
+
+function usePatchCustomEnvironment(): PatchState {
+  const state: PatchState = { called: false, body: undefined, notFound: false };
+  client.scenario.patch(
+    '/projects/static/custom-environments/:idOrSlug',
+    (req, res) => {
+      if (state.notFound) {
+        res.status(404).send();
+        return;
+      }
+      state.called = true;
+      state.body = req.body;
+      res.status(200).json({
+        id: 'env_ph1tjPP20xp8VAuiFsYt4rhRYGys',
+        slug: req.body.slug ?? req.params.idOrSlug,
+        type: 'preview',
+        description: req.body.description ?? '',
+        branchMatcher: req.body.branchMatcher ?? {
+          type: 'startsWith',
+          pattern: 'staging',
+        },
+        domains: [],
+        createdAt: 1717176506341,
+        updatedAt: 1717176506341,
+      });
+    }
+  );
+  return state;
+}
+
+describe('target update', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+      accountId: 'team_dummy',
+    });
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.stderr.isTTY = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('target', 'update', '--help');
+      const exitCodePromise = target(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'target:update',
+        },
+      ]);
+    });
+  });
+
+  describe('usage errors', () => {
+    it('errors with exit code 2 when no name is passed', async () => {
+      client.setArgv('target', 'update');
+      const exitCode = await target(client);
+      expect(exitCode).toEqual(2);
+      await expect(client.stderr).toOutput('Invalid number of arguments');
+    });
+
+    it('errors with exit code 2 when no update flags are provided', async () => {
+      const state = usePatchCustomEnvironment();
+      client.setArgv('target', 'update', 'staging');
+      const exitCode = await target(client);
+      expect(exitCode).toEqual(2);
+      expect(state.called).toBe(false);
+      await expect(client.stderr).toOutput('No changes provided');
+    });
+  });
+
+  it('rejects a built-in environment name without calling the API', async () => {
+    const state = usePatchCustomEnvironment();
+    client.setArgv('target', 'update', 'production', '--description', 'x');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(1);
+    expect(state.called).toBe(false);
+    await expect(client.stderr).toOutput('built-in environment');
+  });
+
+  it('rejects an incomplete branch matcher pair', async () => {
+    const state = usePatchCustomEnvironment();
+    client.setArgv(
+      'target',
+      'update',
+      'staging',
+      '--branch-matcher-pattern',
+      'staging'
+    );
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(1);
+    expect(state.called).toBe(false);
+    await expect(client.stderr).toOutput('must be provided together');
+  });
+
+  it('updates a custom environment and tracks telemetry', async () => {
+    const state = usePatchCustomEnvironment();
+    client.setArgv(
+      'target',
+      'update',
+      'staging',
+      '--slug',
+      'preprod',
+      '--description',
+      'updated',
+      '--branch-matcher-type',
+      'equals',
+      '--branch-matcher-pattern',
+      'preprod'
+    );
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+
+    expect(state.called).toBe(true);
+    expect(state.body).toEqual({
+      slug: 'preprod',
+      description: 'updated',
+      branchMatcher: { type: 'equals', pattern: 'preprod' },
+    });
+
+    await expect(client.stderr).toOutput('Updated custom environment');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:update',
+        value: 'update',
+      },
+      {
+        key: 'argument:name',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:slug',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:description',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:branch-matcher-type',
+        value: 'equals',
+      },
+      {
+        key: 'option:branch-matcher-pattern',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('sends a sparse body when only one field is updated', async () => {
+    const state = usePatchCustomEnvironment();
+    client.setArgv('target', 'update', 'staging', '--description', 'only desc');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(0);
+    expect(state.body).toEqual({ description: 'only desc' });
+  });
+
+  it('errors when the custom environment is not found', async () => {
+    const state = usePatchCustomEnvironment();
+    state.notFound = true;
+    client.setArgv('target', 'update', 'missing', '--description', 'x');
+    const exitCode = await target(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('was not found');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `vercel target update <name-or-id>` to update an existing custom environment on the linked Project via a sparse PATCH.

## Notes
- Endpoint: `PATCH /projects/:idOrName/custom-environments/:environmentSlugOrId`.
- Flags are derived from the public update schema: `--slug` (rename), `--description`, `--branch-matcher-type`, `--branch-matcher-pattern`.
- Requires at least one field flag; only provided fields are sent (sparse PATCH).
- `--branch-matcher-type` and `--branch-matcher-pattern` must be provided together; type must be one of `equals`, `startsWith`, `endsWith` (reuses the shared `parseBranchMatcher` helper from #17459).
- Built-in targets (`production`/`preview`/`development`) are rejected before any API call, since they are not custom environments.
- Telemetry redacts user-provided names/slugs/patterns/descriptions; the branch-matcher-type enum value is recorded.
- Stacked on #17459 (target add), which is stacked on #17458 (target inspect). Stacked follow-up: #17462 (target remove).