### PR TITLE
[CLI] Add domains auth-code subcommand

### DIFF
--- a/.changeset/domains-auth-code.md
+++ b/.changeset/domains-auth-code.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel domains auth-code <domain>` for registrar-managed domains

--- a/packages/cli/src/commands/domains/auth-code.ts
+++ b/packages/cli/src/commands/domains/auth-code.ts
@@ -1,0 +1,116 @@
+import chalk from 'chalk';
+import { errorToString } from '@vercel/error-utils';
+import * as ERRORS from '../../util/errors-ts';
+import fetchAuthCode from '../../util/domains/fetch-auth-code';
+import getScope from '../../util/get-scope';
+import isRootDomain from '../../util/is-root-domain';
+import param from '../../util/output/param';
+import { getCommandName } from '../../util/pkg-name';
+import output from '../../output-manager';
+import { DomainsAuthCodeTelemetryClient } from '../../util/telemetry/commands/domains/auth-code';
+import type Client from '../../util/client';
+import { authCodeSubcommand } from './command';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+
+export default async function authCode(client: Client, argv: string[]) {
+  const telemetry = new DomainsAuthCodeTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(authCodeSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+  const { args } = parsedArgs;
+  const [domainName] = args;
+
+  telemetry.trackCliArgumentDomain(domainName);
+
+  if (args.length !== 1 || !domainName) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        `${getCommandName('domains auth-code <domain>')}`
+      )}`
+    );
+    return 1;
+  }
+
+  if (!isRootDomain(domainName)) {
+    output.error(
+      `Invalid domain name "${domainName}". Run ${getCommandName(
+        `domains --help`
+      )}`
+    );
+    return 1;
+  }
+
+  const { contextName } = await getScope(client);
+
+  output.spinner(`Fetching auth code for ${domainName}`);
+
+  let code: string;
+  try {
+    code = await fetchAuthCode(client, domainName);
+  } catch (err: unknown) {
+    output.stopSpinner();
+    if (ERRORS.isAPIError(err)) {
+      switch (err.code) {
+        case 'domain_not_registered':
+          output.error(
+            `The domain ${param(domainName)} is not registered with Vercel.`
+          );
+          return 1;
+        case 'domain_not_found':
+          output.error(
+            `Domain ${param(domainName)} not found under ${chalk.bold(
+              contextName
+            )}.`
+          );
+          return 1;
+        case 'domain_cannot_be_transfered_out_until':
+          output.error(
+            err.serverMessage ||
+              `The domain ${param(domainName)} cannot be transferred out yet.`
+          );
+          return 1;
+        case 'forbidden':
+          output.error(
+            `You don't have permission to read the auth code for ${param(
+              domainName
+            )} under ${chalk.bold(contextName)}.`
+          );
+          return 1;
+        default:
+          if (err.status < 500) {
+            output.error(err.serverMessage || err.message);
+            return 1;
+          }
+      }
+    }
+    output.error(
+      'An unexpected error occurred while fetching the auth code. Please try again later.'
+    );
+    output.debug(`Server response: ${errorToString(err)}`);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  // The auth code is a sensitive secret. Keep human context and the warning on
+  // stderr so stdout stays a clean, pipeable single line containing only the code.
+  output.warn(
+    `This is a sensitive transfer-out auth code for ${param(domainName)}. ` +
+      'Anyone with it can transfer the domain away from Vercel. Do not share or log it.'
+  );
+  client.stdout.write(`${code}\n`);
+
+  return 0;
+}

--- a/packages/cli/src/commands/domains/command.ts
+++ b/packages/cli/src/commands/domains/command.ts
@@ -391,6 +391,26 @@ export const nameserversSubcommand = {
   ],
 } as const;
 
