### PR TITLE
[CLI] Add compute and functions flags to project update

### DIFF
--- a/.changeset/project-update-compute-flags.md
+++ b/.changeset/project-update-compute-flags.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add compute and functions flags to `vercel project update`: `--fluid-compute`, `--function-region`, `--function-cpu`, `--function-timeout`, `--sandbox-region`, `--build-machine`, `--elastic-concurrency`, and `--node-version`.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -301,6 +301,74 @@ export const updateSubcommand = {
         'Reset a setting to automatic detection; repeat for build-command, dev-command, install-command, output-directory, or root-directory',
       deprecated: false,
     },
+    {
+      name: 'fluid-compute',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description: 'Enable or disable Fluid compute',
+      deprecated: false,
+    },
+    {
+      name: 'function-region',
+      shorthand: null,
+      type: String,
+      argument: 'REGION',
+      description:
+        'Set the default Vercel Functions region(s); comma-separated for multiple (e.g. iad1,sfo1)',
+      deprecated: false,
+    },
+    {
+      name: 'function-cpu',
+      shorthand: null,
+      type: String,
+      argument: 'TIER',
+      description:
+        'Set the default function CPU/memory tier: standard_legacy, standard, performance, or performance_xl',
+      deprecated: false,
+    },
+    {
+      name: 'function-timeout',
+      shorthand: null,
+      type: String,
+      argument: 'SECONDS',
+      description: 'Set the default function max duration in seconds (1-900)',
+      deprecated: false,
+    },
+    {
+      name: 'sandbox-region',
+      shorthand: null,
+      type: String,
+      argument: 'REGION',
+      description: 'Set the default sandbox region: iad1, sfo1, or cle1',
+      deprecated: false,
+    },
+    {
+      name: 'build-machine',
+      shorthand: null,
+      type: String,
+      argument: 'TYPE',
+      description:
+        'Set the build machine type: basic, standard, enhanced, turbo, or elastic',
+      deprecated: false,
+    },
+    {
+      name: 'elastic-concurrency',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description: 'Enable or disable elastic concurrency for builds',
+      deprecated: false,
+    },
+    {
+      name: 'node-version',
+      shorthand: null,
+      type: String,
+      argument: 'VERSION',
+      description:
+        'Set the Node.js version: 24.x, 22.x, 20.x, 18.x, 16.x, 14.x, 12.x, or 10.x',
+      deprecated: false,
+    },
     formatOption,
     jsonOption,
   ],
