### PR TITLE
[CLI] Add env shared inspect subcommand

### DIFF
--- a/.changeset/env-shared-inspect.md
+++ b/.changeset/env-shared-inspect.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel env shared inspect` to show a team Shared Environment Variable in full. The secret value is never fetched or printed.

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -423,17 +423,44 @@ export const sharedListSubcommand = {
   ],
 } as const;
 
+export const sharedInspectSubcommand = {
+  name: 'inspect',
+  aliases: [],
+  description: 'Show a team Shared Environment Variable in full',
+  arguments: [
+    {
+      name: 'name-or-id',
+      required: true,
+    },
+  ],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Inspect a Shared Environment Variable by name',
+      value: `${packageName} env shared inspect API_URL`,
+    },
+    {
+      name: 'Inspect a Shared Environment Variable by ID',
+      value: `${packageName} env shared inspect env_XCG7t7AIHuO2SBA8667zNUiM`,
+    },
+  ],
+} as const;
+
 export const sharedSubcommand = {
   name: 'shared',
   aliases: [],
   description: 'Manage team Shared Environment Variables',
   arguments: [],
-  subcommands: [sharedListSubcommand],
+  subcommands: [sharedListSubcommand, sharedInspectSubcommand],
   options: [],
   examples: [
     {
       name: 'List team Shared Environment Variables',
       value: `${packageName} env shared ls`,
+    },
+    {
+      name: 'Inspect a team Shared Environment Variable',
+      value: `${packageName} env shared inspect API_URL`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/env/shared-inspect.ts
+++ b/packages/cli/src/commands/env/shared-inspect.ts
@@ -1,0 +1,193 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import getSharedEnvRecords, {
+  type SharedEnvVariable,
+} from '../../util/env/get-shared-env-records';
+import table from '../../util/output/table';
+import formatDate from '../../util/format-date';
+import { validateJsonOutput } from '../../util/output-format';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { EnvSharedInspectTelemetryClient } from '../../util/telemetry/commands/env/shared-inspect';
+import { sharedInspectSubcommand } from './command';
+
+const ID_PREFIX = 'env_';
+
+export default async function inspect(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new EnvSharedInspectTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    sharedInspectSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+
+  if (args.length !== 1) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        `${getCommandName('env shared inspect <name-or-id>')}`
+      )}`
+    );
+    return 1;
+  }
+
+  const [nameOrId] = args;
+
+  telemetry.trackCliArgumentNameOrId(nameOrId);
+  telemetry.trackCliOptionFormat(flags['--format']);
+  telemetry.trackCliFlagJson(flags['--json']);
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  const { contextName } = await getScope(client);
+
+  const isId = nameOrId.startsWith(ID_PREFIX);
+
+  output.spinner(
+    `Fetching Shared Environment Variable under ${chalk.bold(contextName)}`
+  );
+
+  let records: SharedEnvVariable[];
+  try {
+    const data = await getSharedEnvRecords(
+      client,
+      // Resolve via the list endpoint (never the get-by-id endpoint) so the
+      // decrypted secret value is never fetched, decrypted, or at risk of being
+      // printed. All displayed metadata is present on the list record.
+      // 50 matches the server's MAX_EV_IDS_COUNT clamp; a larger limit would
+      // be silently reduced to 50 anyway.
+      isId ? { ids: nameOrId, limit: 50 } : { search: nameOrId, limit: 50 }
+    );
+    records = data.data;
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  const matches = isId
+    ? records.filter(env => env.id === nameOrId)
+    : records.filter(env => env.key === nameOrId);
+
+  if (matches.length === 0) {
+    output.error(
+      `No Shared Environment Variable ${chalk.bold(
+        nameOrId
+      )} found under ${chalk.bold(contextName)}.`
+    );
+    return 1;
+  }
+
+  if (matches.length > 1) {
+    output.error(
+      `Multiple Shared Environment Variables named ${chalk.bold(
+        nameOrId
+      )} were found. Inspect one by ID instead:`
+    );
+    for (const env of matches) {
+      const targets = env.target?.join(', ') || '-';
+      output.print(`  ${env.id}  ${chalk.gray(targets)}\n`);
+    }
+    return 1;
+  }
+
+  const record = matches[0];
+
+  if (asJson) {
+    client.stdout.write(`${JSON.stringify(toJson(record), null, 2)}\n`);
+    return 0;
+  }
+
+  output.log(
+    `Shared Environment Variable ${chalk.bold(
+      record.key ?? record.id
+    )} under ${chalk.bold(contextName)}`
+  );
+  client.stdout.write(formatDetails(record));
+
+  return 0;
+}
+
+/**
+ * Explicitly builds the machine-readable shape from known metadata fields so a
+ * decrypted value can never leak into JSON output.
+ */
+function toJson(env: SharedEnvVariable) {
+  return {
+    id: env.id,
+    key: env.key,
+    type: env.type,
+    target: env.target,
+    projectId: env.projectId ?? [],
+    projectCount: env.projectId?.length ?? 0,
+    applyToAllCustomEnvironments: env.applyToAllCustomEnvironments,
+    customEnvironmentIds: env.customEnvironmentIds ?? [],
+    comment: env.comment,
+    createdAt: env.createdAt,
+    updatedAt: env.updatedAt,
+    createdBy: env.createdBy,
+    updatedBy: env.updatedBy,
+    lastEditedByDisplayName: env.lastEditedByDisplayName,
+  };
+}
+
+function formatDetails(env: SharedEnvVariable): string {
+  const rows: string[][] = [
+    ['ID', env.id],
+    ['Name', env.key ?? '-'],
+    // Show the type as the encryption flag; the secret value is never printed.
+    ['Type', env.type ?? 'encrypted'],
+    ['Environments', env.target?.join(', ') || '-'],
+  ];
+
+  const projects = env.projectId ?? [];
+  rows.push(['Linked Projects', projects.length ? `${projects.length}` : '0']);
+
+  if (env.comment) {
+    rows.push(['Comment', env.comment]);
+  }
+
+  rows.push(['Created', formatDate(env.createdAt)]);
+  rows.push(['Updated', formatDate(env.updatedAt)]);
+  if (env.lastEditedByDisplayName) {
+    rows.push(['Last Edited By', env.lastEditedByDisplayName]);
+  }
+
+  let out = `${table(rows, { align: ['l', 'l'], hsep: 2 }).replace(
+    /^(.*)/gm,
+    '  $1'
+  )}\n`;
+
+  if (projects.length) {
+    out += `\n  ${chalk.gray('Linked project IDs:')}\n`;
+    for (const projectId of projects) {
+      out += `  ${projectId}\n`;
+    }
+  }
+
+  return out;
+}

