### PR TITLE
[CLI] Add connect networks manage commands: create and update

### DIFF
--- a/.changeset/connect-networks-create-update.md
+++ b/.changeset/connect-networks-create-update.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel connect networks create` and `vercel connect networks update <id>` to create and rename Secure Compute networks.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -696,12 +696,110 @@ export const networksInspectSubcommand = {
   ],
 } as const;
 
+export const networksCreateSubcommand = {
+  name: 'create',
+  aliases: [],
+  description: 'Create a Secure Compute network',
+  arguments: [],
+  options: [
+    {
+      name: 'name',
+      shorthand: 'n',
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+      description: 'Name of the network',
+    },
+    {
+      name: 'region',
+      shorthand: null,
+      type: String,
+      argument: 'REGION',
+      deprecated: false,
+      description: 'Vercel region where the network is created (e.g. iad1)',
+    },
+    {
+      name: 'cidr',
+      shorthand: null,
+      type: String,
+      argument: 'CIDR',
+      deprecated: false,
+      description:
+        'Private CIDR block for the network (/16 through /24, e.g. 10.0.0.0/16)',
+    },
+    {
+      name: 'availability-zone-id',
+      shorthand: null,
+      type: [String],
+      argument: 'ID',
+      deprecated: false,
+      description:
+        'AWS Availability Zone ID to place the network in. Repeatable; provide exactly two when specified (e.g. use1-az1).',
+    },
+    formatOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'Create a network',
+      value: `${packageName} connect networks create --name prod --region iad1 --cidr 10.0.0.0/16`,
+    },
+    {
+      name: 'Create a network pinned to two Availability Zones',
+      value: `${packageName} connect networks create --name prod --region iad1 --cidr 10.0.0.0/16 --availability-zone-id use1-az1 --availability-zone-id use1-az2`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connect networks create --name prod --region iad1 --cidr 10.0.0.0/16 --json`,
+    },
+  ],
+} as const;
+
+export const networksUpdateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Update a Secure Compute network',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'name',
+      shorthand: 'n',
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+      description: 'New name for the network',
+    },
+    formatOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'Rename a network',
+      value: `${packageName} connect networks update ntw_abc123 --name staging`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connect networks update ntw_abc123 --name staging --json`,
+    },
+  ],
+} as const;
+
 export const networksSubcommand = {
   name: 'networks',
   aliases: [],
   description: 'Manage Secure Compute networks',
   arguments: [],
-  subcommands: [networksListSubcommand, networksInspectSubcommand],
+  subcommands: [
+    networksListSubcommand,
+    networksInspectSubcommand,
+    networksCreateSubcommand,
+    networksUpdateSubcommand,
+  ],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/connex/networks-create.ts
+++ b/packages/cli/src/commands/connex/networks-create.ts
@@ -1,0 +1,103 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import type { JSONObject } from '@vercel-internals/types';
+import { validateJsonOutput } from '../../util/output-format';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
+import { validateNetworkCidr } from '../../util/connex/validate-cidr';
+import type { ConnexNetwork } from './types';
+import { printNetworkDetails, serializeNetwork } from './networks-shared';
+
+export async function networksCreate(
+  client: Client,
+  flags: {
+    '--name'?: string;
+    '--region'?: string;
+    '--cidr'?: string;
+    '--availability-zone-id'?: string[];
+    '--format'?: string;
+    '--json'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  // Validate all local input BEFORE resolving a team or issuing the remote
+  // mutation, so a bad CIDR or missing flag never mutates config or calls out.
+  const name = flags['--name']?.trim();
+  if (!name) {
+    output.error('Missing network name. Provide one with `--name`.');
+    return 1;
+  }
+  if (name.length > 255) {
+    output.error('Network name must be 255 characters or fewer.');
+    return 1;
+  }
+
+  const region = flags['--region']?.trim();
+  if (!region) {
+    output.error('Missing region. Provide one with `--region` (e.g. iad1).');
+    return 1;
+  }
+
+  const cidr = flags['--cidr']?.trim();
+  if (!cidr) {
+    output.error(
+      'Missing CIDR block. Provide one with `--cidr` (e.g. 10.0.0.0/16).'
+    );
+    return 1;
+  }
+  try {
+    validateNetworkCidr(cidr);
+  } catch (err) {
+    output.error((err as Error).message);
+    return 1;
+  }
+
+  const availabilityZoneIds = flags['--availability-zone-id'];
+  if (availabilityZoneIds !== undefined && availabilityZoneIds.length !== 2) {
+    output.error(
+      'Provide exactly two `--availability-zone-id` values when specifying Availability Zones.'
+    );
+    return 1;
+  }
+
+  await selectConnexTeam(client, 'Select the team for this network');
+
+  const body: JSONObject = { name, region, cidr };
+  if (availabilityZoneIds) {
+    body.awsAvailabilityZoneIds = availabilityZoneIds;
+  }
+
+  output.spinner('Creating network…');
+  let network: ConnexNetwork;
+  try {
+    network = await client.fetch<ConnexNetwork>('/v1/connect/networks', {
+      method: 'POST',
+      body,
+    });
+  } catch (err: unknown) {
+    output.stopSpinner();
+    output.error(`Failed to create network: ${(err as Error).message}`);
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(serializeNetwork(network), null, 2)}\n`
+    );
+    return 0;
+  }
+
+  output.success(
+    `Network ${chalk.bold(sanitizeForTerminal(network.name || network.id))} created.`
+  );
+  printNetworkDetails(network);
+  return 0;
+}