+export const authCodeSubcommand = {
+  name: 'auth-code',
+  aliases: [],
+  description:
+    'Print the transfer-out auth code for a registered domain (sensitive)',
+  arguments: [
+    {
+      name: 'domain',
+      required: true,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Print the transfer-out auth code for a domain',
+      value: `${packageName} domains auth-code example.com`,
+    },
+  ],
+} as const;
+
 export const verifySubcommand = {
   name: 'verify',
   aliases: [],
@@ -454,6 +474,7 @@ export const domainsCommand = {
     renewSubcommand,
     autoRenewSubcommand,
     nameserversSubcommand,
+    authCodeSubcommand,
     verifySubcommand,
   ],
   options: [],

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -15,9 +15,11 @@ import search from './search';
 import renew from './renew';
 import autoRenew from './auto-renew';
 import nameservers from './nameservers';
+import authCode from './auth-code';
 import verify from './verify';
 import {
   addSubcommand,
+  authCodeSubcommand,
   autoRenewSubcommand,
   buySubcommand,
   checkSubcommand,
@@ -52,6 +54,7 @@ const COMMAND_CONFIG = {
   renew: ['renew'],
   autoRenew: ['auto-renew'],
   nameservers: ['nameservers', 'ns'],
+  authCode: ['auth-code'],
   verify: ['verify'],
 };
 
@@ -178,6 +181,13 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandNameservers(subcommandOriginal);
       return nameservers(client, args);
+    case 'authCode':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('domains', subcommandOriginal);
+        return printHelp(authCodeSubcommand);
+      }
+      telemetry.trackCliSubcommandAuthCode(subcommandOriginal);
+      return authCode(client, args);
     case 'verify':
       if (needHelp) {
         telemetry.trackCliFlagHelp('domains', subcommandOriginal);

--- a/packages/cli/src/util/domains/fetch-auth-code.ts
+++ b/packages/cli/src/util/domains/fetch-auth-code.ts
@@ -1,0 +1,26 @@
+import type Client from '../client';
+import getScope from '../get-scope';
+
+type AuthCodeResponse = {
+  authCode: string;
+};
+
+/**
+ * Fetches the transfer-out auth (EPP) code for a registered domain. This is a
+ * sensitive secret used to transfer the domain to another registrar, so the
+ * caller must never persist it in telemetry or logs. Throws `APIError` for the
+ * caller to map to messages.
+ */
+export default async function fetchAuthCode(
+  client: Client,
+  name: string
+): Promise<string> {
+  const { team } = await getScope(client);
+  const teamParam = team ? `?teamId=${team.slug}` : '';
+
+  const { authCode } = await client.fetch<AuthCodeResponse>(
+    `/v1/registrar/domains/${encodeURIComponent(name)}/auth-code${teamParam}`
+  );
+
+  return authCode;
+}

--- a/packages/cli/src/util/telemetry/commands/domains/auth-code.ts
+++ b/packages/cli/src/util/telemetry/commands/domains/auth-code.ts
@@ -1,0 +1,17 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { authCodeSubcommand } from '../../../../commands/domains/command';
+
+export class DomainsAuthCodeTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof authCodeSubcommand>
+{
+  trackCliArgumentDomain(domainName: string | undefined) {
+    if (domainName) {
+      this.trackCliArgument({
+        arg: 'domain',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/domains/index.ts
+++ b/packages/cli/src/util/telemetry/commands/domains/index.ts
@@ -90,6 +90,13 @@ export class DomainsTelemetryClient
     });
   }
 
+  trackCliSubcommandAuthCode(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'auth-code',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandList(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'list',

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2270,6 +2270,16 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    a   
                                    reg…
                                    dom…
+  auth-code    domain              Pri…
+                                   the 
+                                   tra…
+                                   auth
+                                   code
+                                   for 
+                                   a   
+                                   reg…
+                                   dom…
+                                   (se…
   verify       domain              Che…
                                    a   
                                    dom…
@@ -2368,6 +2378,8 @@ exports[`help command > domains help output snapshots > domains help column widt
                                    registered domain                           
   nameservers  domain              Show or change the nameservers for a        
                                    registered domain                           
+  auth-code    domain              Print the transfer-out auth code for a      
+                                   registered domain (sensitive)               
   verify       domain              Check a domain's DNS configuration and      
                                    explain what to fix when it is misconfigured
                                    or unverified                               
@@ -2413,6 +2425,7 @@ exports[`help command > domains help output snapshots > domains help column widt
   renew        domain              Renew a registered domain before it expires (charges your account)                  
   auto-renew   domain state        Turn automatic renewal on or off for a registered domain                            
   nameservers  domain              Show or change the nameservers for a registered domain                              
+  auth-code    domain              Print the transfer-out auth code for a registered domain (sensitive)                
   verify       domain              Check a domain's DNS configuration and explain what to fix when it is misconfigured 
                                    or unverified                                                                       
 

--- a/packages/cli/test/unit/commands/domains/auth-code.test.ts
+++ b/packages/cli/test/unit/commands/domains/auth-code.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import domains from '../../../../src/commands/domains';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+
+describe('domains auth-code', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'domains';
+      const subcommand = 'auth-code';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = domains(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  it('errors and tracks subcommand usage when no domain is given', async () => {
+    useUser();
+    client.setArgv('domains', 'auth-code');
+    const exitCode = await domains(client);
+    expect(exitCode, 'exit code for "domains"').toEqual(1);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:auth-code',
+        value: 'auth-code',
+      },
+    ]);
+  });
+
+  it('prints only the code on stdout and warns on stderr', async () => {
+    useUser();
+    client.scenario.get(
+      '/v1/registrar/domains/example.com/auth-code',
+      (_req, res) => {
+        res.json({ authCode: 'SECRET-EPP-CODE-123' });
+      }
+    );
+
+    client.setArgv('domains', 'auth-code', 'example.com');
+    const exitCodePromise = domains(client);
+    await expect(client.stderr).toOutput('sensitive transfer-out auth code');
+    await expect(exitCodePromise).resolves.toEqual(0);
+
+    // stdout carries only the code (pipeable), never prose.
+    expect(client.stdout.getFullOutput()).toEqual('SECRET-EPP-CODE-123\n');
+    expect(client.stderr.getFullOutput()).not.toContain('SECRET-EPP-CODE-123');
+
+    // The code itself must never reach telemetry; only the redacted domain.
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:auth-code',
+        value: 'auth-code',
+      },
+      {
+        key: 'argument:domain',
+        value: '[REDACTED]',
+      },
+    ]);
+    const recordedValues = client.telemetryEventStore.readonlyEvents.map(
+      event => event.value
+    );
+    expect(recordedValues).not.toContain('SECRET-EPP-CODE-123');
+  });
+
+  it('maps domain_cannot_be_transfered_out_until to a friendly error', async () => {
+    useUser();
+    client.scenario.get(
+      '/v1/registrar/domains/example.com/auth-code',
+      (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'domain_cannot_be_transfered_out_until',
+            message: 'Domain cannot be transferred out until 2027-01-01',
+          },
+        });
+      }
+    );
+
+    client.setArgv('domains', 'auth-code', 'example.com');
+    const exitCodePromise = domains(client);
+    await expect(client.stderr).toOutput('cannot be transferred out');
+    await expect(exitCodePromise).resolves.toEqual(1);
+    expect(client.stdout.getFullOutput()).toEqual('');
+  });
+
+  it('maps domain_not_found to a friendly error', async () => {
+    useUser();
+    client.scenario.get(
+      '/v1/registrar/domains/example.com/auth-code',
+      (_req, res) => {
+        res.status(404).json({
+          error: {
+            code: 'domain_not_found',
+            message: 'Domain not found',
+          },
+        });
+      }
+    );
+
+    client.setArgv('domains', 'auth-code', 'example.com');
+    const exitCodePromise = domains(client);
+    await expect(client.stderr).toOutput('not found');
+    await expect(exitCodePromise).resolves.toEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `vercel domains auth-code <domain>` to retrieve the transfer-out auth (EPP) code for a registered domain. The code is sensitive: it is printed to stdout only (single pipeable line), a sensitivity warning goes to stderr, and the code never reaches telemetry — tests assert the code is absent from stderr and from every recorded telemetry value.
- Telemetry client (domain redacted), unit tests (stdout/stderr separation, secret-leak negative assertions, `domain_cannot_be_transfered_out_until` and `domain_not_found` mapping, empty stdout on error), and help snapshot updates.

## Notes
- Calls `GET /v1/registrar/domains/{domain}/auth-code` (handler: `get-domain-auth-code-handler.ts`); the API also disables the registrar transfer lock as a side effect of this call, and `domain_cannot_be_transfered_out_until` is mapped to a friendly error.
- Dropped from this stack for lack of a public contract: `domains registrant` (view/update contact values) and `domains dnssec` (DS record management). Both exist only as dashboard-facing internal RPC handlers (`getRegistrantInfo`/`updateRegistrantInfo`, `listDnssec`/`createDnssec`/`deleteDnssec`); the public REST schema exposes only the contact-info field schema and contact verification status, and no DNSSEC endpoints.
- Stack: #17461 (renew) → #17477 (auto-renew) → #17475 (nameservers) → this PR (tail).