### PR TITLE
[CLI] Add connect networks remove command

### DIFF
--- a/.changeset/connect-networks-remove.md
+++ b/.changeset/connect-networks-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel connect networks remove <id>` to delete a Secure Compute network, with confirmation prompt and `--yes` support.

--- a/packages/cli/src/commands/connex/command.ts
+++ b/packages/cli/src/commands/connex/command.ts
@@ -789,6 +789,40 @@ export const networksUpdateSubcommand = {
   ],
 } as const;
 
+export const networksRemoveSubcommand = {
+  name: 'remove',
+  aliases: ['rm'],
+  description: 'Delete a Secure Compute network',
+  arguments: [
+    {
+      name: 'id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when deleting a network',
+    },
+    formatOption,
+    jsonOption,
+  ],
+  examples: [
+    {
+      name: 'Delete a network by ID',
+      value: `${packageName} connect networks remove ntw_abc123`,
+    },
+    {
+      name: 'Skip the confirmation prompt',
+      value: `${packageName} connect networks remove ntw_abc123 --yes`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} connect networks remove ntw_abc123 --json --yes`,
+    },
+  ],
+} as const;
+
 export const networksSubcommand = {
   name: 'networks',
   aliases: [],
@@ -799,6 +833,7 @@ export const networksSubcommand = {
     networksInspectSubcommand,
     networksCreateSubcommand,
     networksUpdateSubcommand,
+    networksRemoveSubcommand,
   ],
   options: [],
   examples: [

--- a/packages/cli/src/commands/connex/networks-remove.ts
+++ b/packages/cli/src/commands/connex/networks-remove.ts
@@ -1,0 +1,108 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { validateJsonOutput } from '../../util/output-format';
+import { selectConnexTeam } from '../../util/connex/select-team';
+import { sanitizeForTerminal } from '../../util/connex/sanitize';
+import type { ConnexNetwork } from './types';
+
+export async function networksRemove(
+  client: Client,
+  args: string[],
+  flags: {
+    '--yes'?: boolean;
+    '--format'?: string;
+    '--json'?: boolean;
+  }
+): Promise<number> {
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+  const skipConfirmation = !!flags['--yes'];
+
+  if (asJson && !skipConfirmation) {
+    output.error('--json requires --yes to skip confirmation prompts');
+    return 1;
+  }
+
+  const networkId = args[0];
+  if (!networkId) {
+    output.error(
+      'Missing network ID. Usage: vercel connect networks remove <id>'
+    );
+    return 1;
+  }
+
+  await selectConnexTeam(client, 'Select the team for this network');
+
+  output.spinner('Retrieving network…');
+  let network: ConnexNetwork;
+  try {
+    network = await client.fetch<ConnexNetwork>(
+      `/v1/connect/networks/${encodeURIComponent(networkId)}`
+    );
+  } catch (err: unknown) {
+    output.stopSpinner();
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      output.error(`No network found for ${chalk.bold(networkId)}.`);
+      return 1;
+    }
+    output.error(
+      `Failed to look up ${chalk.bold(networkId)}: ${(err as Error).message}`
+    );
+    return 1;
+  }
+  output.stopSpinner();
+
+  const displayName = sanitizeForTerminal(network.name || network.id);
+
+  if (!skipConfirmation && !client.stdin.isTTY) {
+    output.error(
+      'Confirmation required. Use `--yes` to skip the confirmation prompt.'
+    );
+    return 1;
+  }
+
+  if (!skipConfirmation) {
+    output.log(
+      `Network ${chalk.bold(displayName)} will be deleted permanently.`
+    );
+    const confirmed = await client.input.confirm(
+      `${chalk.red('Are you sure?')}`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  try {
+    output.spinner('Deleting network…');
+    await client.fetch<unknown>(
+      `/v1/connect/networks/${encodeURIComponent(network.id)}`,
+      { method: 'DELETE' }
+    );
+  } catch (err: unknown) {
+    output.stopSpinner();
+    output.error(
+      `A problem occurred when attempting to delete ${chalk.bold(displayName)}: ${(err as Error).message}`
+    );
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (asJson) {
+    client.stdout.write(
+      `${JSON.stringify({ id: network.id, removed: true }, null, 2)}\n`
+    );
+    return 0;
+  }
+
+  output.success(`Network ${chalk.bold(displayName)} successfully removed.`);
+  return 0;
+}

--- a/packages/cli/src/commands/connex/networks.ts
+++ b/packages/cli/src/commands/connex/networks.ts
@@ -15,17 +15,20 @@ import {
   networksInspectSubcommand,
   networksCreateSubcommand,
   networksUpdateSubcommand,
+  networksRemoveSubcommand,
 } from './command';
 import { networksList } from './networks-list';
 import { networksInspect } from './networks-inspect';
 import { networksCreate } from './networks-create';
 import { networksUpdate } from './networks-update';
+import { networksRemove } from './networks-remove';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(networksListSubcommand),
   inspect: getCommandAliases(networksInspectSubcommand),
   create: getCommandAliases(networksCreateSubcommand),
   update: getCommandAliases(networksUpdateSubcommand),
+  remove: getCommandAliases(networksRemoveSubcommand),
 };
 
 export async function networks(client: Client): Promise<number> {
@@ -151,6 +154,27 @@ export async function networks(client: Client): Promise<number> {
           client,
           updateParsedArgs.args,
           updateParsedArgs.flags
+        );
+      }
+      case 'remove': {
+        if (needHelp) {
+          telemetry.trackCliFlagHelp('connex networks', subcommandOriginal);
+          printHelp(networksRemoveSubcommand);
+          return 0;
+        }
+        telemetry.trackCliSubcommandRemove(subcommandOriginal);
+
+        const removeFlagsSpec = getFlagsSpecification(
+          networksRemoveSubcommand.options
+        );
+        const removeParsedArgs = parseArguments(args, removeFlagsSpec);
+        telemetry.trackCliArgumentId(removeParsedArgs.args[0]);
+        telemetry.trackCliFlagYes(removeParsedArgs.flags['--yes']);
+        telemetry.trackCliOptionFormat(removeParsedArgs.flags['--format']);
+        return await networksRemove(
+          client,
+          removeParsedArgs.args,
+          removeParsedArgs.flags
         );
       }
       default: {

--- a/packages/cli/src/util/telemetry/commands/connex/networks.ts
+++ b/packages/cli/src/util/telemetry/commands/connex/networks.ts
@@ -29,6 +29,19 @@ export class ConnexNetworksTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
+  trackCliFlagYes(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('yes');
+    }
+  }
+
   trackCliOptionName(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1231,6 +1231,50 @@ exports[`help command > connex help output snapshots > connex networks list subc
 "
 `;
 
+exports[`help command > connex help output snapshots > connex networks remove subcommand > connex networks remove subcommand help column width 120 1`] = `
+"
+  ▲ vercel networks remove id [options]
+
+  Delete a Secure Compute network                                                                                       
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+  -y,  --yes              Skip the confirmation prompt when deleting a network                                          
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Delete a network by ID
+
+    $ vercel connect networks remove ntw_abc123
+
+  - Skip the confirmation prompt
+
+    $ vercel connect networks remove ntw_abc123 --yes
+
+  - Output as JSON
+
+    $ vercel connect networks remove ntw_abc123 --json --yes
+
+"
+`;
+
 exports[`help command > connex help output snapshots > connex networks subcommand > connex networks subcommand help column width 120 1`] = `
 "
   ▲ vercel connect networks command
@@ -1243,6 +1287,7 @@ exports[`help command > connex help output snapshots > connex networks subcomman
   inspect  id  Show details for a single Secure Compute network                                                 
   create       Create a Secure Compute network                                                                  
   update   id  Update a Secure Compute network                                                                  
+  remove   id  Delete a Secure Compute network                                                                  
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/connex/networks-remove.test.ts
+++ b/packages/cli/test/unit/commands/connex/networks-remove.test.ts
@@ -1,0 +1,122 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeam } from '../../../mocks/team';
+import connect from '../../../../src/commands/connex';
+
+function network(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ntw_abc123',
+    name: 'prod',
+    cidr: '10.0.0.0/16',
+    status: 'ready',
+    region: 'iad1',
+    awsRegion: 'us-east-1',
+    awsAccountId: '1234567890',
+    createdAt: 1_700_000_000_000,
+    teamId: 'team_test',
+    ...overrides,
+  };
+}
+
+describe('connex networks remove', () => {
+  beforeEach(() => {
+    client.reset();
+    useUser();
+    const team = useTeam('team_test');
+    client.config.currentTeam = team.id;
+  });
+
+  it('should require a network ID', async () => {
+    client.setArgv('connect', 'networks', 'remove');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('Missing network ID');
+  });
+
+  it('should delete the network when --yes is passed', async () => {
+    let deleteCalled = false;
+    client.scenario.get('/v1/connect/networks/:id', (_req, res) => {
+      res.json(network());
+    });
+    client.scenario.delete('/v1/connect/networks/:id', (req, res) => {
+      deleteCalled = true;
+      expect(req.params.id).toBe('ntw_abc123');
+      res.statusCode = 204;
+      res.end();
+    });
+
+    client.setArgv('connect', 'networks', 'remove', 'ntw_abc123', '--yes');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(deleteCalled).toBe(true);
+    expect(client.stderr.getFullOutput()).toContain('successfully removed');
+  });
+
+  it('should show a not-found error when the network does not exist', async () => {
+    client.scenario.get('/v1/connect/networks/:id', (_req, res) => {
+      res.statusCode = 404;
+      res.json({ error: { code: 'not_found', message: 'Not Found' } });
+    });
+
+    client.setArgv('connect', 'networks', 'remove', 'ntw_missing', '--yes');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('No network found');
+  });
+
+  it('should require --yes when stdin is not a TTY', async () => {
+    let deleteCalled = false;
+    client.scenario.get('/v1/connect/networks/:id', (_req, res) => {
+      res.json(network());
+    });
+    client.scenario.delete('/v1/connect/networks/:id', (_req, res) => {
+      deleteCalled = true;
+      res.statusCode = 204;
+      res.end();
+    });
+
+    client.setArgv('connect', 'networks', 'remove', 'ntw_abc123');
+    (client.stdin as unknown as { isTTY: boolean }).isTTY = false;
+
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(deleteCalled).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('Confirmation required');
+  });
+
+  it('should not fire DELETE when the user declines the prompt', async () => {
+    let deleteCalled = false;
+    client.scenario.get('/v1/connect/networks/:id', (_req, res) => {
+      res.json(network());
+    });
+    client.scenario.delete('/v1/connect/networks/:id', (_req, res) => {
+      deleteCalled = true;
+      res.statusCode = 204;
+      res.end();
+    });
+
+    client.setArgv('connect', 'networks', 'remove', 'ntw_abc123');
+
+    const exitCodePromise = connect(client);
+    await expect(client.stderr).toOutput('Are you sure?');
+    client.stdin.write('n\n');
+    const exitCode = await exitCodePromise;
+
+    expect(exitCode).toBe(0);
+    expect(deleteCalled).toBe(false);
+    expect(client.stderr.getFullOutput()).toContain('Canceled');
+  });
+
+  it('should require --yes when using --json', async () => {
+    client.setArgv('connect', 'networks', 'remove', 'ntw_abc123', '--json');
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(1);
+    expect(client.stderr.getFullOutput()).toContain('--json requires --yes');
+  });
+});

--- a/packages/cli/test/unit/commands/connex/networks-remove.test.ts
+++ b/packages/cli/test/unit/commands/connex/networks-remove.test.ts
@@ -119,4 +119,31 @@ describe('connex networks remove', () => {
     expect(exitCode).toBe(1);
     expect(client.stderr.getFullOutput()).toContain('--json requires --yes');
   });
+
+  it('should output { id, removed: true } for --json --yes', async () => {
+    let deleteCalled = false;
+    client.scenario.get('/v1/connect/networks/:id', (_req, res) => {
+      res.json(network());
+    });
+    client.scenario.delete('/v1/connect/networks/:id', (_req, res) => {
+      deleteCalled = true;
+      res.statusCode = 204;
+      res.end();
+    });
+
+    client.setArgv(
+      'connect',
+      'networks',
+      'remove',
+      'ntw_abc123',
+      '--json',
+      '--yes'
+    );
+    const exitCode = await connect(client);
+
+    expect(exitCode).toBe(0);
+    expect(deleteCalled).toBe(true);
+    const parsed = JSON.parse(client.stdout.getFullOutput().trim());
+    expect(parsed).toEqual({ id: 'ntw_abc123', removed: true });
+  });
 });

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -570,6 +570,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('connex networks remove subcommand', () => {
+      it('connex networks remove subcommand help column width 120', () => {
+        expect(
+          help(connex.networksRemoveSubcommand, {
+            columns: 120,
+            parent: connex.networksSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('integration help output snapshots', () => {


### PR DESCRIPTION
## Summary

- Adds `vercel connect networks remove <id>` (alias `rm`) to delete a Secure Compute network.
- Interactive TTY runs show the network name and a default-No `Are you sure?` confirmation; `--yes` skips it; non-interactive runs without `--yes` fail with a confirmation-required error and exit 1.
- `--json`/`--format json` requires `--yes` and prints `{ id, removed: true }` on success; the network is looked up first so a bad ID fails with a not-found error before any DELETE.
- Tests assert the decline path never fires the DELETE request, plus the non-TTY, not-found, `--yes`, and `--json`-without-`--yes` paths; telemetry and help snapshot included.

## Notes

- Endpoint: `DELETE /v1/connect/networks/:networkId` (returns 204; server marks the configuration `delete_in_progress`). Secure Compute networks are distinct from connectors; connector subcommands are untouched.
- Naming: parity spec `vercel connect networks remove` — the `connex` directory's canonical command name is `connect`.
- Split out of the create/update PR to keep each within budget.
- Pre-existing failure: `help.test.ts > connex create subcommand help column width 120` fails identically on `main` (stale snapshot); untouched here.
- Stacked on #17472 (which stacks on #17471).

🤖 Generated with [Claude Code](https://claude.com/claude-code)