### PR TITLE
[CLI] Add build and Git flags to project update

### DIFF
--- a/.changeset/project-update-git-flags.md
+++ b/.changeset/project-update-git-flags.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add build and Git flags to `vercel project update`: `--ignore-build-command`, `--include-files-outside-root`, `--affected-projects`, `--git-lfs`, `--git-comment-on-pr`, and `--git-comment-on-commit`.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -369,6 +369,57 @@ export const updateSubcommand = {
         'Set the Node.js version: 24.x, 22.x, 20.x, 18.x, 16.x, 14.x, 12.x, or 10.x',
       deprecated: false,
     },
+    {
+      name: 'ignore-build-command',
+      shorthand: null,
+      type: String,
+      argument: 'COMMAND',
+      description:
+        'Set the command that decides whether to skip a build (Ignored Build Step)',
+      deprecated: false,
+    },
+    {
+      name: 'include-files-outside-root',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description:
+        'Include source files outside of the root directory in the build',
+      deprecated: false,
+    },
+    {
+      name: 'affected-projects',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description:
+        'Skip deployments when the root directory and its dependencies are unchanged',
+      deprecated: false,
+    },
+    {
+      name: 'git-lfs',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description: 'Enable or disable Git LFS for this project',
+      deprecated: false,
+    },
+    {
+      name: 'git-comment-on-pr',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description: 'Enable or disable Vercel comments on pull requests',
+      deprecated: false,
+    },
+    {
+      name: 'git-comment-on-commit',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description: 'Enable or disable Vercel comments on commits',
+      deprecated: false,
+    },
     formatOption,
     jsonOption,
   ],
