### PR TITLE
[CLI] Add remaining settings flags to project update

### DIFF
--- a/.changeset/project-update-misc-flags.md
+++ b/.changeset/project-update-misc-flags.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add remaining settings flags to `vercel project update`: `--oidc-issuer-mode`, `--directory-listing`, `--source-protection`, `--preview-suffix`, `--toolbar`, `--expose-system-envs`, and `--auto-assign-custom-domains`.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -420,6 +420,65 @@ export const updateSubcommand = {
       description: 'Enable or disable Vercel comments on commits',
       deprecated: false,
     },
+    {
+      name: 'oidc-issuer-mode',
+      shorthand: null,
+      type: String,
+      argument: 'MODE',
+      description: 'Set the OIDC token issuer mode: team or global',
+      deprecated: false,
+    },
+    {
+      name: 'directory-listing',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description: 'Enable or disable directory listing for this project',
+      deprecated: false,
+    },
+    {
+      name: 'source-protection',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description:
+        'Enable or disable protected source maps (authentication required to access)',
+      deprecated: false,
+    },
+    {
+      name: 'preview-suffix',
+      shorthand: null,
+      type: String,
+      argument: 'DOMAIN',
+      description: 'Set the custom domain suffix for preview deployments',
+      deprecated: false,
+    },
+    {
+      name: 'toolbar',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description:
+        'Enable or disable the Vercel Toolbar for preview and production',
+      deprecated: false,
+    },
+    {
+      name: 'expose-system-envs',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description: 'Automatically expose System Environment Variables',
+      deprecated: false,
+    },
+    {
+      name: 'auto-assign-custom-domains',
+      shorthand: null,
+      type: String,
+      argument: 'on|off',
+      description:
+        'Automatically assign custom production domains to new production deployments',
+      deprecated: false,
+    },
     formatOption,
     jsonOption,
   ],
