### PR TITLE
[CLI] Add connect networks read commands: list and inspect

### DIFF
--- a/.changeset/connect-networks-read.md
+++ b/.changeset/connect-networks-read.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel connect networks list` and `vercel connect networks inspect <id>` to view Secure Compute networks (read-only).

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -640,6 +640,81 @@ export const detachSubcommand = {
   ],
 } as const;
 
+export const networksListSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List Secure Compute networks on the current team',
+  arguments: [],
+  options: [
+    {
+      name: 'search',
+      shorthand: null,
+      type: String,
+      argument: 'TEXT',
+      deprecated: false,
+      description: 'Filter networks by name',
+    },
+    formatOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'List networks on the current team',
+      value: `${packageName} connect networks list`,
+    },
+    {
+      name: 'Filter networks by name',
+      value: `${packageName} connect networks list --search prod`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connect networks list --json`,
+    },
+  ],
+} as const;
+
+export const networksInspectSubcommand = {
+  name: 'inspect',
+  aliases: [],
+  description: 'Show details for a single Secure Compute network',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Inspect a network by ID',
+      value: `${packageName} connect networks inspect ntw_abc123`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connect networks inspect ntw_abc123 --json`,
+    },
+  ],
+} as const;
+
+export const networksSubcommand = {
+  name: 'networks',
+  aliases: [],
+  description: 'Manage Secure Compute networks',
+  arguments: [],
+  subcommands: [networksListSubcommand, networksInspectSubcommand],
+  options: [],
+  examples: [
+    {
+      name: 'List networks on the current team',
+      value: `${packageName} connect networks list`,
+    },
+    {
+      name: 'Inspect a network by ID',
+      value: `${packageName} connect networks inspect ntw_abc123`,
+    },
+  ],
+} as const;
+
 export const connexCommand = {
   name: 'connect',
   aliases: [],
@@ -657,6 +732,7 @@ export const connexCommand = {
     removeSubcommand,
     revokeTokensSubcommand,
     openSubcommand,
+    networksSubcommand,
   ],
   examples: [
     {

--- a/packages/cli/src/commands/connex/index.ts
+++ b/packages/cli/src/commands/connex/index.ts
@@ -17,6 +17,7 @@ import {
   removeSubcommand,
   revokeTokensSubcommand,
   openSubcommand,
+  networksSubcommand,
   connexCommand,
 } from './command';
 import { create } from './create';
@@ -28,6 +29,7 @@ import { detach } from './detach';
 import { remove } from './remove';
 import { revokeTokens } from './revoke-tokens';
 import { openClient } from './open';
+import { networks } from './networks';
 import {
   buildCommandWithGlobalFlags,
   outputAgentError,
@@ -45,6 +47,7 @@ const COMMAND_CONFIG = {
   remove: getCommandAliases(removeSubcommand),
   'revoke-tokens': getCommandAliases(revokeTokensSubcommand),
   open: getCommandAliases(openSubcommand),
+  networks: getCommandAliases(networksSubcommand),
 };
 
 export default async function connex(client: Client): Promise<number> {
@@ -303,6 +306,10 @@ export default async function connex(client: Client): Promise<number> {
           openParsedArgs.args,
           openParsedArgs.flags
         );
+      }
+      case 'networks': {
+        telemetry.trackCliSubcommandNetworks(subcommandOriginal);
+        return await networks(client);
       }
       default: {
         const validSubcommands = Object.keys(COMMAND_CONFIG).join(' | ');

--- a/packages/cli/src/commands/connex/networks-inspect.ts
+++ b/packages/cli/src/commands/connex/networks-inspect.ts
@@ -1,0 +1,63 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { validateJsonOutput } from '../../util/output-format';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import type { ConnexNetwork } from './types';
+import { printNetworkDetails, serializeNetwork } from './networks-shared';
+
+export async function networksInspect(
+  client: Client,
+  args: string[],
+  flags: {
+    '--format'?: string;
+    '--json'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const networkId = args[0];
+  if (!networkId) {
+    output.error(
+      'Missing network ID. Usage: vercel connect networks inspect <id>'
+    );
+    return 1;
+  }
+
+  await selectConnexTeam(client, 'Select the team for this network');
+
+  output.spinner('Fetching network…');
+  let network: ConnexNetwork;
+  try {
+    network = await client.fetch<ConnexNetwork>(
+      `/v1/connect/networks/${encodeURIComponent(networkId)}`
+    );
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      output.error(`No network found for ${chalk.bold(networkId)}.`);
+      return 1;
+    }
+    output.error(
+      `Failed to look up ${chalk.bold(networkId)}: ${(err as Error).message}`
+    );
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(serializeNetwork(network), null, 2)}\n`
+    );
+    return 0;
+  }
+
+  printNetworkDetails(network);
+  return 0;
+}