@@ -396,6 +447,10 @@ export const updateSubcommand = {
     {
       name: 'Pin the Node.js version and default function region',
       value: `${packageName} project update my-project --node-version 20.x --function-region iad1`,
+    },
+    {
+      name: 'Toggle Git behavior: LFS on and PR comments off',
+      value: `${packageName} project update my-project --git-lfs on --git-comment-on-pr off`,
     },
     {
       name: 'Clear the framework preset and return JSON',

--- a/packages/cli/src/commands/project/update.ts
+++ b/packages/cli/src/commands/project/update.ts
@@ -229,6 +229,11 @@ interface AdvancedProjectFields {
     buildMachineType?: string;
   } | null;
   sandbox?: { region?: string; failoverRegions?: string[] } | null;
+  gitComments?: { onPullRequest?: boolean; onCommit?: boolean } | null;
+  sourceFilesOutsideRootDirectory?: boolean;
+  enableAffectedProjectsDeployments?: boolean;
+  gitLFS?: boolean;
+  commandForIgnoringBuildStep?: string | null;
 }
 
 interface AdvancedSettingDefinition {
@@ -262,6 +267,24 @@ function ensureResourceConfig(body: PatchBody): Record<string, unknown> {
     (body.resourceConfig as Record<string, unknown> | undefined) ?? {};
   body.resourceConfig = resourceConfig;
   return resourceConfig;
+}
+
+// The public schema requires both `onPullRequest` and `onCommit` whenever
+// `gitComments` is sent, so seed the object from the current project (both
+// flags share it) and let each flag override only the field it targets.
+function ensureGitComments(
+  body: PatchBody,
+  project: Project
+): { onPullRequest: boolean; onCommit: boolean } {
+  const current = getAdvancedFields(project).gitComments;
+  const gitComments = (body.gitComments as
+    | { onPullRequest: boolean; onCommit: boolean }
+    | undefined) ?? {
+    onPullRequest: current?.onPullRequest ?? false,
+    onCommit: current?.onCommit ?? false,
+  };
+  body.gitComments = gitComments;
+  return gitComments;
 }
 
 function parseOnOff(flag: string, raw: string): AdvancedParseResult {
@@ -441,6 +464,88 @@ const advancedSettingDefinitions: readonly AdvancedSettingDefinition[] = [
     },
     display: displayValue,
   },
+  {
+    key: 'commandForIgnoringBuildStep',
+    flag: '--ignore-build-command',
+    label: 'Ignored Build Step',
+    parse: raw => {
+      if (raw.length > MAX_SETTING_LENGTH) {
+        return {
+          ok: false,
+          message: `Ignored Build Step command must be ${MAX_SETTING_LENGTH} characters or fewer.`,
+        };
+      }
+      if (CONTROL_CHARACTERS.test(raw)) {
+        return {
+          ok: false,
+          message:
+            "Ignored Build Step command can't contain control characters.",
+        };
+      }
+      return { ok: true, value: raw };
+    },
+    read: project => getAdvancedFields(project).commandForIgnoringBuildStep,
+    apply: (body, value) => {
+      body.commandForIgnoringBuildStep = value as string;
+    },
+    display: value => (value === '' ? '""' : displayValue(value)),
+  },
+  {
+    key: 'sourceFilesOutsideRootDirectory',
+    flag: '--include-files-outside-root',
+    label: 'Files Outside Root',
+    parse: raw => parseOnOff('--include-files-outside-root', raw),
+    read: project => getAdvancedFields(project).sourceFilesOutsideRootDirectory,
+    apply: (body, value) => {
+      body.sourceFilesOutsideRootDirectory = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'enableAffectedProjectsDeployments',
+    flag: '--affected-projects',
+    label: 'Affected Projects',
+    parse: raw => parseOnOff('--affected-projects', raw),
+    read: project =>
+      getAdvancedFields(project).enableAffectedProjectsDeployments,
+    apply: (body, value) => {
+      body.enableAffectedProjectsDeployments = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'gitLFS',
+    flag: '--git-lfs',
+    label: 'Git LFS',
+    parse: raw => parseOnOff('--git-lfs', raw),
+    read: project => getAdvancedFields(project).gitLFS,
+    apply: (body, value) => {
+      body.gitLFS = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'gitCommentOnPullRequest',
+    flag: '--git-comment-on-pr',
+    label: 'Git Comments on PR',
+    parse: raw => parseOnOff('--git-comment-on-pr', raw),
+    read: project => getAdvancedFields(project).gitComments?.onPullRequest,
+    apply: (body, value, project) => {
+      ensureGitComments(body, project).onPullRequest = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'gitCommentOnCommit',
+    flag: '--git-comment-on-commit',
+    label: 'Git Comments on Commit',
+    parse: raw => parseOnOff('--git-comment-on-commit', raw),
+    read: project => getAdvancedFields(project).gitComments?.onCommit,
+    apply: (body, value, project) => {
+      ensureGitComments(body, project).onCommit = value as boolean;
+    },
+    display: displayOnOff,
+  },
 ];
 
 function advancedValuesEqual(
@@ -584,6 +689,14 @@ export default async function update(
   telemetry.trackCliOptionBuildMachine(flags['--build-machine']);
   telemetry.trackCliOptionElasticConcurrency(flags['--elastic-concurrency']);
   telemetry.trackCliOptionNodeVersion(flags['--node-version']);
+  telemetry.trackCliOptionIgnoreBuildCommand(flags['--ignore-build-command']);
+  telemetry.trackCliOptionIncludeFilesOutsideRoot(
+    flags['--include-files-outside-root']
+  );
+  telemetry.trackCliOptionAffectedProjects(flags['--affected-projects']);
+  telemetry.trackCliOptionGitLfs(flags['--git-lfs']);
+  telemetry.trackCliOptionGitCommentOnPr(flags['--git-comment-on-pr']);
+  telemetry.trackCliOptionGitCommentOnCommit(flags['--git-comment-on-commit']);
 
   if (args.length > 1) {
     return printUsageError(

--- a/packages/cli/src/util/telemetry/commands/project/update.ts
+++ b/packages/cli/src/util/telemetry/commands/project/update.ts
@@ -126,6 +126,36 @@ export class ProjectUpdateTelemetryClient
     ]);
   }
 
+  trackCliOptionIgnoreBuildCommand(value: string | undefined) {
+    // The ignored-build-step command is free-form input, so redact the value.
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'ignore-build-command',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionIncludeFilesOutsideRoot(value: string | undefined) {
+    this.trackOnOffOption('include-files-outside-root', value);
+  }
+
+  trackCliOptionAffectedProjects(value: string | undefined) {
+    this.trackOnOffOption('affected-projects', value);
+  }
+
+  trackCliOptionGitLfs(value: string | undefined) {
+    this.trackOnOffOption('git-lfs', value);
+  }
+
+  trackCliOptionGitCommentOnPr(value: string | undefined) {
+    this.trackOnOffOption('git-comment-on-pr', value);
+  }
+
+  trackCliOptionGitCommentOnCommit(value: string | undefined) {
+    this.trackOnOffOption('git-comment-on-commit', value);
+  }
+
   private trackOnOffOption(option: string, value: string | undefined) {
     if (value !== undefined) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/project/update.test.ts
+++ b/packages/cli/test/unit/commands/project/update.test.ts
@@ -65,6 +65,12 @@ describe('project update', () => {
       expect(helpOutput).toContain('--build-machine');
       expect(helpOutput).toContain('--elastic-concurrency');
       expect(helpOutput).toContain('--node-version');
+      expect(helpOutput).toContain('--ignore-build-command');
+      expect(helpOutput).toContain('--include-files-outside-root');
+      expect(helpOutput).toContain('--affected-projects');
+      expect(helpOutput).toContain('--git-lfs');
+      expect(helpOutput).toContain('--git-comment-on-pr');
+      expect(helpOutput).toContain('--git-comment-on-commit');
       expect(helpOutput).toContain('--format');
       expect(helpOutput).toContain('omitted settings remain unchanged');
       expect(helpOutput).toContain('Update multiple settings in one command');
@@ -929,6 +935,187 @@ describe('project update', () => {
       expect(exitCode).toBe(1);
       expect(client.stderr.getFullOutput()).toContain(
         'Function timeout must be between 1 and 900 seconds.'
+      );
+    });
+  });
+
+  describe('build and Git flags', () => {
+    it('enables Git LFS at the top level', async () => {
+      const currentProject = useSettingsProject({}, body => {
+        expect(body).toEqual({ gitLFS: true });
+      });
+
+      client.setArgv('project', 'update', 'my-project', '--git-lfs', 'on');
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      // @ts-expect-error gitLFS is not modeled on the CLI Project type
+      expect(currentProject.gitLFS).toBe(true);
+      expect(client.stderr.getFullOutput()).toContain('Git LFS');
+    });
+
+    it('disables affected-projects deployments', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({ enableAffectedProjectsDeployments: false });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--affected-projects',
+        'off'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('includes source files outside the root directory', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({ sourceFilesOutsideRootDirectory: true });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--include-files-outside-root',
+        'on'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('sets the ignored build step command', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({ commandForIgnoringBuildStep: 'exit 0' });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--ignore-build-command',
+        'exit 0'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('merges git-comment-on-pr with the existing commit setting', async () => {
+      useSettingsProject(
+        {
+          // @ts-expect-error gitComments is not modeled on the CLI Project type
+          gitComments: { onPullRequest: false, onCommit: true },
+        },
+        body => {
+          expect(body).toEqual({
+            gitComments: { onPullRequest: true, onCommit: true },
+          });
+        }
+      );
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--git-comment-on-pr',
+        'on'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('sends both git comment fields when only one is provided and none exist', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          gitComments: { onPullRequest: false, onCommit: false },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--git-comment-on-commit',
+        'off'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('combines both git comment flags into one gitComments object', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          gitComments: { onPullRequest: true, onCommit: false },
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--git-comment-on-pr',
+        'on',
+        '--git-comment-on-commit',
+        'off'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('records boolean values but redacts the ignored build command', async () => {
+      useSettingsProject({});
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--git-lfs',
+        'on',
+        '--ignore-build-command',
+        'exit 0'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:update', value: 'update' },
+        { key: 'argument:name', value: '[REDACTED]' },
+        { key: 'option:ignore-build-command', value: '[REDACTED]' },
+        { key: 'option:git-lfs', value: 'on' },
+      ]);
+    });
+
+    it('rejects an ignored build command that is too long', async () => {
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--ignore-build-command',
+        'x'.repeat(257)
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Ignored Build Step command must be 256 characters or fewer.'
+      );
+    });
+
+    it('rejects a non on/off value for a Git toggle before resolving a project', async () => {
+      client.setArgv('project', 'update', 'my-project', '--git-lfs', 'true');
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '--git-lfs must be "on" or "off".'
       );
     });
   });


### PR DESCRIPTION
## Summary
- Add build/Git/monorepo flags to `vercel project update`: `--ignore-build-command`, `--include-files-outside-root`, `--affected-projects`, `--git-lfs`, `--git-comment-on-pr`, and `--git-comment-on-commit`.
- Boolean toggles take `on|off`; values are validated locally before any request; only changed settings are sent as a sparse PATCH. Existing behavior is unchanged.

## Notes
- **Private-field disclosure (API-owner sign-off requested):** `--git-comment-on-pr` and `--git-comment-on-commit` map to the `gitComments` field, which is marked `private: true` in the public PATCH schema (`update-project.ts`). The validator accepts it at runtime — `private` affects doc visibility only — and no public alternative field exists for Git comment toggles. This mirrors the `--require-2fa` situation where we dropped a private field; here we surface the flags instead because the dashboard-parity row explicitly asks for them. Both flags can be descoped from this PR if the API owners prefer.
- Flag → public PATCH schema field mapping:
  - `--ignore-build-command <command>` → `commandForIgnoringBuildStep` (string, ≤256 chars)
  - `--include-files-outside-root on|off` → `sourceFilesOutsideRootDirectory` (boolean)
  - `--affected-projects on|off` → `enableAffectedProjectsDeployments` (boolean)
  - `--git-lfs on|off` → `gitLFS` (boolean)
  - `--git-comment-on-pr on|off` → `gitComments.onPullRequest` (boolean)
  - `--git-comment-on-commit on|off` → `gitComments.onCommit` (boolean)
- The schema requires both `onPullRequest` and `onCommit` whenever `gitComments` is sent, so either flag sends the full object, seeding the untouched field from the project's current value.
- No flags dropped in this batch.
- Telemetry: boolean values recorded literally; `--ignore-build-command` redacted (free-form script).
- Stacked on #17467. Base: `add-project-update-compute-flags`. Follow-up: #17469.