### PR TITLE
[CLI] Add project protection trusted-sources subcommand

### DIFF
--- a/.changeset/project-protection-settings.md
+++ b/.changeset/project-protection-settings.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project protection trusted-sources|options-allowlist|protected-sourcemaps` subcommands with get/set/disable actions to manage the remaining deployment-protection settings via the public project PATCH endpoint.

--- a/.changeset/project-protection-settings.md
+++ b/.changeset/project-protection-settings.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Add `vercel project protection trusted-sources|options-allowlist` subcommands with get/set/disable actions to manage deployment-protection settings via the public project PATCH endpoint.
+Add `vercel project protection trusted-sources get|set|disable` to manage the Trusted Sources deployment-protection config via the public project PATCH endpoint.

--- a/.changeset/project-protection-settings.md
+++ b/.changeset/project-protection-settings.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-Add `vercel project protection trusted-sources|options-allowlist|protected-sourcemaps` subcommands with get/set/disable actions to manage the remaining deployment-protection settings via the public project PATCH endpoint.
+Add `vercel project protection trusted-sources|options-allowlist` subcommands with get/set/disable actions to manage deployment-protection settings via the public project PATCH endpoint.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -724,35 +724,6 @@ export const optionsAllowlistSubcommand = {
   ],
 } as const;
 
-/**
- * `vercel project protection protected-sourcemaps get|set|disable`.
- */
-export const protectedSourcemapsSubcommand = {
-  name: 'protection protected-sourcemaps',
-  aliases: [],
-  description:
-    'Show or toggle whether sourcemaps require authentication to access',
-  arguments: [
-    { name: 'action', required: false },
-    { name: 'name', required: false },
-  ],
-  options: [formatOption, jsonOption, yesOption],
-  examples: [
-    {
-      name: 'Show the Protected Sourcemaps setting for the linked project',
-      value: `${packageName} project protection protected-sourcemaps get`,
-    },
-    {
-      name: 'Protect sourcemaps behind authentication',
-      value: `${packageName} project protection protected-sourcemaps set my-app`,
-    },
-    {
-      name: 'Disable sourcemap protection',
-      value: `${packageName} project protection protected-sourcemaps disable my-app --yes`,
-    },
-  ],
-} as const;
-
 export const accessGroupsSubcommand = {
   name: 'access-groups',
   aliases: ['accessgroups'],

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -639,6 +639,120 @@ export const trustedIpsSubcommand = {
   ],
 } as const;
 
+/**
+ * `vercel project protection trusted-sources get|set|disable`.
+ * Same nesting pattern as `protection trusted-ips`.
+ */
+export const trustedSourcesSubcommand = {
+  name: 'protection trusted-sources',
+  aliases: [],
+  description:
+    'Show, set, or clear the Trusted Sources deployment protection config',
+  arguments: [
+    { name: 'action', required: false },
+    { name: 'name', required: false },
+  ],
+  options: [
+    formatOption,
+    jsonOption,
+    yesOption,
+    {
+      name: 'file',
+      shorthand: null,
+      type: String,
+      argument: 'FILE',
+      description:
+        'Path to a JSON file with the Trusted Sources config (`projects` and/or `oidcProviders` keys, per the public project PATCH schema)',
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Show the Trusted Sources config for the linked project',
+      value: `${packageName} project protection trusted-sources get`,
+    },
+    {
+      name: 'Replace the Trusted Sources config from a JSON file',
+      value: `${packageName} project protection trusted-sources set my-app --file ./trusted-sources.json`,
+    },
+    {
+      name: 'Clear the Trusted Sources config',
+      value: `${packageName} project protection trusted-sources disable my-app --yes`,
+    },
+  ],
+} as const;
+
+/**
+ * `vercel project protection options-allowlist get|set|disable`.
+ */
+export const optionsAllowlistSubcommand = {
+  name: 'protection options-allowlist',
+  aliases: [],
+  description:
+    'Show, set, or clear paths exempt from Deployment Protection for CORS preflight (OPTIONS) requests',
+  arguments: [
+    { name: 'action', required: false },
+    { name: 'name', required: false },
+  ],
+  options: [
+    formatOption,
+    jsonOption,
+    yesOption,
+    {
+      name: 'path',
+      shorthand: null,
+      type: [String],
+      argument: 'PATH',
+      description:
+        'Regex path that should not be protected (repeatable, must start with "/")',
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Show the OPTIONS allowlist for the linked project',
+      value: `${packageName} project protection options-allowlist get`,
+    },
+    {
+      name: 'Allow CORS preflight on API paths',
+      value: `${packageName} project protection options-allowlist set my-app --path /api/.* --path /webhooks/stripe`,
+    },
+    {
+      name: 'Clear the OPTIONS allowlist',
+      value: `${packageName} project protection options-allowlist disable my-app --yes`,
+    },
+  ],
+} as const;
+
+/**
+ * `vercel project protection protected-sourcemaps get|set|disable`.
+ */
+export const protectedSourcemapsSubcommand = {
+  name: 'protection protected-sourcemaps',
+  aliases: [],
+  description:
+    'Show or toggle whether sourcemaps require authentication to access',
+  arguments: [
+    { name: 'action', required: false },
+    { name: 'name', required: false },
+  ],
+  options: [formatOption, jsonOption, yesOption],
+  examples: [
+    {
+      name: 'Show the Protected Sourcemaps setting for the linked project',
+      value: `${packageName} project protection protected-sourcemaps get`,
+    },
+    {
+      name: 'Protect sourcemaps behind authentication',
+      value: `${packageName} project protection protected-sourcemaps set my-app`,
+    },
+    {
+      name: 'Disable sourcemap protection',
+      value: `${packageName} project protection protected-sourcemaps disable my-app --yes`,
+    },
+  ],
+} as const;
+
 export const accessGroupsSubcommand = {
   name: 'access-groups',
   aliases: ['accessgroups'],

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -682,48 +682,6 @@ export const trustedSourcesSubcommand = {
   ],
 } as const;
 
-/**
- * `vercel project protection options-allowlist get|set|disable`.
- */
-export const optionsAllowlistSubcommand = {
-  name: 'protection options-allowlist',
-  aliases: [],
-  description:
-    'Show, set, or clear paths exempt from Deployment Protection for CORS preflight (OPTIONS) requests',
-  arguments: [
-    { name: 'action', required: false },
-    { name: 'name', required: false },
-  ],
-  options: [
-    formatOption,
-    jsonOption,
-    yesOption,
-    {
-      name: 'path',
-      shorthand: null,
-      type: [String],
-      argument: 'PATH',
-      description:
-        'Regex path that should not be protected (repeatable, must start with "/")',
-      deprecated: false,
-    },
-  ],
-  examples: [
-    {
-      name: 'Show the OPTIONS allowlist for the linked project',
-      value: `${packageName} project protection options-allowlist get`,
-    },
-    {
-      name: 'Allow CORS preflight on API paths',
-      value: `${packageName} project protection options-allowlist set my-app --path /api/.* --path /webhooks/stripe`,
-    },
-    {
-      name: 'Clear the OPTIONS allowlist',
-      value: `${packageName} project protection options-allowlist disable my-app --yes`,
-    },
-  ],
-} as const;
-
 export const accessGroupsSubcommand = {
   name: 'access-groups',
   aliases: ['accessgroups'],

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -27,7 +27,6 @@ import {
   membersSubcommand,
   projectCommand,
   protectionSubcommand,
-  optionsAllowlistSubcommand,
   renameSubcommand,
   removeSubcommand,
   speedInsightsSubcommand,
@@ -174,7 +173,6 @@ export default async function main(client: Client) {
       const nestedProtectionHelp: Record<string, Command> = {
         'trusted-ips': trustedIpsSubcommand,
         'trusted-sources': trustedSourcesSubcommand,
-        'options-allowlist': optionsAllowlistSubcommand,
       };
       const nested = args[0] ? nestedProtectionHelp[args[0]] : undefined;
       if (needHelp) {

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -27,11 +27,14 @@ import {
   membersSubcommand,
   projectCommand,
   protectionSubcommand,
+  optionsAllowlistSubcommand,
+  protectedSourcemapsSubcommand,
   renameSubcommand,
   removeSubcommand,
   speedInsightsSubcommand,
   tokenSubcommand,
   trustedIpsSubcommand,
+  trustedSourcesSubcommand,
   updateSubcommand,
   webAnalyticsSubcommand,
 } from './command';
@@ -168,18 +171,25 @@ export default async function main(client: Client) {
       telemetry.trackCliSubcommandAccessGroups(subcommandOriginal);
       exitCode = await accessGroups(client, args);
       break;
-    case 'protection':
+    case 'protection': {
+      const nestedProtectionHelp: Record<string, Command> = {
+        'trusted-ips': trustedIpsSubcommand,
+        'trusted-sources': trustedSourcesSubcommand,
+        'options-allowlist': optionsAllowlistSubcommand,
+        'protected-sourcemaps': protectedSourcemapsSubcommand,
+      };
+      const nested = args[0] ? nestedProtectionHelp[args[0]] : undefined;
       if (needHelp) {
-        if (args[0] === 'trusted-ips') {
-          telemetry.trackCliFlagHelp('project', 'protection trusted-ips');
-          return printHelp(trustedIpsSubcommand);
+        if (nested) {
+          telemetry.trackCliFlagHelp('project', `protection ${args[0]}`);
+          return printHelp(nested);
         }
         telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(protectionSubcommand);
       }
       telemetry.trackCliSubcommandProtection(
-        args[0] === 'trusted-ips'
-          ? 'protection trusted-ips'
+        nested
+          ? `protection ${args[0]}`
           : args[0] === 'enable'
             ? 'protection enable'
             : args[0] === 'disable'
@@ -188,6 +198,7 @@ export default async function main(client: Client) {
       );
       exitCode = await protection(client, args);
       break;
+    }
     case 'webAnalytics':
       if (needHelp) {
         telemetry.trackCliFlagHelp('project', subcommandOriginal);

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -28,7 +28,6 @@ import {
   projectCommand,
   protectionSubcommand,
   optionsAllowlistSubcommand,
-  protectedSourcemapsSubcommand,
   renameSubcommand,
   removeSubcommand,
   speedInsightsSubcommand,
@@ -176,7 +175,6 @@ export default async function main(client: Client) {
         'trusted-ips': trustedIpsSubcommand,
         'trusted-sources': trustedSourcesSubcommand,
         'options-allowlist': optionsAllowlistSubcommand,
-        'protected-sourcemaps': protectedSourcemapsSubcommand,
       };
       const nested = args[0] ? nestedProtectionHelp[args[0]] : undefined;
       if (needHelp) {

--- a/packages/cli/src/commands/project/protection-settings.ts
+++ b/packages/cli/src/commands/project/protection-settings.ts
@@ -24,8 +24,9 @@ import type { JSONObject, Project } from '@vercel-internals/types';
 const ACTIONS = ['get', 'set', 'disable'] as const;
 type Action = (typeof ACTIONS)[number];
 
-// Schema: optionsAllowlist.paths is limited server-side; mirror a sane cap.
-const MAX_OPTIONS_ALLOWLIST_PATHS = 100;
+// Schema: optionsAllowlist.paths maxItems — mirror the API's LIMIT (5) so
+// the user gets a clean local error instead of a remote validation failure.
+const MAX_OPTIONS_ALLOWLIST_PATHS = 5;
 
 interface SettingSpec {
   /** Project PATCH body field, verbatim from the public schema. */

--- a/packages/cli/src/commands/project/protection-settings.ts
+++ b/packages/cli/src/commands/project/protection-settings.ts
@@ -1,0 +1,392 @@
+import chalk from 'chalk';
+import { readFileSync } from 'fs';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import {
+  buildCommandWithGlobalFlags,
+  exitWithNonInteractiveError,
+  outputAgentError,
+} from '../../util/agent-output';
+import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
+import {
+  optionsAllowlistSubcommand,
+  protectedSourcemapsSubcommand,
+  trustedSourcesSubcommand,
+} from './command';
+import { validateJsonOutput } from '../../util/output-format';
+import output from '../../output-manager';
+import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
+import { ProjectTelemetryClient } from '../../util/telemetry/commands/project';
+import type { JSONObject, Project } from '@vercel-internals/types';
+
+const ACTIONS = ['get', 'set', 'disable'] as const;
+type Action = (typeof ACTIONS)[number];
+
+// Schema: optionsAllowlist.paths is limited server-side; mirror a sane cap.
+const MAX_OPTIONS_ALLOWLIST_PATHS = 100;
+
+interface SettingSpec {
+  /** Project PATCH body field, verbatim from the public schema. */
+  field: 'trustedSources' | 'optionsAllowlist' | 'protectedSourcemaps';
+  /** CLI segment, e.g. `trusted-sources`. */
+  slug: string;
+  /** Human label used in output. */
+  label: string;
+  commandName: string;
+  subcommand:
+    | typeof trustedSourcesSubcommand
+    | typeof optionsAllowlistSubcommand
+    | typeof protectedSourcemapsSubcommand;
+  /**
+   * Build the PATCH value for `set` from parsed flags. Returns an error
+   * message when local validation fails (nothing is sent remotely).
+   */
+  buildSetValue(
+    flags: Record<string, unknown>
+  ): { ok: true; value: unknown } | { ok: false; message: string };
+  /** Value used to turn the setting off. */
+  disableValue: unknown;
+}
+
+function fail(message: string): { ok: false; message: string } {
+  return { ok: false, message };
+}
+
+/**
+ * Local structural validation for `--file` JSON passed to trusted-sources
+ * set. Deep semantic validation (env slugs, claims, limits) is enforced by
+ * the API; here we ensure the payload is an object limited to the public
+ * schema's top-level keys so malformed input never reaches the wire.
+ */
+function parseTrustedSourcesFile(
+  filePath: string
+): { ok: true; value: unknown } | { ok: false; message: string } {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (err) {
+    return fail(
+      `Could not read --file: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return fail('Invalid --file: expected a JSON object.');
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return fail(
+      'Invalid --file: expected a JSON object with `projects` and/or `oidcProviders` keys.'
+    );
+  }
+  const keys = Object.keys(parsed as Record<string, unknown>);
+  const allowed = ['projects', 'oidcProviders'];
+  const unknown = keys.filter(k => !allowed.includes(k));
+  if (unknown.length > 0) {
+    return fail(
+      `Invalid --file: unknown key(s) ${unknown.join(', ')}. Allowed keys: ${allowed.join(', ')}.`
+    );
+  }
+  if (keys.length === 0) {
+    return fail(
+      'Invalid --file: provide at least one of `projects` or `oidcProviders`.'
+    );
+  }
+  return { ok: true, value: parsed };
+}
+
+const TRUSTED_SOURCES: SettingSpec = {
+  field: 'trustedSources',
+  slug: 'trusted-sources',
+  label: 'Trusted Sources',
+  commandName: 'project protection trusted-sources',
+  subcommand: trustedSourcesSubcommand,
+  buildSetValue(flags) {
+    const file = flags['--file'] as string | undefined;
+    if (!file) {
+      return fail(
+        '`--file <path>` with the Trusted Sources JSON config is required for set.'
+      );
+    }
+    return parseTrustedSourcesFile(file);
+  },
+  disableValue: null,
+};
+
+const OPTIONS_ALLOWLIST: SettingSpec = {
+  field: 'optionsAllowlist',
+  slug: 'options-allowlist',
+  label: 'OPTIONS Allowlist',
+  commandName: 'project protection options-allowlist',
+  subcommand: optionsAllowlistSubcommand,
+  buildSetValue(flags) {
+    const paths = (flags['--path'] as string[] | undefined) ?? [];
+    if (paths.length === 0) {
+      return fail('At least one `--path </path>` is required for set.');
+    }
+    if (paths.length > MAX_OPTIONS_ALLOWLIST_PATHS) {
+      return fail(
+        `Too many paths (${paths.length}); the maximum is ${MAX_OPTIONS_ALLOWLIST_PATHS}.`
+      );
+    }
+    const seen = new Set<string>();
+    const entries: Array<{ value: string }> = [];
+    for (const raw of paths) {
+      const value = raw.trim();
+      // Schema: pattern '^/.*' — every path must start with '/'.
+      if (!value.startsWith('/')) {
+        return fail(
+          `Invalid --path "${value}": paths must start with "/" (regex paths are allowed, e.g. /api/.*).`
+        );
+      }
+      if (seen.has(value)) {
+        return fail(`Duplicate path "${value}" in --path.`);
+      }
+      seen.add(value);
+      entries.push({ value });
+    }
+    return { ok: true, value: { paths: entries } };
+  },
+  disableValue: null,
+};
+
+const PROTECTED_SOURCEMAPS: SettingSpec = {
+  field: 'protectedSourcemaps',
+  slug: 'protected-sourcemaps',
+  label: 'Protected Sourcemaps',
+  commandName: 'project protection protected-sourcemaps',
+  subcommand: protectedSourcemapsSubcommand,
+  // Boolean setting: `set` turns it on, `disable` turns it off.
+  buildSetValue() {
+    return { ok: true, value: true };
+  },
+  disableValue: false,
+};
+
+const SPECS: Record<string, SettingSpec> = {
+  'trusted-sources': TRUSTED_SOURCES,
+  'options-allowlist': OPTIONS_ALLOWLIST,
+  'protected-sourcemaps': PROTECTED_SOURCEMAPS,
+};
+
+export function getProtectionSettingSpec(slug: string): SettingSpec | null {
+  return SPECS[slug] ?? null;
+}
+
+export async function projectProtectionSetting(
+  client: Client,
+  spec: SettingSpec,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new ProjectTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(spec.subcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (error) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: error instanceof Error ? error.message : String(error),
+      },
+      1
+    );
+    printError(error);
+    return 1;
+  }
+
+  const actionArg = parsedArgs.args[0];
+  const action = (ACTIONS as readonly string[]).includes(actionArg ?? '')
+    ? (actionArg as Action)
+    : undefined;
+
+  if (!action || parsedArgs.args.length > 2) {
+    const msg = `Invalid arguments. Usage: \`vercel ${spec.commandName} get|set|disable [name]\``;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+        next: [
+          {
+            command: buildCommandWithGlobalFlags(
+              client.argv,
+              `${spec.commandName} get`
+            ),
+            when: `Show the current ${spec.label} configuration`,
+          },
+        ],
+      },
+      2
+    );
+    output.error(msg);
+    return 2;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: formatResult.error,
+      },
+      1
+    );
+    output.error(formatResult.error);
+    return 1;
+  }
+  const preferJson = formatResult.jsonOutput || Boolean(client.nonInteractive);
+
+  const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
+  telemetry.trackCliArgumentAction(action);
+  telemetry.trackCliOptionPath(parsedArgs.flags['--path'] as string[]);
+  telemetry.trackCliOptionFile(parsedArgs.flags['--file'] as string);
+  telemetry.trackCliFlagYes(skipConfirmation);
+
+  // Local validation before any remote call.
+  let setValue: unknown;
+  if (action === 'set') {
+    const built = spec.buildSetValue(parsedArgs.flags);
+    if (!built.ok) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: built.message,
+        },
+        1
+      );
+      output.error(built.message);
+      return 1;
+    }
+    setValue = built.value;
+  }
+
+  if (action === 'disable' && !skipConfirmation) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+          message: `Confirm disabling ${spec.label} by adding --yes.`,
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                `${spec.commandName} disable ${parsedArgs.args[1] ?? ''}`.trim() +
+                  ' --yes'
+              ),
+              when: `confirm and disable ${spec.label}`,
+            },
+          ],
+        },
+        1
+      );
+      return 1;
+    }
+    if (!client.stdin.isTTY) {
+      output.error(
+        'Missing required flag --yes. Use --yes to skip the confirmation prompt in non-interactive mode.'
+      );
+      return 1;
+    }
+  }
+
+  let project: Project;
+  try {
+    project = await getProjectByCwdOrLink({
+      client,
+      commandName: spec.commandName,
+      projectNameOrId: parsedArgs.args[1],
+      forReadOnlyCommand: action === 'get',
+    });
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
+    printError(err);
+    return 1;
+  }
+
+  if (action === 'get') {
+    const raw = project as Project & Record<string, unknown>;
+    const current = spec.field in raw ? raw[spec.field] : null;
+    if (preferJson) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            projectId: project.id,
+            name: project.name,
+            [spec.field]: current ?? null,
+          },
+          null,
+          2
+        )}\n`
+      );
+      return 0;
+    }
+    output.log(
+      `${chalk.bold(spec.label)} for ${chalk.cyan(project.name)} (${project.id})`
+    );
+    if (current === null || current === undefined) {
+      output.log(`${spec.label} is not configured for this project.`);
+      return 0;
+    }
+    output.log(JSON.stringify(current, null, 2));
+    return 0;
+  }
+
+  if (action === 'disable' && !skipConfirmation) {
+    const confirmed = await client.input.confirm(
+      `Disable ${spec.label} for ${chalk.bold(project.name)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Aborted');
+      return 0;
+    }
+  }
+
+  const patchValue = action === 'set' ? setValue : spec.disableValue;
+  try {
+    await client.fetch(`/v9/projects/${encodeURIComponent(project.id)}`, {
+      method: 'PATCH',
+      body: { [spec.field]: patchValue } as unknown as JSONObject,
+    });
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
+    printError(err);
+    return 1;
+  }
+
+  if (preferJson) {
+    client.stdout.write(
+      `${JSON.stringify(
+        {
+          action,
+          projectId: project.id,
+          projectName: project.name,
+          [spec.field]: patchValue,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+  output.log(
+    `${chalk.bold(spec.label)} ${action === 'set' ? 'updated' : 'disabled'} for ${chalk.cyan(project.name)}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/project/protection-settings.ts
+++ b/packages/cli/src/commands/project/protection-settings.ts
@@ -10,10 +10,7 @@ import {
   outputAgentError,
 } from '../../util/agent-output';
 import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
-import {
-  optionsAllowlistSubcommand,
-  trustedSourcesSubcommand,
-} from './command';
+import { trustedSourcesSubcommand } from './command';
 import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
@@ -23,21 +20,15 @@ import type { JSONObject, Project } from '@vercel-internals/types';
 const ACTIONS = ['get', 'set', 'disable'] as const;
 type Action = (typeof ACTIONS)[number];
 
-// Schema: optionsAllowlist.paths maxItems — mirror the API's LIMIT (5) so
-// the user gets a clean local error instead of a remote validation failure.
-const MAX_OPTIONS_ALLOWLIST_PATHS = 5;
-
 interface SettingSpec {
   /** Project PATCH body field, verbatim from the public schema. */
-  field: 'trustedSources' | 'optionsAllowlist';
+  field: 'trustedSources';
   /** CLI segment, e.g. `trusted-sources`. */
   slug: string;
   /** Human label used in output. */
   label: string;
   commandName: string;
-  subcommand:
-    | typeof trustedSourcesSubcommand
-    | typeof optionsAllowlistSubcommand;
+  subcommand: typeof trustedSourcesSubcommand;
   /**
    * Build the PATCH value for `set` from parsed flags. Returns an error
    * message when local validation fails (nothing is sent remotely).
@@ -115,46 +106,8 @@ const TRUSTED_SOURCES: SettingSpec = {
   disableValue: null,
 };
 
-const OPTIONS_ALLOWLIST: SettingSpec = {
-  field: 'optionsAllowlist',
-  slug: 'options-allowlist',
-  label: 'OPTIONS Allowlist',
-  commandName: 'project protection options-allowlist',
-  subcommand: optionsAllowlistSubcommand,
-  buildSetValue(flags) {
-    const paths = (flags['--path'] as string[] | undefined) ?? [];
-    if (paths.length === 0) {
-      return fail('At least one `--path </path>` is required for set.');
-    }
-    if (paths.length > MAX_OPTIONS_ALLOWLIST_PATHS) {
-      return fail(
-        `Too many paths (${paths.length}); the maximum is ${MAX_OPTIONS_ALLOWLIST_PATHS}.`
-      );
-    }
-    const seen = new Set<string>();
-    const entries: Array<{ value: string }> = [];
-    for (const raw of paths) {
-      const value = raw.trim();
-      // Schema: pattern '^/.*' — every path must start with '/'.
-      if (!value.startsWith('/')) {
-        return fail(
-          `Invalid --path "${value}": paths must start with "/" (regex paths are allowed, e.g. /api/.*).`
-        );
-      }
-      if (seen.has(value)) {
-        return fail(`Duplicate path "${value}" in --path.`);
-      }
-      seen.add(value);
-      entries.push({ value });
-    }
-    return { ok: true, value: { paths: entries } };
-  },
-  disableValue: null,
-};
-
 const SPECS: Record<string, SettingSpec> = {
   'trusted-sources': TRUSTED_SOURCES,
-  'options-allowlist': OPTIONS_ALLOWLIST,
 };
 
 export function getProtectionSettingSpec(slug: string): SettingSpec | null {
@@ -235,7 +188,6 @@ export async function projectProtectionSetting(
 
   const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
   telemetry.trackCliArgumentAction(action);
-  telemetry.trackCliOptionPath(parsedArgs.flags['--path'] as string[]);
   telemetry.trackCliOptionFile(parsedArgs.flags['--file'] as string);
   telemetry.trackCliFlagYes(skipConfirmation);
 

--- a/packages/cli/src/commands/project/protection-settings.ts
+++ b/packages/cli/src/commands/project/protection-settings.ts
@@ -12,7 +12,6 @@ import {
 import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
 import {
   optionsAllowlistSubcommand,
-  protectedSourcemapsSubcommand,
   trustedSourcesSubcommand,
 } from './command';
 import { validateJsonOutput } from '../../util/output-format';
@@ -30,7 +29,7 @@ const MAX_OPTIONS_ALLOWLIST_PATHS = 5;
 
 interface SettingSpec {
   /** Project PATCH body field, verbatim from the public schema. */
-  field: 'trustedSources' | 'optionsAllowlist' | 'protectedSourcemaps';
+  field: 'trustedSources' | 'optionsAllowlist';
   /** CLI segment, e.g. `trusted-sources`. */
   slug: string;
   /** Human label used in output. */
@@ -38,8 +37,7 @@ interface SettingSpec {
   commandName: string;
   subcommand:
     | typeof trustedSourcesSubcommand
-    | typeof optionsAllowlistSubcommand
-    | typeof protectedSourcemapsSubcommand;
+    | typeof optionsAllowlistSubcommand;
   /**
    * Build the PATCH value for `set` from parsed flags. Returns an error
    * message when local validation fails (nothing is sent remotely).
@@ -154,23 +152,9 @@ const OPTIONS_ALLOWLIST: SettingSpec = {
   disableValue: null,
 };
 
-const PROTECTED_SOURCEMAPS: SettingSpec = {
-  field: 'protectedSourcemaps',
-  slug: 'protected-sourcemaps',
-  label: 'Protected Sourcemaps',
-  commandName: 'project protection protected-sourcemaps',
-  subcommand: protectedSourcemapsSubcommand,
-  // Boolean setting: `set` turns it on, `disable` turns it off.
-  buildSetValue() {
-    return { ok: true, value: true };
-  },
-  disableValue: false,
-};
-
 const SPECS: Record<string, SettingSpec> = {
   'trusted-sources': TRUSTED_SOURCES,
   'options-allowlist': OPTIONS_ALLOWLIST,
-  'protected-sourcemaps': PROTECTED_SOURCEMAPS,
 };
 
 export function getProtectionSettingSpec(slug: string): SettingSpec | null {

--- a/packages/cli/src/commands/project/protection.ts
+++ b/packages/cli/src/commands/project/protection.ts
@@ -10,6 +10,10 @@ import {
 import { AGENT_REASON } from '../../util/agent-output-constants';
 import { protectionSubcommand } from './command';
 import { projectProtectionTrustedIps } from './protection-trusted-ips';
+import {
+  getProtectionSettingSpec,
+  projectProtectionSetting,
+} from './protection-settings';
 import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
@@ -84,6 +88,13 @@ export default async function protection(
   // Nested subcommand: `project protection trusted-ips get|set|disable`.
   if (argv[0] === 'trusted-ips') {
     return projectProtectionTrustedIps(client, argv.slice(1));
+  }
+
+  // Nested subcommands: trusted-sources, options-allowlist,
+  // protected-sourcemaps — each with get|set|disable.
+  const settingSpec = argv[0] ? getProtectionSettingSpec(argv[0]) : null;
+  if (settingSpec) {
+    return projectProtectionSetting(client, settingSpec, argv.slice(1));
   }
 
   let parsedArgs;

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -166,18 +166,6 @@ export class ProjectTelemetryClient
   }
 
   /**
-   * `--path` allowlist entries. Paths are sensitive infra data, so only the
-   * redacted presence is recorded.
-   */
-  trackCliOptionPath(values: string[] | undefined) {
-    if (!values || values.length === 0) return;
-    this.trackCliOption({
-      option: 'path',
-      value: this.redactedValue,
-    });
-  }
-
-  /**
    * `--file` config file path. File paths and contents are never recorded;
    * only the redacted presence is tracked.
    */

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -164,4 +164,28 @@ export class ProjectTelemetryClient
       this.trackCliFlag('yes');
     }
   }
+
+  /**
+   * `--path` allowlist entries. Paths are sensitive infra data, so only the
+   * redacted presence is recorded.
+   */
+  trackCliOptionPath(values: string[] | undefined) {
+    if (!values || values.length === 0) return;
+    this.trackCliOption({
+      option: 'path',
+      value: this.redactedValue,
+    });
+  }
+
+  /**
+   * `--file` config file path. File paths and contents are never recorded;
+   * only the redacted presence is tracked.
+   */
+  trackCliOptionFile(value: string | undefined) {
+    if (!value) return;
+    this.trackCliOption({
+      option: 'file',
+      value: this.redactedValue,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5985,6 +5985,95 @@ exports[`help command > project help output snapshots > project list help output
 "
 `;
 
+exports[`help command > project help output snapshots > project protection options-allowlist help output snapshots > project protection options-allowlist help column width 120 1`] = `
+"
+  ▲ vercel project protection options-allowlist [action] [name] [options]
+
+  Show, set, or clear paths exempt from Deployment Protection for CORS preflight (OPTIONS) requests                     
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+       --path <PATH>      Regex path that should not be protected (repeatable, must start with "/")                     
+  -y,  --yes              Accept default value for all prompts                                                          
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Show the OPTIONS allowlist for the linked project
+
+    $ vercel project protection options-allowlist get
+
+  - Allow CORS preflight on API paths
+
+    $ vercel project protection options-allowlist set my-app --path /api/.* --path /webhooks/stripe
+
+  - Clear the OPTIONS allowlist
+
+    $ vercel project protection options-allowlist disable my-app --yes
+
+"
+`;
+
+exports[`help command > project help output snapshots > project protection protected-sourcemaps help output snapshots > project protection protected-sourcemaps help column width 120 1`] = `
+"
+  ▲ vercel project protection protected-sourcemaps [action] [name] [options]
+
+  Show or toggle whether sourcemaps require authentication to access                                                    
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+  -y,  --yes              Accept default value for all prompts                                                          
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Show the Protected Sourcemaps setting for the linked project
+
+    $ vercel project protection protected-sourcemaps get
+
+  - Protect sourcemaps behind authentication
+
+    $ vercel project protection protected-sourcemaps set my-app
+
+  - Disable sourcemap protection
+
+    $ vercel project protection protected-sourcemaps disable my-app --yes
+
+"
+`;
+
 exports[`help command > project help output snapshots > project protection trusted-ips help output snapshots > project protection trusted-ips help column width 120 1`] = `
 "
   ▲ vercel project protection trusted-ips [action] [name] [options]
@@ -6035,6 +6124,52 @@ exports[`help command > project help output snapshots > project protection trust
   - Clear the Trusted IPs allowlist
 
     $ vercel project protection trusted-ips disable my-app --yes
+
+"
+`;
+
+exports[`help command > project help output snapshots > project protection trusted-sources help output snapshots > project protection trusted-sources help column width 120 1`] = `
+"
+  ▲ vercel project protection trusted-sources [action] [name] [options]
+
+  Show, set, or clear the Trusted Sources deployment protection config                                                  
+
+  Options:
+
+       --file <FILE>      Path to a JSON file with the Trusted Sources config (\`projects\` and/or \`oidcProviders\` keys,  
+                          per the public project PATCH schema)                                                          
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+  -y,  --yes              Accept default value for all prompts                                                          
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Show the Trusted Sources config for the linked project
+
+    $ vercel project protection trusted-sources get
+
+  - Replace the Trusted Sources config from a JSON file
+
+    $ vercel project protection trusted-sources set my-app --file ./trusted-sources.json
+
+  - Clear the Trusted Sources config
+
+    $ vercel project protection trusted-sources disable my-app --yes
 
 "
 `;

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -6030,49 +6030,6 @@ exports[`help command > project help output snapshots > project protection optio
 "
 `;
 
-exports[`help command > project help output snapshots > project protection protected-sourcemaps help output snapshots > project protection protected-sourcemaps help column width 120 1`] = `
-"
-  ▲ vercel project protection protected-sourcemaps [action] [name] [options]
-
-  Show or toggle whether sourcemaps require authentication to access                                                    
-
-  Options:
-
-  -F,  --format <FORMAT>  Specify the output format (json)                                                              
-       --json             Output as JSON                                                                                
-  -y,  --yes              Accept default value for all prompts                                                          
-
-
-  Global Options:
-
-       --cwd <DIR>            Sets the current working directory for a single run of a command                          
-  -d,  --debug                Debug mode (default off)                                                                  
-  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
-  -h,  --help                 Output usage information                                                                  
-  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
-       --no-color             No color mode (default off)                                                               
-       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
-  -S,  --scope                Set a custom scope                                                                        
-  -t,  --token <TOKEN>        Login token                                                                               
-  -v,  --version              Output the version number                                                                 
-
-
-  Examples:
-
-  - Show the Protected Sourcemaps setting for the linked project
-
-    $ vercel project protection protected-sourcemaps get
-
-  - Protect sourcemaps behind authentication
-
-    $ vercel project protection protected-sourcemaps set my-app
-
-  - Disable sourcemap protection
-
-    $ vercel project protection protected-sourcemaps disable my-app --yes
-
-"
-`;
 
 exports[`help command > project help output snapshots > project protection trusted-ips help output snapshots > project protection trusted-ips help column width 120 1`] = `
 "

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5985,50 +5985,6 @@ exports[`help command > project help output snapshots > project list help output
 "
 `;
 
-exports[`help command > project help output snapshots > project protection options-allowlist help output snapshots > project protection options-allowlist help column width 120 1`] = `
-"
-  ▲ vercel project protection options-allowlist [action] [name] [options]
-
-  Show, set, or clear paths exempt from Deployment Protection for CORS preflight (OPTIONS) requests                     
-
-  Options:
-
-  -F,  --format <FORMAT>  Specify the output format (json)                                                              
-       --json             Output as JSON                                                                                
-       --path <PATH>      Regex path that should not be protected (repeatable, must start with "/")                     
-  -y,  --yes              Accept default value for all prompts                                                          
-
-
-  Global Options:
-
-       --cwd <DIR>            Sets the current working directory for a single run of a command                          
-  -d,  --debug                Debug mode (default off)                                                                  
-  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
-  -h,  --help                 Output usage information                                                                  
-  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
-       --no-color             No color mode (default off)                                                               
-       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
-  -S,  --scope                Set a custom scope                                                                        
-  -t,  --token <TOKEN>        Login token                                                                               
-  -v,  --version              Output the version number                                                                 
-
-
-  Examples:
-
-  - Show the OPTIONS allowlist for the linked project
-
-    $ vercel project protection options-allowlist get
-
-  - Allow CORS preflight on API paths
-
-    $ vercel project protection options-allowlist set my-app --path /api/.* --path /webhooks/stripe
-
-  - Clear the OPTIONS allowlist
-
-    $ vercel project protection options-allowlist disable my-app --yes
-
-"
-`;
 
 
 exports[`help command > project help output snapshots > project protection trusted-ips help output snapshots > project protection trusted-ips help column width 120 1`] = `

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -804,16 +804,6 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
-    describe('project protection protected-sourcemaps help output snapshots', () => {
-      it('project protection protected-sourcemaps help column width 120', () => {
-        expect(
-          help(project.protectedSourcemapsSubcommand, {
-            columns: 120,
-            parent: project.projectCommand,
-          })
-        ).toMatchSnapshot();
-      });
-    });
   });
 
   describe('promote help output snapshots', () => {

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -794,16 +794,6 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
-    describe('project protection options-allowlist help output snapshots', () => {
-      it('project protection options-allowlist help column width 120', () => {
-        expect(
-          help(project.optionsAllowlistSubcommand, {
-            columns: 120,
-            parent: project.projectCommand,
-          })
-        ).toMatchSnapshot();
-      });
-    });
   });
 
   describe('promote help output snapshots', () => {

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -784,6 +784,36 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('project protection trusted-sources help output snapshots', () => {
+      it('project protection trusted-sources help column width 120', () => {
+        expect(
+          help(project.trustedSourcesSubcommand, {
+            columns: 120,
+            parent: project.projectCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
+    describe('project protection options-allowlist help output snapshots', () => {
+      it('project protection options-allowlist help column width 120', () => {
+        expect(
+          help(project.optionsAllowlistSubcommand, {
+            columns: 120,
+            parent: project.projectCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
+    describe('project protection protected-sourcemaps help output snapshots', () => {
+      it('project protection protected-sourcemaps help column width 120', () => {
+        expect(
+          help(project.protectedSourcemapsSubcommand, {
+            columns: 120,
+            parent: project.projectCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('promote help output snapshots', () => {

--- a/packages/cli/test/unit/commands/project/protection-settings.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-settings.test.ts
@@ -1,0 +1,433 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import project from '../../../../src/commands/project';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+import { defaultProject, useProject } from '../../../mocks/project';
+
+/**
+ * Registers user/team/project mocks. When `onPatch` is provided, a PATCH
+ * handler is registered BEFORE `useProject` so it wins route matching over
+ * the generic `useProject` PATCH mock (first registered route wins).
+ */
+function setupProject(
+  extra: Record<string, unknown> = {},
+  onPatch?: (body: unknown) => void
+) {
+  useUser();
+  useTeams('team_dummy');
+  if (onPatch) {
+    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
+      onPatch(req.body);
+      res.json({ id: 'prj_123' });
+    });
+  }
+  useProject({
+    ...defaultProject,
+    id: 'prj_123',
+    name: 'my-project',
+    ...extra,
+  } as never);
+}
+
+describe('project protection settings subcommands', () => {
+  afterEach(() => {
+    client.stdin.isTTY = true;
+    client.nonInteractive = false;
+    vi.restoreAllMocks();
+  });
+
+  describe('options-allowlist', () => {
+    it('shows the allowlist as JSON on get', async () => {
+      setupProject({ optionsAllowlist: { paths: [{ value: '/api/.*' }] } });
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'get',
+        'my-project',
+        '--json'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toMatchObject({
+        projectId: 'prj_123',
+        optionsAllowlist: { paths: [{ value: '/api/.*' }] },
+      });
+    });
+
+    it('replaces the allowlist via PATCH on set', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        '--path',
+        '/api/.*',
+        '--path',
+        '/webhooks/stripe'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({
+        optionsAllowlist: {
+          paths: [{ value: '/api/.*' }, { value: '/webhooks/stripe' }],
+        },
+      });
+    });
+
+    it('rejects paths not starting with "/" before any HTTP request', async () => {
+      let patched = false;
+      setupProject({}, () => {
+        patched = true;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        '--path',
+        'api/foo'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('must start with "/"');
+    });
+
+    it('rejects duplicate paths', async () => {
+      setupProject();
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        '--path',
+        '/api',
+        '--path',
+        '/api'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Duplicate path');
+    });
+
+    it('requires at least one --path on set', async () => {
+      setupProject();
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('At least one');
+    });
+
+    it('clears the allowlist (null) on disable --yes', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'disable',
+        'my-project',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ optionsAllowlist: null });
+    });
+
+    it('redacts --path values in telemetry', async () => {
+      setupProject({}, () => {});
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        '--path',
+        '/internal/secret-route'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const events = client.telemetryEventStore.readonlyEvents;
+      const pathEvent = events.find(e => e.key === 'option:path');
+      expect(pathEvent?.value).toBe('[REDACTED]');
+      expect(events.every(e => !String(e.value).includes('secret-route'))).toBe(
+        true
+      );
+    });
+  });
+
+  describe('protected-sourcemaps', () => {
+    it('shows the current setting on get', async () => {
+      setupProject({ protectedSourcemaps: true });
+      client.setArgv(
+        'project',
+        'protection',
+        'protected-sourcemaps',
+        'get',
+        'my-project',
+        '--json'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toMatchObject({
+        projectId: 'prj_123',
+        protectedSourcemaps: true,
+      });
+    });
+
+    it('sends true on set', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'protected-sourcemaps',
+        'set',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ protectedSourcemaps: true });
+    });
+
+    it('sends false on disable --yes', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'protected-sourcemaps',
+        'disable',
+        'my-project',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ protectedSourcemaps: false });
+    });
+  });
+
+  describe('trusted-sources', () => {
+    it('shows the config on get', async () => {
+      setupProject({
+        trustedSources: { projects: { prj_abc: { label: 'peer' } } },
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-sources',
+        'get',
+        'my-project',
+        '--json'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toMatchObject({
+        projectId: 'prj_123',
+        trustedSources: { projects: { prj_abc: { label: 'peer' } } },
+      });
+    });
+
+    it('replaces the config from --file on set', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      const dir = mkdtempSync(join(tmpdir(), 'vc-cli-ts-'));
+      const filePath = join(dir, 'trusted-sources.json');
+      const config = {
+        projects: {
+          prj_abc: {
+            label: 'monorepo peer',
+            customAllow: [
+              { from: { slugs: ['preview'] }, to: { slugs: ['preview'] } },
+            ],
+          },
+        },
+      };
+      writeFileSync(filePath, JSON.stringify(config));
+      try {
+        client.setArgv(
+          'project',
+          'protection',
+          'trusted-sources',
+          'set',
+          'my-project',
+          '--file',
+          filePath
+        );
+        const exitCode = await project(client);
+        expect(exitCode).toBe(0);
+        expect(body).toEqual({ trustedSources: config });
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects a config with unknown keys before any HTTP request', async () => {
+      let patched = false;
+      setupProject({}, () => {
+        patched = true;
+      });
+      const dir = mkdtempSync(join(tmpdir(), 'vc-cli-ts-bad-'));
+      const filePath = join(dir, 'bad.json');
+      writeFileSync(
+        filePath,
+        JSON.stringify({ projects: {}, somethingElse: 1 })
+      );
+      try {
+        client.setArgv(
+          'project',
+          'protection',
+          'trusted-sources',
+          'set',
+          'my-project',
+          '--file',
+          filePath
+        );
+        const exitCode = await project(client);
+        expect(exitCode).toBe(1);
+        expect(patched).toBe(false);
+        await expect(client.stderr).toOutput('unknown key');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('requires --file on set', async () => {
+      setupProject();
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-sources',
+        'set',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('--file');
+    });
+
+    it('clears the config (null) on disable --yes', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-sources',
+        'disable',
+        'my-project',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ trustedSources: null });
+    });
+  });
+
+  describe('shared disable confirmation behavior', () => {
+    it('requires --yes in non-interactive mode (confirmation_required)', async () => {
+      let patched = false;
+      setupProject({}, () => {
+        patched = true;
+      });
+      vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+        throw new Error('exit');
+      }) as () => never);
+      client.nonInteractive = true;
+      client.input.confirm = vi.fn();
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'disable',
+        'my-project'
+      );
+      await expect(project(client)).rejects.toThrow('exit');
+      expect(patched).toBe(false);
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out.reason).toBe('confirmation_required');
+    });
+
+    it('aborts without mutating when the prompt is declined', async () => {
+      let patched = false;
+      setupProject({}, () => {
+        patched = true;
+      });
+      client.input.confirm = vi.fn().mockResolvedValue(false);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-sources',
+        'disable',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('Aborted');
+    });
+  });
+
+  it('rejects an unknown action', async () => {
+    setupProject();
+    client.setArgv(
+      'project',
+      'protection',
+      'options-allowlist',
+      'frobnicate',
+      'my-project'
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(2);
+    await expect(client.stderr).toOutput('Invalid arguments');
+  });
+
+  describe('--help', () => {
+    it.each([
+      'trusted-sources',
+      'options-allowlist',
+      'protected-sourcemaps',
+    ])('prints help and tracks telemetry for %s', async slug => {
+      client.setArgv('project', 'protection', slug, '--help');
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `project:protection ${slug}`,
+        },
+      ]);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/project/protection-settings.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-settings.test.ts
@@ -40,168 +40,6 @@ describe('project protection settings subcommands', () => {
     vi.restoreAllMocks();
   });
 
-  describe('options-allowlist', () => {
-    it('shows the allowlist as JSON on get', async () => {
-      setupProject({ optionsAllowlist: { paths: [{ value: '/api/.*' }] } });
-      client.setArgv(
-        'project',
-        'protection',
-        'options-allowlist',
-        'get',
-        'my-project',
-        '--json'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      const out = JSON.parse(client.stdout.getFullOutput().trim());
-      expect(out).toMatchObject({
-        projectId: 'prj_123',
-        optionsAllowlist: { paths: [{ value: '/api/.*' }] },
-      });
-    });
-
-    it('replaces the allowlist via PATCH on set', async () => {
-      let body: unknown;
-      setupProject({}, b => {
-        body = b;
-      });
-      client.setArgv(
-        'project',
-        'protection',
-        'options-allowlist',
-        'set',
-        'my-project',
-        '--path',
-        '/api/.*',
-        '--path',
-        '/webhooks/stripe'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      expect(body).toEqual({
-        optionsAllowlist: {
-          paths: [{ value: '/api/.*' }, { value: '/webhooks/stripe' }],
-        },
-      });
-    });
-
-    it('rejects paths not starting with "/" before any HTTP request', async () => {
-      let patched = false;
-      setupProject({}, () => {
-        patched = true;
-      });
-      client.setArgv(
-        'project',
-        'protection',
-        'options-allowlist',
-        'set',
-        'my-project',
-        '--path',
-        'api/foo'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      expect(patched).toBe(false);
-      await expect(client.stderr).toOutput('must start with "/"');
-    });
-
-    it('rejects duplicate paths', async () => {
-      setupProject();
-      client.setArgv(
-        'project',
-        'protection',
-        'options-allowlist',
-        'set',
-        'my-project',
-        '--path',
-        '/api',
-        '--path',
-        '/api'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput('Duplicate path');
-    });
-
-    it('requires at least one --path on set', async () => {
-      setupProject();
-      client.setArgv(
-        'project',
-        'protection',
-        'options-allowlist',
-        'set',
-        'my-project'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      await expect(client.stderr).toOutput('At least one');
-    });
-
-    it('rejects more than 5 paths before any HTTP request', async () => {
-      let patched = false;
-      setupProject({}, () => {
-        patched = true;
-      });
-      const pathFlags = Array.from({ length: 6 }, (_, i) => [
-        '--path',
-        `/route-${i}`,
-      ]).flat();
-      client.setArgv(
-        'project',
-        'protection',
-        'options-allowlist',
-        'set',
-        'my-project',
-        ...pathFlags
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(1);
-      expect(patched).toBe(false);
-      await expect(client.stderr).toOutput(
-        'Too many paths (6); the maximum is 5'
-      );
-    });
-
-    it('clears the allowlist (null) on disable --yes', async () => {
-      let body: unknown;
-      setupProject({}, b => {
-        body = b;
-      });
-      client.setArgv(
-        'project',
-        'protection',
-        'options-allowlist',
-        'disable',
-        'my-project',
-        '--yes'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      expect(body).toEqual({ optionsAllowlist: null });
-    });
-
-    it('redacts --path values in telemetry', async () => {
-      setupProject({}, () => {});
-      client.setArgv(
-        'project',
-        'protection',
-        'options-allowlist',
-        'set',
-        'my-project',
-        '--path',
-        '/internal/secret-route'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      const events = client.telemetryEventStore.readonlyEvents;
-      const pathEvent = events.find(e => e.key === 'option:path');
-      expect(pathEvent?.value).toBe('[REDACTED]');
-      expect(events.every(e => !String(e.value).includes('secret-route'))).toBe(
-        true
-      );
-    });
-  });
-
   describe('trusted-sources', () => {
     it('shows the config on get', async () => {
       setupProject({
@@ -368,7 +206,7 @@ describe('project protection settings subcommands', () => {
       client.setArgv(
         'project',
         'protection',
-        'options-allowlist',
+        'trusted-sources',
         'disable',
         'my-project'
       );
@@ -404,7 +242,7 @@ describe('project protection settings subcommands', () => {
     client.setArgv(
       'project',
       'protection',
-      'options-allowlist',
+      'trusted-sources',
       'frobnicate',
       'my-project'
     );
@@ -416,7 +254,6 @@ describe('project protection settings subcommands', () => {
   describe('--help', () => {
     it.each([
       'trusted-sources',
-      'options-allowlist',
     ])('prints help and tracks telemetry for %s', async slug => {
       client.setArgv('project', 'protection', slug, '--help');
       const exitCode = await project(client);

--- a/packages/cli/test/unit/commands/project/protection-settings.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-settings.test.ts
@@ -137,6 +137,31 @@ describe('project protection settings subcommands', () => {
       await expect(client.stderr).toOutput('At least one');
     });
 
+    it('rejects more than 5 paths before any HTTP request', async () => {
+      let patched = false;
+      setupProject({}, () => {
+        patched = true;
+      });
+      const pathFlags = Array.from({ length: 6 }, (_, i) => [
+        '--path',
+        `/route-${i}`,
+      ]).flat();
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        ...pathFlags
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput(
+        'Too many paths (6); the maximum is 5'
+      );
+    });
+
     it('clears the allowlist (null) on disable --yes', async () => {
       let body: unknown;
       setupProject({}, b => {
@@ -316,6 +341,37 @@ describe('project protection settings subcommands', () => {
         expect(exitCode).toBe(1);
         expect(patched).toBe(false);
         await expect(client.stderr).toOutput('unknown key');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it.each([
+      ['malformed JSON', '{ not json', 'expected a JSON object'],
+      ['an empty object', '{}', 'at least one of'],
+      ['a JSON array', '[]', 'expected a JSON object'],
+    ])('rejects %s in --file before any HTTP request', async (_name, contents, expected) => {
+      let patched = false;
+      setupProject({}, () => {
+        patched = true;
+      });
+      const dir = mkdtempSync(join(tmpdir(), 'vc-cli-ts-invalid-'));
+      const filePath = join(dir, 'config.json');
+      writeFileSync(filePath, contents);
+      try {
+        client.setArgv(
+          'project',
+          'protection',
+          'trusted-sources',
+          'set',
+          'my-project',
+          '--file',
+          filePath
+        );
+        const exitCode = await project(client);
+        expect(exitCode).toBe(1);
+        expect(patched).toBe(false);
+        await expect(client.stderr).toOutput(expected);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/packages/cli/test/unit/commands/project/protection-settings.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-settings.test.ts
@@ -202,62 +202,6 @@ describe('project protection settings subcommands', () => {
     });
   });
 
-  describe('protected-sourcemaps', () => {
-    it('shows the current setting on get', async () => {
-      setupProject({ protectedSourcemaps: true });
-      client.setArgv(
-        'project',
-        'protection',
-        'protected-sourcemaps',
-        'get',
-        'my-project',
-        '--json'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      const out = JSON.parse(client.stdout.getFullOutput().trim());
-      expect(out).toMatchObject({
-        projectId: 'prj_123',
-        protectedSourcemaps: true,
-      });
-    });
-
-    it('sends true on set', async () => {
-      let body: unknown;
-      setupProject({}, b => {
-        body = b;
-      });
-      client.setArgv(
-        'project',
-        'protection',
-        'protected-sourcemaps',
-        'set',
-        'my-project'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      expect(body).toEqual({ protectedSourcemaps: true });
-    });
-
-    it('sends false on disable --yes', async () => {
-      let body: unknown;
-      setupProject({}, b => {
-        body = b;
-      });
-      client.setArgv(
-        'project',
-        'protection',
-        'protected-sourcemaps',
-        'disable',
-        'my-project',
-        '--yes'
-      );
-      const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      expect(body).toEqual({ protectedSourcemaps: false });
-    });
-  });
-
   describe('trusted-sources', () => {
     it('shows the config on get', async () => {
       setupProject({
@@ -473,7 +417,6 @@ describe('project protection settings subcommands', () => {
     it.each([
       'trusted-sources',
       'options-allowlist',
-      'protected-sourcemaps',
     ])('prints help and tracks telemetry for %s', async slug => {
       client.setArgv('project', 'protection', slug, '--help');
       const exitCode = await project(client);


### PR DESCRIPTION
## Summary

- Adds `vercel project protection trusted-sources get|set|disable [name]` to manage the Trusted Sources deployment-protection config via the public project `PATCH /v9/projects/:id` endpoint.
- Introduces a shared get/set/disable runner (`protection-settings.ts`) that the stacked options-allowlist and protected-sourcemaps PRs reuse.
- `set` takes `--file <json>` with the Trusted Sources config; `disable` clears it (`trustedSources: null`) behind a confirmation prompt (`--yes` to skip; non-interactive without `--yes` exits 1 with `confirmation_required`); `get` prints the current value with `--json`/`--format json` support.

## Notes

- Schema fields verbatim from the public project PATCH schema: `trustedSources` (`projects` map and `oidcProviders` map, nullable).
- Local validation before any request: the `--file` JSON must be an object restricted to the schema's top-level keys (`projects`, `oidcProviders`); malformed JSON, empty objects, and arrays are rejected with exit 1 and no PATCH sent. Deep semantic validation (env slugs, claims, per-map limits) is enforced by the API, which is authoritative; flattening the nested structure into flags was intentionally not attempted.
- Telemetry redacts `--file` values; only the action enum and flag presence are recorded.
- Existing `project protection` and `project protection trusted-ips` behavior is untouched.
- Stack: #17481 (trusted-ips get) ← #17490 (trusted-ips set/disable) ← this PR ← #17491 (options-allowlist) ← #17492 (protected-sourcemaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
