### PR TITLE
[CLI] Add access-group members remove subcommand

### DIFF
--- a/.changeset/access-group-members-remove.md
+++ b/.changeset/access-group-members-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel access-group members remove` subcommand

--- a/packages/cli/src/commands/access-group/command.ts
+++ b/packages/cli/src/commands/access-group/command.ts
@@ -144,12 +144,39 @@ export const membersAddSubcommand = {
   ],
 } as const;
 
+export const membersRemoveSubcommand = {
+  name: 'remove',
+  aliases: ['rm'],
+  description: 'Remove a member from an access group',
+  arguments: [
+    {
+      name: 'group',
+      required: true,
+    },
+    {
+      name: 'member',
+      required: true,
+    },
+  ],
+  options: [yesOption],
+  examples: [
+    {
+      name: 'Remove a member (by id, email, or username) from an access group',
+      value: `${packageName} access-group members rm my-access-group user@example.com`,
+    },
+  ],
+} as const;
+
 export const membersSubcommand = {
   name: 'members',
   aliases: [],
   description: 'Manage the members of an access group',
   arguments: [],
-  subcommands: [membersListSubcommand, membersAddSubcommand],
+  subcommands: [
+    membersListSubcommand,
+    membersAddSubcommand,
+    membersRemoveSubcommand,
+  ],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/access-group/members-remove.ts
+++ b/packages/cli/src/commands/access-group/members-remove.ts
@@ -1,0 +1,98 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { AccessGroupMembersTelemetryClient } from '../../util/telemetry/commands/access-group/members';
+import updateAccessGroup from '../../util/access-group/update-access-group';
+import getAccessGroupMembers from '../../util/access-group/get-access-group-members';
+import { resolveMemberId } from '../../util/access-group/resolve-member';
+import { handleAccessGroupError } from '../../util/access-group/error';
+import { membersRemoveSubcommand } from './command';
+
+export default async function rm(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AccessGroupMembersTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    membersRemoveSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const [group, member] = parsedArgs.args;
+  if (!group || !member) {
+    output.error(
+      `Please provide an access group and a member. See ${getCommandName(
+        'access-group members rm <group> <member>'
+      )}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentGroup(group);
+  telemetry.trackCliArgumentMember(member);
+  telemetry.trackCliFlagYes(flags['--yes']);
+
+  const skipConfirmation = flags['--yes'] || false;
+
+  if (client.nonInteractive && !skipConfirmation) {
+    output.error(
+      'In non-interactive mode, `--yes` is required to remove a member.'
+    );
+    return 1;
+  }
+
+  let uid: string | undefined;
+  try {
+    const members = await getAccessGroupMembers(client, group);
+    uid = resolveMemberId(members, member);
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  if (!uid) {
+    output.error(
+      `Could not find a member matching ${chalk.bold(
+        member
+      )} in access group ${chalk.bold(group)}.`
+    );
+    return 1;
+  }
+
+  if (!skipConfirmation) {
+    const confirmed = await client.input.confirm(
+      `Are you sure you want to remove ${chalk.bold(
+        member
+      )} from access group ${chalk.bold(group)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  try {
+    await updateAccessGroup(client, group, { membersToRemove: [uid] });
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  output.success(
+    `Member ${chalk.bold(member)} removed from access group ${chalk.bold(group)}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/access-group/members.ts
+++ b/packages/cli/src/commands/access-group/members.ts
@@ -4,10 +4,12 @@ import getSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import list from './members-list';
 import add from './members-add';
+import rm from './members-remove';
 import {
   membersSubcommand,
   membersListSubcommand,
   membersAddSubcommand,
+  membersRemoveSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -18,6 +20,7 @@ import { printError } from '../../util/error';
 const COMMAND_CONFIG = {
   list: getCommandAliases(membersListSubcommand),
   add: getCommandAliases(membersAddSubcommand),
+  rm: getCommandAliases(membersRemoveSubcommand),
 };
 
 export default async function members(client: Client): Promise<number> {
@@ -68,6 +71,14 @@ export default async function members(client: Client): Promise<number> {
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
+    case 'rm':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group members', subcommandOriginal);
+        printHelp(membersRemoveSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
+      return rm(client, args);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('access-group members', subcommandOriginal);

--- a/packages/cli/src/util/access-group/update-access-group.ts
+++ b/packages/cli/src/util/access-group/update-access-group.ts
@@ -5,6 +5,7 @@ import type { AccessGroup } from './types';
 export interface UpdateAccessGroupBody {
   name?: string;
   membersToAdd?: string[];
+  membersToRemove?: string[];
 }
 
 export default async function updateAccessGroup(

--- a/packages/cli/src/util/telemetry/commands/access-group/members.ts
+++ b/packages/cli/src/util/telemetry/commands/access-group/members.ts
@@ -20,6 +20,13 @@ export class AccessGroupMembersTelemetryClient
     });
   }
 
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
   trackCliArgumentGroup(group: string | undefined) {
     if (group) {
       this.trackCliArgument({
@@ -35,6 +42,12 @@ export class AccessGroupMembersTelemetryClient
         arg: 'member',
         value: this.redactedValue,
       });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
     }
   }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -326,8 +326,9 @@ exports[`help command > access-group help output snapshots > access-group member
 
   Commands:
 
-  list  group         List the members of an access group (default)                                              
-  add   group member  Add a member to an access group                                                            
+  list    group         List the members of an access group (default)                                           
+  add     group member  Add a member to an access group                                                         
+  remove  group member  Remove a member from an access group                                                    
 
 
   Global Options:
@@ -384,6 +385,40 @@ exports[`help command > access-group help output snapshots > access-group member
   - List the members of an access group
 
     $ vercel access-group members ls my-access-group
+
+"
+`;
+
+exports[`help command > access-group help output snapshots > access-group members help output snapshots > access-group members remove help column width 120 1`] = `
+"
+  ▲ vercel members remove group member [options]
+
+  Remove a member from an access group                                                                                  
+
+  Options:
+
+  -y,  --yes  Accept default value for all prompts                                                                      
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Remove a member (by id, email, or username) from an access group
+
+    $ vercel access-group members rm my-access-group user@example.com
 
 "
 `;

--- a/packages/cli/test/unit/commands/access-group/members-remove.test.ts
+++ b/packages/cli/test/unit/commands/access-group/members-remove.test.ts
@@ -1,0 +1,90 @@
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+import { useAccessGroupMembers } from '../../../mocks/access-group';
+
+describe('access-group members remove', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  afterEach(() => {
+    client.nonInteractive = false;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('access-group', 'members', 'rm', '--help');
+      const exitCodePromise = accessGroup(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:members',
+          value: 'members',
+        },
+        {
+          key: 'flag:help',
+          value: 'access-group members:rm',
+        },
+      ]);
+    });
+  });
+
+  it('requires --yes in non-interactive mode and does not update', async () => {
+    let updated = false;
+    client.scenario.post('/v1/access-groups/ag_1', (_req, res) => {
+      updated = true;
+      res.json({});
+    });
+
+    client.nonInteractive = true;
+    client.setArgv('access-group', 'members', 'rm', 'ag_1', 'jane');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    expect(updated).toEqual(false);
+    await expect(client.stderr).toOutput('`--yes` is required');
+  });
+
+  it('does not update when the user declines', async () => {
+    useAccessGroupMembers('ag_1');
+    let updated = false;
+    client.scenario.post('/v1/access-groups/ag_1', (_req, res) => {
+      updated = true;
+      res.json({});
+    });
+
+    client.setArgv('access-group', 'members', 'rm', 'ag_1', 'jane');
+    const exitCodePromise = accessGroup(client);
+    await expect(client.stderr).toOutput('Are you sure');
+    client.stdin.write('n\n');
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode).toEqual(0);
+    expect(updated).toEqual(false);
+  });
+
+  it('resolves a member and removes it with --yes', async () => {
+    useAccessGroupMembers('ag_1');
+    let body: unknown;
+    client.scenario.post('/v1/access-groups/ag_1', (req, res) => {
+      body = req.body;
+      res.json({});
+    });
+
+    client.setArgv('access-group', 'members', 'rm', 'ag_1', 'jane', '--yes');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+    expect(body).toEqual({ membersToRemove: ['usr_1'] });
+    await expect(client.stderr).toOutput('removed from access group');
+  });
+
+  it('errors when the member is not in the group', async () => {
+    useAccessGroupMembers('ag_1');
+    client.setArgv('access-group', 'members', 'rm', 'ag_1', 'nobody', '--yes');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Could not find a member matching');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -184,6 +184,14 @@ describe('help command', () => {
           })
         ).toMatchSnapshot();
       });
+      it('access-group members remove help column width 120', () => {
+        expect(
+          help(accessGroup.membersRemoveSubcommand, {
+            columns: 120,
+            parent: accessGroup.membersSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `vercel access-group members remove <group> <member>` (alias `rm`) to remove a member from an access group by user id, email, or username.
- Confirms before mutating (default No), skips with `--yes`, and refuses in non-interactive mode without `--yes` (exit 1).

## Notes
- Endpoint (public v1): there is no dedicated member-remove endpoint, so the identifier is resolved against the group's members (`GET /v1/access-groups/:group/members`) and applied as `membersToRemove` via the group update endpoint `POST /v1/access-groups/:group`.
- Telemetry redacts the group/member arguments; `--yes` is recorded as a boolean.
- Unit tests cover confirm/decline/`--yes`/non-interactive paths and resolution failures, asserting the update is not fired on decline or missing `--yes`.
- Help snapshots regenerated; the pre-existing `connex` width-120 snapshot failure is unrelated and left untouched.
- Stack: #17460 (read) → #17464 (add/update) → #17476 (remove) → #17470 (members list) → #17488 (members add) → #17478 (members remove) → #17474 (projects list) → #17493 (projects add) → #17480 (projects update/remove).