### PR TITLE
[CLI] Add access-group projects update and remove subcommands

### DIFF
--- a/.changeset/access-group-projects-manage.md
+++ b/.changeset/access-group-projects-manage.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel access-group projects update` and `remove` subcommands

--- a/packages/cli/src/commands/access-group/command.ts
+++ b/packages/cli/src/commands/access-group/command.ts
@@ -239,12 +239,63 @@ export const projectsAddSubcommand = {
   ],
 } as const;
 
+export const projectsUpdateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Update the role of a project in an access group',
+  arguments: [
+    {
+      name: 'group',
+      required: true,
+    },
+    {
+      name: 'project',
+      required: true,
+    },
+  ],
+  options: [roleOption],
+  examples: [
+    {
+      name: "Change a project's role in an access group",
+      value: `${packageName} access-group projects update my-access-group my-project --role ADMIN`,
+    },
+  ],
+} as const;
+
+export const projectsRemoveSubcommand = {
+  name: 'remove',
+  aliases: ['rm'],
+  description: 'Remove a project from an access group',
+  arguments: [
+    {
+      name: 'group',
+      required: true,
+    },
+    {
+      name: 'project',
+      required: true,
+    },
+  ],
+  options: [yesOption],
+  examples: [
+    {
+      name: 'Remove a project from an access group',
+      value: `${packageName} access-group projects rm my-access-group my-project`,
+    },
+  ],
+} as const;
+
 export const projectsSubcommand = {
   name: 'projects',
   aliases: [],
   description: 'Manage the projects of an access group',
   arguments: [],
-  subcommands: [projectsListSubcommand, projectsAddSubcommand],
+  subcommands: [
+    projectsListSubcommand,
+    projectsAddSubcommand,
+    projectsUpdateSubcommand,
+    projectsRemoveSubcommand,
+  ],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/access-group/projects-remove.ts
+++ b/packages/cli/src/commands/access-group/projects-remove.ts
@@ -1,0 +1,89 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
+import { AccessGroupProjectsTelemetryClient } from '../../util/telemetry/commands/access-group/projects';
+import { deleteAccessGroupProject } from '../../util/access-group/mutate-access-group-project';
+import { handleAccessGroupError } from '../../util/access-group/error';
+import { projectsRemoveSubcommand } from './command';
+
+export default async function rm(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AccessGroupProjectsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    projectsRemoveSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const [group, project] = parsedArgs.args;
+  if (!group || !project) {
+    output.error(
+      `Please provide an access group and a project. See ${getCommandName(
+        'access-group projects rm <group> <project>'
+      )}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentGroup(group);
+  telemetry.trackCliArgumentProject(project);
+  telemetry.trackCliFlagYes(flags['--yes']);
+
+  const skipConfirmation = flags['--yes'] || false;
+
+  if (client.nonInteractive && !skipConfirmation) {
+    output.error(
+      'In non-interactive mode, `--yes` is required to remove a project.'
+    );
+    return 1;
+  }
+
+  const resolved = await getProjectByNameOrId(client, project);
+  if (resolved instanceof ProjectNotFound) {
+    output.error(`Project ${chalk.bold(project)} not found.`);
+    return 1;
+  }
+
+  if (!skipConfirmation) {
+    const confirmed = await client.input.confirm(
+      `Are you sure you want to remove ${chalk.bold(
+        project
+      )} from access group ${chalk.bold(group)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  try {
+    await deleteAccessGroupProject(client, group, resolved.id);
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  output.success(
+    `Project ${chalk.bold(project)} removed from access group ${chalk.bold(
+      group
+    )}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/access-group/projects-update.ts
+++ b/packages/cli/src/commands/access-group/projects-update.ts
@@ -1,0 +1,95 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
+import { AccessGroupProjectsTelemetryClient } from '../../util/telemetry/commands/access-group/projects';
+import { updateAccessGroupProject } from '../../util/access-group/mutate-access-group-project';
+import { handleAccessGroupError } from '../../util/access-group/error';
+import {
+  ACCESS_GROUP_PROJECT_ROLES,
+  type AccessGroupProjectRole,
+} from '../../util/access-group/types';
+import { projectsUpdateSubcommand } from './command';
+
+export default async function update(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AccessGroupProjectsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    projectsUpdateSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const [group, project] = parsedArgs.args;
+  if (!group || !project) {
+    output.error(
+      `Please provide an access group and a project. See ${getCommandName(
+        'access-group projects update <group> <project> --role <role>'
+      )}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentGroup(group);
+  telemetry.trackCliArgumentProject(project);
+
+  const role = flags['--role'];
+  telemetry.trackCliOptionRole(role);
+
+  if (!role) {
+    output.error(
+      `Please provide a role with \`--role\`. Valid roles: ${ACCESS_GROUP_PROJECT_ROLES.join(
+        ', '
+      )}.`
+    );
+    return 1;
+  }
+  if (!(ACCESS_GROUP_PROJECT_ROLES as readonly string[]).includes(role)) {
+    output.error(
+      `Invalid role "${role}". Valid roles: ${ACCESS_GROUP_PROJECT_ROLES.join(
+        ', '
+      )}.`
+    );
+    return 1;
+  }
+
+  const resolved = await getProjectByNameOrId(client, project);
+  if (resolved instanceof ProjectNotFound) {
+    output.error(`Project ${chalk.bold(project)} not found.`);
+    return 1;
+  }
+
+  try {
+    await updateAccessGroupProject(
+      client,
+      group,
+      resolved.id,
+      role as AccessGroupProjectRole
+    );
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  output.success(
+    `Project ${chalk.bold(project)} in access group ${chalk.bold(
+      group
+    )} updated to role ${chalk.bold(role)}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/access-group/projects.ts
+++ b/packages/cli/src/commands/access-group/projects.ts
@@ -4,10 +4,14 @@ import getSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import list from './projects-list';
 import add from './projects-add';
+import update from './projects-update';
+import rm from './projects-remove';
 import {
   projectsSubcommand,
   projectsListSubcommand,
   projectsAddSubcommand,
+  projectsUpdateSubcommand,
+  projectsRemoveSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -18,6 +22,8 @@ import { printError } from '../../util/error';
 const COMMAND_CONFIG = {
   list: getCommandAliases(projectsListSubcommand),
   add: getCommandAliases(projectsAddSubcommand),
+  update: getCommandAliases(projectsUpdateSubcommand),
+  rm: getCommandAliases(projectsRemoveSubcommand),
 };
 
 export default async function projects(client: Client): Promise<number> {
@@ -68,6 +74,22 @@ export default async function projects(client: Client): Promise<number> {
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
+    case 'update':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group projects', subcommandOriginal);
+        printHelp(projectsUpdateSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandUpdate(subcommandOriginal);
+      return update(client, args);
+    case 'rm':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group projects', subcommandOriginal);
+        printHelp(projectsRemoveSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
+      return rm(client, args);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('access-group projects', subcommandOriginal);

--- a/packages/cli/src/util/access-group/mutate-access-group-project.ts
+++ b/packages/cli/src/util/access-group/mutate-access-group-project.ts
@@ -15,3 +15,31 @@ export function createAccessGroupProject(
     }
   );
 }
+
+export function updateAccessGroupProject(
+  client: Client,
+  group: string,
+  projectId: string,
+  role: AccessGroupProjectRole
+): Promise<AccessGroupProject> {
+  return client.fetch<AccessGroupProject>(
+    `/v1/access-groups/${encodeURIComponent(group)}/projects/${encodeURIComponent(projectId)}`,
+    {
+      method: 'PATCH',
+      body: { role },
+    }
+  );
+}
+
+export async function deleteAccessGroupProject(
+  client: Client,
+  group: string,
+  projectId: string
+): Promise<void> {
+  await client.fetch(
+    `/v1/access-groups/${encodeURIComponent(group)}/projects/${encodeURIComponent(projectId)}`,
+    {
+      method: 'DELETE',
+    }
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/access-group/projects.ts
+++ b/packages/cli/src/util/telemetry/commands/access-group/projects.ts
@@ -21,6 +21,20 @@ export class AccessGroupProjectsTelemetryClient
     });
   }
 
+  trackCliSubcommandUpdate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
   trackCliArgumentGroup(group: string | undefined) {
     if (group) {
       this.trackCliArgument({
@@ -48,6 +62,12 @@ export class AccessGroupProjectsTelemetryClient
         option: 'role',
         value: known ? role : this.redactedValue,
       });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
     }
   }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -471,8 +471,10 @@ exports[`help command > access-group help output snapshots > access-group projec
 
   Commands:
 
-  list  group          List the projects of an access group (default)                                            
-  add   group project  Add a project to an access group                                                          
+  list    group          List the projects of an access group (default)                                         
+  add     group project  Add a project to an access group                                                       
+  update  group project  Update the role of a project in an access group                                        
+  remove  group project  Remove a project from an access group                                                  
 
 
   Global Options:
@@ -529,6 +531,74 @@ exports[`help command > access-group help output snapshots > access-group projec
   - List the projects of an access group
 
     $ vercel access-group projects ls my-access-group
+
+"
+`;
+
+exports[`help command > access-group help output snapshots > access-group projects help output snapshots > access-group projects remove help column width 120 1`] = `
+"
+  ▲ vercel projects remove group project [options]
+
+  Remove a project from an access group                                                                                 
+
+  Options:
+
+  -y,  --yes  Accept default value for all prompts                                                                      
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Remove a project from an access group
+
+    $ vercel access-group projects rm my-access-group my-project
+
+"
+`;
+
+exports[`help command > access-group help output snapshots > access-group projects help output snapshots > access-group projects update help column width 120 1`] = `
+"
+  ▲ vercel projects update group project [options]
+
+  Update the role of a project in an access group                                                                       
+
+  Options:
+
+   --role <ROLE>  The project role: ADMIN, PROJECT_VIEWER, PROJECT_DEVELOPER, or PROJECT_GUEST                           
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Change a project's role in an access group
+
+    $ vercel access-group projects update my-access-group my-project --role ADMIN
 
 "
 `;

--- a/packages/cli/test/unit/commands/access-group/projects-remove.test.ts
+++ b/packages/cli/test/unit/commands/access-group/projects-remove.test.ts
@@ -1,0 +1,104 @@
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+
+describe('access-group projects remove', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  afterEach(() => {
+    client.nonInteractive = false;
+  });
+
+  function useProjectLookup() {
+    client.scenario.get('/v9/projects/my-project', (_req, res) => {
+      res.json({ id: 'prj_1', name: 'my-project' });
+    });
+  }
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('access-group', 'projects', 'rm', '--help');
+      const exitCodePromise = accessGroup(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:projects',
+          value: 'projects',
+        },
+        {
+          key: 'flag:help',
+          value: 'access-group projects:rm',
+        },
+      ]);
+    });
+  });
+
+  it('requires --yes in non-interactive mode and does not delete', async () => {
+    useProjectLookup();
+    let deleted = false;
+    client.scenario.delete(
+      '/v1/access-groups/ag_1/projects/prj_1',
+      (_req, res) => {
+        deleted = true;
+        res.status(200).end();
+      }
+    );
+
+    client.nonInteractive = true;
+    client.setArgv('access-group', 'projects', 'rm', 'ag_1', 'my-project');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    expect(deleted).toEqual(false);
+    await expect(client.stderr).toOutput('`--yes` is required');
+  });
+
+  it('does not delete when the user declines', async () => {
+    useProjectLookup();
+    let deleted = false;
+    client.scenario.delete(
+      '/v1/access-groups/ag_1/projects/prj_1',
+      (_req, res) => {
+        deleted = true;
+        res.status(200).end();
+      }
+    );
+
+    client.setArgv('access-group', 'projects', 'rm', 'ag_1', 'my-project');
+    const exitCodePromise = accessGroup(client);
+    await expect(client.stderr).toOutput('Are you sure');
+    client.stdin.write('n\n');
+
+    const exitCode = await exitCodePromise;
+    expect(exitCode).toEqual(0);
+    expect(deleted).toEqual(false);
+  });
+
+  it('deletes the project with --yes', async () => {
+    useProjectLookup();
+    let deleted = false;
+    client.scenario.delete(
+      '/v1/access-groups/ag_1/projects/prj_1',
+      (_req, res) => {
+        deleted = true;
+        res.status(200).end();
+      }
+    );
+
+    client.setArgv(
+      'access-group',
+      'projects',
+      'rm',
+      'ag_1',
+      'my-project',
+      '--yes'
+    );
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+    expect(deleted).toEqual(true);
+    await expect(client.stderr).toOutput('removed from access group');
+  });
+});