@@ -451,6 +510,10 @@ export const updateSubcommand = {
     {
       name: 'Toggle Git behavior: LFS on and PR comments off',
       value: `${packageName} project update my-project --git-lfs on --git-comment-on-pr off`,
+    },
+    {
+      name: 'Set the OIDC issuer mode and enable the Vercel Toolbar',
+      value: `${packageName} project update my-project --oidc-issuer-mode global --toolbar on`,
     },
     {
       name: 'Clear the framework preset and return JSON',

--- a/packages/cli/src/commands/project/update.ts
+++ b/packages/cli/src/commands/project/update.ts
@@ -234,6 +234,13 @@ interface AdvancedProjectFields {
   enableAffectedProjectsDeployments?: boolean;
   gitLFS?: boolean;
   commandForIgnoringBuildStep?: string | null;
+  oidcTokenConfig?: { enabled?: boolean; issuerMode?: string } | null;
+  directoryListing?: boolean;
+  protectedSourcemaps?: boolean;
+  previewDeploymentSuffix?: string | null;
+  enablePreviewFeedback?: boolean | null;
+  enableProductionFeedback?: boolean | null;
+  autoAssignCustomDomains?: boolean;
 }
 
 interface AdvancedSettingDefinition {
@@ -244,6 +251,9 @@ interface AdvancedSettingDefinition {
   read: (project: Project) => AdvancedValue | null | undefined;
   apply: (body: PatchBody, value: AdvancedValue, project: Project) => void;
   display: (value: AdvancedValue | null | undefined) => string;
+  // Optional override when a single flag maps to more than one project field
+  // (for example `--toolbar` toggling both preview and production feedback).
+  changed?: (project: Project, value: AdvancedValue) => boolean;
 }
 
 interface AdvancedPreviewRow {
@@ -546,6 +556,108 @@ const advancedSettingDefinitions: readonly AdvancedSettingDefinition[] = [
     },
     display: displayOnOff,
   },
+  {
+    key: 'oidcIssuerMode',
+    flag: '--oidc-issuer-mode',
+    label: 'OIDC Issuer Mode',
+    parse: raw => parseEnumValue('OIDC issuer mode', raw, ['team', 'global']),
+    read: project => getAdvancedFields(project).oidcTokenConfig?.issuerMode,
+    apply: (body, value) => {
+      body.oidcTokenConfig = { issuerMode: value as string };
+    },
+    display: displayValue,
+  },
+  {
+    key: 'directoryListing',
+    flag: '--directory-listing',
+    label: 'Directory Listing',
+    parse: raw => parseOnOff('--directory-listing', raw),
+    read: project => getAdvancedFields(project).directoryListing,
+    apply: (body, value) => {
+      body.directoryListing = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'protectedSourcemaps',
+    flag: '--source-protection',
+    label: 'Source Protection',
+    parse: raw => parseOnOff('--source-protection', raw),
+    read: project => getAdvancedFields(project).protectedSourcemaps,
+    apply: (body, value) => {
+      body.protectedSourcemaps = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'previewDeploymentSuffix',
+    flag: '--preview-suffix',
+    label: 'Preview Suffix',
+    parse: raw => {
+      if (raw.length > 253) {
+        return {
+          ok: false,
+          message: 'Preview suffix must be 253 characters or fewer.',
+        };
+      }
+      if (CONTROL_CHARACTERS.test(raw)) {
+        return {
+          ok: false,
+          message: "Preview suffix can't contain control characters.",
+        };
+      }
+      return { ok: true, value: raw };
+    },
+    read: project => getAdvancedFields(project).previewDeploymentSuffix,
+    apply: (body, value) => {
+      body.previewDeploymentSuffix = value as string;
+    },
+    display: value => (value === '' ? '""' : displayValue(value)),
+  },
+  {
+    key: 'toolbar',
+    flag: '--toolbar',
+    label: 'Vercel Toolbar',
+    parse: raw => parseOnOff('--toolbar', raw),
+    read: project =>
+      getAdvancedFields(project).enablePreviewFeedback ??
+      getAdvancedFields(project).enableProductionFeedback ??
+      undefined,
+    apply: (body, value) => {
+      body.enablePreviewFeedback = value as boolean;
+      body.enableProductionFeedback = value as boolean;
+    },
+    display: displayOnOff,
+    changed: (project, value) => {
+      const fields = getAdvancedFields(project);
+      return (
+        (fields.enablePreviewFeedback ?? undefined) !== value ||
+        (fields.enableProductionFeedback ?? undefined) !== value
+      );
+    },
+  },
+  {
+    key: 'autoExposeSystemEnvs',
+    flag: '--expose-system-envs',
+    label: 'Expose System Envs',
+    parse: raw => parseOnOff('--expose-system-envs', raw),
+    read: project => project.autoExposeSystemEnvs,
+    apply: (body, value) => {
+      body.autoExposeSystemEnvs = value as boolean;
+    },
+    display: displayOnOff,
+  },
+  {
+    key: 'autoAssignCustomDomains',
+    flag: '--auto-assign-custom-domains',
+    label: 'Auto-assign Domains',
+    parse: raw => parseOnOff('--auto-assign-custom-domains', raw),
+    read: project => getAdvancedFields(project).autoAssignCustomDomains,
+    apply: (body, value) => {
+      body.autoAssignCustomDomains = value as boolean;
+    },
+    display: displayOnOff,
+  },
 ];
 
 function advancedValuesEqual(
@@ -697,6 +809,15 @@ export default async function update(
   telemetry.trackCliOptionGitLfs(flags['--git-lfs']);
   telemetry.trackCliOptionGitCommentOnPr(flags['--git-comment-on-pr']);
   telemetry.trackCliOptionGitCommentOnCommit(flags['--git-comment-on-commit']);
+  telemetry.trackCliOptionOidcIssuerMode(flags['--oidc-issuer-mode']);
+  telemetry.trackCliOptionDirectoryListing(flags['--directory-listing']);
+  telemetry.trackCliOptionSourceProtection(flags['--source-protection']);
+  telemetry.trackCliOptionPreviewSuffix(flags['--preview-suffix']);
+  telemetry.trackCliOptionToolbar(flags['--toolbar']);
+  telemetry.trackCliOptionExposeSystemEnvs(flags['--expose-system-envs']);
+  telemetry.trackCliOptionAutoAssignCustomDomains(
+    flags['--auto-assign-custom-domains']
+  );
 
   if (args.length > 1) {
     return printUsageError(
@@ -846,7 +967,9 @@ export default async function update(
   const advancedSettings: Record<string, AdvancedValue> = {};
   for (const { definition, value } of providedAdvanced) {
     const previous = definition.read(project);
-    const changed = !advancedValuesEqual(previous, value);
+    const changed = definition.changed
+      ? definition.changed(project, value)
+      : !advancedValuesEqual(previous, value);
     advancedSettings[definition.key] = value;
     advancedRows.push({
       label: definition.label,

--- a/packages/cli/src/util/telemetry/commands/project/update.ts
+++ b/packages/cli/src/util/telemetry/commands/project/update.ts
@@ -156,6 +156,40 @@ export class ProjectUpdateTelemetryClient
     this.trackOnOffOption('git-comment-on-commit', value);
   }
 
+  trackCliOptionOidcIssuerMode(value: string | undefined) {
+    this.trackEnumOption('oidc-issuer-mode', value, ['team', 'global']);
+  }
+
+  trackCliOptionDirectoryListing(value: string | undefined) {
+    this.trackOnOffOption('directory-listing', value);
+  }
+
+  trackCliOptionSourceProtection(value: string | undefined) {
+    this.trackOnOffOption('source-protection', value);
+  }
+
+  trackCliOptionPreviewSuffix(value: string | undefined) {
+    // Preview suffixes are free-form domains, so redact the value.
+    if (value !== undefined) {
+      this.trackCliOption({
+        option: 'preview-suffix',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionToolbar(value: string | undefined) {
+    this.trackOnOffOption('toolbar', value);
+  }
+
+  trackCliOptionExposeSystemEnvs(value: string | undefined) {
+    this.trackOnOffOption('expose-system-envs', value);
+  }
+
+  trackCliOptionAutoAssignCustomDomains(value: string | undefined) {
+    this.trackOnOffOption('auto-assign-custom-domains', value);
+  }
+
   private trackOnOffOption(option: string, value: string | undefined) {
     if (value !== undefined) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/project/update.test.ts
+++ b/packages/cli/test/unit/commands/project/update.test.ts
@@ -1218,7 +1218,6 @@ describe('project update', () => {
         {
           // @ts-expect-error feedback flags are not modeled on the CLI Project type
           enablePreviewFeedback: true,
-          // @ts-expect-error feedback flags are not modeled on the CLI Project type
           enableProductionFeedback: false,
         },
         body => {

--- a/packages/cli/test/unit/commands/project/update.test.ts
+++ b/packages/cli/test/unit/commands/project/update.test.ts
@@ -71,6 +71,13 @@ describe('project update', () => {
       expect(helpOutput).toContain('--git-lfs');
       expect(helpOutput).toContain('--git-comment-on-pr');
       expect(helpOutput).toContain('--git-comment-on-commit');
+      expect(helpOutput).toContain('--oidc-issuer-mode');
+      expect(helpOutput).toContain('--directory-listing');
+      expect(helpOutput).toContain('--source-protection');
+      expect(helpOutput).toContain('--preview-suffix');
+      expect(helpOutput).toContain('--toolbar');
+      expect(helpOutput).toContain('--expose-system-envs');
+      expect(helpOutput).toContain('--auto-assign-custom-domains');
       expect(helpOutput).toContain('--format');
       expect(helpOutput).toContain('omitted settings remain unchanged');
       expect(helpOutput).toContain('Update multiple settings in one command');
@@ -1116,6 +1123,231 @@ describe('project update', () => {
       expect(exitCode).toBe(1);
       expect(client.stderr.getFullOutput()).toContain(
         '--git-lfs must be "on" or "off".'
+      );
+    });
+  });
+
+  describe('remaining settings flags', () => {
+    it('sets the OIDC issuer mode via oidcTokenConfig', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({ oidcTokenConfig: { issuerMode: 'global' } });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--oidc-issuer-mode',
+        'global'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.stderr.getFullOutput()).toContain('OIDC Issuer Mode');
+    });
+
+    it('toggles directory listing', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({ directoryListing: true });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--directory-listing',
+        'on'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('maps source protection to protectedSourcemaps', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({ protectedSourcemaps: true });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--source-protection',
+        'on'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('sets the preview deployment suffix', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          previewDeploymentSuffix: 'preview.example.com',
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--preview-suffix',
+        'preview.example.com'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('enables the Vercel Toolbar for preview and production together', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          enablePreviewFeedback: true,
+          enableProductionFeedback: true,
+        });
+      });
+
+      client.setArgv('project', 'update', 'my-project', '--toolbar', 'on');
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('detects a toolbar change when only one feedback field differs', async () => {
+      useSettingsProject(
+        {
+          // @ts-expect-error feedback flags are not modeled on the CLI Project type
+          enablePreviewFeedback: true,
+          // @ts-expect-error feedback flags are not modeled on the CLI Project type
+          enableProductionFeedback: false,
+        },
+        body => {
+          expect(body).toEqual({
+            enablePreviewFeedback: true,
+            enableProductionFeedback: true,
+          });
+        }
+      );
+
+      client.setArgv('project', 'update', 'my-project', '--toolbar', 'on');
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('exposes system environment variables', async () => {
+      const currentProject = useSettingsProject({}, body => {
+        expect(body).toEqual({ autoExposeSystemEnvs: true });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--expose-system-envs',
+        'on'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      expect(currentProject.autoExposeSystemEnvs).toBe(true);
+    });
+
+    it('toggles auto-assign custom domains', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({ autoAssignCustomDomains: false });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--auto-assign-custom-domains',
+        'off'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('combines misc flags into one sparse PATCH', async () => {
+      useSettingsProject({}, body => {
+        expect(body).toEqual({
+          oidcTokenConfig: { issuerMode: 'team' },
+          directoryListing: true,
+          autoExposeSystemEnvs: true,
+        });
+      });
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--oidc-issuer-mode',
+        'team',
+        '--directory-listing',
+        'on',
+        '--expose-system-envs',
+        'on'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('records enum and boolean values but redacts the preview suffix', async () => {
+      useSettingsProject({});
+
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--oidc-issuer-mode',
+        'global',
+        '--toolbar',
+        'on',
+        '--preview-suffix',
+        'preview.example.com',
+        '--expose-system-envs',
+        'off'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:update', value: 'update' },
+        { key: 'argument:name', value: '[REDACTED]' },
+        { key: 'option:oidc-issuer-mode', value: 'global' },
+        { key: 'option:preview-suffix', value: '[REDACTED]' },
+        { key: 'option:toolbar', value: 'on' },
+        { key: 'option:expose-system-envs', value: 'off' },
+      ]);
+    });
+
+    it('rejects an invalid OIDC issuer mode before resolving a project', async () => {
+      client.setArgv(
+        'project',
+        'update',
+        'my-project',
+        '--oidc-issuer-mode',
+        'personal'
+      );
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'OIDC issuer mode must be one of: team, global.'
+      );
+      expect(client.stdout.getFullOutput()).toBe('');
+    });
+
+    it('rejects a non on/off value for a misc toggle before resolving a project', async () => {
+      client.setArgv('project', 'update', 'my-project', '--toolbar', 'enabled');
+      const exitCode = await project(client);
+
+      expect(exitCode).toBe(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        '--toolbar must be "on" or "off".'
       );
     });
   });


### PR DESCRIPTION
## Summary
- Add remaining project settings flags to `vercel project update`: `--oidc-issuer-mode`, `--directory-listing`, `--source-protection`, `--preview-suffix`, `--toolbar`, and `--auto-assign-custom-domains`.
- Add `--expose-system-envs on|off` → `autoExposeSystemEnvs` (its own parity row).
- Boolean toggles take `on|off`; values are validated locally before any request; only changed settings are sent as a sparse PATCH. Existing behavior is unchanged.

## Notes
- Flag → public PATCH schema field mapping:
  - `--oidc-issuer-mode <mode>` → `oidcTokenConfig.issuerMode` (enum: `team`, `global`)
  - `--directory-listing on|off` → `directoryListing` (boolean)
  - `--source-protection on|off` → `protectedSourcemaps` (boolean)
  - `--preview-suffix <domain>` → `previewDeploymentSuffix` (string, ≤253 chars)
  - `--toolbar on|off` → `enablePreviewFeedback` + `enableProductionFeedback` (both booleans; a single flag toggles both, and a change is detected when either field differs)
  - `--expose-system-envs on|off` → `autoExposeSystemEnvs` (boolean) — separate parity row
  - `--auto-assign-custom-domains on|off` → `autoAssignCustomDomains` (boolean; accepted by the schema)
- No flags dropped in this batch.
- Telemetry: enum/boolean values recorded literally; `--preview-suffix` redacted (free-form domain).
- Stacked on #17468. Base: `add-project-update-git-flags`.