@@ -320,6 +388,14 @@ export const updateSubcommand = {
     {
       name: 'Reset individual settings to automatic detection',
       value: `${packageName} project update my-project --auto-detect build-command --auto-detect output-directory`,
+    },
+    {
+      name: 'Enable Fluid compute and set the function CPU tier',
+      value: `${packageName} project update my-project --fluid-compute on --function-cpu performance`,
+    },
+    {
+      name: 'Pin the Node.js version and default function region',
+      value: `${packageName} project update my-project --node-version 20.x --function-region iad1`,
     },
     {
       name: 'Clear the framework preset and return JSON',

--- a/packages/cli/src/commands/project/update.ts
+++ b/packages/cli/src/commands/project/update.ts
@@ -325,10 +325,15 @@ const advancedSettingDefinitions: readonly AdvancedSettingDefinition[] = [
     flag: '--function-region',
     label: 'Function Regions',
     parse: raw => {
-      const regions = raw
-        .split(',')
-        .map(region => region.trim())
-        .filter(region => region.length > 0);
+      // The public schema requires unique items, so drop duplicates locally.
+      const regions = [
+        ...new Set(
+          raw
+            .split(',')
+            .map(region => region.trim())
+            .filter(region => region.length > 0)
+        ),
+      ];
       if (regions.length === 0) {
         return {
           ok: false,

--- a/packages/cli/src/commands/project/update.ts
+++ b/packages/cli/src/commands/project/update.ts
@@ -176,18 +176,319 @@ function parseAutoDetectSettings(inputs: string[]): string[] {
   return inputs.flatMap(input => input.split(',')).map(input => input.trim());
 }
 
+// --- Advanced project settings (compute / functions) ---
+//
+// These flags map to the nested `resourceConfig` and `sandbox` objects and to
+// top-level project fields on the public project PATCH schema. Each definition
+// parses and validates its flag value locally before any request, reads the
+// current value for change detection and preview, and applies the change to a
+// sparse PATCH body so only the fields the user provided are sent.
+const NODE_VERSIONS = [
+  '24.x',
+  '22.x',
+  '20.x',
+  '18.x',
+  '16.x',
+  '14.x',
+  '12.x',
+  '10.x',
+] as const;
+const FUNCTION_CPU_TIERS = [
+  'standard_legacy',
+  'standard',
+  'performance',
+  'performance_xl',
+] as const;
+const BUILD_MACHINE_TYPES = [
+  'basic',
+  'standard',
+  'enhanced',
+  'turbo',
+  'elastic',
+] as const;
+const SANDBOX_REGIONS = ['iad1', 'sfo1', 'cle1'] as const;
+const MIN_FUNCTION_TIMEOUT = 1;
+const MAX_FUNCTION_TIMEOUT = 900;
+
+type AdvancedValue = string | number | boolean | string[];
+type PatchBody = Record<string, unknown>;
+type AdvancedParseResult =
+  | { ok: true; value: AdvancedValue }
+  | { ok: false; message: string };
+
+// Subset of project fields the advanced flags read for change detection and
+// merge. These exist on the API response but are not modeled on the CLI
+// `Project` type, so they are read through this narrow view.
+interface AdvancedProjectFields {
+  resourceConfig?: {
+    fluid?: boolean;
+    functionDefaultRegions?: string[];
+    functionDefaultMemoryType?: string;
+    functionDefaultTimeout?: number;
+    elasticConcurrencyEnabled?: boolean;
+    buildMachineType?: string;
+  } | null;
+  sandbox?: { region?: string; failoverRegions?: string[] } | null;
+}
+
+interface AdvancedSettingDefinition {
+  key: string;
+  flag: string;
+  label: string;
+  parse: (raw: string) => AdvancedParseResult;
+  read: (project: Project) => AdvancedValue | null | undefined;
+  apply: (body: PatchBody, value: AdvancedValue, project: Project) => void;
+  display: (value: AdvancedValue | null | undefined) => string;
+}
+
+interface AdvancedPreviewRow {
+  label: string;
+  previous: string;
+  next: string;
+  changed: boolean;
+}
+
+interface ProvidedAdvancedSetting {
+  definition: AdvancedSettingDefinition;
+  value: AdvancedValue;
+}
+
+function getAdvancedFields(project: Project): AdvancedProjectFields {
+  return project as Project & AdvancedProjectFields;
+}
+
+function ensureResourceConfig(body: PatchBody): Record<string, unknown> {
+  const resourceConfig =
+    (body.resourceConfig as Record<string, unknown> | undefined) ?? {};
+  body.resourceConfig = resourceConfig;
+  return resourceConfig;
+}
+
+function parseOnOff(flag: string, raw: string): AdvancedParseResult {
+  if (raw === 'on') {
+    return { ok: true, value: true };
+  }
+  if (raw === 'off') {
+    return { ok: true, value: false };
+  }
+  return { ok: false, message: `${flag} must be "on" or "off".` };
+}
+
+function parseEnumValue(
+  label: string,
+  raw: string,
+  allowed: readonly string[]
+): AdvancedParseResult {
+  if (allowed.includes(raw)) {
+    return { ok: true, value: raw };
+  }
+  return {
+    ok: false,
+    message: `${label} must be one of: ${allowed.join(', ')}.`,
+  };
+}
+
+function displayOnOff(value: AdvancedValue | null | undefined): string {
+  if (value === true) {
+    return 'on';
+  }
+  if (value === false) {
+    return 'off';
+  }
+  return 'Auto';
+}
+
+function displayValue(value: AdvancedValue | null | undefined): string {
+  if (value === null || value === undefined) {
+    return 'Auto';
+  }
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+  return String(value);
+}
+
+const advancedSettingDefinitions: readonly AdvancedSettingDefinition[] = [
+  {
+    key: 'fluid',
+    flag: '--fluid-compute',
+    label: 'Fluid Compute',
+    parse: raw => parseOnOff('--fluid-compute', raw),
+    read: project => getAdvancedFields(project).resourceConfig?.fluid,
+    apply: (body, value) => {
+      ensureResourceConfig(body).fluid = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'functionDefaultRegions',
+    flag: '--function-region',
+    label: 'Function Regions',
+    parse: raw => {
+      const regions = raw
+        .split(',')
+        .map(region => region.trim())
+        .filter(region => region.length > 0);
+      if (regions.length === 0) {
+        return {
+          ok: false,
+          message: '--function-region requires at least one region.',
+        };
+      }
+      for (const region of regions) {
+        if (region.length < 3 || region.length > 4) {
+          return {
+            ok: false,
+            message: `Function region "${region}" must be a 3-4 character region such as "iad1".`,
+          };
+        }
+      }
+      return { ok: true, value: regions };
+    },
+    read: project =>
+      getAdvancedFields(project).resourceConfig?.functionDefaultRegions,
+    apply: (body, value) => {
+      ensureResourceConfig(body).functionDefaultRegions = value as string[];
+    },
+    display: displayValue,
+  },
+  {
+    key: 'functionDefaultMemoryType',
+    flag: '--function-cpu',
+    label: 'Function CPU',
+    parse: raw => parseEnumValue('Function CPU', raw, FUNCTION_CPU_TIERS),
+    read: project =>
+      getAdvancedFields(project).resourceConfig?.functionDefaultMemoryType,
+    apply: (body, value) => {
+      ensureResourceConfig(body).functionDefaultMemoryType = value as string;
+    },
+    display: displayValue,
+  },
+  {
+    key: 'functionDefaultTimeout',
+    flag: '--function-timeout',
+    label: 'Function Timeout',
+    parse: raw => {
+      const trimmed = raw.trim();
+      if (!/^\d+$/.test(trimmed)) {
+        return {
+          ok: false,
+          message: `Function timeout must be an integer between ${MIN_FUNCTION_TIMEOUT} and ${MAX_FUNCTION_TIMEOUT} seconds.`,
+        };
+      }
+      const seconds = Number(trimmed);
+      if (seconds < MIN_FUNCTION_TIMEOUT || seconds > MAX_FUNCTION_TIMEOUT) {
+        return {
+          ok: false,
+          message: `Function timeout must be between ${MIN_FUNCTION_TIMEOUT} and ${MAX_FUNCTION_TIMEOUT} seconds.`,
+        };
+      }
+      return { ok: true, value: seconds };
+    },
+    read: project =>
+      getAdvancedFields(project).resourceConfig?.functionDefaultTimeout,
+    apply: (body, value) => {
+      ensureResourceConfig(body).functionDefaultTimeout = value as number;
+    },
+    display: value => (typeof value === 'number' ? `${value}s` : 'Auto'),
+  },
+  {
+    key: 'sandboxRegion',
+    flag: '--sandbox-region',
+    label: 'Sandbox Region',
+    parse: raw => parseEnumValue('Sandbox region', raw, SANDBOX_REGIONS),
+    read: project => getAdvancedFields(project).sandbox?.region,
+    apply: (body, value, project) => {
+      body.sandbox = {
+        ...(getAdvancedFields(project).sandbox ?? {}),
+        region: value as string,
+      };
+    },
+    display: displayValue,
+  },
+  {
+    key: 'buildMachineType',
+    flag: '--build-machine',
+    label: 'Build Machine',
+    parse: raw => parseEnumValue('Build machine', raw, BUILD_MACHINE_TYPES),
+    read: project =>
+      getAdvancedFields(project).resourceConfig?.buildMachineType,
+    apply: (body, value) => {
+      ensureResourceConfig(body).buildMachineType = value as string;
+    },
+    display: displayValue,
+  },
+  {
+    key: 'elasticConcurrencyEnabled',
+    flag: '--elastic-concurrency',
+    label: 'Elastic Concurrency',
+    parse: raw => parseOnOff('--elastic-concurrency', raw),
+    read: project =>
+      getAdvancedFields(project).resourceConfig?.elasticConcurrencyEnabled,
+    apply: (body, value) => {
+      ensureResourceConfig(body).elasticConcurrencyEnabled = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'nodeVersion',
+    flag: '--node-version',
+    label: 'Node.js Version',
+    parse: raw => parseEnumValue('Node.js version', raw, NODE_VERSIONS),
+    read: project => project.nodeVersion,
+    apply: (body, value) => {
+      body.nodeVersion = value as string;
+    },
+    display: displayValue,
+  },
+];
+
+function advancedValuesEqual(
+  a: AdvancedValue | null | undefined,
+  b: AdvancedValue | null | undefined
+): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, index) => item === b[index]);
+  }
+  return a === b;
+}
+
+function collectAdvancedSettings(
+  flags: Record<string, unknown>
+):
+  | { ok: true; provided: ProvidedAdvancedSetting[] }
+  | { ok: false; flag: string; message: string } {
+  const provided: ProvidedAdvancedSetting[] = [];
+  for (const definition of advancedSettingDefinitions) {
+    const raw = flags[definition.flag] as string | undefined;
+    if (raw === undefined) {
+      continue;
+    }
+    const result = definition.parse(raw);
+    if (!result.ok) {
+      return { ok: false, flag: definition.flag, message: result.message };
+    }
+    provided.push({ definition, value: result.value });
+  }
+  return { ok: true, provided };
+}
+
 function writeResult({
   changedSettings,
   project,
   previousSettings,
   requestedSettings,
+  advancedRows,
+  advancedSettings,
   asJson,
   client,
 }: {
-  changedSettings: ProjectSettingKey[];
+  changedSettings: string[];
   project: Project;
   previousSettings: ProjectSettingsUpdate;
   requestedSettings: ProjectSettingsUpdate;
+  advancedRows: AdvancedPreviewRow[];
+  advancedSettings: Record<string, AdvancedValue>;
   asJson: boolean;
   client: Client;
 }) {
@@ -200,7 +501,7 @@ function writeResult({
           changedSettings,
           projectId: project.id,
           projectName: project.name,
-          settings: requestedSettings,
+          settings: { ...requestedSettings, ...advancedSettings },
         },
         null,
         2
@@ -223,6 +524,10 @@ function writeResult({
       ? `${formatSettingValue(key, previous)} → ${formatSettingValue(key, next)}`
       : formatSettingValue(key, next);
     printAlignedLabel(settingLabels[key], value);
+  }
+  for (const row of advancedRows) {
+    const value = row.changed ? `${row.previous} → ${row.next}` : row.next;
+    printAlignedLabel(row.label, value);
   }
 }
 
@@ -271,6 +576,14 @@ export default async function update(
     flags['--auto-detect'] as [string] | undefined
   );
   telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliOptionFluidCompute(flags['--fluid-compute']);
+  telemetry.trackCliOptionFunctionRegion(flags['--function-region']);
+  telemetry.trackCliOptionFunctionCpu(flags['--function-cpu']);
+  telemetry.trackCliOptionFunctionTimeout(flags['--function-timeout']);
+  telemetry.trackCliOptionSandboxRegion(flags['--sandbox-region']);
+  telemetry.trackCliOptionBuildMachine(flags['--build-machine']);
+  telemetry.trackCliOptionElasticConcurrency(flags['--elastic-concurrency']);
+  telemetry.trackCliOptionNodeVersion(flags['--node-version']);
 
   if (args.length > 1) {
     return printUsageError(
@@ -361,10 +674,25 @@ export default async function update(
     }
   }
 
-  if (settingOrder.every(key => !hasSetting(requestedSettings, key))) {
+  const advancedResult = collectAdvancedSettings(flags);
+  if (!advancedResult.ok) {
     return printUsageError(
       client,
-      'Provide at least one setting option: --framework, --build-command, --dev-command, --install-command, --output-directory, --root-directory, or --auto-detect.',
+      advancedResult.message,
+      1,
+      'invalid_arguments',
+      `project update <name> ${advancedResult.flag} <value>`
+    );
+  }
+  const providedAdvanced = advancedResult.provided;
+
+  if (
+    settingOrder.every(key => !hasSetting(requestedSettings, key)) &&
+    providedAdvanced.length === 0
+  ) {
+    return printUsageError(
+      client,
+      'Provide at least one setting option. Run "vercel project update --help" to see every available option.',
       2,
       'missing_arguments'
     );
@@ -385,7 +713,7 @@ export default async function update(
   }
 
   const previousSettings: ProjectSettingsUpdate = {};
-  const changedSettings: ProjectSettingKey[] = [];
+  const changedSettings: string[] = [];
   const changedUpdates: ProjectSettingsUpdate = {};
   for (const key of settingOrder) {
     if (!hasSetting(requestedSettings, key)) {
@@ -400,6 +728,25 @@ export default async function update(
     }
   }
 
+  const body: PatchBody = { ...changedUpdates };
+  const advancedRows: AdvancedPreviewRow[] = [];
+  const advancedSettings: Record<string, AdvancedValue> = {};
+  for (const { definition, value } of providedAdvanced) {
+    const previous = definition.read(project);
+    const changed = !advancedValuesEqual(previous, value);
+    advancedSettings[definition.key] = value;
+    advancedRows.push({
+      label: definition.label,
+      previous: definition.display(previous),
+      next: definition.display(value),
+      changed,
+    });
+    if (changed) {
+      changedSettings.push(definition.key);
+      definition.apply(body, value, project);
+    }
+  }
+
   let updatedProject = project;
   if (changedSettings.length > 0) {
     try {
@@ -407,7 +754,7 @@ export default async function update(
         `/v9/projects/${encodeURIComponent(project.id)}`,
         {
           method: 'PATCH',
-          body: changedUpdates as JSONObject,
+          body: body as JSONObject,
         }
       );
     } catch (error) {
@@ -422,6 +769,8 @@ export default async function update(
     project: updatedProject,
     previousSettings,
     requestedSettings,
+    advancedRows,
+    advancedSettings,
     asJson: formatResult.jsonOutput,
     client,
   });

--- a/packages/cli/src/util/telemetry/commands/project/update.ts
+++ b/packages/cli/src/util/telemetry/commands/project/update.ts
@@ -62,6 +62,92 @@ export class ProjectUpdateTelemetryClient
     }
   }
 
+  trackCliOptionFluidCompute(value: string | undefined) {
+    this.trackOnOffOption('fluid-compute', value);
+  }
+
+  trackCliOptionFunctionRegion(value: string | undefined) {
+    // Region identifiers are free-form input, so redact the value.
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'function-region',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFunctionCpu(value: string | undefined) {
+    this.trackEnumOption('function-cpu', value, [
+      'standard_legacy',
+      'standard',
+      'performance',
+      'performance_xl',
+    ]);
+  }
+
+  trackCliOptionFunctionTimeout(value: string | undefined) {
+    if (value !== undefined) {
+      const trimmed = value.trim();
+      this.trackCliOption({
+        option: 'function-timeout',
+        value: /^\d+$/.test(trimmed) ? trimmed : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSandboxRegion(value: string | undefined) {
+    this.trackEnumOption('sandbox-region', value, ['iad1', 'sfo1', 'cle1']);
+  }
+
+  trackCliOptionBuildMachine(value: string | undefined) {
+    this.trackEnumOption('build-machine', value, [
+      'basic',
+      'standard',
+      'enhanced',
+      'turbo',
+      'elastic',
+    ]);
+  }
+
+  trackCliOptionElasticConcurrency(value: string | undefined) {
+    this.trackOnOffOption('elastic-concurrency', value);
+  }
+
+  trackCliOptionNodeVersion(value: string | undefined) {
+    this.trackEnumOption('node-version', value, [
+      '24.x',
+      '22.x',
+      '20.x',
+      '18.x',
+      '16.x',
+      '14.x',
+      '12.x',
+      '10.x',
+    ]);
+  }
+
+  private trackOnOffOption(option: string, value: string | undefined) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option,
+        value: value === 'on' || value === 'off' ? value : this.redactedValue,
+      });
+    }
+  }
+
+  private trackEnumOption(
+    option: string,
+    value: string | undefined,
+    allowed: readonly string[]
+  ) {
+    if (value !== undefined) {
+      this.trackCliOption({
+        option,
+        value: allowed.includes(value) ? value : this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagJson(json: boolean | undefined) {
     if (json) {
       this.trackCliFlag('json');

--- a/packages/cli/test/unit/commands/project/update.test.ts
+++ b/packages/cli/test/unit/commands/project/update.test.ts
@@ -57,6 +57,14 @@ describe('project update', () => {
       expect(helpOutput).toContain('--install-command');
       expect(helpOutput).toContain('--output-directory');
       expect(helpOutput).toContain('--auto-detect');
+      expect(helpOutput).toContain('--fluid-compute');
+      expect(helpOutput).toContain('--function-region');
+      expect(helpOutput).toContain('--function-cpu');
+      expect(helpOutput).toContain('--function-timeout');
+      expect(helpOutput).toContain('--sandbox-region');
+      expect(helpOutput).toContain('--build-machine');
+      expect(helpOutput).toContain('--elastic-concurrency');
+      expect(helpOutput).toContain('--node-version');
       expect(helpOutput).toContain('--format');
       expect(helpOutput).toContain('omitted settings remain unchanged');
       expect(helpOutput).toContain('Update multiple settings in one command');
@@ -534,6 +542,394 @@ describe('project update', () => {
         )
       ).toBe(true);
       expect(client.stderr.getFullOutput()).toBe('');
+    });
+  });
+
+  describe('compute and functions flags', () => {
+    it('enables Fluid compute via resourceConfig', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({ resourceConfig: { fluid: true } });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--fluid-compute',
+        'on'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.stderr.getFullOutput()).toContain('Fluid Compute');
+      expect(client.stderr.getFullOutput()).toContain('on');
+    });
+
+    it('disables elastic concurrency via resourceConfig', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          resourceConfig: { elasticConcurrencyEnabled: false },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--elastic-concurrency',
+        'off'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('sets the default function region(s)', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          resourceConfig: { functionDefaultRegions: ['iad1', 'sfo1'] },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--function-region',
+        'iad1,sfo1'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('sets the function CPU tier', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          resourceConfig: { functionDefaultMemoryType: 'performance' },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--function-cpu',
+        'performance'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('sets the function timeout as an integer', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          resourceConfig: { functionDefaultTimeout: 30 },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--function-timeout',
+        '30'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('sets the build machine type', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          resourceConfig: { buildMachineType: 'enhanced' },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--build-machine',
+        'enhanced'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('sets the Node.js version at the top level', async () => {
+      const currentProject = useSettingsProject({}, body => {
+        expect(body).toEqual({ nodeVersion: '20.x' });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--node-version',
+        '20.x'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      expect(currentProject.nodeVersion).toBe('20.x');
+    });
+
+    it('merges sandbox region with existing failover regions', async () => {
+      useSettingsProject(
+        {
+          // @ts-expect-error sandbox is not modeled on the CLI Project type
+          sandbox: { region: 'iad1', failoverRegions: ['sfo1'] },
+        },
+        body => {
+          expect(body).toEqual({
+            sandbox: { region: 'cle1', failoverRegions: ['sfo1'] },
+          });
+        }
+      );
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--sandbox-region',
+        'cle1'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('combines multiple compute flags into one sparse PATCH', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          resourceConfig: {
+            fluid: true,
+            functionDefaultTimeout: 60,
+            functionDefaultMemoryType: 'performance_xl',
+          },
+          nodeVersion: '22.x',
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--fluid-compute',
+        'on',
+        '--function-timeout',
+        '60',
+        '--function-cpu',
+        'performance_xl',
+        '--node-version',
+        '22.x'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('preserves existing framework behavior alongside compute flags', async () => {
+      const currentProject = useSettingsProject({ framework: 'vite' }, body => {
+        expect(body).toEqual({
+          framework: 'nextjs',
+          resourceConfig: { fluid: true },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--framework',
+        'nextjs',
+        '--fluid-compute',
+        'on'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      expect(currentProject.framework).toBe('nextjs');
+    });
+
+    it('does not send a PATCH when the compute value is unchanged', async () => {
+      const currentProject: Project = {
+        ...defaultProject,
+        id: 'prj_123',
+        name: 'my-project',
+        nodeVersion: '20.x',
+      };
+      client.scenario.get('/v9/projects/my-project', (_req, res) => {
+        res.json(currentProject);
+      });
+      const fetchSpy = vi.spyOn(client, 'fetch');
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--node-version',
+        '20.x',
+        '--format',
+        'json'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      const patchCall = fetchSpy.mock.calls.find(
+        ([, options]) => options?.method === 'PATCH'
+      );
+      expect(patchCall).toBeUndefined();
+      expect(JSON.parse(client.stdout.getFullOutput().trim())).toEqual({
+        changed: false,
+        changedSettings: [],
+        projectId: 'prj_123',
+        projectName: 'my-project',
+        settings: { nodeVersion: '20.x' },
+      });
+    });
+
+    it('returns advanced settings in JSON output', async () => {
+      useSettingsProject({});
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--fluid-compute',
+        'on',
+        '--node-version',
+        '20.x',
+        '--format',
+        'json'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      const payload = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(payload.changed).toBe(true);
+      expect(payload.changedSettings).toEqual(
+        expect.arrayContaining(['fluid', 'nodeVersion'])
+      );
+      expect(payload.settings).toMatchObject({
+        fluid: true,
+        nodeVersion: '20.x',
+      });
+      expect(client.stderr.getFullOutput()).toBe('');
+    });
+
+    it('records enum and boolean values but redacts regions in telemetry', async () => {
+      useSettingsProject({});
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--fluid-compute',
+        'on',
+        '--function-cpu',
+        'performance',
+        '--function-region',
+        'iad1',
+        '--node-version',
+        '20.x'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:update', value: 'update' },
+        { key: 'argument:name', value: '[REDACTED]' },
+        { key: 'option:fluid-compute', value: 'on' },
+        { key: 'option:function-region', value: '[REDACTED]' },
+        { key: 'option:function-cpu', value: 'performance' },
+        { key: 'option:node-version', value: '20.x' },
+      ]);
+    });
+
+    it('rejects an invalid node version before resolving a project', async () => {
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--node-version',
+        '19.x'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Node.js version must be one of'
+      );
+      expect(client.stdout.getFullOutput()).toBe('');
+    });
+
+    it('rejects an invalid function CPU tier before resolving a project', async () => {
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--function-cpu',
+        'mega'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Function CPU must be one of'
+      );
+    });
+
+    it('rejects a non on/off boolean value before resolving a project', async () => {
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--fluid-compute',
+        'yes'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '--fluid-compute must be "on" or "off".'
+      );
+    });
+
+    it('rejects a non-integer function timeout before resolving a project', async () => {
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--function-timeout',
+        '30.5'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Function timeout must be an integer between 1 and 900 seconds.'
+      );
+    });
+
+    it('rejects a function timeout outside the allowed range', async () => {
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--function-timeout',
+        '1000'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Function timeout must be between 1 and 900 seconds.'
+      );
     });
   });
 });

--- a/packages/cli/test/unit/commands/project/update.test.ts
+++ b/packages/cli/test/unit/commands/project/update.test.ts
@@ -603,6 +603,25 @@ describe('project update', () => {
       expect(exitCode).toBe(0);
     });
 
+    it('dedupes repeated function regions before the request', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          resourceConfig: { functionDefaultRegions: ['iad1', 'sfo1'] },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--function-region',
+        'iad1,sfo1,iad1'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
     it('sets the function CPU tier', async () => {
       useSettingsProject({}, body => {
         expect(body).toEqual({


### PR DESCRIPTION
## Summary
- Add compute/functions flags to `vercel project update`: `--fluid-compute`, `--function-region`, `--function-cpu`, `--function-timeout`, `--sandbox-region`, `--build-machine`, `--elastic-concurrency`, and `--node-version`.
- Boolean toggles take `on|off`; enums and numbers are validated locally before any request; only changed settings are sent as a sparse PATCH.
- Existing behavior (framework/build/dev/install/output/root-directory, `--auto-detect`, JSON output, telemetry) is unchanged.

## Notes
- **Private-field disclosure (API-owner sign-off requested):** `--sandbox-region` maps to the `sandbox` field, which is marked `private: true` in the public PATCH schema (`update-project.ts`). The validator accepts it at runtime — `private` affects doc visibility only — and no public alternative field exists for the sandbox region. This mirrors the `--require-2fa` situation where we dropped a private field; here we surface the flag instead because the dashboard-parity row explicitly asks for it. The flag can be descoped from this PR if the API owners prefer.
- Flag → public PATCH schema field mapping:
  - `--fluid-compute on|off` → `resourceConfig.fluid` (boolean)
  - `--function-region <region[,region]>` → `resourceConfig.functionDefaultRegions` (string[]; duplicates deduped locally to satisfy the schema's `uniqueItems`)
  - `--function-cpu <tier>` → `resourceConfig.functionDefaultMemoryType` (enum: `standard_legacy`, `standard`, `performance`, `performance_xl`)
  - `--function-timeout <seconds>` → `resourceConfig.functionDefaultTimeout` (integer 1–900)
  - `--sandbox-region <region>` → `sandbox.region` (enum: `iad1`, `sfo1`, `cle1`; merged with existing `failoverRegions`)
  - `--build-machine <type>` → `resourceConfig.buildMachineType` (enum: `basic`, `standard`, `enhanced`, `turbo`, `elastic`)
  - `--elastic-concurrency on|off` → `resourceConfig.elasticConcurrencyEnabled` (boolean)
  - `--node-version <version>` → `nodeVersion` (enum: `24.x`, `22.x`, `20.x`, `18.x`, `16.x`, `14.x`, `12.x`, `10.x`)
- Dropped `--function-memory`: the public PATCH schema exposes no numeric memory field. Function memory is selected through the CPU/memory tier (`resourceConfig.functionDefaultMemoryType`), which is surfaced as `--function-cpu`.
- Telemetry: enum/boolean values are recorded literally; `--function-region` is redacted (free-form region identifiers).
- Stacked PRs (base `main`): PR1 (this) → PR2 build/Git flags (#17468) → PR3 remaining settings flags (#17469).