### PR TITLE
[CLI] Add project protection trusted-ips get subcommand

### DIFF
--- a/.changeset/project-protection-trusted-ips.md
+++ b/.changeset/project-protection-trusted-ips.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Add `vercel project protection trusted-ips get|set|disable` to manage the Trusted IPs allowlist for deployment protection. IPv4/CIDR input is validated locally before any request; IPv6 is rejected.
+Add `vercel project protection trusted-ips get` to show the Trusted IPs allowlist for deployment protection.

--- a/.changeset/project-protection-trusted-ips.md
+++ b/.changeset/project-protection-trusted-ips.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project protection trusted-ips get|set|disable` to manage the Trusted IPs allowlist for deployment protection. IPv4/CIDR input is validated locally before any request; IPv6 is rejected.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -571,7 +571,7 @@ export const protectionSubcommand = {
 } as const;
 
 /**
- * `vercel project protection trusted-ips get|set|disable`.
+ * `vercel project protection trusted-ips get`.
  *
  * Nested under `project protection`; the name embeds the middle segment so the
  * help synopsis renders `vercel project protection trusted-ips` with
@@ -581,60 +581,20 @@ export const protectionSubcommand = {
 export const trustedIpsSubcommand = {
   name: 'protection trusted-ips',
   aliases: [],
-  description:
-    'Show, set, or clear the Trusted IPs allowlist for deployment protection',
+  description: 'Show the Trusted IPs allowlist for deployment protection',
   arguments: [
     { name: 'action', required: false },
     { name: 'name', required: false },
   ],
-  options: [
-    formatOption,
-    jsonOption,
-    yesOption,
-    {
-      name: 'ip',
-      shorthand: null,
-      type: [String],
-      argument: 'IP',
-      description:
-        'IPv4 address or CIDR to allowlist (repeatable). Append an optional note with "=", e.g. 203.0.113.4=office. IPv6 is not supported.',
-      deprecated: false,
-    },
-    {
-      name: 'deployment-type',
-      shorthand: null,
-      type: String,
-      argument: 'TYPE',
-      description:
-        'Deployment target the allowlist applies to: all, preview, production, prod_deployment_urls_and_all_previews, all_except_custom_domains',
-      deprecated: false,
-    },
-    {
-      name: 'mode',
-      shorthand: null,
-      type: String,
-      argument: 'MODE',
-      description:
-        'Protection mode: additional (IP must match plus another protection) or exclusive (IP match alone bypasses protection)',
-      deprecated: false,
-    },
-  ],
+  options: [formatOption, jsonOption],
   examples: [
     {
       name: 'Show the Trusted IPs allowlist for the linked project',
       value: `${packageName} project protection trusted-ips get`,
     },
     {
-      name: 'Allowlist IPs for all deployments in additional mode',
-      value: `${packageName} project protection trusted-ips set my-app --ip 203.0.113.4 --ip 198.51.100.0/24 --deployment-type all --mode additional`,
-    },
-    {
-      name: 'Allowlist an IP with a note',
-      value: `${packageName} project protection trusted-ips set --ip "203.0.113.4=office VPN" --deployment-type production --mode exclusive`,
-    },
-    {
-      name: 'Clear the Trusted IPs allowlist',
-      value: `${packageName} project protection trusted-ips disable my-app --yes`,
+      name: 'Show the allowlist for a named project as JSON',
+      value: `${packageName} project protection trusted-ips get my-app --json`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -570,6 +570,75 @@ export const protectionSubcommand = {
   ],
 } as const;
 
+/**
+ * `vercel project protection trusted-ips get|set|disable`.
+ *
+ * Nested under `project protection`; the name embeds the middle segment so the
+ * help synopsis renders `vercel project protection trusted-ips` with
+ * `parent: projectCommand`. Not listed in `projectCommand.subcommands` because
+ * it is routed from inside `protection`, not from the top-level `project`.
+ */
+export const trustedIpsSubcommand = {
+  name: 'protection trusted-ips',
+  aliases: [],
+  description:
+    'Show, set, or clear the Trusted IPs allowlist for deployment protection',
+  arguments: [
+    { name: 'action', required: false },
+    { name: 'name', required: false },
+  ],
+  options: [
+    formatOption,
+    jsonOption,
+    yesOption,
+    {
+      name: 'ip',
+      shorthand: null,
+      type: [String],
+      argument: 'IP',
+      description:
+        'IPv4 address or CIDR to allowlist (repeatable). Append an optional note with "=", e.g. 203.0.113.4=office. IPv6 is not supported.',
+      deprecated: false,
+    },
+    {
+      name: 'deployment-type',
+      shorthand: null,
+      type: String,
+      argument: 'TYPE',
+      description:
+        'Deployment target the allowlist applies to: all, preview, production, prod_deployment_urls_and_all_previews, all_except_custom_domains',
+      deprecated: false,
+    },
+    {
+      name: 'mode',
+      shorthand: null,
+      type: String,
+      argument: 'MODE',
+      description:
+        'Protection mode: additional (IP must match plus another protection) or exclusive (IP match alone bypasses protection)',
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Show the Trusted IPs allowlist for the linked project',
+      value: `${packageName} project protection trusted-ips get`,
+    },
+    {
+      name: 'Allowlist IPs for all deployments in additional mode',
+      value: `${packageName} project protection trusted-ips set my-app --ip 203.0.113.4 --ip 198.51.100.0/24 --deployment-type all --mode additional`,
+    },
+    {
+      name: 'Allowlist an IP with a note',
+      value: `${packageName} project protection trusted-ips set --ip "203.0.113.4=office VPN" --deployment-type production --mode exclusive`,
+    },
+    {
+      name: 'Clear the Trusted IPs allowlist',
+      value: `${packageName} project protection trusted-ips disable my-app --yes`,
+    },
+  ],
+} as const;
+
 export const accessGroupsSubcommand = {
   name: 'access-groups',
   aliases: ['accessgroups'],

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -31,6 +31,7 @@ import {
   removeSubcommand,
   speedInsightsSubcommand,
   tokenSubcommand,
+  trustedIpsSubcommand,
   updateSubcommand,
   webAnalyticsSubcommand,
 } from './command';
@@ -169,15 +170,21 @@ export default async function main(client: Client) {
       break;
     case 'protection':
       if (needHelp) {
+        if (args[0] === 'trusted-ips') {
+          telemetry.trackCliFlagHelp('project', 'protection trusted-ips');
+          return printHelp(trustedIpsSubcommand);
+        }
         telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(protectionSubcommand);
       }
       telemetry.trackCliSubcommandProtection(
-        args[0] === 'enable'
-          ? 'protection enable'
-          : args[0] === 'disable'
-            ? 'protection disable'
-            : subcommandOriginal
+        args[0] === 'trusted-ips'
+          ? 'protection trusted-ips'
+          : args[0] === 'enable'
+            ? 'protection enable'
+            : args[0] === 'disable'
+              ? 'protection disable'
+              : subcommandOriginal
       );
       exitCode = await protection(client, args);
       break;

--- a/packages/cli/src/commands/project/protection-trusted-ips.ts
+++ b/packages/cli/src/commands/project/protection-trusted-ips.ts
@@ -1,0 +1,466 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import {
+  buildCommandWithGlobalFlags,
+  exitWithNonInteractiveError,
+  outputAgentError,
+} from '../../util/agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import { trustedIpsSubcommand } from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import output from '../../output-manager';
+import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
+import { ProjectTelemetryClient } from '../../util/telemetry/commands/project';
+import type { JSONObject, Project } from '@vercel-internals/types';
+
+const TRUSTED_IPS_ACTIONS = ['get', 'set', 'disable'] as const;
+type TrustedIpsAction = (typeof TRUSTED_IPS_ACTIONS)[number];
+
+// Verbatim from the public project PATCH schema (trustedIps.deploymentType).
+const DEPLOYMENT_SCOPES = [
+  'all',
+  'preview',
+  'production',
+  'prod_deployment_urls_and_all_previews',
+  'all_except_custom_domains',
+] as const;
+type DeploymentScope = (typeof DEPLOYMENT_SCOPES)[number];
+
+// Verbatim from the public project PATCH schema (trustedIps.protectionMode).
+const PROTECTION_MODES = ['additional', 'exclusive'] as const;
+type ProtectionMode = (typeof PROTECTION_MODES)[number];
+
+// Schema: note has maxLength 20.
+const MAX_NOTE_LENGTH = 20;
+
+interface TrustedIpAddress {
+  value: string;
+  note?: string;
+}
+
+interface TrustedIpsConfig {
+  deploymentType: DeploymentScope;
+  addresses: TrustedIpAddress[];
+  protectionMode: ProtectionMode;
+}
+
+function isTrustedIpsAction(v: string | undefined): v is TrustedIpsAction {
+  return !!v && (TRUSTED_IPS_ACTIONS as readonly string[]).includes(v);
+}
+
+/**
+ * Validate an IPv4 address or IPv4 CIDR string locally. IPv6 is intentionally
+ * rejected because the API does not support it. This is a security-critical
+ * gate: never forward unvalidated address strings to the remote PATCH.
+ */
+function isValidIpv4OrCidr(value: string): boolean {
+  const [addr, ...rest] = value.split('/');
+  if (rest.length > 1) return false;
+
+  if (rest.length === 1) {
+    const prefix = rest[0];
+    if (!/^\d{1,2}$/.test(prefix)) return false;
+    const prefixNum = Number(prefix);
+    if (prefixNum < 0 || prefixNum > 32) return false;
+  }
+
+  const octets = addr.split('.');
+  if (octets.length !== 4) return false;
+  for (const octet of octets) {
+    if (!/^\d{1,3}$/.test(octet)) return false;
+    const n = Number(octet);
+    if (n < 0 || n > 255) return false;
+    // Reject non-canonical leading zeros (e.g. "01").
+    if (octet.length > 1 && octet[0] === '0') return false;
+  }
+  return true;
+}
+
+/**
+ * Parse a single `--ip` value into an address plus optional note. Notes are
+ * separated with `=`; an IPv4/CIDR value never contains `=`, so splitting on
+ * the first `=` is unambiguous.
+ */
+function parseIpEntry(
+  raw: string
+): { ok: true; entry: TrustedIpAddress } | { ok: false; message: string } {
+  const trimmed = raw.trim();
+  const eqIndex = trimmed.indexOf('=');
+  const value = (eqIndex === -1 ? trimmed : trimmed.slice(0, eqIndex)).trim();
+  const note =
+    eqIndex === -1 ? undefined : trimmed.slice(eqIndex + 1).trim() || undefined;
+
+  if (value === '') {
+    return {
+      ok: false,
+      message: `Invalid --ip: expected an IPv4 address or CIDR, received an empty value.`,
+    };
+  }
+  if (value.includes(':')) {
+    return {
+      ok: false,
+      message: `Invalid --ip "${value}": IPv6 addresses are not supported.`,
+    };
+  }
+  if (!isValidIpv4OrCidr(value)) {
+    return {
+      ok: false,
+      message: `Invalid --ip "${value}": expected an IPv4 address (e.g. 203.0.113.4) or CIDR (e.g. 198.51.100.0/24).`,
+    };
+  }
+  if (note !== undefined && note.length > MAX_NOTE_LENGTH) {
+    return {
+      ok: false,
+      message: `Invalid note for --ip "${value}": notes must be at most ${MAX_NOTE_LENGTH} characters.`,
+    };
+  }
+
+  return {
+    ok: true,
+    entry: note === undefined ? { value } : { value, note },
+  };
+}
+
+function readTrustedIps(project: Project): TrustedIpsConfig | null {
+  const raw = project as Project & Record<string, unknown>;
+  const value = raw.trustedIps;
+  if (!value || typeof value !== 'object') return null;
+  return value as TrustedIpsConfig;
+}
+
+export async function projectProtectionTrustedIps(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new ProjectTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    trustedIpsSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: error instanceof Error ? error.message : String(error),
+      },
+      1
+    );
+    printError(error);
+    return 1;
+  }
+
+  const actionArg = parsedArgs.args[0];
+  const action = isTrustedIpsAction(actionArg) ? actionArg : undefined;
+
+  if (!action) {
+    const msg =
+      'Invalid action. Usage: `vercel project protection trusted-ips get|set|disable [name]`';
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              'project protection trusted-ips get'
+            ),
+            when: 'Show the current Trusted IPs allowlist',
+          },
+        ],
+      },
+      2
+    );
+    output.error(msg);
+    return 2;
+  }
+
+  if (parsedArgs.args.length > 2) {
+    const msg = `Invalid arguments. Usage: \`vercel project protection trusted-ips ${action} [name]\``;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+      },
+      2
+    );
+    output.error(msg);
+    return 2;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: formatResult.error,
+      },
+      1
+    );
+    output.error(formatResult.error);
+    return 1;
+  }
+  const preferJson = formatResult.jsonOutput || Boolean(client.nonInteractive);
+
+  const scopeFlag = parsedArgs.flags['--deployment-type'] as string | undefined;
+  const modeFlag = parsedArgs.flags['--mode'] as string | undefined;
+  const ipFlags = (parsedArgs.flags['--ip'] as string[] | undefined) ?? [];
+  const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
+
+  // Telemetry: enums verbatim (allowlisted); IPs redacted (sensitive infra).
+  telemetry.trackCliArgumentAction(action);
+  telemetry.trackCliOptionDeploymentType(scopeFlag);
+  telemetry.trackCliOptionMode(modeFlag);
+  telemetry.trackCliOptionIp(ipFlags);
+  telemetry.trackCliFlagYes(skipConfirmation);
+
+  // Local validation must happen before any remote lookup or mutation.
+  let trustedIpsBody: TrustedIpsConfig | undefined;
+  if (action === 'set') {
+    if (
+      !scopeFlag ||
+      !DEPLOYMENT_SCOPES.includes(scopeFlag as DeploymentScope)
+    ) {
+      const msg = `\`--deployment-type\` is required and must be one of: ${DEPLOYMENT_SCOPES.join(', ')}`;
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: msg,
+        },
+        1
+      );
+      output.error(msg);
+      return 1;
+    }
+    if (!modeFlag || !PROTECTION_MODES.includes(modeFlag as ProtectionMode)) {
+      const msg = `\`--mode\` is required and must be one of: ${PROTECTION_MODES.join(', ')}`;
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: msg,
+        },
+        1
+      );
+      output.error(msg);
+      return 1;
+    }
+    if (ipFlags.length === 0) {
+      const msg =
+        'At least one `--ip <address|CIDR>` is required to set Trusted IPs.';
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.MISSING_ARGUMENTS,
+          message: msg,
+        },
+        1
+      );
+      output.error(msg);
+      return 1;
+    }
+
+    const addresses: TrustedIpAddress[] = [];
+    const seen = new Set<string>();
+    for (const raw of ipFlags) {
+      const parsed = parseIpEntry(raw);
+      if (!parsed.ok) {
+        outputAgentError(
+          client,
+          {
+            status: AGENT_STATUS.ERROR,
+            reason: AGENT_REASON.INVALID_ARGUMENTS,
+            message: parsed.message,
+          },
+          1
+        );
+        output.error(parsed.message);
+        return 1;
+      }
+      if (seen.has(parsed.entry.value)) {
+        const msg = `Duplicate IP address "${parsed.entry.value}" in --ip.`;
+        outputAgentError(
+          client,
+          {
+            status: AGENT_STATUS.ERROR,
+            reason: AGENT_REASON.INVALID_ARGUMENTS,
+            message: msg,
+          },
+          1
+        );
+        output.error(msg);
+        return 1;
+      }
+      seen.add(parsed.entry.value);
+      addresses.push(parsed.entry);
+    }
+
+    trustedIpsBody = {
+      deploymentType: scopeFlag as DeploymentScope,
+      addresses,
+      protectionMode: modeFlag as ProtectionMode,
+    };
+  } else if (scopeFlag || modeFlag || ipFlags.length > 0) {
+    const msg = `\`--ip\`, \`--deployment-type\`, and \`--mode\` can only be used with \`project protection trusted-ips set\`.`;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+      },
+      2
+    );
+    output.error(msg);
+    return 2;
+  }
+
+  // disable requires confirmation before the destructive clear.
+  if (action === 'disable' && !skipConfirmation) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+          message:
+            'Confirm clearing the Trusted IPs allowlist by adding --yes.',
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                `project protection trusted-ips disable ${parsedArgs.args[1] ?? ''}`.trim() +
+                  ' --yes'
+              ),
+              when: 'confirm and clear the Trusted IPs allowlist',
+            },
+          ],
+        },
+        1
+      );
+      return 1;
+    }
+    if (!client.stdin.isTTY) {
+      output.error(
+        'Missing required flag --yes. Use --yes to skip the confirmation prompt in non-interactive mode.'
+      );
+      return 1;
+    }
+  }
+
+  let project: Project;
+  try {
+    project = await getProjectByCwdOrLink({
+      client,
+      commandName: 'project protection trusted-ips',
+      projectNameOrId: parsedArgs.args[1],
+      forReadOnlyCommand: action === 'get',
+    });
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
+    printError(err);
+    return 1;
+  }
+
+  if (action === 'get') {
+    const config = readTrustedIps(project);
+    if (preferJson) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            projectId: project.id,
+            name: project.name,
+            trustedIps: config,
+          },
+          null,
+          2
+        )}\n`
+      );
+      return 0;
+    }
+    output.log(
+      `${chalk.bold('Trusted IPs')} for ${chalk.cyan(project.name)} (${project.id})`
+    );
+    if (!config) {
+      output.log('Trusted IPs are not configured for this project.');
+      return 0;
+    }
+    output.log(`${chalk.cyan('scope:')} ${config.deploymentType}`);
+    output.log(`${chalk.cyan('mode:')} ${config.protectionMode}`);
+    output.log(`${chalk.cyan('addresses:')}`);
+    for (const addr of config.addresses ?? []) {
+      output.log(`  - ${addr.value}${addr.note ? ` (${addr.note})` : ''}`);
+    }
+    return 0;
+  }
+
+  if (action === 'disable' && !skipConfirmation) {
+    const confirmed = await client.input.confirm(
+      `Clear the Trusted IPs allowlist for ${chalk.bold(project.name)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Aborted');
+      return 0;
+    }
+  }
+
+  const patchBody: JSONObject = {
+    trustedIps:
+      action === 'set' ? (trustedIpsBody as unknown as JSONObject) : null,
+  };
+
+  try {
+    await client.fetch(`/v9/projects/${encodeURIComponent(project.id)}`, {
+      method: 'PATCH',
+      body: patchBody,
+    });
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
+    printError(err);
+    return 1;
+  }
+
+  if (preferJson) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          action,
+          projectId: project.id,
+          projectName: project.name,
+          trustedIps: action === 'set' ? trustedIpsBody : null,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  output.log(
+    action === 'set'
+      ? `${chalk.bold('Trusted IPs')} updated for ${chalk.cyan(project.name)}`
+      : `${chalk.bold('Trusted IPs')} cleared for ${chalk.cyan(project.name)}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/project/protection-trusted-ips.ts
+++ b/packages/cli/src/commands/project/protection-trusted-ips.ts
@@ -14,27 +14,21 @@ import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
 import { ProjectTelemetryClient } from '../../util/telemetry/commands/project';
-import type { JSONObject, Project } from '@vercel-internals/types';
+import type { Project } from '@vercel-internals/types';
 
-const TRUSTED_IPS_ACTIONS = ['get', 'set', 'disable'] as const;
+const TRUSTED_IPS_ACTIONS = ['get'] as const;
 type TrustedIpsAction = (typeof TRUSTED_IPS_ACTIONS)[number];
 
 // Verbatim from the public project PATCH schema (trustedIps.deploymentType).
-const DEPLOYMENT_SCOPES = [
-  'all',
-  'preview',
-  'production',
-  'prod_deployment_urls_and_all_previews',
-  'all_except_custom_domains',
-] as const;
-type DeploymentScope = (typeof DEPLOYMENT_SCOPES)[number];
+type DeploymentScope =
+  | 'all'
+  | 'preview'
+  | 'production'
+  | 'prod_deployment_urls_and_all_previews'
+  | 'all_except_custom_domains';
 
 // Verbatim from the public project PATCH schema (trustedIps.protectionMode).
-const PROTECTION_MODES = ['additional', 'exclusive'] as const;
-type ProtectionMode = (typeof PROTECTION_MODES)[number];
-
-// Schema: note has maxLength 20.
-const MAX_NOTE_LENGTH = 20;
+type ProtectionMode = 'additional' | 'exclusive';
 
 interface TrustedIpAddress {
   value: string;
@@ -49,79 +43,6 @@ interface TrustedIpsConfig {
 
 function isTrustedIpsAction(v: string | undefined): v is TrustedIpsAction {
   return !!v && (TRUSTED_IPS_ACTIONS as readonly string[]).includes(v);
-}
-
-/**
- * Validate an IPv4 address or IPv4 CIDR string locally. IPv6 is intentionally
- * rejected because the API does not support it. This is a security-critical
- * gate: never forward unvalidated address strings to the remote PATCH.
- */
-function isValidIpv4OrCidr(value: string): boolean {
-  const [addr, ...rest] = value.split('/');
-  if (rest.length > 1) return false;
-
-  if (rest.length === 1) {
-    const prefix = rest[0];
-    if (!/^\d{1,2}$/.test(prefix)) return false;
-    const prefixNum = Number(prefix);
-    if (prefixNum < 0 || prefixNum > 32) return false;
-  }
-
-  const octets = addr.split('.');
-  if (octets.length !== 4) return false;
-  for (const octet of octets) {
-    if (!/^\d{1,3}$/.test(octet)) return false;
-    const n = Number(octet);
-    if (n < 0 || n > 255) return false;
-    // Reject non-canonical leading zeros (e.g. "01").
-    if (octet.length > 1 && octet[0] === '0') return false;
-  }
-  return true;
-}
-
-/**
- * Parse a single `--ip` value into an address plus optional note. Notes are
- * separated with `=`; an IPv4/CIDR value never contains `=`, so splitting on
- * the first `=` is unambiguous.
- */
-function parseIpEntry(
-  raw: string
-): { ok: true; entry: TrustedIpAddress } | { ok: false; message: string } {
-  const trimmed = raw.trim();
-  const eqIndex = trimmed.indexOf('=');
-  const value = (eqIndex === -1 ? trimmed : trimmed.slice(0, eqIndex)).trim();
-  const note =
-    eqIndex === -1 ? undefined : trimmed.slice(eqIndex + 1).trim() || undefined;
-
-  if (value === '') {
-    return {
-      ok: false,
-      message: `Invalid --ip: expected an IPv4 address or CIDR, received an empty value.`,
-    };
-  }
-  if (value.includes(':')) {
-    return {
-      ok: false,
-      message: `Invalid --ip "${value}": IPv6 addresses are not supported.`,
-    };
-  }
-  if (!isValidIpv4OrCidr(value)) {
-    return {
-      ok: false,
-      message: `Invalid --ip "${value}": expected an IPv4 address (e.g. 203.0.113.4) or CIDR (e.g. 198.51.100.0/24).`,
-    };
-  }
-  if (note !== undefined && note.length > MAX_NOTE_LENGTH) {
-    return {
-      ok: false,
-      message: `Invalid note for --ip "${value}": notes must be at most ${MAX_NOTE_LENGTH} characters.`,
-    };
-  }
-
-  return {
-    ok: true,
-    entry: note === undefined ? { value } : { value, note },
-  };
 }
 
 function readTrustedIps(project: Project): TrustedIpsConfig | null {
@@ -164,7 +85,7 @@ export async function projectProtectionTrustedIps(
 
   if (!action) {
     const msg =
-      'Invalid action. Usage: `vercel project protection trusted-ips get|set|disable [name]`';
+      'Invalid action. Usage: `vercel project protection trusted-ips get [name]`';
     outputAgentError(
       client,
       {
@@ -218,155 +139,7 @@ export async function projectProtectionTrustedIps(
   }
   const preferJson = formatResult.jsonOutput || Boolean(client.nonInteractive);
 
-  const scopeFlag = parsedArgs.flags['--deployment-type'] as string | undefined;
-  const modeFlag = parsedArgs.flags['--mode'] as string | undefined;
-  const ipFlags = (parsedArgs.flags['--ip'] as string[] | undefined) ?? [];
-  const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
-
-  // Telemetry: enums verbatim (allowlisted); IPs redacted (sensitive infra).
   telemetry.trackCliArgumentAction(action);
-  telemetry.trackCliOptionDeploymentType(scopeFlag);
-  telemetry.trackCliOptionMode(modeFlag);
-  telemetry.trackCliOptionIp(ipFlags);
-  telemetry.trackCliFlagYes(skipConfirmation);
-
-  // Local validation must happen before any remote lookup or mutation.
-  let trustedIpsBody: TrustedIpsConfig | undefined;
-  if (action === 'set') {
-    if (
-      !scopeFlag ||
-      !DEPLOYMENT_SCOPES.includes(scopeFlag as DeploymentScope)
-    ) {
-      const msg = `\`--deployment-type\` is required and must be one of: ${DEPLOYMENT_SCOPES.join(', ')}`;
-      outputAgentError(
-        client,
-        {
-          status: AGENT_STATUS.ERROR,
-          reason: AGENT_REASON.INVALID_ARGUMENTS,
-          message: msg,
-        },
-        1
-      );
-      output.error(msg);
-      return 1;
-    }
-    if (!modeFlag || !PROTECTION_MODES.includes(modeFlag as ProtectionMode)) {
-      const msg = `\`--mode\` is required and must be one of: ${PROTECTION_MODES.join(', ')}`;
-      outputAgentError(
-        client,
-        {
-          status: AGENT_STATUS.ERROR,
-          reason: AGENT_REASON.INVALID_ARGUMENTS,
-          message: msg,
-        },
-        1
-      );
-      output.error(msg);
-      return 1;
-    }
-    if (ipFlags.length === 0) {
-      const msg =
-        'At least one `--ip <address|CIDR>` is required to set Trusted IPs.';
-      outputAgentError(
-        client,
-        {
-          status: AGENT_STATUS.ERROR,
-          reason: AGENT_REASON.MISSING_ARGUMENTS,
-          message: msg,
-        },
-        1
-      );
-      output.error(msg);
-      return 1;
-    }
-
-    const addresses: TrustedIpAddress[] = [];
-    const seen = new Set<string>();
-    for (const raw of ipFlags) {
-      const parsed = parseIpEntry(raw);
-      if (!parsed.ok) {
-        outputAgentError(
-          client,
-          {
-            status: AGENT_STATUS.ERROR,
-            reason: AGENT_REASON.INVALID_ARGUMENTS,
-            message: parsed.message,
-          },
-          1
-        );
-        output.error(parsed.message);
-        return 1;
-      }
-      if (seen.has(parsed.entry.value)) {
-        const msg = `Duplicate IP address "${parsed.entry.value}" in --ip.`;
-        outputAgentError(
-          client,
-          {
-            status: AGENT_STATUS.ERROR,
-            reason: AGENT_REASON.INVALID_ARGUMENTS,
-            message: msg,
-          },
-          1
-        );
-        output.error(msg);
-        return 1;
-      }
-      seen.add(parsed.entry.value);
-      addresses.push(parsed.entry);
-    }
-
-    trustedIpsBody = {
-      deploymentType: scopeFlag as DeploymentScope,
-      addresses,
-      protectionMode: modeFlag as ProtectionMode,
-    };
-  } else if (scopeFlag || modeFlag || ipFlags.length > 0) {
-    const msg = `\`--ip\`, \`--deployment-type\`, and \`--mode\` can only be used with \`project protection trusted-ips set\`.`;
-    outputAgentError(
-      client,
-      {
-        status: AGENT_STATUS.ERROR,
-        reason: AGENT_REASON.INVALID_ARGUMENTS,
-        message: msg,
-      },
-      2
-    );
-    output.error(msg);
-    return 2;
-  }
-
-  // disable requires confirmation before the destructive clear.
-  if (action === 'disable' && !skipConfirmation) {
-    if (client.nonInteractive) {
-      outputAgentError(
-        client,
-        {
-          status: AGENT_STATUS.ERROR,
-          reason: AGENT_REASON.CONFIRMATION_REQUIRED,
-          message:
-            'Confirm clearing the Trusted IPs allowlist by adding --yes.',
-          next: [
-            {
-              command: buildCommandWithGlobalFlags(
-                client.argv,
-                `project protection trusted-ips disable ${parsedArgs.args[1] ?? ''}`.trim() +
-                  ' --yes'
-              ),
-              when: 'confirm and clear the Trusted IPs allowlist',
-            },
-          ],
-        },
-        1
-      );
-      return 1;
-    }
-    if (!client.stdin.isTTY) {
-      output.error(
-        'Missing required flag --yes. Use --yes to skip the confirmation prompt in non-interactive mode.'
-      );
-      return 1;
-    }
-  }
 
   let project: Project;
   try {
@@ -374,7 +147,7 @@ export async function projectProtectionTrustedIps(
       client,
       commandName: 'project protection trusted-ips',
       projectNameOrId: parsedArgs.args[1],
-      forReadOnlyCommand: action === 'get',
+      forReadOnlyCommand: true,
     });
   } catch (err: unknown) {
     exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
@@ -382,73 +155,14 @@ export async function projectProtectionTrustedIps(
     return 1;
   }
 
-  if (action === 'get') {
-    const config = readTrustedIps(project);
-    if (preferJson) {
-      client.stdout.write(
-        `${JSON.stringify(
-          {
-            projectId: project.id,
-            name: project.name,
-            trustedIps: config,
-          },
-          null,
-          2
-        )}\n`
-      );
-      return 0;
-    }
-    output.log(
-      `${chalk.bold('Trusted IPs')} for ${chalk.cyan(project.name)} (${project.id})`
-    );
-    if (!config) {
-      output.log('Trusted IPs are not configured for this project.');
-      return 0;
-    }
-    output.log(`${chalk.cyan('scope:')} ${config.deploymentType}`);
-    output.log(`${chalk.cyan('mode:')} ${config.protectionMode}`);
-    output.log(`${chalk.cyan('addresses:')}`);
-    for (const addr of config.addresses ?? []) {
-      output.log(`  - ${addr.value}${addr.note ? ` (${addr.note})` : ''}`);
-    }
-    return 0;
-  }
-
-  if (action === 'disable' && !skipConfirmation) {
-    const confirmed = await client.input.confirm(
-      `Clear the Trusted IPs allowlist for ${chalk.bold(project.name)}?`,
-      false
-    );
-    if (!confirmed) {
-      output.log('Aborted');
-      return 0;
-    }
-  }
-
-  const patchBody: JSONObject = {
-    trustedIps:
-      action === 'set' ? (trustedIpsBody as unknown as JSONObject) : null,
-  };
-
-  try {
-    await client.fetch(`/v9/projects/${encodeURIComponent(project.id)}`, {
-      method: 'PATCH',
-      body: patchBody,
-    });
-  } catch (err: unknown) {
-    exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
-    printError(err);
-    return 1;
-  }
-
+  const config = readTrustedIps(project);
   if (preferJson) {
     client.stdout.write(
       `${JSON.stringify(
         {
-          action,
           projectId: project.id,
-          projectName: project.name,
-          trustedIps: action === 'set' ? trustedIpsBody : null,
+          name: project.name,
+          trustedIps: config,
         },
         null,
         2
@@ -456,11 +170,18 @@ export async function projectProtectionTrustedIps(
     );
     return 0;
   }
-
   output.log(
-    action === 'set'
-      ? `${chalk.bold('Trusted IPs')} updated for ${chalk.cyan(project.name)}`
-      : `${chalk.bold('Trusted IPs')} cleared for ${chalk.cyan(project.name)}`
+    `${chalk.bold('Trusted IPs')} for ${chalk.cyan(project.name)} (${project.id})`
   );
+  if (!config) {
+    output.log('Trusted IPs are not configured for this project.');
+    return 0;
+  }
+  output.log(`${chalk.cyan('scope:')} ${config.deploymentType}`);
+  output.log(`${chalk.cyan('mode:')} ${config.protectionMode}`);
+  output.log(`${chalk.cyan('addresses:')}`);
+  for (const addr of config.addresses ?? []) {
+    output.log(`  - ${addr.value}${addr.note ? ` (${addr.note})` : ''}`);
+  }
   return 0;
 }

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -9,6 +9,7 @@ import {
 } from '../../util/agent-output';
 import { AGENT_REASON } from '../../util/agent-output-constants';
 import { protectionSubcommand } from './command';
+import { projectProtectionTrustedIps } from './protection-trusted-ips';
 import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
@@ -80,6 +81,11 @@ export default async function protection(
   client: Client,
   argv: string[]
 ): Promise<number> {
+  // Nested subcommand: `project protection trusted-ips get|set|disable`.
+  if (argv[0] === 'trusted-ips') {
+    return projectProtectionTrustedIps(client, argv.slice(1));
+  }
+
   let parsedArgs;
   const flagsSpecification = getFlagsSpecification(
     protectionSubcommand.options

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -105,7 +105,7 @@ export class ProjectTelemetryClient
   }
 
   /**
-   * `project protection trusted-ips` action (get/set/disable). Verbatim: these
+   * `project protection trusted-ips` action (get). Verbatim: these
    * are a closed, non-sensitive set.
    */
   trackCliArgumentAction(action: string | undefined) {
@@ -113,55 +113,5 @@ export class ProjectTelemetryClient
       arg: 'action',
       value: action,
     });
-  }
-
-  /**
-   * `--deployment-type` deployment target. Value is an allowlisted enum, so it
-   * is safe to record verbatim; anything unexpected is redacted.
-   */
-  trackCliOptionDeploymentType(value: string | undefined) {
-    if (!value) return;
-    const allowed = [
-      'all',
-      'preview',
-      'production',
-      'prod_deployment_urls_and_all_previews',
-      'all_except_custom_domains',
-    ];
-    this.trackCliOption({
-      option: 'deployment-type',
-      value: allowed.includes(value) ? value : this.redactedValue,
-    });
-  }
-
-  /**
-   * `--mode` protection mode. Allowlisted enum recorded verbatim; anything
-   * unexpected is redacted.
-   */
-  trackCliOptionMode(value: string | undefined) {
-    if (!value) return;
-    const allowed = ['additional', 'exclusive'];
-    this.trackCliOption({
-      option: 'mode',
-      value: allowed.includes(value) ? value : this.redactedValue,
-    });
-  }
-
-  /**
-   * `--ip` allowlist entries. IP addresses and their notes are sensitive infra
-   * data, so only the redacted presence is recorded.
-   */
-  trackCliOptionIp(values: string[] | undefined) {
-    if (!values || values.length === 0) return;
-    this.trackCliOption({
-      option: 'ip',
-      value: this.redactedValue,
-    });
-  }
-
-  trackCliFlagYes(present: boolean | undefined) {
-    if (present) {
-      this.trackCliFlag('yes');
-    }
   }
 }

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -103,4 +103,65 @@ export class ProjectTelemetryClient
       value: actual,
     });
   }
+
+  /**
+   * `project protection trusted-ips` action (get/set/disable). Verbatim: these
+   * are a closed, non-sensitive set.
+   */
+  trackCliArgumentAction(action: string | undefined) {
+    this.trackCliArgument({
+      arg: 'action',
+      value: action,
+    });
+  }
+
+  /**
+   * `--deployment-type` deployment target. Value is an allowlisted enum, so it
+   * is safe to record verbatim; anything unexpected is redacted.
+   */
+  trackCliOptionDeploymentType(value: string | undefined) {
+    if (!value) return;
+    const allowed = [
+      'all',
+      'preview',
+      'production',
+      'prod_deployment_urls_and_all_previews',
+      'all_except_custom_domains',
+    ];
+    this.trackCliOption({
+      option: 'deployment-type',
+      value: allowed.includes(value) ? value : this.redactedValue,
+    });
+  }
+
+  /**
+   * `--mode` protection mode. Allowlisted enum recorded verbatim; anything
+   * unexpected is redacted.
+   */
+  trackCliOptionMode(value: string | undefined) {
+    if (!value) return;
+    const allowed = ['additional', 'exclusive'];
+    this.trackCliOption({
+      option: 'mode',
+      value: allowed.includes(value) ? value : this.redactedValue,
+    });
+  }
+
+  /**
+   * `--ip` allowlist entries. IP addresses and their notes are sensitive infra
+   * data, so only the redacted presence is recorded.
+   */
+  trackCliOptionIp(values: string[] | undefined) {
+    if (!values || values.length === 0) return;
+    this.trackCliOption({
+      option: 'ip',
+      value: this.redactedValue,
+    });
+  }
+
+  trackCliFlagYes(present: boolean | undefined) {
+    if (present) {
+      this.trackCliFlag('yes');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5985,6 +5985,60 @@ exports[`help command > project help output snapshots > project list help output
 "
 `;
 
+exports[`help command > project help output snapshots > project protection trusted-ips help output snapshots > project protection trusted-ips help column width 120 1`] = `
+"
+  ▲ vercel project protection trusted-ips [action] [name] [options]
+
+  Show, set, or clear the Trusted IPs allowlist for deployment protection                                               
+
+  Options:
+
+       --deployment-type <TYPE>  Deployment target the allowlist applies to: all, preview, production,                       
+                                 prod_deployment_urls_and_all_previews, all_except_custom_domains                            
+  -F,  --format <FORMAT>         Specify the output format (json)                                                            
+       --ip <IP>                 IPv4 address or CIDR to allowlist (repeatable). Append an optional note with "=", e.g.      
+                                 203.0.113.4=office. IPv6 is not supported.                                                  
+       --json                    Output as JSON                                                                              
+       --mode <MODE>             Protection mode: additional (IP must match plus another protection) or exclusive (IP match  
+                                 alone bypasses protection)                                                                  
+  -y,  --yes                     Accept default value for all prompts                                                        
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Show the Trusted IPs allowlist for the linked project
+
+    $ vercel project protection trusted-ips get
+
+  - Allowlist IPs for all deployments in additional mode
+
+    $ vercel project protection trusted-ips set my-app --ip 203.0.113.4 --ip 198.51.100.0/24 --deployment-type all --mode additional
+
+  - Allowlist an IP with a note
+
+    $ vercel project protection trusted-ips set --ip "203.0.113.4=office VPN" --deployment-type production --mode exclusive
+
+  - Clear the Trusted IPs allowlist
+
+    $ vercel project protection trusted-ips disable my-app --yes
+
+"
+`;
+
 exports[`help command > project help output snapshots > project remove help output snapshots > project remove help column width 120 1`] = `
 "
   ▲ vercel project remove name

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5989,19 +5989,12 @@ exports[`help command > project help output snapshots > project protection trust
 "
   ▲ vercel project protection trusted-ips [action] [name] [options]
 
-  Show, set, or clear the Trusted IPs allowlist for deployment protection                                               
+  Show the Trusted IPs allowlist for deployment protection                                                              
 
   Options:
 
-       --deployment-type <TYPE>  Deployment target the allowlist applies to: all, preview, production,                       
-                                 prod_deployment_urls_and_all_previews, all_except_custom_domains                            
-  -F,  --format <FORMAT>         Specify the output format (json)                                                            
-       --ip <IP>                 IPv4 address or CIDR to allowlist (repeatable). Append an optional note with "=", e.g.      
-                                 203.0.113.4=office. IPv6 is not supported.                                                  
-       --json                    Output as JSON                                                                              
-       --mode <MODE>             Protection mode: additional (IP must match plus another protection) or exclusive (IP match  
-                                 alone bypasses protection)                                                                  
-  -y,  --yes                     Accept default value for all prompts                                                        
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
 
 
   Global Options:
@@ -6024,17 +6017,9 @@ exports[`help command > project help output snapshots > project protection trust
 
     $ vercel project protection trusted-ips get
 
-  - Allowlist IPs for all deployments in additional mode
+  - Show the allowlist for a named project as JSON
 
-    $ vercel project protection trusted-ips set my-app --ip 203.0.113.4 --ip 198.51.100.0/24 --deployment-type all --mode additional
-
-  - Allowlist an IP with a note
-
-    $ vercel project protection trusted-ips set --ip "203.0.113.4=office VPN" --deployment-type production --mode exclusive
-
-  - Clear the Trusted IPs allowlist
-
-    $ vercel project protection trusted-ips disable my-app --yes
+    $ vercel project protection trusted-ips get my-app --json
 
 "
 `;

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -774,6 +774,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('project protection trusted-ips help output snapshots', () => {
+      it('project protection trusted-ips help column width 120', () => {
+        expect(
+          help(project.trustedIpsSubcommand, {
+            columns: 120,
+            parent: project.projectCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('promote help output snapshots', () => {

--- a/packages/cli/test/unit/commands/project/protection-trusted-ips.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-trusted-ips.test.ts
@@ -5,20 +5,9 @@ import { useUser } from '../../../mocks/user';
 import { useTeams } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
 
-/**
- * Registers user/team/project mocks. When `onPatch` is provided, a PATCH
- * handler is registered BEFORE `useProject` so it wins route matching over
- * the generic `useProject` PATCH mock (first registered route wins).
- */
-function setupProject(trustedIps?: unknown, onPatch?: (body: unknown) => void) {
+function setupProject(trustedIps?: unknown) {
   useUser();
   useTeams('team_dummy');
-  if (onPatch) {
-    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
-      onPatch(req.body);
-      res.json({ id: 'prj_123' });
-    });
-  }
   useProject({
     ...defaultProject,
     id: 'prj_123',
@@ -76,353 +65,48 @@ describe('project protection trusted-ips', () => {
         },
       });
     });
-  });
 
-  describe('set', () => {
-    it('replaces trustedIps via PATCH and returns JSON', async () => {
-      let body: unknown;
-      setupProject(null, b => {
-        body = b;
+    it('shows scope, mode, and addresses in human output', async () => {
+      setupProject({
+        deploymentType: 'production',
+        addresses: [{ value: '198.51.100.0/24' }],
+        protectionMode: 'exclusive',
       });
-
       client.setArgv(
         'project',
         'protection',
         'trusted-ips',
-        'set',
-        'my-project',
-        '--ip',
-        '203.0.113.4',
-        '--ip',
-        '198.51.100.0/24=corp net',
-        '--deployment-type',
-        'all',
-        '--mode',
-        'additional',
-        '--json'
+        'get',
+        'my-project'
       );
       const exitCode = await project(client);
       expect(exitCode).toBe(0);
-      expect(body).toEqual({
-        trustedIps: {
-          deploymentType: 'all',
-          protectionMode: 'additional',
-          addresses: [
-            { value: '203.0.113.4' },
-            { value: '198.51.100.0/24', note: 'corp net' },
-          ],
-        },
-      });
+      await expect(client.stderr).toOutput('scope: production');
+      await expect(client.stderr).toOutput('mode: exclusive');
+      await expect(client.stderr).toOutput('198.51.100.0/24');
     });
 
-    it('requires --deployment-type', async () => {
-      let patched = false;
-      setupProject(null, () => {
-        patched = true;
-      });
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        '--ip',
-        '203.0.113.4',
-        '--mode',
-        'additional'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      expect(patched).toBe(false);
-      await expect(client.stderr).toOutput('--deployment-type');
-    });
-
-    it('rejects an invalid --mode', async () => {
+    it('tracks the action argument verbatim in telemetry', async () => {
       setupProject(null);
       client.setArgv(
         'project',
         'protection',
         'trusted-ips',
-        'set',
-        '--ip',
-        '203.0.113.4',
-        '--deployment-type',
-        'all',
-        '--mode',
-        'bogus'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput('--mode');
-    });
-
-    it('requires at least one --ip', async () => {
-      setupProject(null);
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        '--deployment-type',
-        'all',
-        '--mode',
-        'additional'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput('At least one');
-    });
-
-    it('rejects an invalid IP before any HTTP request', async () => {
-      let patched = false;
-      setupProject(null, () => {
-        patched = true;
-      });
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        '--ip',
-        '999.1.1.1',
-        '--deployment-type',
-        'all',
-        '--mode',
-        'additional'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      expect(patched).toBe(false);
-      await expect(client.stderr).toOutput('Invalid --ip');
-    });
-
-    it('rejects an invalid CIDR prefix before any HTTP request', async () => {
-      setupProject(null);
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        '--ip',
-        '10.0.0.0/33',
-        '--deployment-type',
-        'all',
-        '--mode',
-        'additional'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput('Invalid --ip');
-    });
-
-    it.each([
-      ['leading-zero octet', '01.2.3.4'],
-      ['too few octets', '1.2.3'],
-      ['negative CIDR prefix', '10.0.0.0/-1'],
-    ])('rejects %s before any HTTP request', async (_name, ip) => {
-      let patched = false;
-      setupProject(null, () => {
-        patched = true;
-      });
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        '--ip',
-        ip,
-        '--deployment-type',
-        'all',
-        '--mode',
-        'additional'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      expect(patched).toBe(false);
-      await expect(client.stderr).toOutput('Invalid --ip');
-    });
-
-    it('rejects IPv6 addresses', async () => {
-      setupProject(null);
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        '--ip',
-        '2001:db8::1',
-        '--deployment-type',
-        'all',
-        '--mode',
-        'additional'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput('IPv6');
-    });
-
-    it('rejects a note longer than 20 characters', async () => {
-      setupProject(null);
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        '--ip',
-        '203.0.113.4=this note is way too long to be accepted',
-        '--deployment-type',
-        'all',
-        '--mode',
-        'additional'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput('at most 20');
-    });
-
-    it('rejects duplicate IPs', async () => {
-      setupProject(null);
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        '--ip',
-        '203.0.113.4',
-        '--ip',
-        '203.0.113.4',
-        '--deployment-type',
-        'all',
-        '--mode',
-        'additional'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput('Duplicate');
-    });
-
-    it('redacts IPs but records enums verbatim in telemetry', async () => {
-      setupProject(null, () => {});
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'set',
-        'my-project',
-        '--ip',
-        '203.0.113.4',
-        '--deployment-type',
-        'production',
-        '--mode',
-        'exclusive'
+        'get',
+        'my-project'
       );
       const exitCode = await project(client);
       expect(exitCode).toBe(0);
-
-      const events = client.telemetryEventStore.readonlyEvents;
-      const ipEvent = events.find(e => e.key === 'option:ip');
-      expect(ipEvent?.value).toBe('[REDACTED]');
-      expect(events).toContainEqual(
-        expect.objectContaining({
-          key: 'option:deployment-type',
-          value: 'production',
-        })
-      );
-      expect(events).toContainEqual(
-        expect.objectContaining({ key: 'option:mode', value: 'exclusive' })
-      );
-      // The raw IP must never appear in any telemetry value.
-      expect(events.every(e => !String(e.value).includes('203.0.113.4'))).toBe(
-        true
-      );
-    });
-  });
-
-  describe('disable', () => {
-    it('clears trustedIps with --yes', async () => {
-      let body: unknown;
-      setupProject(
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
-          deploymentType: 'all',
-          addresses: [{ value: '203.0.113.4' }],
-          protectionMode: 'additional',
+          key: 'subcommand:protection',
+          value: 'protection trusted-ips',
         },
-        b => {
-          body = b;
-        }
-      );
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'disable',
-        'my-project',
-        '--yes'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      expect(body).toEqual({ trustedIps: null });
-      await expect(client.stderr).toOutput('Trusted IPs cleared');
-    });
-
-    it('requires --yes in non-interactive mode (confirmation_required)', async () => {
-      let patched = false;
-      setupProject(null, () => {
-        patched = true;
-      });
-      vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
-        throw new Error('exit');
-      }) as () => never);
-      client.nonInteractive = true;
-      client.input.confirm = vi.fn();
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'disable',
-        'my-project'
-      );
-      await expect(project(client)).rejects.toThrow('exit');
-      expect(patched).toBe(false);
-      expect(client.input.confirm).not.toHaveBeenCalled();
-      const out = JSON.parse(client.stdout.getFullOutput().trim());
-      expect(out.reason).toBe('confirmation_required');
-    });
-
-    it('aborts without mutating when the prompt is declined', async () => {
-      let patched = false;
-      setupProject(null, () => {
-        patched = true;
-      });
-      client.input.confirm = vi.fn().mockResolvedValue(false);
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'disable',
-        'my-project'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      expect(patched).toBe(false);
-      await expect(client.stderr).toOutput('Aborted');
-    });
-
-    it('clears trustedIps when the prompt is confirmed', async () => {
-      let body: unknown;
-      setupProject(null, b => {
-        body = b;
-      });
-      client.input.confirm = vi.fn().mockResolvedValue(true);
-      client.setArgv(
-        'project',
-        'protection',
-        'trusted-ips',
-        'disable',
-        'my-project'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      expect(body).toEqual({ trustedIps: null });
+        {
+          key: 'argument:action',
+          value: 'get',
+        },
+      ]);
     });
   });
 
@@ -432,31 +116,6 @@ describe('project protection trusted-ips', () => {
     const exitCode = await project(client);
     expect(exitCode).toBe(2);
     await expect(client.stderr).toOutput('Invalid action');
-  });
-
-  it.each([
-    ['get', ['--ip', '203.0.113.4'] as string[]],
-    ['get', ['--deployment-type', 'all'] as string[]],
-    ['disable', ['--mode', 'additional', '--yes'] as string[]],
-  ])('rejects set-only flags with %s (exit 2, no mutation)', async (action, flags) => {
-    let patched = false;
-    setupProject(null, () => {
-      patched = true;
-    });
-    client.setArgv(
-      'project',
-      'protection',
-      'trusted-ips',
-      action,
-      'my-project',
-      ...flags
-    );
-    const exitCode = await project(client);
-    expect(exitCode).toBe(2);
-    expect(patched).toBe(false);
-    await expect(client.stderr).toOutput(
-      'can only be used with `project protection trusted-ips set`'
-    );
   });
 
   describe('--help', () => {

--- a/packages/cli/test/unit/commands/project/protection-trusted-ips.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-trusted-ips.test.ts
@@ -1,0 +1,423 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import project from '../../../../src/commands/project';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+import { defaultProject, useProject } from '../../../mocks/project';
+
+/**
+ * Registers user/team/project mocks. When `onPatch` is provided, a PATCH
+ * handler is registered BEFORE `useProject` so it wins route matching over
+ * the generic `useProject` PATCH mock (first registered route wins).
+ */
+function setupProject(trustedIps?: unknown, onPatch?: (body: unknown) => void) {
+  useUser();
+  useTeams('team_dummy');
+  if (onPatch) {
+    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
+      onPatch(req.body);
+      res.json({ id: 'prj_123' });
+    });
+  }
+  useProject({
+    ...defaultProject,
+    id: 'prj_123',
+    name: 'my-project',
+    ...(trustedIps !== undefined ? { trustedIps } : {}),
+  } as never);
+}
+
+describe('project protection trusted-ips', () => {
+  afterEach(() => {
+    client.stdin.isTTY = true;
+    client.nonInteractive = false;
+    vi.restoreAllMocks();
+  });
+
+  describe('get', () => {
+    it('reports when Trusted IPs are not configured', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'get',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      await expect(client.stderr).toOutput('Trusted IPs are not configured');
+    });
+
+    it('shows the allowlist as JSON', async () => {
+      setupProject({
+        deploymentType: 'all',
+        addresses: [{ value: '203.0.113.4', note: 'office' }],
+        protectionMode: 'additional',
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'get',
+        'my-project',
+        '--json'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toMatchObject({
+        projectId: 'prj_123',
+        name: 'my-project',
+        trustedIps: {
+          deploymentType: 'all',
+          protectionMode: 'additional',
+          addresses: [{ value: '203.0.113.4', note: 'office' }],
+        },
+      });
+    });
+  });
+
+  describe('set', () => {
+    it('replaces trustedIps via PATCH and returns JSON', async () => {
+      let body: unknown;
+      setupProject(null, b => {
+        body = b;
+      });
+
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        'my-project',
+        '--ip',
+        '203.0.113.4',
+        '--ip',
+        '198.51.100.0/24=corp net',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional',
+        '--json'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({
+        trustedIps: {
+          deploymentType: 'all',
+          protectionMode: 'additional',
+          addresses: [
+            { value: '203.0.113.4' },
+            { value: '198.51.100.0/24', note: 'corp net' },
+          ],
+        },
+      });
+    });
+
+    it('requires --deployment-type', async () => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '203.0.113.4',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('--deployment-type');
+    });
+
+    it('rejects an invalid --mode', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '203.0.113.4',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'bogus'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('--mode');
+    });
+
+    it('requires at least one --ip', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('At least one');
+    });
+
+    it('rejects an invalid IP before any HTTP request', async () => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '999.1.1.1',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('Invalid --ip');
+    });
+
+    it('rejects an invalid CIDR prefix before any HTTP request', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '10.0.0.0/33',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid --ip');
+    });
+
+    it('rejects IPv6 addresses', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '2001:db8::1',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('IPv6');
+    });
+
+    it('rejects a note longer than 20 characters', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '203.0.113.4=this note is way too long to be accepted',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('at most 20');
+    });
+
+    it('rejects duplicate IPs', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '203.0.113.4',
+        '--ip',
+        '203.0.113.4',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Duplicate');
+    });
+
+    it('redacts IPs but records enums verbatim in telemetry', async () => {
+      setupProject(null, () => {});
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        'my-project',
+        '--ip',
+        '203.0.113.4',
+        '--deployment-type',
+        'production',
+        '--mode',
+        'exclusive'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+
+      const events = client.telemetryEventStore.readonlyEvents;
+      const ipEvent = events.find(e => e.key === 'option:ip');
+      expect(ipEvent?.value).toBe('[REDACTED]');
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          key: 'option:deployment-type',
+          value: 'production',
+        })
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({ key: 'option:mode', value: 'exclusive' })
+      );
+      // The raw IP must never appear in any telemetry value.
+      expect(events.every(e => !String(e.value).includes('203.0.113.4'))).toBe(
+        true
+      );
+    });
+  });
+
+  describe('disable', () => {
+    it('clears trustedIps with --yes', async () => {
+      let body: unknown;
+      setupProject(
+        {
+          deploymentType: 'all',
+          addresses: [{ value: '203.0.113.4' }],
+          protectionMode: 'additional',
+        },
+        b => {
+          body = b;
+        }
+      );
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'disable',
+        'my-project',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ trustedIps: null });
+      await expect(client.stderr).toOutput('Trusted IPs cleared');
+    });
+
+    it('requires --yes in non-interactive mode (confirmation_required)', async () => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+        throw new Error('exit');
+      }) as () => never);
+      client.nonInteractive = true;
+      client.input.confirm = vi.fn();
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'disable',
+        'my-project'
+      );
+      await expect(project(client)).rejects.toThrow('exit');
+      expect(patched).toBe(false);
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out.reason).toBe('confirmation_required');
+    });
+
+    it('aborts without mutating when the prompt is declined', async () => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      client.input.confirm = vi.fn().mockResolvedValue(false);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'disable',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('Aborted');
+    });
+
+    it('clears trustedIps when the prompt is confirmed', async () => {
+      let body: unknown;
+      setupProject(null, b => {
+        body = b;
+      });
+      client.input.confirm = vi.fn().mockResolvedValue(true);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'disable',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ trustedIps: null });
+    });
+  });
+
+  it('rejects an unknown action', async () => {
+    setupProject(null);
+    client.setArgv('project', 'protection', 'trusted-ips', 'frobnicate');
+    const exitCode = await project(client);
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput('Invalid action');
+  });
+
+  describe('--help', () => {
+    it('prints help and tracks telemetry', async () => {
+      client.setArgv('project', 'protection', 'trusted-ips', '--help');
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'project:protection trusted-ips',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/project/protection-trusted-ips.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-trusted-ips.test.ts
@@ -214,6 +214,33 @@ describe('project protection trusted-ips', () => {
       await expect(client.stderr).toOutput('Invalid --ip');
     });
 
+    it.each([
+      ['leading-zero octet', '01.2.3.4'],
+      ['too few octets', '1.2.3'],
+      ['negative CIDR prefix', '10.0.0.0/-1'],
+    ])('rejects %s before any HTTP request', async (_name, ip) => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        ip,
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('Invalid --ip');
+    });
+
     it('rejects IPv6 addresses', async () => {
       setupProject(null);
       client.setArgv(
@@ -405,6 +432,31 @@ describe('project protection trusted-ips', () => {
     const exitCode = await project(client);
     expect(exitCode).toBe(2);
     await expect(client.stderr).toOutput('Invalid action');
+  });
+
+  it.each([
+    ['get', ['--ip', '203.0.113.4'] as string[]],
+    ['get', ['--deployment-type', 'all'] as string[]],
+    ['disable', ['--mode', 'additional', '--yes'] as string[]],
+  ])('rejects set-only flags with %s (exit 2, no mutation)', async (action, flags) => {
+    let patched = false;
+    setupProject(null, () => {
+      patched = true;
+    });
+    client.setArgv(
+      'project',
+      'protection',
+      'trusted-ips',
+      action,
+      'my-project',
+      ...flags
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(2);
+    expect(patched).toBe(false);
+    await expect(client.stderr).toOutput(
+      'can only be used with `project protection trusted-ips set`'
+    );
   });
 
   describe('--help', () => {


### PR DESCRIPTION
## Summary

- Adds `vercel project protection trusted-ips get [name]` to show the Trusted IPs allowlist for deployment protection: addresses (with optional notes), deployment scope, and protection mode, with `--json`/`--format json` and non-interactive output per the project command family conventions.
- Includes the `trusted-ips` nested-subcommand scaffolding under `project protection` (routing, help, telemetry) that the stacked follow-ups build on.

## Notes

- Read-only: no mutations in this PR. The displayed config fields are verbatim from the public project PATCH schema (`trustedIps.deploymentType`, `trustedIps.addresses[].value`/`note`, `trustedIps.protectionMode`).
- Existing `project protection` (enable/disable of SSO, password, skew, bypass, etc.) behavior is untouched; `trusted-ips` is routed as a nested subcommand before the existing action parsing.
- Telemetry records only the closed action enum.
- Stack: this PR ← #17490 (trusted-ips set/disable) ← #17482 (trusted-sources + shared runner) ← #17491 (options-allowlist) ← #17492 (protected-sourcemaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