--- a/packages/cli/src/commands/connex/networks-update.ts
+++ b/packages/cli/src/commands/connex/networks-update.ts
@@ -1,0 +1,87 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import type { JSONObject } from '@vercel-internals/types';
+import { validateJsonOutput } from '../../util/output-format';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
+import type { ConnexNetwork } from './types';
+import { serializeNetwork } from './networks-shared';
+
+export async function networksUpdate(
+  client: Client,
+  args: string[],
+  flags: {
+    '--name'?: string;
+    '--format'?: string;
+    '--json'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const networkId = args[0];
+  if (!networkId) {
+    output.error(
+      'Missing network ID. Usage: vercel connect networks update <id>'
+    );
+    return 1;
+  }
+
+  // `name` is the only updatable field, so "at least one flag" reduces to
+  // requiring it. Validate locally before any remote mutation.
+  const name = flags['--name']?.trim();
+  if (name === undefined) {
+    output.error('Specify a new name with `--name`.');
+    return 1;
+  }
+  if (name.length === 0) {
+    output.error('Network name cannot be empty.');
+    return 1;
+  }
+  if (name.length > 255) {
+    output.error('Network name must be 255 characters or fewer.');
+    return 1;
+  }
+
+  await selectConnexTeam(client, 'Select the team for this network');
+
+  const body: JSONObject = { name };
+
+  output.spinner('Updating network…');
+  let network: ConnexNetwork;
+  try {
+    network = await client.fetch<ConnexNetwork>(
+      `/v1/connect/networks/${encodeURIComponent(networkId)}`,
+      { method: 'PATCH', body }
+    );
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      output.error(`No network found for ${chalk.bold(networkId)}.`);
+      return 1;
+    }
+    output.error(
+      `Failed to update ${chalk.bold(networkId)}: ${(err as Error).message}`
+    );
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify(serializeNetwork(network), null, 2)}\n`
+    );
+    return 0;
+  }
+
+  output.success(
+    `Network ${chalk.bold(sanitizeForTerminal(network.name || network.id))} updated.`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/connex/networks.ts
+++ b/packages/cli/src/commands/connex/networks.ts
@@ -13,13 +13,19 @@ import {
   networksSubcommand,
   networksListSubcommand,
   networksInspectSubcommand,
+  networksCreateSubcommand,
+  networksUpdateSubcommand,
 } from './command';
 import { networksList } from './networks-list';
 import { networksInspect } from './networks-inspect';
+import { networksCreate } from './networks-create';
+import { networksUpdate } from './networks-update';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(networksListSubcommand),
   inspect: getCommandAliases(networksInspectSubcommand),
+  create: getCommandAliases(networksCreateSubcommand),
+  update: getCommandAliases(networksUpdateSubcommand),
 };
 
 export async function networks(client: Client): Promise<number> {
@@ -103,6 +109,48 @@ export async function networks(client: Client): Promise<number> {
           client,
           inspectParsedArgs.args,
           inspectParsedArgs.flags
+        );
+      }
+      case 'create': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex networks', subcommandOriginal);
+          printHelp(networksCreateSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandCreate(subcommandOriginal);
+
+        const createFlagsSpec = getFlagsSpecification(
+          networksCreateSubcommand.options
+        );
+        const createParsedArgs = parseArguments(args, createFlagsSpec);
+        telemetry.trackCliOptionName(createParsedArgs.flags['--name']);
+        telemetry.trackCliOptionRegion(createParsedArgs.flags['--region']);
+        telemetry.trackCliOptionCidr(createParsedArgs.flags['--cidr']);
+        telemetry.trackCliOptionAvailabilityZoneId(
+          createParsedArgs.flags['--availability-zone-id']
+        );
+        telemetry.trackCliOptionFormat(createParsedArgs.flags['--format']);
+        return await networksCreate(client, createParsedArgs.flags);
+      }
+      case 'update': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex networks', subcommandOriginal);
+          printHelp(networksUpdateSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandUpdate(subcommandOriginal);
+
+        const updateFlagsSpec = getFlagsSpecification(
+          networksUpdateSubcommand.options
+        );
+        const updateParsedArgs = parseArguments(args, updateFlagsSpec);
+        telemetry.trackCliArgumentId(updateParsedArgs.args[0]);
+        telemetry.trackCliOptionName(updateParsedArgs.flags['--name']);
+        telemetry.trackCliOptionFormat(updateParsedArgs.flags['--format']);
+        return await networksUpdate(
+          client,
+          updateParsedArgs.args,
+          updateParsedArgs.flags
         );
       }
       default: {

--- a/packages/cli/src/util/connex/validate-cidr.ts
+++ b/packages/cli/src/util/connex/validate-cidr.ts
@@ -1,8 +1,12 @@
 /**
- * Validate an IPv4 CIDR block for Secure Compute networks, mirroring the
- * server-side rules so obviously-invalid input is rejected before any remote
- * call: it must parse as IPv4 CIDR, sit within a private address range, and
+ * Validate an IPv4 CIDR block for Secure Compute networks before any remote
+ * call: it must parse as IPv4 CIDR, sit within an RFC 1918 private range, and
  * use a prefix length between /16 and /24 (inclusive).
+ *
+ * The private-range check is a deliberately stricter CLI-side guardrail than
+ * the server's: the server accepts any address `ip.isPrivate()` allows
+ * (including loopback and link-local), but those are nonsensical VPC CIDRs,
+ * so the CLI only accepts the RFC 1918 ranges.
  *
  * Throws an Error with a user-facing message when invalid.
  */
@@ -25,7 +29,9 @@ export function validateNetworkCidr(cidr: string): void {
   }
 
   if (!isPrivateIpv4(octets)) {
-    throw new Error('The provided CIDR block must be a private address range.');
+    throw new Error(
+      'The provided CIDR block must be within a private (RFC 1918) address range.'
+    );
   }
 }
 

--- a/packages/cli/src/util/connex/validate-cidr.ts
+++ b/packages/cli/src/util/connex/validate-cidr.ts
@@ -1,0 +1,41 @@
+/**
+ * Validate an IPv4 CIDR block for Secure Compute networks, mirroring the
+ * server-side rules so obviously-invalid input is rejected before any remote
+ * call: it must parse as IPv4 CIDR, sit within a private address range, and
+ * use a prefix length between /16 and /24 (inclusive).
+ *
+ * Throws an Error with a user-facing message when invalid.
+ */
+export function validateNetworkCidr(cidr: string): void {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})$/.exec(
+    cidr.trim()
+  );
+  if (!match) {
+    throw new Error('The provided CIDR block is not valid.');
+  }
+
+  const octets = [match[1], match[2], match[3], match[4]].map(Number);
+  if (octets.some(o => o > 255)) {
+    throw new Error('The provided CIDR block is not valid.');
+  }
+
+  const prefix = Number(match[5]);
+  if (prefix < 16 || prefix > 24) {
+    throw new Error('The provided CIDR block must be a /16 through /24 range.');
+  }
+
+  if (!isPrivateIpv4(octets)) {
+    throw new Error('The provided CIDR block must be a private address range.');
+  }
+}
+
+/**
+ * Returns true when the address falls inside an RFC 1918 private range:
+ * 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16.
+ */
+function isPrivateIpv4([a, b]: number[]): boolean {
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  return false;
+}

--- a/packages/cli/src/util/telemetry/commands/connex/networks.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/networks.ts
@@ -15,6 +15,62 @@ export class ConnexNetworksTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliSubcommandCreate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'create',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandUpdate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update',
+      value: actual,
+    });
+  }
+
+  trackCliOptionName(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'name',
+        // Network names are team-controlled free-form text — redact.
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionRegion(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'region',
+        // Region is an enum-like identifier (e.g. iad1) — safe to record.
+        value: v,
+      });
+    }
+  }
+
+  trackCliOptionCidr(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'cidr',
+        // CIDR blocks describe private network topology — redact.
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionAvailabilityZoneId(v: string[] | undefined) {
+    if (v && v.length > 0) {
+      // AZ IDs are public AWS identifiers (e.g. use1-az1); record each.
+      for (const az of v) {
+        this.trackCliOption({
+          option: 'availability-zone-id',
+          value: az,
+        });
+      }
+    }
+  }
+
   trackCliArgumentId(v: string | undefined) {
     if (v) {
       this.trackCliArgument({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1100,6 +1100,54 @@ exports[`help command > connex help output snapshots > connex list subcommand > 
 "
 `;
 
+exports[`help command > connex help output snapshots > connex networks create subcommand > connex networks create subcommand help column width 120 1`] = `
+"
+  ▲ vercel networks create [options]
+
+  Create a Secure Compute network                                                                                       
+
+  Options:
+
+       --availability-zone-id <ID>  AWS Availability Zone ID to place the network in. Repeatable; provide exactly two when   
+                                    specified (e.g. use1-az1).                                                               
+       --cidr <CIDR>                Private CIDR block for the network (/16 through /24, e.g. 10.0.0.0/16)                   
+  -F,  --format <FORMAT>            Specify the output format (json)                                                         
+       --json                       Output as JSON                                                                           
+  -n,  --name <NAME>                Name of the network                                                                      
+       --region <REGION>            Vercel region where the network is created (e.g. iad1)                                   
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Create a network
+
+    $ vercel connect networks create --name prod --region iad1 --cidr 10.0.0.0/16
+
+  - Create a network pinned to two Availability Zones
+
+    $ vercel connect networks create --name prod --region iad1 --cidr 10.0.0.0/16 --availability-zone-id use1-az1 --availability-zone-id use1-az2
+
+  - Output as JSON
+
+    $ vercel connect networks create --name prod --region iad1 --cidr 10.0.0.0/16 --json
+
+"
+`;
+
 exports[`help command > connex help output snapshots > connex networks inspect subcommand > connex networks inspect subcommand help column width 120 1`] = `
 "
   ▲ vercel networks inspect id [options]
@@ -1193,6 +1241,8 @@ exports[`help command > connex help output snapshots > connex networks subcomman
 
   list         List Secure Compute networks on the current team                                                 
   inspect  id  Show details for a single Secure Compute network                                                 
+  create       Create a Secure Compute network                                                                  
+  update   id  Update a Secure Compute network                                                                  
 
 
   Global Options:
@@ -1218,6 +1268,46 @@ exports[`help command > connex help output snapshots > connex networks subcomman
   - Inspect a network by ID
 
     $ vercel connect networks inspect ntw_abc123
+
+"
+`;
+
+exports[`help command > connex help output snapshots > connex networks update subcommand > connex networks update subcommand help column width 120 1`] = `
+"
+  ▲ vercel networks update id [options]
+
+  Update a Secure Compute network                                                                                       
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+  -n,  --name <NAME>      New name for the network                                                                      
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Rename a network
+
+    $ vercel connect networks update ntw_abc123 --name staging
+
+  - Output as JSON
+
+    $ vercel connect networks update ntw_abc123 --name staging --json
 
 "
 `;

--- a/packages/cli/test/unit/commands/connex/networks-create.test.ts
+++ b/packages/cli/test/unit/commands/connex/networks-create.test.ts
@@ -1,0 +1,233 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connect from '../../../../src/commands/connex';
+
+function createdNetwork(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ntw_new',
+    name: 'prod',
+    cidr: '10.0.0.0/16',
+    status: 'create_in_progress',
+    region: 'iad1',
+    awsRegion: 'us-east-1',
+    awsAccountId: '1234567890',
+    createdAt: 1_700_000_000_000,
+    teamId: 'team_test',
+    ...overrides,
+  };
+}
+
+describe('connex networks create', () => {
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    const team = useTeam('team_test');
+    client.config.currentTeam = team.id;
+  });
+
+  it('should error and skip the request when --name is missing', async () => {
+    let posted = false;
+    client.scenario.post('/v1/connect/networks', (_req, res) => {
+      posted = true;
+      res.json(createdNetwork());
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--region',
+      'iad1',
+      '--cidr',
+      '10.0.0.0/16'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(posted).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('Missing network name');
+  });
+
+  it('should error when --region is missing', async () => {
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--name',
+      'prod',
+      '--cidr',
+      '10.0.0.0/16'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Missing region');
+  });
+
+  it('should reject an invalid CIDR before any request', async () => {
+    let posted = false;
+    client.scenario.post('/v1/connect/networks', (_req, res) => {
+      posted = true;
+      res.json(createdNetwork());
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--name',
+      'prod',
+      '--region',
+      'iad1',
+      '--cidr',
+      'not-a-cidr'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(posted).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('not valid');
+  });
+
+  it('should reject a non-private CIDR range', async () => {
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--name',
+      'prod',
+      '--region',
+      'iad1',
+      '--cidr',
+      '8.8.0.0/16'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('private address range');
+  });
+
+  it('should reject a prefix length outside /16 through /24', async () => {
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--name',
+      'prod',
+      '--region',
+      'iad1',
+      '--cidr',
+      '10.0.0.0/25'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('/16 through /24');
+  });
+
+  it('should require exactly two Availability Zone IDs when specified', async () => {
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--name',
+      'prod',
+      '--region',
+      'iad1',
+      '--cidr',
+      '10.0.0.0/16',
+      '--availability-zone-id',
+      'use1-az1'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'exactly two `--availability-zone-id`'
+    );
+  });
+
+  it('should POST name/region/cidr and report success', async () => {
+    let body: Record<string, unknown> = {};
+    client.scenario.post('/v1/connect/networks', (req, res) => {
+      body = req.body;
+      res.statusCode = 201;
+      res.json(createdNetwork());
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--name',
+      'prod',
+      '--region',
+      'iad1',
+      '--cidr',
+      '10.0.0.0/16'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(body).toEqual({ name: 'prod', region: 'iad1', cidr: '10.0.0.0/16' });
+    expect(body).not.toHaveProperty('awsAvailabilityZoneIds');
+    expect(client.stderr.getFullOutput()).toContain('created');
+  });
+
+  it('should include awsAvailabilityZoneIds when two are provided', async () => {
+    let body: Record<string, unknown> = {};
+    client.scenario.post('/v1/connect/networks', (req, res) => {
+      body = req.body;
+      res.statusCode = 201;
+      res.json(createdNetwork());
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--name',
+      'prod',
+      '--region',
+      'iad1',
+      '--cidr',
+      '10.0.0.0/16',
+      '--availability-zone-id',
+      'use1-az1',
+      '--availability-zone-id',
+      'use1-az2'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(body.awsAvailabilityZoneIds).toEqual(['use1-az1', 'use1-az2']);
+  });
+
+  it('should output JSON for the created network', async () => {
+    client.scenario.post('/v1/connect/networks', (_req, res) => {
+      res.statusCode = 201;
+      res.json(createdNetwork());
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'create',
+      '--name',
+      'prod',
+      '--region',
+      'iad1',
+      '--cidr',
+      '10.0.0.0/16',
+      '--json'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(parsed.id).toBe('ntw_new');
+    expect(parsed.status).toBe('create_in_progress');
+  });
+});

--- a/packages/cli/test/unit/commands/connex/networks-create.test.ts
+++ b/packages/cli/test/unit/commands/connex/networks-create.test.ts
@@ -106,7 +106,9 @@ describe('connex networks create', () => {
     const exitCode = await connect(client);
 
     expect(exitCode).toBe(1);
-    expect(client.stderr.getFullOutput()).toContain('private address range');
+    expect(client.stderr.getFullOutput()).toContain(
+      'private (RFC 1918) address range'
+    );
   });
 
   it('should reject a prefix length outside /16 through /24', async () => {

--- a/packages/cli/test/unit/commands/connex/networks-update.test.ts
+++ b/packages/cli/test/unit/commands/connex/networks-update.test.ts
@@ -35,6 +35,87 @@ describe('connex networks update', () => {
     expect(client.stderr.getFullOutput()).toContain('Specify a new name');
   });
 
+  it('should reject an empty --name and skip the request', async () => {
+    let patched = false;
+    client.scenario.patch('/v1/connect/networks/:id', (_req, res) => {
+      patched = true;
+      res.json({});
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'update',
+      'ntw_abc123',
+      '--name',
+      '   '
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(patched).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('cannot be empty');
+  });
+
+  it('should reject a name over 255 characters and skip the request', async () => {
+    let patched = false;
+    client.scenario.patch('/v1/connect/networks/:id', (_req, res) => {
+      patched = true;
+      res.json({});
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'update',
+      'ntw_abc123',
+      '--name',
+      'x'.repeat(256)
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(patched).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('255 characters or fewer');
+  });
+
+  it('should output the updated network as JSON', async () => {
+    client.scenario.patch('/v1/connect/networks/:id', (_req, res) => {
+      res.json({
+        id: 'ntw_abc123',
+        name: 'staging',
+        cidr: '10.0.0.0/16',
+        status: 'ready',
+        region: 'iad1',
+        awsRegion: 'us-east-1',
+        awsAccountId: '1234567890',
+        createdAt: 1_700_000_000_000,
+        teamId: 'team_test',
+        teamPrincipalRoleArn: 'arn:aws:iam::123:role/secret',
+      });
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'update',
+      'ntw_abc123',
+      '--name',
+      'staging',
+      '--json'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    const stdout = client.stdout.getFullOutput();
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.id).toBe('ntw_abc123');
+    expect(parsed.name).toBe('staging');
+    expect(parsed.status).toBe('ready');
+    expect(parsed).not.toHaveProperty('teamPrincipalRoleArn');
+    expect(stdout).not.toContain('secret');
+  });
+
   it('should PATCH the new name', async () => {
     let body: Record<string, unknown> = {};
     let requestUrl = '';

--- a/packages/cli/test/unit/commands/connex/networks-update.test.ts
+++ b/packages/cli/test/unit/commands/connex/networks-update.test.ts
@@ -1,0 +1,92 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connect from '../../../../src/commands/connex';
+
+describe('connex networks update', () => {
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    const team = useTeam('team_test');
+    client.config.currentTeam = team.id;
+  });
+
+  it('should require a network ID', async () => {
+    client.setArgv('connect', 'networks', 'update', '--name', 'staging');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Missing network ID');
+  });
+
+  it('should require --name and skip the request', async () => {
+    let patched = false;
+    client.scenario.patch('/v1/connect/networks/:id', (_req, res) => {
+      patched = true;
+      res.json({});
+    });
+
+    client.setArgv('connect', 'networks', 'update', 'ntw_abc123');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(patched).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('Specify a new name');
+  });
+
+  it('should PATCH the new name', async () => {
+    let body: Record<string, unknown> = {};
+    let requestUrl = '';
+    client.scenario.patch('/v1/connect/networks/:id', (req, res) => {
+      body = req.body;
+      requestUrl = req.url ?? '';
+      res.json({
+        id: 'ntw_abc123',
+        name: 'staging',
+        cidr: '10.0.0.0/16',
+        status: 'ready',
+        region: 'iad1',
+        awsRegion: 'us-east-1',
+        awsAccountId: '1234567890',
+        createdAt: 1_700_000_000_000,
+        teamId: 'team_test',
+      });
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'update',
+      'ntw_abc123',
+      '--name',
+      'staging'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(requestUrl).toContain('/v1/connect/networks/ntw_abc123');
+    expect(body).toEqual({ name: 'staging' });
+    expect(client.stderr.getFullOutput()).toContain('updated');
+  });
+
+  it('should show a not-found error on 404', async () => {
+    client.scenario.patch('/v1/connect/networks/:id', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'update',
+      'ntw_missing',
+      '--name',
+      'staging'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('No network found');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -550,6 +550,26 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('connex networks create subcommand', () => {
+      it('connex networks create subcommand help column width 120', () => {
+        expect(
+          help(connex.networksCreateSubcommand, {
+            columns: 120,
+            parent: connex.networksSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
+    describe('connex networks update subcommand', () => {
+      it('connex networks update subcommand help column width 120', () => {
+        expect(
+          help(connex.networksUpdateSubcommand, {
+            columns: 120,
+            parent: connex.networksSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('integration help output snapshots', () => {


### PR DESCRIPTION
## Summary

- Adds `vercel connect networks create --name <NAME> --region <REGION> --cidr <CIDR> [--availability-zone-id <ID> --availability-zone-id <ID>]`, with flags derived from the POST body schema (`name`, `region`, `cidr` required; `awsAvailabilityZoneIds` optional, exactly two when given).
- Adds `vercel connect networks update <id> --name <NAME>` — `name` is the only field the PATCH schema accepts, so the sparse-update "at least one flag" requirement reduces to requiring `--name`.
- Validates all input locally before any remote mutation: CIDR must parse, be a private (RFC 1918) range, and use a /16–/24 prefix; name length and AZ count are checked up front.
- Telemetry (name/CIDR redacted; region and AZ IDs recorded as identifier values), unit tests with request-body assertions (including negative tests that no request fires on invalid input, `--json` output for update, and empty/too-long name rejections), and help snapshots.

## Notes

- Endpoints: `POST /v1/connect/networks` (create, returns 201 with the network DTO) and `PATCH /v1/connect/networks/:networkId` (rename). These are Secure Compute network endpoints, distinct from the connector endpoints; connector subcommands are untouched.
- Naming: parity spec `vercel connect networks ...` — the `connex` directory's canonical command name is `connect`.
- The local CIDR private-range check is a deliberately stricter CLI-side guardrail than the server's: the server accepts anything `ip.isPrivate()` allows (including loopback and link-local), which are nonsensical VPC CIDRs, so the CLI only accepts the RFC 1918 ranges (10/8, 172.16/12, 192.168/16). The prefix-length rule (/16–/24) matches the server.
- `networks remove` is split into a stacked follow-up PR (#17473) to keep this one within budget.
- Pre-existing failure: `help.test.ts > connex create subcommand help column width 120` fails identically on `main` (stale snapshot); this PR's snapshot regeneration leaves that block untouched.
- Stacked on #17471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)