--- a/packages/cli/test/unit/commands/access-group/projects-update.test.ts
+++ b/packages/cli/test/unit/commands/access-group/projects-update.test.ts
@@ -1,0 +1,71 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+
+describe('access-group projects update', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  function useProjectLookup() {
+    client.scenario.get('/v9/projects/my-project', (_req, res) => {
+      res.json({ id: 'prj_1', name: 'my-project' });
+    });
+  }
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('access-group', 'projects', 'update', '--help');
+      const exitCodePromise = accessGroup(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:projects',
+          value: 'projects',
+        },
+        {
+          key: 'flag:help',
+          value: 'access-group projects:update',
+        },
+      ]);
+    });
+  });
+
+  it('errors when --role is missing', async () => {
+    client.setArgv('access-group', 'projects', 'update', 'ag_1', 'my-project');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Please provide a role');
+  });
+
+  it('resolves the project and updates its role via PATCH', async () => {
+    useProjectLookup();
+    let body: unknown;
+    let method: string | undefined;
+    client.scenario.patch(
+      '/v1/access-groups/ag_1/projects/prj_1',
+      (req, res) => {
+        body = req.body;
+        method = req.method;
+        res.json({ projectId: 'prj_1', role: 'ADMIN' });
+      }
+    );
+
+    client.setArgv(
+      'access-group',
+      'projects',
+      'update',
+      'ag_1',
+      'my-project',
+      '--role',
+      'ADMIN'
+    );
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+    expect(method).toEqual('PATCH');
+    expect(body).toEqual({ role: 'ADMIN' });
+    await expect(client.stderr).toOutput('updated to role');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -218,6 +218,22 @@ describe('help command', () => {
           })
         ).toMatchSnapshot();
       });