--- a/packages/cli/src/commands/connex/networks-list.ts
+++ b/packages/cli/src/commands/connex/networks-list.ts
@@ -1,0 +1,91 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { validateJsonOutput } from '../../util/output-format';
+import { printError } from '../../util/error';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import table from '../../util/output/table';
+import { packageName } from '../../util/pkg-name';
+import type { ConnexNetwork } from './types';
+import { serializeNetwork } from './networks-shared';
+
+export async function networksList(
+  client: Client,
+  flags: {
+    '--search'?: string;
+    '--format'?: string;
+    '--json'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+  const searchQuery = flags['--search'];
+
+  await selectConnexTeam(
+    client,
+    'Select the team whose networks you want to list'
+  );
+
+  const params = new URLSearchParams();
+  if (searchQuery) {
+    params.set('search', searchQuery);
+  }
+  const query = params.toString();
+  const url = `/v1/connect/networks${query ? `?${query}` : ''}`;
+
+  output.spinner('Fetching networks…');
+  let networks: ConnexNetwork[];
+  try {
+    networks = await client.fetch<ConnexNetwork[]>(url);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      output.error(
+        'Connect is not enabled for this team. Contact support to enable it.'
+      );
+      return 1;
+    }
+    printError(err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  networks = networks ?? [];
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify({ networks: networks.map(serializeNetwork) }, null, 2)}\n`
+    );
+    return 0;
+  }
+
+  if (networks.length === 0) {
+    output.log(
+      `No networks found. Create one with \`${packageName} connect networks create\`.`
+    );
+    return 0;
+  }
+
+  const headers = ['ID', 'Name', 'Region', 'CIDR', 'Status'];
+  const rows = networks.map(n => [
+    n.id,
+    sanitizeForTerminal(n.name || '') || chalk.gray('–'),
+    n.region ?? chalk.gray('–'),
+    n.cidr,
+    n.status,
+  ]);
+
+  output.print(
+    `${table([headers.map(h => chalk.bold(chalk.cyan(h))), ...rows], {
+      hsep: 4,
+    })}\n`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/connex/networks-shared.ts
+++ b/packages/cli/src/commands/connex/networks-shared.ts
@@ -1,0 +1,85 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
+import type { ConnexNetwork } from './types';
+
+/**
+ * Build the public JSON representation of a network. Fields are copied
+ * explicitly (rather than passing the raw API object through) so private
+ * response fields such as `teamPrincipalRoleArn` are never surfaced.
+ */
+export function serializeNetwork(
+  network: ConnexNetwork
+): Record<string, unknown> {
+  return {
+    id: network.id,
+    name: network.name,
+    status: network.status,
+    region: network.region ?? null,
+    awsRegion: network.awsRegion,
+    cidr: network.cidr,
+    awsAccountId: network.awsAccountId,
+    awsAvailabilityZoneIds: network.awsAvailabilityZoneIds ?? [],
+    vpcId: network.vpcId ?? null,
+    egressCidrBlock: network.egressCidrBlock ?? null,
+    egressIpAddresses: network.egressIpAddresses ?? [],
+    hostedZones: network.hostedZones ?? null,
+    peeringConnections: network.peeringConnections ?? null,
+    projects: network.projects ?? null,
+    createdAt: network.createdAt,
+    teamId: network.teamId,
+  };
+}
+
+/**
+ * Print a network's full details as an aligned key/value block for `inspect`.
+ * Rendered to stderr (via the output manager); team-controlled values (name)
+ * are sanitized for terminal safety.
+ */
+export function printNetworkDetails(network: ConnexNetwork): void {
+  const rows: [string, string][] = [
+    ['ID', network.id],
+    ['Name', sanitizeForTerminal(network.name || '') || '–'],
+    ['Status', network.status],
+    ['Region', network.region ?? '–'],
+    ['AWS Region', network.awsRegion],
+    ['CIDR', network.cidr],
+    ['AWS Account', network.awsAccountId],
+  ];
+
+  if (network.awsAvailabilityZoneIds?.length) {
+    rows.push([
+      'Availability Zones',
+      network.awsAvailabilityZoneIds.join(', '),
+    ]);
+  }
+  if (network.vpcId) {
+    rows.push(['VPC ID', network.vpcId]);
+  }
+  if (network.egressCidrBlock) {
+    rows.push(['Egress CIDR', network.egressCidrBlock]);
+  }
+  if (network.egressIpAddresses?.length) {
+    rows.push(['Egress IPs', network.egressIpAddresses.join(', ')]);
+  }
+  if (network.peeringConnections) {
+    rows.push([
+      'Peering Connections',
+      String(network.peeringConnections.count),
+    ]);
+  }
+  if (network.hostedZones) {
+    rows.push(['Hosted Zones', String(network.hostedZones.count)]);
+  }
+  if (network.projects) {
+    rows.push(['Projects', String(network.projects.count)]);
+  }
+  rows.push(['Created', new Date(network.createdAt).toISOString()]);
+
+  const labelWidth = Math.max(...rows.map(([label]) => label.length));
+  for (const [label, value] of rows) {
+    output.print(
+      `${chalk.bold(chalk.cyan(label.padEnd(labelWidth)))}  ${value}\n`
+    );
+  }
+}

--- a/packages/cli/src/commands/connex/networks.ts
+++ b/packages/cli/src/commands/connex/networks.ts
@@ -1,0 +1,123 @@
+import { getCommandAliases } from '..';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import getSubcommand from '../../util/get-subcommand';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import { ConnexNetworksTelemetryClient } from '../../util/telemetry/commands/connex/networks';
+import { type Command, help } from '../help';
+import {
+  connexCommand,
+  networksSubcommand,
+  networksListSubcommand,
+  networksInspectSubcommand,
+} from './command';
+import { networksList } from './networks-list';
+import { networksInspect } from './networks-inspect';
+
+const COMMAND_CONFIG = {
+  list: getCommandAliases(networksListSubcommand),
+  inspect: getCommandAliases(networksInspectSubcommand),
+};
+
+export async function networks(client: Client): Promise<number> {
+  const telemetry = new ConnexNetworksTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  const flagsSpecification = getFlagsSpecification(networksSubcommand.options);
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(client.argv.slice(4), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { subcommand, subcommandOriginal, args } = getSubcommand(
+    parsedArgs.args,
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('connex networks', subcommand);
+    output.print(
+      help(networksSubcommand, {
+        parent: connexCommand,
+        columns: client.stderr.columns,
+      })
+    );
+    return 0;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        parent: networksSubcommand,
+        columns: client.stderr.columns,
+      })
+    );
+  }
+
+  try {
+    switch (subcommand) {
+      case 'list': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex networks', subcommandOriginal);
+          printHelp(networksListSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandList(subcommandOriginal);
+
+        const listFlagsSpec = getFlagsSpecification(
+          networksListSubcommand.options
+        );
+        const listParsedArgs = parseArguments(args, listFlagsSpec);
+        telemetry.trackCliOptionSearch(listParsedArgs.flags['--search']);
+        telemetry.trackCliOptionFormat(listParsedArgs.flags['--format']);
+        return await networksList(client, listParsedArgs.flags);
+      }
+      case 'inspect': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex networks', subcommandOriginal);
+          printHelp(networksInspectSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandInspect(subcommandOriginal);
+
+        const inspectFlagsSpec = getFlagsSpecification(
+          networksInspectSubcommand.options
+        );
+        const inspectParsedArgs = parseArguments(args, inspectFlagsSpec);
+        telemetry.trackCliArgumentId(inspectParsedArgs.args[0]);
+        telemetry.trackCliOptionFormat(inspectParsedArgs.flags['--format']);
+        return await networksInspect(
+          client,
+          inspectParsedArgs.args,
+          inspectParsedArgs.flags
+        );
+      }
+      default: {
+        output.error(getInvalidSubcommand(COMMAND_CONFIG));
+        output.print(
+          help(networksSubcommand, {
+            parent: connexCommand,
+            columns: client.stderr.columns,
+          })
+        );
+        return 2;
+      }
+    }
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/connex/types.ts
+++ b/packages/cli/src/commands/connex/types.ts
@@ -48,3 +48,29 @@ export interface ConnexClientProjectListResponse {
   projects: ConnexClientProject[];
   cursor?: string;
 }
+
+/**
+ * A Secure Compute network (referred to as a "configuration" internally).
+ * Mirrors the public `GET /v1/connect/networks[/:id]` response shape. The
+ * private `teamPrincipalRoleArn` field is intentionally omitted here so it is
+ * never surfaced through the CLI.
+ */
+export interface ConnexNetwork {
+  id: string;
+  name: string;
+  cidr: string;
+  status: 'create_in_progress' | 'ready' | 'delete_in_progress';
+  /** Vercel region (data center) identifier, e.g. `iad1`. */
+  region?: string;
+  awsRegion: string;
+  awsAccountId: string;
+  awsAvailabilityZoneIds?: string[];
+  vpcId?: string;
+  egressIpAddresses?: string[];
+  egressCidrBlock?: string;
+  createdAt: number;
+  teamId: string;
+  hostedZones?: { count: number };
+  peeringConnections?: { count: number };
+  projects?: { count: number; ids: string[] };
+}

--- a/packages/cli/src/util/telemetry/commands/connex/index.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/index.ts
@@ -70,6 +70,13 @@ export class ConnexTelemetryClient
     });
   }
 