--- a/packages/cli/src/commands/env/shared.ts
+++ b/packages/cli/src/commands/env/shared.ts
@@ -5,7 +5,13 @@ import getSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import { printError } from '../../util/error';
 import ls from './shared-ls';
-import { envCommand, sharedSubcommand, sharedListSubcommand } from './command';
+import inspect from './shared-inspect';
+import {
+  envCommand,
+  sharedSubcommand,
+  sharedListSubcommand,
+  sharedInspectSubcommand,
+} from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
@@ -13,6 +19,7 @@ import { EnvSharedTelemetryClient } from '../../util/telemetry/commands/env/shar
 
 const COMMAND_CONFIG = {
   ls: getCommandAliases(sharedListSubcommand),
+  inspect: getCommandAliases(sharedInspectSubcommand),
 };
 
 export default async function shared(client: Client): Promise<number> {
@@ -70,6 +77,14 @@ export default async function shared(client: Client): Promise<number> {
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
+    case 'inspect':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('env shared', subcommandOriginal);
+        printHelp(sharedInspectSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandInspect(subcommandOriginal);
+      return inspect(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(

--- a/packages/cli/src/util/telemetry/commands/env/shared-inspect.ts
+++ b/packages/cli/src/util/telemetry/commands/env/shared-inspect.ts
@@ -1,0 +1,32 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { sharedInspectSubcommand } from '../../../../commands/env/command';
+
+export class EnvSharedInspectTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof sharedInspectSubcommand>
+{
+  trackCliArgumentNameOrId(nameOrId: string | undefined) {
+    if (nameOrId) {
+      this.trackCliArgument({
+        arg: 'name-or-id',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      this.trackCliOption({
+        option: 'format',
+        value: format,
+      });
+    }
+  }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/env/shared.ts
+++ b/packages/cli/src/util/telemetry/commands/env/shared.ts
@@ -12,4 +12,11 @@ export class EnvSharedTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3119,7 +3119,8 @@ exports[`help command > env help output snapshots > env shared help output snaps
 
   Commands:
 
-  list    List team Shared Environment Variables                                                                
+  list                 List team Shared Environment Variables                                                   
+  inspect  name-or-id  Show a team Shared Environment Variable in full                                          
 
 
   Global Options:
@@ -3141,6 +3142,49 @@ exports[`help command > env help output snapshots > env shared help output snaps
   - List team Shared Environment Variables
 
     $ vercel env shared ls
+
+  - Inspect a team Shared Environment Variable
+
+    $ vercel env shared inspect API_URL
+
+"
+`;
+
+exports[`help command > env help output snapshots > env shared help output snapshots > env shared inspect help column width 120 1`] = `
+"
+  ▲ vercel shared inspect name-or-id [options]
+
+  Show a team Shared Environment Variable in full                                                                       
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Inspect a Shared Environment Variable by name
+
+    $ vercel env shared inspect API_URL
+
+  - Inspect a Shared Environment Variable by ID
+
+    $ vercel env shared inspect env_XCG7t7AIHuO2SBA8667zNUiM
 
 "
 `;

--- a/packages/cli/test/unit/commands/env/shared-inspect.test.ts
+++ b/packages/cli/test/unit/commands/env/shared-inspect.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import env from '../../../../src/commands/env';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+
+const SECRET = 'super-secret-value-do-not-print';
+
+const sampleShared = {
+  id: 'env_1',
+  key: 'API_URL',
+  type: 'encrypted',
+  target: ['production', 'preview'],
+  projectId: ['prj_a', 'prj_b'],
+  comment: 'shared api url',
+  createdAt: 1700000000000,
+  updatedAt: 1700000500000,
+  decrypted: true,
+  // Prove the CLI never prints the value even if the API returns it.
+  value: SECRET,
+};
+
+function useSharedEnv(data: unknown[] = [sampleShared]) {
+  let query: Record<string, unknown> | undefined;
+  client.scenario.get('/v1/env', (req, res) => {
+    query = req.query;
+    res.json({
+      data,
+      pagination: { count: data.length, next: null, prev: null },
+    });
+  });
+  return () => query;
+}
+
+describe('env shared inspect', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('--help', () => {
+    it('renders help and tracks telemetry', async () => {
+      client.setArgv('env', 'shared', 'inspect', '--help');
+      const exitCode = await env(client);
+      expect(exitCode).toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:shared', value: 'shared' },
+        { key: 'flag:help', value: 'env shared:inspect' },
+      ]);
+    });
+  });
+
+  it('inspects by name without exposing the value', async () => {
+    useSharedEnv();
+    client.setArgv('env', 'shared', 'inspect', 'API_URL');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(0);
+
+    const stdout = client.stdout.getFullOutput();
+    const stderr = client.stderr.getFullOutput();
+    expect(stdout).toContain('env_1');
+    expect(stdout).toContain('production, preview');
+    expect(stdout).not.toContain(SECRET);
+    expect(stderr).not.toContain(SECRET);
+  });
+
+  it('tracks the inspect subcommand and redacts the argument', async () => {
+    useSharedEnv();
+    client.setArgv('env', 'shared', 'inspect', 'API_URL');
+    await env(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:shared', value: 'shared' },
+      { key: 'subcommand:inspect', value: 'inspect' },
+      { key: 'argument:name-or-id', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('resolves an ID via the ids filter (never the get-by-id endpoint)', async () => {
+    const getQuery = useSharedEnv();
+    client.setArgv('env', 'shared', 'inspect', 'env_1');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(0);
+    expect(getQuery()).toMatchObject({ ids: 'env_1' });
+  });
+
+  it('emits clean JSON with --json and no value', async () => {
+    useSharedEnv();
+    client.setArgv('env', 'shared', 'inspect', 'API_URL', '--json');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(0);
+
+    const stdout = client.stdout.getFullOutput();
+    expect(stdout).not.toContain(SECRET);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toMatchObject({ id: 'env_1', key: 'API_URL' });
+    expect(parsed).not.toHaveProperty('value');
+  });
+
+  it('errors when the variable is not found', async () => {
+    useSharedEnv([]);
+    client.setArgv('env', 'shared', 'inspect', 'MISSING');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'No Shared Environment Variable MISSING found'
+    );
+  });
+
+  it('errors when multiple variables share the name', async () => {
+    useSharedEnv([
+      { ...sampleShared, id: 'env_1', target: ['production'] },
+      { ...sampleShared, id: 'env_2', target: ['preview'] },
+    ]);
+    client.setArgv('env', 'shared', 'inspect', 'API_URL');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Multiple Shared Environment Variables');
+    expect(stderr).toContain('env_1');
+    expect(stderr).toContain('env_2');
+  });
+
+  it('errors when no argument is provided', async () => {
+    client.setArgv('env', 'shared', 'inspect');
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid number of arguments');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -415,6 +415,14 @@ describe('help command', () => {
           })
         ).toMatchSnapshot();
       });
+      it('env shared inspect help column width 120', () => {
+        expect(
+          help(env.sharedInspectSubcommand, {
+            columns: 120,
+            parent: env.sharedSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `vercel env shared inspect <name-or-id>` to show one team Shared Environment Variable in full (id, name, type, environments, linked projects, comment, timestamps), with human and `--json`/`--format json` output.
- Telemetry client, unit tests, and help snapshots. The secret value is never fetched or printed.

## Notes
- Resolves via `GET /v1/env` (by `ids=` for `env_*` ids, else `search=` + exact key match) — never the get-by-id endpoint — so the decrypted value is never fetched, decrypted, or at risk of printing. The list limit is 50 to match the server MAX_EV_IDS_COUNT clamp.
- JSON output is built explicitly from known metadata fields (no `value`); the type field doubles as the encrypted/sensitive flag. Tests assert the value never appears on stdout/stderr.
- Ambiguous names error with the matching ids and environments so the user can inspect by id.
- Stack: #17483 (`ls`) → this PR → #17484 (`add`) → #17486 (`update`) → #17485 (`remove`) → #17489 (`unlink`).