### PR TITLE
[CLI] Add env shared update subcommand

### DIFF
--- a/.changeset/env-shared-update.md
+++ b/.changeset/env-shared-update.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel env shared update` to apply sparse updates to team Shared Environment Variables (value, targets, project link/unlink, sensitive type, comment). Values are read from an argument, stdin, or a prompt and are never printed.

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -514,6 +514,83 @@ export const sharedAddSubcommand = {
   ],
 } as const;
 
+export const sharedUpdateSubcommand = {
+  name: 'update',
+  aliases: [],
+  description: 'Update a team Shared Environment Variable',
+  arguments: [
+    {
+      name: 'name-or-id',
+      required: true,
+    },
+    {
+      name: 'value',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'environment',
+      description:
+        'Replace the target environments: production, preview, or development (repeatable)',
+      shorthand: 'e',
+      type: [String],
+      argument: 'TARGET',
+      deprecated: false,
+    },
+    {
+      name: 'link-project',
+      description: 'Link the variable to a project by ID (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'ID',
+      deprecated: false,
+    },
+    {
+      name: 'unlink-project',
+      description: 'Unlink the variable from a project by ID (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'ID',
+      deprecated: false,
+    },
+    {
+      name: 'sensitive',
+      description:
+        'Update the variable to sensitive so it cannot be read later',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      name: 'comment',
+      description: 'Update the comment describing the variable',
+      shorthand: null,
+      type: String,
+      argument: 'TEXT',
+      deprecated: false,
+    },
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when updating the variable',
+    },
+  ],
+  examples: [
+    {
+      name: 'Update the value of a Shared Environment Variable',
+      value: `${packageName} env shared update API_URL "<value>"`,
+    },
+    {
+      name: 'Replace the target environments',
+      value: `${packageName} env shared update API_URL -e production -e preview`,
+    },
+    {
+      name: 'Link and unlink projects without deleting the variable',
+      value: `${packageName} env shared update API_URL --link-project new-project --unlink-project old-project`,
+    },
+  ],
+} as const;
+
 export const sharedSubcommand = {
   name: 'shared',
   aliases: [],
@@ -523,6 +600,7 @@ export const sharedSubcommand = {
     sharedListSubcommand,
     sharedInspectSubcommand,
     sharedAddSubcommand,
+    sharedUpdateSubcommand,
   ],
   options: [],
   examples: [

--- a/packages/cli/src/commands/env/shared-update.ts
+++ b/packages/cli/src/commands/env/shared-update.ts
@@ -1,0 +1,238 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import {
+  updateSharedEnvRecord,
+  type SharedEnvUpdate,
+} from '../../util/env/shared-env-mutations';
+import resolveSharedEnvVariable from '../../util/env/resolve-shared-env';
+import type { SharedEnvTarget } from '../../util/env/get-shared-env-records';
+import { envTargetChoices, isValidEnvTarget } from '../../util/env/env-target';
+import readStandardInput from '../../util/input/read-standard-input';
+import { normalizeStdinEnvValue } from '../../util/env/validate-env';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { isAPIError } from '../../util/errors-ts';
+import { EnvSharedUpdateTelemetryClient } from '../../util/telemetry/commands/env/shared-update';
+import { sharedUpdateSubcommand } from './command';
+
+function collectTargets(raw: string[] | undefined): string[] {
+  const targets: string[] = [];
+  for (const entry of raw ?? []) {
+    for (const t of entry.split(',').map(s => s.trim())) {
+      if (t && !targets.includes(t)) {
+        targets.push(t);
+      }
+    }
+  }
+  return targets;
+}
+
+export default async function update(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new EnvSharedUpdateTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    sharedUpdateSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  const stdInput = await readStandardInput(client.stdin);
+  const [nameOrId, valueArg] = args;
+
+  telemetry.trackCliArgumentNameOrId(nameOrId);
+  telemetry.trackCliArgumentValue(valueArg);
+  telemetry.trackCliOptionEnvironment(
+    flags['--environment'] as [string] | undefined
+  );
+  telemetry.trackCliOptionLinkProject(
+    flags['--link-project'] as [string] | undefined
+  );
+  telemetry.trackCliOptionUnlinkProject(
+    flags['--unlink-project'] as [string] | undefined
+  );
+  telemetry.trackCliFlagSensitive(flags['--sensitive']);
+  telemetry.trackCliOptionComment(flags['--comment']);
+  telemetry.trackCliFlagYes(flags['--yes']);
+
+  if (args.length < 1 || args.length > 2) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        `${getCommandName('env shared update <name-or-id> [value]')}`
+      )}`
+    );
+    return 1;
+  }
+
+  const { contextName } = await getScope(client);
+
+  // Build the sparse update from the provided flags/args only.
+  const update: SharedEnvUpdate = {};
+  const changes: string[] = [];
+
+  let value: string | undefined = valueArg;
+  if (value === undefined && stdInput) {
+    value = normalizeStdinEnvValue(stdInput).value;
+  }
+  if (value !== undefined) {
+    update.value = value;
+    changes.push('value');
+  }
+
+  const targets = collectTargets(flags['--environment']);
+  if (targets.length) {
+    const invalid = targets.filter(t => !isValidEnvTarget(t));
+    if (invalid.length) {
+      output.error(
+        `Invalid environment ${invalid.map(t => chalk.bold(t)).join(', ')}. Use ${envTargetChoices
+          .map(c => chalk.bold(c.value))
+          .join(', ')}.`
+      );
+      return 1;
+    }
+    update.target = targets as SharedEnvTarget[];
+    changes.push(`environments (${targets.join(', ')})`);
+  }
+
+  const link = flags['--link-project'] ?? [];
+  const unlink = flags['--unlink-project'] ?? [];
+  if (link.length || unlink.length) {
+    update.projectIdUpdates = {
+      ...(link.length ? { link } : {}),
+      ...(unlink.length ? { unlink } : {}),
+    };
+    if (link.length) {
+      changes.push(`link ${link.join(', ')}`);
+    }
+    if (unlink.length) {
+      changes.push(`unlink ${unlink.join(', ')}`);
+    }
+  }
+
+  if (flags['--sensitive']) {
+    update.type = 'sensitive';
+    changes.push('type (sensitive)');
+  }
+
+  if (typeof flags['--comment'] === 'string') {
+    update.comment = flags['--comment'];
+    changes.push('comment');
+  }
+
+  if (changes.length === 0) {
+    output.error(
+      `Nothing to update. Provide a new value, ${chalk.cyan(
+        '--environment'
+      )}, ${chalk.cyan('--link-project')}/${chalk.cyan(
+        '--unlink-project'
+      )}, ${chalk.cyan('--sensitive')}, or ${chalk.cyan('--comment')}.`
+    );
+    return 1;
+  }
+
+  output.spinner(
+    `Resolving Shared Environment Variable under ${chalk.bold(contextName)}`
+  );
+
+  let resolved;
+  try {
+    resolved = await resolveSharedEnvVariable(client, nameOrId);
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (resolved.status === 'not_found') {
+    output.error(
+      `No Shared Environment Variable ${chalk.bold(
+        nameOrId
+      )} found under ${chalk.bold(contextName)}.`
+    );
+    return 1;
+  }
+  if (resolved.status === 'ambiguous') {
+    output.error(
+      `Multiple Shared Environment Variables named ${chalk.bold(
+        nameOrId
+      )} were found. Update one by ID instead:`
+    );
+    for (const env of resolved.matches) {
+      output.print(
+        `  ${env.id}  ${chalk.gray(env.target?.join(', ') || '-')}\n`
+      );
+    }
+    return 1;
+  }
+
+  const record = resolved.record;
+
+  if (!flags['--yes'] && !client.nonInteractive) {
+    output.print(
+      `Updating Shared Environment Variable ${chalk.bold(
+        record.key ?? record.id
+      )} under ${chalk.bold(contextName)}\n`
+    );
+    printAlignedLabel('Changes', changes.join('; '));
+    const confirmed = await client.input.confirm('Apply this update?', true);
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  const updateStamp = stamp();
+  output.spinner('Updating');
+
+  let result;
+  try {
+    result = await updateSharedEnvRecord(client, record.id, update);
+  } catch (err) {
+    output.stopSpinner();
+    if (isAPIError(err) && err.serverMessage) {
+      output.error(err.serverMessage);
+      return 1;
+    }
+    printError(err);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  if (!result.updated.length) {
+    const failure = result.failed[0];
+    output.error(
+      failure?.message ?? 'Failed to update the Shared Environment Variable.'
+    );
+    return 1;
+  }
+
+  printAlignedLabel(
+    'Updated',
+    `${record.key ?? record.id} ${chalk.gray(updateStamp())}`,
+    {
+      gutter: '✓',
+    }
+  );
+  printAlignedLabel('Team', contextName);
+  printAlignedLabel('Changes', changes.join('; '));
+
+  return 0;
+}

--- a/packages/cli/src/commands/env/shared.ts
+++ b/packages/cli/src/commands/env/shared.ts
@@ -7,12 +7,14 @@ import { printError } from '../../util/error';
 import ls from './shared-ls';
 import inspect from './shared-inspect';
 import add from './shared-add';
+import update from './shared-update';
 import {
   envCommand,
   sharedSubcommand,
   sharedListSubcommand,
   sharedInspectSubcommand,
   sharedAddSubcommand,
+  sharedUpdateSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -23,6 +25,7 @@ const COMMAND_CONFIG = {
   ls: getCommandAliases(sharedListSubcommand),
   inspect: getCommandAliases(sharedInspectSubcommand),
   add: getCommandAliases(sharedAddSubcommand),
+  update: getCommandAliases(sharedUpdateSubcommand),
 };
 
 export default async function shared(client: Client): Promise<number> {
@@ -96,6 +99,14 @@ export default async function shared(client: Client): Promise<number> {
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
+    case 'update':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('env shared', subcommandOriginal);
+        printHelp(sharedUpdateSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandUpdate(subcommandOriginal);
+      return update(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(

--- a/packages/cli/src/util/env/resolve-shared-env.ts
+++ b/packages/cli/src/util/env/resolve-shared-env.ts
@@ -22,7 +22,9 @@ export default async function resolveSharedEnvVariable(
   const isId = nameOrId.startsWith(ID_PREFIX);
   const { data } = await getSharedEnvRecords(
     client,
-    isId ? { ids: nameOrId, limit: 100 } : { search: nameOrId, limit: 100 }
+    // 50 matches the server's MAX_EV_IDS_COUNT clamp; a larger limit would be
+    // silently reduced to 50 anyway.
+    isId ? { ids: nameOrId, limit: 50 } : { search: nameOrId, limit: 50 }
   );
 
   const matches = isId

--- a/packages/cli/src/util/telemetry/commands/env/shared-update.ts
+++ b/packages/cli/src/util/telemetry/commands/env/shared-update.ts
@@ -1,0 +1,75 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { sharedUpdateSubcommand } from '../../../../commands/env/command';
+
+const KNOWN_TARGETS = ['production', 'preview', 'development'];
+
+export class EnvSharedUpdateTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof sharedUpdateSubcommand>
+{
+  trackCliArgumentNameOrId(nameOrId: string | undefined) {
+    if (nameOrId) {
+      this.trackCliArgument({ arg: 'name-or-id', value: this.redactedValue });
+    }
+  }
+
+  trackCliArgumentValue(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({ arg: 'value', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionEnvironment(environments: [string] | undefined) {
+    if (environments && environments.length) {
+      for (const environment of environments) {
+        this.trackCliOption({
+          option: 'environment',
+          value: KNOWN_TARGETS.includes(environment)
+            ? environment
+            : this.redactedValue,
+        });
+      }
+    }
+  }
+
+  trackCliOptionLinkProject(projects: [string] | undefined) {
+    if (projects && projects.length) {
+      for (const _project of projects) {
+        this.trackCliOption({
+          option: 'link-project',
+          value: this.redactedValue,
+        });
+      }
+    }
+  }
+
+  trackCliOptionUnlinkProject(projects: [string] | undefined) {
+    if (projects && projects.length) {
+      for (const _project of projects) {
+        this.trackCliOption({
+          option: 'unlink-project',
+          value: this.redactedValue,
+        });
+      }
+    }
+  }
+
+  trackCliFlagSensitive(sensitive: boolean | undefined) {
+    if (sensitive) {
+      this.trackCliFlag('sensitive');
+    }
+  }
+
+  trackCliOptionComment(comment: string | undefined) {
+    if (comment) {
+      this.trackCliOption({ option: 'comment', value: this.redactedValue });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/env/shared.ts
+++ b/packages/cli/src/util/telemetry/commands/env/shared.ts
@@ -26,4 +26,11 @@ export class EnvSharedTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandUpdate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'update',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3165,9 +3165,10 @@ exports[`help command > env help output snapshots > env shared help output snaps
 
   Commands:
 
-  list                   List team Shared Environment Variables                                                   
-  inspect  name-or-id    Show a team Shared Environment Variable in full                                          
-  add      name [value]  Add a team Shared Environment Variable                                                   
+  list                         List team Shared Environment Variables                                            
+  inspect  name-or-id          Show a team Shared Environment Variable in full                                   
+  add      name [value]        Add a team Shared Environment Variable                                            
+  update   name-or-id [value]  Update a team Shared Environment Variable                                         
 
 
   Global Options:
@@ -3274,6 +3275,53 @@ exports[`help command > env help output snapshots > env shared help output snaps
   - List Shared Environment Variables linked to a project
 
     $ vercel env shared ls --project my-project
+
+"
+`;
+
+exports[`help command > env help output snapshots > env shared help output snapshots > env shared update help column width 120 1`] = `
+"
+  ▲ vercel shared update name-or-id [value] [options]
+
+  Update a team Shared Environment Variable                                                                             
+
+  Options:
+
+       --comment <TEXT>        Update the comment describing the variable                                               
+  -e,  --environment <TARGET>  Replace the target environments: production, preview, or development (repeatable)        
+       --link-project <ID>     Link the variable to a project by ID (repeatable)                                        
+       --sensitive             Update the variable to sensitive so it cannot be read later                              
+       --unlink-project <ID>   Unlink the variable from a project by ID (repeatable)                                    
+  -y,  --yes                   Skip the confirmation prompt when updating the variable                                  
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Update the value of a Shared Environment Variable
+
+    $ vercel env shared update API_URL "<value>"
+
+  - Replace the target environments
+
+    $ vercel env shared update API_URL -e production -e preview
+
+  - Link and unlink projects without deleting the variable
+
+    $ vercel env shared update API_URL --link-project new-project --unlink-project old-project
 
 "
 `;

--- a/packages/cli/test/unit/commands/env/shared-update.test.ts
+++ b/packages/cli/test/unit/commands/env/shared-update.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import env from '../../../../src/commands/env';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+
+const SECRET = 'super-secret-new-value';
+
+const record = {
+  id: 'env_1',
+  key: 'API_URL',
+  type: 'encrypted',
+  target: ['production'],
+  projectId: ['prj_a'],
+  createdAt: 1700000000000,
+  updatedAt: 1700000500000,
+};
+
+function useResolve(data: unknown[] = [record]) {
+  let query: Record<string, unknown> | undefined;
+  client.scenario.get('/v1/env', (req, res) => {
+    query = req.query;
+    res.json({
+      data,
+      pagination: { count: data.length, next: null, prev: null },
+    });
+  });
+  return () => query;
+}
+
+function usePatch() {
+  let body: Record<string, unknown> | undefined;
+  let called = false;
+  client.scenario.patch('/v1/env', (req, res) => {
+    called = true;
+    body = req.body;
+    res.json({ updated: [record], failed: [] });
+  });
+  return { getBody: () => body, wasCalled: () => called };
+}
+
+describe('env shared update', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('--help', () => {
+    it('renders help and tracks telemetry', async () => {
+      client.setArgv('env', 'shared', 'update', '--help');
+      const exitCode = await env(client);
+      expect(exitCode).toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:shared', value: 'shared' },
+        { key: 'flag:help', value: 'env shared:update' },
+      ]);
+    });
+  });
+
+  it('updates the value and never prints it', async () => {
+    useResolve();
+    const patch = usePatch();
+    client.setArgv('env', 'shared', 'update', 'API_URL', SECRET, '--yes');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(0);
+
+    expect(patch.wasCalled()).toBe(true);
+    const body = patch.getBody() as {
+      updates: Record<string, { value?: string }>;
+    };
+    expect(body.updates.env_1.value).toEqual(SECRET);
+
+    const stdout = client.stdout.getFullOutput();
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Updated');
+    expect(stdout).not.toContain(SECRET);
+    expect(stderr).not.toContain(SECRET);
+  });
+
+  it('resolves an id via the ids filter', async () => {
+    const getQuery = useResolve();
+    usePatch();
+    client.setArgv('env', 'shared', 'update', 'env_1', '--sensitive', '--yes');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(0);
+    expect(getQuery()).toMatchObject({ ids: 'env_1' });
+  });
+
+  it('sends projectIdUpdates for link and unlink', async () => {
+    useResolve();
+    const patch = usePatch();
+    client.setArgv(
+      'env',
+      'shared',
+      'update',
+      'API_URL',
+      '--link-project',
+      'prj_b',
+      '--unlink-project',
+      'prj_a',
+      '--yes'
+    );
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(0);
+    const body = patch.getBody() as {
+      updates: Record<
+        string,
+        { projectIdUpdates?: { link?: string[]; unlink?: string[] } }
+      >;
+    };
+    expect(body.updates.env_1.projectIdUpdates).toEqual({
+      link: ['prj_b'],
+      unlink: ['prj_a'],
+    });
+  });
+
+  it('marks the variable sensitive', async () => {
+    useResolve();
+    const patch = usePatch();
+    client.setArgv(
+      'env',
+      'shared',
+      'update',
+      'API_URL',
+      '--sensitive',
+      '--yes'
+    );
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(0);
+    const body = patch.getBody() as {
+      updates: Record<string, { type?: string }>;
+    };
+    expect(body.updates.env_1.type).toEqual('sensitive');
+  });
+
+  it('errors when nothing is provided to update', async () => {
+    const patch = usePatch();
+    client.setArgv('env', 'shared', 'update', 'API_URL', '--yes');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    expect(patch.wasCalled()).toBe(false);
+    await expect(client.stderr).toOutput('Nothing to update');
+  });
+
+  it('errors when the variable is not found', async () => {
+    useResolve([]);
+    const patch = usePatch();
+    client.setArgv('env', 'shared', 'update', 'MISSING', SECRET, '--yes');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    expect(patch.wasCalled()).toBe(false);
+    await expect(client.stderr).toOutput(
+      'No Shared Environment Variable MISSING found'
+    );
+  });
+
+  it('errors when multiple variables share the name', async () => {
+    useResolve([
+      { ...record, id: 'env_1' },
+      { ...record, id: 'env_2' },
+    ]);
+    const patch = usePatch();
+    client.setArgv('env', 'shared', 'update', 'API_URL', SECRET, '--yes');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    expect(patch.wasCalled()).toBe(false);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Multiple Shared Environment Variables');
+  });
+
+  it('tracks telemetry with redacted argument and value', async () => {
+    useResolve();
+    usePatch();
+    client.setArgv('env', 'shared', 'update', 'API_URL', SECRET, '--yes');
+    await env(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:shared', value: 'shared' },
+      { key: 'subcommand:update', value: 'update' },
+      { key: 'argument:name-or-id', value: '[REDACTED]' },
+      { key: 'argument:value', value: '[REDACTED]' },
+      { key: 'flag:yes', value: 'TRUE' },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/env/shared-update.test.ts
+++ b/packages/cli/test/unit/commands/env/shared-update.test.ts
@@ -77,6 +77,28 @@ describe('env shared update', () => {
     expect(stderr).not.toContain(SECRET);
   });
 
+  it('ingests the new value from piped stdin and strips the trailing newline', async () => {
+    useResolve();
+    const patch = usePatch();
+    client.stdin.isTTY = false;
+    client.setArgv('env', 'shared', 'update', 'API_URL', '--yes');
+
+    const exitCodePromise = env(client);
+    setImmediate(() => client.stdin.emit('data', `${SECRET}\n`));
+
+    expect(await exitCodePromise).toEqual(0);
+    expect(patch.wasCalled()).toBe(true);
+    const body = patch.getBody() as {
+      updates: Record<string, { value?: string }>;
+    };
+    expect(body.updates.env_1.value).toEqual(SECRET);
+
+    const stdout = client.stdout.getFullOutput();
+    const stderr = client.stderr.getFullOutput();
+    expect(stdout).not.toContain(SECRET);
+    expect(stderr).not.toContain(SECRET);
+  });
+
   it('resolves an id via the ids filter', async () => {
     const getQuery = useResolve();
     usePatch();

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -431,6 +431,14 @@ describe('help command', () => {
           })
         ).toMatchSnapshot();
       });
+      it('env shared update help column width 120', () => {
+        expect(
+          help(env.sharedUpdateSubcommand, {
+            columns: 120,
+            parent: env.sharedSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `vercel env shared update <name-or-id> [value]` to apply a sparse update to a team Shared Environment Variable: new value (argument, stdin, or prompt), replacement target environments (repeatable `-e/--environment`), incremental project linking (`--link-project`/`--unlink-project`), `--sensitive`, and `--comment`. Resolves the target by id or exact name, previews the changes, and confirms in TTY (`--yes` skips).
- Telemetry client, unit tests (including a piped-stdin ingestion test with request-body assertion), and help snapshots. The secret value is never printed in success output, errors, or telemetry.

## Notes
- Endpoint: `PATCH /v1/env` with `{ updates: { <id>: { value?, target?, projectIdUpdates?, type?, comment? } } }`. All flags are derived from the api-environment zod/JSON schemas; only provided fields are sent.
- Project linking uses the PATCH `projectIdUpdates.link`/`unlink` arrays for incremental changes without resending the full `projectId` list; the flags take project IDs (the schema does not resolve names).
- `<name-or-id>` resolves through the list endpoint (never the get-by-id endpoint) with a limit of 50 matching the server MAX_EV_IDS_COUNT clamp, so the secret value is never fetched; ambiguous names error with the matching ids.
- Secret-handling: the plaintext value is sent only in the request body, redacted in telemetry, and asserted absent from stdout/stderr by tests.
- Stack: #17483 (`ls`) → #17487 (`inspect`) → #17484 (`add`) → this PR → #17485 (`remove`) → #17489 (`unlink`).