+      it('access-group projects update help column width 120', () => {
+        expect(
+          help(accessGroup.projectsUpdateSubcommand, {
+            columns: 120,
+            parent: accessGroup.projectsSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
+      it('access-group projects remove help column width 120', () => {
+        expect(
+          help(accessGroup.projectsRemoveSubcommand, {
+            columns: 120,
+            parent: accessGroup.projectsSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `vercel access-group projects update <group> <project> --role <role>` to change a project's role in an access group (ADMIN, PROJECT_VIEWER, PROJECT_DEVELOPER, PROJECT_GUEST).
- Adds `vercel access-group projects remove <group> <project>` (alias `rm`); confirms before mutating (default No), skips with `--yes`, and refuses in non-interactive mode without `--yes` (exit 1).

## Notes
- Endpoints (public v1): `PATCH /v1/access-groups/:group/projects/:projectId` (update `{role}`) and `DELETE /v1/access-groups/:group/projects/:projectId` (remove). The `<project>` argument is resolved via `getProjectByNameOrId` (`GET /v9/projects/:idOrName`) first; role is validated client-side against the schema enum.
- Telemetry redacts group/project arguments; the `--role` enum is recorded verbatim (unknown values redacted) and `--yes` as a boolean.
- Unit tests assert request method/path/body, usage errors (missing/invalid role), and the decline / non-interactive paths (the mutation is not fired).
- Help snapshots regenerated; the pre-existing `connex` width-120 snapshot failure is unrelated and left untouched.
- Stack: #17460 (read) → #17464 (add/update) → #17476 (remove) → #17470 (members list) → #17488 (members add) → #17478 (members remove) → #17474 (projects list) → #17493 (projects add) → #17480 (projects update/remove). Completes the `access-group` family.