+  trackCliSubcommandNetworks(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'networks',
+      value: actual,
+    });
+  }
+
   trackCliArgumentClient(v: string | undefined) {
     if (v) {
       this.trackCliArgument({

--- a/packages/cli/src/util/telemetry/commands/connex/networks.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/networks.ts
@@ -1,0 +1,44 @@
+import { TelemetryClient } from '../..';
+
+export class ConnexNetworksTelemetryClient extends TelemetryClient {
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: actual,
+    });
+  }
+
+  trackCliArgumentId(v: string | undefined) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'id',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSearch(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'search',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFormat(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'format',
+        value: v,
+      });
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -978,6 +978,7 @@ exports[`help command > connex help output snapshots > connex help column width 
   remove         connector  Delete a connector                          
   revoke-tokens  connector  Revoke tokens issued from a connector       
   open           id         Open a connector in the Vercel dashboard    
+  networks                  Manage Secure Compute networks              
 
 
   Global Options:
@@ -1095,6 +1096,128 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
   - Output as JSON
 
     $ vercel connect list --json
+
+"
+`;
+
+exports[`help command > connex help output snapshots > connex networks inspect subcommand > connex networks inspect subcommand help column width 120 1`] = `
+"
+  ▲ vercel networks inspect id [options]
+
+  Show details for a single Secure Compute network                                                                      
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Inspect a network by ID
+
+    $ vercel connect networks inspect ntw_abc123
+
+  - Output as JSON
+
+    $ vercel connect networks inspect ntw_abc123 --json
+
+"
+`;
+
+exports[`help command > connex help output snapshots > connex networks list subcommand > connex networks list subcommand help column width 120 1`] = `
+"
+  ▲ vercel networks list [options]
+
+  List Secure Compute networks on the current team                                                                      
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+       --search <TEXT>    Filter networks by name                                                                       
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - List networks on the current team
+
+    $ vercel connect networks list
+
+  - Filter networks by name
+
+    $ vercel connect networks list --search prod
+
+  - Output as JSON
+
+    $ vercel connect networks list --json
+
+"
+`;
+
+exports[`help command > connex help output snapshots > connex networks subcommand > connex networks subcommand help column width 120 1`] = `
+"
+  ▲ vercel connect networks command
+
+  Manage Secure Compute networks                                                                                        
+
+  Commands:
+
+  list         List Secure Compute networks on the current team                                                 
+  inspect  id  Show details for a single Secure Compute network                                                 
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - List networks on the current team
+
+    $ vercel connect networks list
+
+  - Inspect a network by ID
+
+    $ vercel connect networks inspect ntw_abc123
 
 "
 `;

--- a/packages/cli/test/unit/commands/connex/networks-inspect.test.ts
+++ b/packages/cli/test/unit/commands/connex/networks-inspect.test.ts
@@ -1,0 +1,96 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connect from '../../../../src/commands/connex';
+
+function readyNetwork(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ntw_abc123',
+    name: 'prod-network',
+    cidr: '10.0.0.0/16',
+    status: 'ready',
+    region: 'iad1',
+    awsRegion: 'us-east-1',
+    awsAccountId: '1234567890',
+    awsAvailabilityZoneIds: ['use1-az1', 'use1-az2'],
+    createdAt: 1_700_000_000_000,
+    teamId: 'team_test',
+    vpcId: 'vpc-123',
+    peeringConnections: { count: 2 },
+    hostedZones: { count: 0 },
+    projects: { count: 1, ids: ['proj_1'] },
+    ...overrides,
+  };
+}
+
+describe('connex networks inspect', () => {
+  let team: { id: string; slug: string };
+
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    team = useTeam('team_test');
+    client.config.currentTeam = team.id;
+  });
+
+  it('should require a network ID argument', async () => {
+    client.setArgv('connect', 'networks', 'inspect');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Missing network ID');
+  });
+
+  it('should fetch GET /v1/connect/networks/:id and render details', async () => {
+    let requestUrl = '';
+    client.scenario.get('/v1/connect/networks/ntw_abc123', (req, res) => {
+      requestUrl = req.url ?? '';
+      res.json(readyNetwork());
+    });
+
+    client.setArgv('connect', 'networks', 'inspect', 'ntw_abc123');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestUrl).toContain('/v1/connect/networks/ntw_abc123');
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('ntw_abc123');
+    expect(stderr).toContain('prod-network');
+    expect(stderr).toContain('10.0.0.0/16');
+    expect(stderr).toContain('use1-az1, use1-az2');
+    expect(stderr).toContain('vpc-123');
+  });
+
+  it('should output JSON and omit teamPrincipalRoleArn', async () => {
+    client.scenario.get('/v1/connect/networks/ntw_abc123', (_req, res) => {
+      res.json(
+        readyNetwork({ teamPrincipalRoleArn: 'arn:aws:iam::123:role/secret' })
+      );
+    });
+
+    client.setArgv('connect', 'networks', 'inspect', 'ntw_abc123', '--json');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const stdout = client.stdout.getFullOutput();
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.id).toBe('ntw_abc123');
+    expect(parsed.awsAvailabilityZoneIds).toEqual(['use1-az1', 'use1-az2']);
+    expect(parsed).not.toHaveProperty('teamPrincipalRoleArn');
+    expect(stdout).not.toContain('secret');
+  });
+
+  it('should show a not-found error for a missing network (404)', async () => {
+    client.scenario.get('/v1/connect/networks/ntw_missing', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv('connect', 'networks', 'inspect', 'ntw_missing');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('No network found');
+  });
+});

