### PR TITLE
[CLI] Add domains auto-renew subcommand

### DIFF
--- a/.changeset/domains-auto-renew.md
+++ b/.changeset/domains-auto-renew.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel domains auto-renew <domain> on|off` for registrar-managed domains

--- a/packages/cli/src/commands/domains/auto-renew.ts
+++ b/packages/cli/src/commands/domains/auto-renew.ts
@@ -1,0 +1,126 @@
+import chalk from 'chalk';
+import { errorToString } from '@vercel/error-utils';
+import * as ERRORS from '../../util/errors-ts';
+import getScope from '../../util/get-scope';
+import isRootDomain from '../../util/is-root-domain';
+import param from '../../util/output/param';
+import updateAutoRenew from '../../util/domains/update-auto-renew';
+import { getCommandName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { DomainsAutoRenewTelemetryClient } from '../../util/telemetry/commands/domains/auto-renew';
+import type Client from '../../util/client';
+import { autoRenewSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+
+export default async function autoRenew(client: Client, argv: string[]) {
+  const telemetry = new DomainsAutoRenewTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(autoRenewSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args } = parsedArgs;
+  const [domainName, state] = args;
+
+  telemetry.trackCliArgumentDomain(domainName);
+  telemetry.trackCliArgumentState(state);
+
+  if (args.length !== 2 || !domainName || !state) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        `${getCommandName('domains auto-renew <domain> <on|off>')}`
+      )}`
+    );
+    return 1;
+  }
+
+  if (!isRootDomain(domainName)) {
+    output.error(
+      `Invalid domain name "${domainName}". Run ${getCommandName(
+        `domains --help`
+      )}`
+    );
+    return 1;
+  }
+
+  if (state !== 'on' && state !== 'off') {
+    output.error(
+      `Invalid state "${state}". Expected ${chalk.bold('on')} or ${chalk.bold(
+        'off'
+      )}.`
+    );
+    return 1;
+  }
+
+  const enabled = state === 'on';
+  const { contextName } = await getScope(client);
+
+  output.spinner(`Turning automatic renewal ${state} for ${domainName}`);
+
+  try {
+    await updateAutoRenew(client, domainName, enabled);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    if (ERRORS.isAPIError(err)) {
+      switch (err.code) {
+        case 'domain_not_registered':
+          output.error(
+            `The domain ${param(domainName)} is not registered with Vercel.`
+          );
+          return 1;
+        case 'domain_not_found':
+          output.error(
+            `Domain ${param(domainName)} not found under ${chalk.bold(
+              contextName
+            )}.`
+          );
+          return 1;
+        case 'domain_not_renewable':
+          output.error(
+            `The domain ${param(domainName)} cannot be renewed, so automatic renewal can't be changed.`
+          );
+          return 1;
+        case 'domain_already_renewing':
+          output.error(
+            `The domain ${param(domainName)} is already renewing, so automatic renewal can't be changed right now.`
+          );
+          return 1;
+        case 'forbidden':
+          output.error(
+            `You don't have permission to update ${param(
+              domainName
+            )} under ${chalk.bold(contextName)}.`
+          );
+          return 1;
+        default:
+          if (err.status < 500) {
+            output.error(err.serverMessage || err.message);
+            return 1;
+          }
+      }
+    }
+    output.error(
+      'An unexpected error occurred while updating automatic renewal. Please try again later.'
+    );
+    output.debug(`Server response: ${errorToString(err)}`);
+    return 1;
+  }
+
+  output.stopSpinner();
+  output.success(
+    enabled
+      ? `Automatic renewal turned on for ${param(domainName)}`
+      : `Automatic renewal turned off for ${param(domainName)}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -314,6 +314,33 @@ export const renewSubcommand = {
   ],
 } as const;
 
+export const autoRenewSubcommand = {
+  name: 'auto-renew',
+  aliases: [],
+  description: 'Turn automatic renewal on or off for a registered domain',
+  arguments: [
+    {
+      name: 'domain',
+      required: true,
+    },
+    {
+      name: 'state',
+      required: true,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Turn automatic renewal on',
+      value: `${packageName} domains auto-renew example.com on`,
+    },
+    {
+      name: 'Turn automatic renewal off',
+      value: `${packageName} domains auto-renew example.com off`,
+    },
+  ],
+} as const;
+
 export const verifySubcommand = {
   name: 'verify',
   aliases: [],
@@ -375,6 +402,7 @@ export const domainsCommand = {
     transferInSubcommand,
     removeSubcommand,
     renewSubcommand,
+    autoRenewSubcommand,
     verifySubcommand,
   ],
   options: [],

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -13,9 +13,11 @@ import move from './move';
 import price from './price';
 import search from './search';
 import renew from './renew';
+import autoRenew from './auto-renew';
 import verify from './verify';
 import {
   addSubcommand,
+  autoRenewSubcommand,
   buySubcommand,
   checkSubcommand,
   domainsCommand,
@@ -46,6 +48,7 @@ const COMMAND_CONFIG = {
   rm: ['rm', 'remove'],
   transferIn: ['transfer-in'],
   renew: ['renew'],
+  autoRenew: ['auto-renew'],
   verify: ['verify'],
 };
 
@@ -158,6 +161,13 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandRenew(subcommandOriginal);
       return renew(client, args);
+    case 'autoRenew':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('domains', subcommandOriginal);
+        return printHelp(autoRenewSubcommand);
+      }
+      telemetry.trackCliSubcommandAutoRenew(subcommandOriginal);
+      return autoRenew(client, args);
     case 'verify':
       if (needHelp) {
         telemetry.trackCliFlagHelp('domains', subcommandOriginal);

--- a/packages/cli/src/util/domains/update-auto-renew.ts
+++ b/packages/cli/src/util/domains/update-auto-renew.ts
@@ -1,0 +1,26 @@
+import type Client from '../client';
+import getScope from '../get-scope';
+
+/**
+ * Turns automatic renewal on or off for a registered domain. This does not
+ * charge the account; billing only happens when the domain actually renews.
+ * Throws `APIError` for the caller to map to messages.
+ */
+export default async function updateAutoRenew(
+  client: Client,
+  name: string,
+  autoRenew: boolean
+) {
+  const { team } = await getScope(client);
+  const teamParam = team ? `?teamId=${team.slug}` : '';
+
+  return client.fetch(
+    `/v1/registrar/domains/${encodeURIComponent(name)}/auto-renew${teamParam}`,
+    {
+      method: 'PATCH',
+      body: {
+        autoRenew,
+      },
+    }
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/domains/auto-renew.ts
+++ b/packages/cli/src/util/telemetry/commands/domains/auto-renew.ts
@@ -1,0 +1,27 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { autoRenewSubcommand } from '../../../../commands/domains/command';
+
+export class DomainsAutoRenewTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof autoRenewSubcommand>
+{
+  trackCliArgumentDomain(domainName: string | undefined) {
+    if (domainName) {
+      this.trackCliArgument({
+        arg: 'domain',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentState(state: string | undefined) {
+    if (state === 'on' || state === 'off') {
+      // `state` is a bounded enum (`on`/`off`), so the literal value is safe to record.
+      this.trackCliArgument({
+        arg: 'state',
+        value: state,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/domains/index.ts
+++ b/packages/cli/src/util/telemetry/commands/domains/index.ts
@@ -76,6 +76,13 @@ export class DomainsTelemetryClient
     });
   }
 
+  trackCliSubcommandAutoRenew(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'auto-renew',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandList(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'list',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2251,6 +2251,16 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    (ch…
                                    your
                                    acc…
+  auto-renew   domain state        Turn
+                                   aut…
+                                   ren…
+                                   on  
+                                   or  
+                                   off 
+                                   for 
+                                   a   
+                                   reg…
+                                   dom…
   verify       domain              Che…
                                    a   
                                    dom…
@@ -2345,6 +2355,8 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    Vercel Team                                 
   renew        domain              Renew a registered domain before it expires 
                                    (charges your account)                      
+  auto-renew   domain state        Turn automatic renewal on or off for a      
+                                   registered domain                           
   verify       domain              Check a domain's DNS configuration and      
                                    explain what to fix when it is misconfigured
                                    or unverified                               
@@ -2388,6 +2400,7 @@ exports[`help command > domains help output snapshots > domains help column widt
   transfer-in  domain              Transfer in a domain name to Vercel                                                 
   remove       domain              Remove ownership of a domain name from a Vercel Team                                
   renew        domain              Renew a registered domain before it expires (charges your account)                  
+  auto-renew   domain state        Turn automatic renewal on or off for a registered domain                            
   verify       domain              Check a domain's DNS configuration and explain what to fix when it is misconfigured 
                                    or unverified                                                                       
 

--- a/packages/cli/test/unit/commands/domains/auto-renew.test.ts
+++ b/packages/cli/test/unit/commands/domains/auto-renew.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import domains from '../../../../src/commands/domains';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+
+describe('domains auto-renew', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'domains';
+      const subcommand = 'auto-renew';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = domains(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  it('errors and tracks subcommand usage when no arguments are given', async () => {
+    useUser();
+    client.setArgv('domains', 'auto-renew');
+    const exitCode = await domains(client);
+    expect(exitCode, 'exit code for "domains"').toEqual(1);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:auto-renew',
+        value: 'auto-renew',
+      },
+    ]);
+  });
+
+  it('rejects an invalid state', async () => {
+    useUser();
+    client.setArgv('domains', 'auto-renew', 'example.com', 'maybe');
+    const exitCodePromise = domains(client);
+    await expect(client.stderr).toOutput('Invalid state "maybe"');
+    await expect(exitCodePromise).resolves.toEqual(1);
+
+    // `state` is only recorded for the `on`/`off` enum, never arbitrary values.
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:auto-renew',
+        value: 'auto-renew',
+      },
+      {
+        key: 'argument:domain',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  describe('on', () => {
+    it('turns auto-renew on and records the enum value', async () => {
+      useUser();
+      let body: Record<string, unknown> | undefined;
+      client.scenario.patch(
+        '/v1/registrar/domains/example.com/auto-renew',
+        (req, res) => {
+          body = req.body;
+          res.status(204).end();
+        }
+      );
+
+      client.setArgv('domains', 'auto-renew', 'example.com', 'on');
+      const exitCodePromise = domains(client);
+      await expect(client.stderr).toOutput(
+        'Automatic renewal turned on for "example.com"'
+      );
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      expect(body).toEqual({ autoRenew: true });
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:auto-renew',
+          value: 'auto-renew',
+        },
+        {
+          key: 'argument:domain',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'argument:state',
+          value: 'on',
+        },
+      ]);
+    });
+  });
+
+  describe('off', () => {
+    it('turns auto-renew off', async () => {
+      useUser();
+      let body: Record<string, unknown> | undefined;
+      client.scenario.patch(
+        '/v1/registrar/domains/example.com/auto-renew',
+        (req, res) => {
+          body = req.body;
+          res.status(204).end();
+        }
+      );
+
+      client.setArgv('domains', 'auto-renew', 'example.com', 'off');
+      const exitCodePromise = domains(client);
+      await expect(client.stderr).toOutput(
+        'Automatic renewal turned off for "example.com"'
+      );
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      expect(body).toEqual({ autoRenew: false });
+    });
+  });
+
+  it('maps domain_not_registered to a friendly error', async () => {
+    useUser();
+    client.scenario.patch(
+      '/v1/registrar/domains/example.com/auto-renew',
+      (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'domain_not_registered',
+            message: 'Not registered',
+          },
+        });
+      }
+    );
+
+    client.setArgv('domains', 'auto-renew', 'example.com', 'on');
+    const exitCodePromise = domains(client);
+    await expect(client.stderr).toOutput('is not registered with Vercel');
+    await expect(exitCodePromise).resolves.toEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `vercel domains auto-renew <domain> on|off` to turn automatic renewal on or off for a registered domain. Toggling is not a billing event (billing happens only when the domain actually renews), so it follows the family's non-destructive mutation conventions: no confirmation prompt, spinner + success line.
- Telemetry client (domain redacted; the bounded `on|off` enum recorded literally), unit tests (request-body assertions for on/off, invalid-state rejection with a negative telemetry assertion, `domain_not_registered` error mapping), and help snapshot updates.

## Notes
- Calls `PATCH /v1/registrar/domains/{domain}/auto-renew` (handler: `update-domain-auto-renew-handler.ts`) with `{ autoRenew: boolean }` (204). Maps `domain_not_registered`, `domain_not_found`, `domain_not_renewable`, `domain_already_renewing`, and `forbidden` to friendly errors.
- The legacy `PATCH /v{3,4,5}/domains/{domain}` body field `renew` is deprecated in that endpoint's own schema in favor of this dedicated registrar endpoint.
- Stack: #17461 (renew) → this PR → #17475 (nameservers) → auth-code.