### PR TITLE
[CLI] Add access-group remove subcommand

### DIFF
--- a/.changeset/access-group-remove.md
+++ b/.changeset/access-group-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel access-group remove` subcommand

--- a/packages/cli/src/commands/access-group/command.ts
+++ b/packages/cli/src/commands/access-group/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { formatOption, jsonOption } from '../../util/arg-common';
+import { formatOption, jsonOption, yesOption } from '../../util/arg-common';
 
 const nameOption = {
   name: 'name',
@@ -82,6 +82,25 @@ export const updateSubcommand = {
   ],
 } as const;
 
+export const removeSubcommand = {
+  name: 'remove',
+  aliases: ['rm'],
+  description: 'Remove an access group',
+  arguments: [
+    {
+      name: 'idOrName',
+      required: true,
+    },
+  ],
+  options: [yesOption],
+  examples: [
+    {
+      name: 'Remove an access group',
+      value: `${packageName} access-group rm my-access-group`,
+    },
+  ],
+} as const;
+
 export const accessGroupCommand = {
   name: 'access-group',
   aliases: ['access-groups'],
@@ -92,6 +111,7 @@ export const accessGroupCommand = {
     inspectSubcommand,
     addSubcommand,
     updateSubcommand,
+    removeSubcommand,
   ],
   options: [],
   examples: [

--- a/packages/cli/src/commands/access-group/index.ts
+++ b/packages/cli/src/commands/access-group/index.ts
@@ -5,12 +5,14 @@ import inspect from './inspect';
 import ls from './ls';
 import add from './add';
 import update from './update';
+import rm from './rm';
 import {
   accessGroupCommand,
   inspectSubcommand,
   listSubcommand,
   addSubcommand,
   updateSubcommand,
+  removeSubcommand,
 } from './command';
 import { type Command, help } from '../help';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
@@ -24,6 +26,7 @@ const COMMAND_CONFIG = {
   ls: getCommandAliases(listSubcommand),
   add: getCommandAliases(addSubcommand),
   update: getCommandAliases(updateSubcommand),
+  rm: getCommandAliases(removeSubcommand),
 };
 
 export default async function accessGroup(client: Client) {
@@ -93,6 +96,14 @@ export default async function accessGroup(client: Client) {
       }
       telemetry.trackCliSubcommandUpdate(subcommandOriginal);
       return update(client, args);
+    case 'rm':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group', subcommandOriginal);
+        printHelp(removeSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
+      return rm(client, args);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('access-group', subcommandOriginal);

--- a/packages/cli/src/commands/access-group/rm.ts
+++ b/packages/cli/src/commands/access-group/rm.ts
@@ -1,0 +1,87 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { AccessGroupTelemetryClient } from '../../util/telemetry/commands/access-group';
+import getAccessGroup from '../../util/access-group/get-access-group';
+import deleteAccessGroup from '../../util/access-group/delete-access-group';
+import { handleAccessGroupError } from '../../util/access-group/error';
+import { removeSubcommand } from './command';
+
+export default async function rm(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AccessGroupTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(removeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const idOrName = parsedArgs.args[0];
+  if (!idOrName) {
+    output.error(
+      `Please provide an access group id or name. See ${getCommandName(
+        'access-group rm <idOrName>'
+      )}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentIdOrName(idOrName);
+  telemetry.trackCliFlagYes(flags['--yes']);
+
+  const skipConfirmation = flags['--yes'] || false;
+
+  if (client.nonInteractive && !skipConfirmation) {
+    output.error(
+      'In non-interactive mode, `--yes` is required to remove an access group.'
+    );
+    return 1;
+  }
+
+  // Resolve the group first so the confirmation names the real target.
+  let accessGroup;
+  try {
+    accessGroup = await getAccessGroup(client, idOrName);
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  if (!skipConfirmation) {
+    const confirmed = await client.input.confirm(
+      `Are you sure you want to remove the access group ${chalk.bold(
+        accessGroup.name
+      )} (${accessGroup.accessGroupId})?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  try {
+    await deleteAccessGroup(client, accessGroup.accessGroupId);
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  output.success(
+    `Access group ${chalk.bold(accessGroup.name)} (${
+      accessGroup.accessGroupId
+    }) removed`
+  );
+  return 0;
+}

--- a/packages/cli/src/util/access-group/delete-access-group.ts
+++ b/packages/cli/src/util/access-group/delete-access-group.ts
@@ -1,0 +1,10 @@
+import type Client from '../client';
+
+export default async function deleteAccessGroup(
+  client: Client,
+  idOrName: string
+): Promise<void> {
+  await client.fetch(`/v1/access-groups/${encodeURIComponent(idOrName)}`, {
+    method: 'DELETE',
+  });
+}

--- a/packages/cli/src/util/telemetry/commands/access-group/index.ts
+++ b/packages/cli/src/util/telemetry/commands/access-group/index.ts
@@ -34,6 +34,13 @@ export class AccessGroupTelemetryClient
     });
   }
 
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
   trackCliArgumentIdOrName(idOrName: string | undefined) {
     if (idOrName) {
       this.trackCliArgument({
@@ -58,6 +65,12 @@ export class AccessGroupTelemetryClient
         option: 'name',
         value: this.redactedValue,
       });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
     }
   }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -60,6 +60,9 @@ exports[`help command > access-group help output snapshots > access-group help c
   update   idOrName  Update an  
                      access     
                      group      
+  remove   idOrName  Remove an  
+                     access     
+                     group      
 
 
   Global Options:
@@ -136,6 +139,7 @@ exports[`help command > access-group help output snapshots > access-group help c
   inspect  idOrName  Show an access group in full                       
   add      name      Create an access group                             
   update   idOrName  Update an access group                             
+  remove   idOrName  Remove an access group                             
 
 
   Global Options:
@@ -179,6 +183,7 @@ exports[`help command > access-group help output snapshots > access-group help c
   inspect  idOrName  Show an access group in full                                                               
   add      name      Create an access group                                                                     
   update   idOrName  Update an access group                                                                     
+  remove   idOrName  Remove an access group                                                                     
 
 
   Global Options:
@@ -274,6 +279,40 @@ exports[`help command > access-group help output snapshots > access-group list h
   - List all access groups on the current team
 
     $ vercel access-group ls
+
+"
+`;
+
+exports[`help command > access-group help output snapshots > access-group remove help output snapshots > access-group remove help column width 120 1`] = `
+"
+  ▲ vercel access-group remove idOrName [options]
+
+  Remove an access group                                                                                                
+
+  Options:
+
+  -y,  --yes  Accept default value for all prompts                                                                      
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Remove an access group
+
+    $ vercel access-group rm my-access-group
 
 "
 `;

--- a/packages/cli/test/unit/commands/access-group/rm.test.ts
+++ b/packages/cli/test/unit/commands/access-group/rm.test.ts
@@ -1,0 +1,142 @@
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+import { useAccessGroups } from '../../../mocks/access-group';
+
+describe('access-group rm', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  afterEach(() => {
+    client.nonInteractive = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('access-group', 'rm', '--help');
+      const exitCodePromise = accessGroup(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'access-group:rm',
+        },
+      ]);
+    });
+  });
+
+  it('errors when no id or name is passed', async () => {
+    client.setArgv('access-group', 'rm');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Please provide an access group id or name'
+    );
+  });
+
+  it('requires --yes in non-interactive mode and does not delete', async () => {
+    useAccessGroups();
+    let deleted = false;
+    client.scenario.delete('/v1/access-groups/ag_1', (_req, res) => {
+      deleted = true;
+      res.status(200).end();
+    });
+
+    client.nonInteractive = true;
+    client.setArgv('access-group', 'rm', 'ag_1');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    expect(deleted).toEqual(false);
+    await expect(client.stderr).toOutput('`--yes` is required');
+  });
+
+  it('does not delete when the user declines', async () => {
+    useAccessGroups();
+    let deleted = false;
+    client.scenario.delete('/v1/access-groups/ag_1', (_req, res) => {
+      deleted = true;
+      res.status(200).end();
+    });
+
+    client.setArgv('access-group', 'rm', 'ag_1');
+    const exitCodePromise = accessGroup(client);
+    await expect(client.stderr).toOutput('Are you sure');
+    client.stdin.write('n\n');
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode).toEqual(0);
+    expect(deleted).toEqual(false);
+  });
+
+  it('deletes when the user confirms', async () => {
+    useAccessGroups();
+    let deleted = false;
+    client.scenario.delete('/v1/access-groups/ag_1', (_req, res) => {
+      deleted = true;
+      res.status(200).end();
+    });
+
+    client.setArgv('access-group', 'rm', 'ag_1');
+    const exitCodePromise = accessGroup(client);
+    await expect(client.stderr).toOutput('Are you sure');
+    client.stdin.write('y\n');
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode).toEqual(0);
+    expect(deleted).toEqual(true);
+    await expect(client.stderr).toOutput('removed');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:remove',
+        value: 'rm',
+      },
+      {
+        key: 'argument:idOrName',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('skips confirmation with --yes', async () => {
+    useAccessGroups();
+    let deleted = false;
+    client.scenario.delete('/v1/access-groups/ag_1', (_req, res) => {
+      deleted = true;
+      res.status(200).end();
+    });
+
+    client.setArgv('access-group', 'rm', 'ag_1', '--yes');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+    expect(deleted).toEqual(true);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:remove',
+        value: 'rm',
+      },
+      {
+        key: 'argument:idOrName',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'flag:yes',
+        value: 'TRUE',
+      },
+    ]);
+  });
+
+  it('maps a 404 to a not-found message', async () => {
+    client.scenario.get('/v1/access-groups/ag_missing', (_req, res) => {
+      res.status(404).json({ error: { code: 'not_found', message: 'nope' } });
+    });
+    client.setArgv('access-group', 'rm', 'ag_missing', '--yes');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Access group not found.');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -149,6 +149,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('access-group remove help output snapshots', () => {
+      it('access-group remove help column width 120', () => {
+        expect(
+          help(accessGroup.removeSubcommand, {
+            columns: 120,
+            parent: accessGroup.accessGroupCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('alias help output snapshots', () => {


### PR DESCRIPTION
## Summary
- Adds `vercel access-group remove <idOrName>` (alias `rm`) to delete an access group.
- Confirms before deleting (default No), skips with `--yes`, and refuses in non-interactive mode without `--yes` (exit 1) rather than prompting.

## Notes
- Endpoint (public v1): `DELETE /v1/access-groups/:idOrName`. The group is resolved first (`GET /v1/access-groups/:idOrName`) so the confirmation names the real target.
- Telemetry redacts the `idOrName` argument; `--yes` is recorded as a boolean.
- Unit tests cover confirm/decline/`--yes`/non-interactive paths and assert the DELETE is not fired on decline or missing `--yes`.
- Help snapshots regenerated for the new subcommand; the pre-existing `connex` width-120 snapshot failure is unrelated and left untouched.
- Stack: #17460 (read) → #17464 (add/update) → #17476 (remove) → #17470 (members list) → #17488 (members add) → #17478 (members remove) → #17474 (projects list) → #17493 (projects add) → #17480 (projects update/remove).