--- a/packages/cli/test/unit/commands/connex/networks-list.test.ts
+++ b/packages/cli/test/unit/commands/connex/networks-list.test.ts
@@ -1,0 +1,142 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connect from '../../../../src/commands/connex';
+
+function readyNetwork(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ntw_abc123',
+    name: 'prod-network',
+    cidr: '10.0.0.0/16',
+    status: 'ready',
+    region: 'iad1',
+    awsRegion: 'us-east-1',
+    awsAccountId: '1234567890',
+    createdAt: 1_700_000_000_000,
+    teamId: 'team_test',
+    vpcId: 'vpc-123',
+    peeringConnections: { count: 2 },
+    hostedZones: { count: 0 },
+    projects: { count: 1, ids: ['proj_1'] },
+    ...overrides,
+  };
+}
+
+describe('connex networks list', () => {
+  let team: { id: string; slug: string };
+
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    team = useTeam('team_test');
+    client.config.currentTeam = team.id;
+  });
+
+  it('should exit 0 and print help for `networks --help`', async () => {
+    client.setArgv('connect', 'networks', '--help');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Manage Secure Compute networks'
+    );
+  });
+
+  it('should list networks from GET /v1/connect/networks and render a table', async () => {
+    let requestUrl = '';
+    client.scenario.get('/v1/connect/networks', (req, res) => {
+      requestUrl = req.url ?? '';
+      res.json([readyNetwork()]);
+    });
+
+    client.setArgv('connect', 'networks', 'list');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestUrl).toContain('/v1/connect/networks');
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('ntw_abc123');
+    expect(stderr).toContain('prod-network');
+    expect(stderr).toContain('iad1');
+    expect(stderr).toContain('10.0.0.0/16');
+    expect(stderr).toContain('ready');
+  });
+
+  it('should show an empty-state message when there are no networks', async () => {
+    client.scenario.get('/v1/connect/networks', (_req, res) => {
+      res.json([]);
+    });
+
+    client.setArgv('connect', 'networks', 'list');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(client.stderr.getFullOutput()).toContain('No networks found');
+  });
+
+  it('should forward --search as a query param', async () => {
+    let requestUrl = '';
+    client.scenario.get('/v1/connect/networks', (req, res) => {
+      requestUrl = req.url ?? '';
+      res.json([]);
+    });
+
+    client.setArgv('connect', 'networks', 'list', '--search', 'prod');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestUrl).toContain('search=prod');
+  });
+
+  it('should output JSON with a networks array and omit teamPrincipalRoleArn', async () => {
+    client.scenario.get('/v1/connect/networks', (_req, res) => {
+      res.json([
+        readyNetwork({
+          teamPrincipalRoleArn: 'arn:aws:iam::123:role/secret',
+        }),
+      ]);
+    });
+
+    client.setArgv('connect', 'networks', 'list', '--format=json');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const stdout = client.stdout.getFullOutput();
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.networks).toHaveLength(1);
+    const [first] = parsed.networks;
+    expect(first.id).toBe('ntw_abc123');
+    expect(first.cidr).toBe('10.0.0.0/16');
+    expect(first.status).toBe('ready');
+    expect(first).not.toHaveProperty('teamPrincipalRoleArn');
+    expect(stdout).not.toContain('secret');
+  });
+
+  it('should show a friendly error when Connect is not enabled (404)', async () => {
+    client.scenario.get('/v1/connect/networks', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv('connect', 'networks', 'list');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Connect is not enabled');
+  });
+
+  it('should strip ansi escape sequences from the name cell', async () => {
+    client.scenario.get('/v1/connect/networks', (_req, res) => {
+      res.json([readyNetwork({ name: 'ev\x1b[2Jil' })]);
+    });
+
+    client.setArgv('connect', 'networks', 'list');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('evil');
+    expect(stderr).not.toContain('\x1b[2J');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -520,6 +520,36 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('connex networks subcommand', () => {
+      it('connex networks subcommand help column width 120', () => {
+        expect(
+          help(connex.networksSubcommand, {
+            columns: 120,
+            parent: connex.connexCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
+    describe('connex networks list subcommand', () => {
+      it('connex networks list subcommand help column width 120', () => {
+        expect(
+          help(connex.networksListSubcommand, {
+            columns: 120,
+            parent: connex.networksSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
+    describe('connex networks inspect subcommand', () => {
+      it('connex networks inspect subcommand help column width 120', () => {
+        expect(
+          help(connex.networksInspectSubcommand, {
+            columns: 120,
+            parent: connex.networksSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('integration help output snapshots', () => {


### PR DESCRIPTION
## Summary

- Adds a `networks` subcommand group under `vercel connect` for Secure Compute networks, with read-only `vercel connect networks list` (table output, `--search` filter) and `vercel connect networks inspect <id>` (full details: name, region, CIDR, status, AWS account/region/AZs, VPC, egress IPs/CIDR, peering-connection/hosted-zone/project counts).
- Both commands support machine-readable output via the family's `--format json` / `--json` convention, with an explicit field allowlist so the private `teamPrincipalRoleArn` response field is never surfaced.
- Includes a nested `ConnexNetworksTelemetryClient` (IDs/search redacted), unit tests with request assertions, and help snapshots.

## Notes

- Endpoints: `GET /v1/connect/networks` (list, `search` query param) and `GET /v1/connect/networks/:networkId` (read) — the public Secure Compute network endpoints. Networks ("configurations" internally) are a distinct resource from connectors (`/v1/connect/connectors`); the existing connector subcommands are untouched.
- Naming: the parity spec's `vercel connect networks ...` maps directly — the `connex` source directory's canonical user-facing command name is `connect`, so invocations are `vercel connect networks list|inspect`.
- Help for the `networks` group and its subcommands exits `0`, matching the connect family convention.
- Pre-existing failure: `help.test.ts > connex create subcommand help column width 120` already fails on `main` (stale snapshot missing the newer `--trigger-event` description). This PR's snapshot regeneration intentionally does not touch that block, so the failure remains identical to `main`.
- Stacked follow-ups: `networks create`/`update` in #17472 and `networks remove` in #17473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)