### PR TITLE
[CLI] Add access-group members add subcommand

### DIFF
--- a/.changeset/access-group-members-add.md
+++ b/.changeset/access-group-members-add.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel access-group members add` subcommand

--- a/packages/cli/src/commands/access-group/command.ts
+++ b/packages/cli/src/commands/access-group/command.ts
@@ -121,12 +121,35 @@ export const membersListSubcommand = {
   ],
 } as const;
 
+export const membersAddSubcommand = {
+  name: 'add',
+  aliases: [],
+  description: 'Add a member to an access group',
+  arguments: [
+    {
+      name: 'group',
+      required: true,
+    },
+    {
+      name: 'member',
+      required: true,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Add a member (by id, email, or username) to an access group',
+      value: `${packageName} access-group members add my-access-group user@example.com`,
+    },
+  ],
+} as const;
+
 export const membersSubcommand = {
   name: 'members',
   aliases: [],
   description: 'Manage the members of an access group',
   arguments: [],
-  subcommands: [membersListSubcommand],
+  subcommands: [membersListSubcommand, membersAddSubcommand],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/access-group/members-add.ts
+++ b/packages/cli/src/commands/access-group/members-add.ts
@@ -1,0 +1,83 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { AccessGroupMembersTelemetryClient } from '../../util/telemetry/commands/access-group/members';
+import updateAccessGroup from '../../util/access-group/update-access-group';
+import getTeamMembers from '../../util/access-group/get-team-members';
+import { resolveMemberId } from '../../util/access-group/resolve-member';
+import { handleAccessGroupError } from '../../util/access-group/error';
+import { membersAddSubcommand } from './command';
+
+export default async function add(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AccessGroupMembersTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    membersAddSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const [group, member] = parsedArgs.args;
+  if (!group || !member) {
+    output.error(
+      `Please provide an access group and a member. See ${getCommandName(
+        'access-group members add <group> <member>'
+      )}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentGroup(group);
+  telemetry.trackCliArgumentMember(member);
+
+  const { contextName, team } = await getScope(client);
+  if (!team) {
+    output.error('Access groups are only available on a team scope.');
+    return 1;
+  }
+
+  let uid: string | undefined;
+  try {
+    const teamMembers = await getTeamMembers(client, team.id);
+    uid = resolveMemberId(teamMembers, member);
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  if (!uid) {
+    output.error(
+      `Could not find a team member matching ${chalk.bold(
+        member
+      )}. Pass a user id, email, or username of a member of ${chalk.bold(
+        contextName
+      )}.`
+    );
+    return 1;
+  }
+
+  try {
+    await updateAccessGroup(client, group, { membersToAdd: [uid] });
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  output.success(
+    `Member ${chalk.bold(member)} added to access group ${chalk.bold(group)}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/access-group/members.ts
+++ b/packages/cli/src/commands/access-group/members.ts
@@ -3,7 +3,12 @@ import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import list from './members-list';
-import { membersSubcommand, membersListSubcommand } from './command';
+import add from './members-add';
+import {
+  membersSubcommand,
+  membersListSubcommand,
+  membersAddSubcommand,
+} from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
@@ -12,6 +17,7 @@ import { printError } from '../../util/error';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(membersListSubcommand),
+  add: getCommandAliases(membersAddSubcommand),
 };
 
 export default async function members(client: Client): Promise<number> {
@@ -53,11 +59,22 @@ export default async function members(client: Client): Promise<number> {
     );
   }
 
-  if (needHelp) {
-    telemetry.trackCliFlagHelp('access-group members', subcommandOriginal);
-    printHelp(membersListSubcommand);
-    return 2;
+  switch (subcommand) {
+    case 'add':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group members', subcommandOriginal);
+        printHelp(membersAddSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
+      return add(client, args);
+    default:
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group members', subcommandOriginal);
+        printHelp(membersListSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return list(client, args);
   }
-  telemetry.trackCliSubcommandList(subcommandOriginal);
-  return list(client, args);
 }

--- a/packages/cli/src/util/access-group/get-team-members.ts
+++ b/packages/cli/src/util/access-group/get-team-members.ts
@@ -1,0 +1,41 @@
+import type Client from '../client';
+
+export interface TeamMember {
+  uid: string;
+  email?: string;
+  username?: string;
+  name?: string;
+  role?: string;
+}
+
+interface TeamMembersResponse {
+  members: TeamMember[];
+  pagination?: {
+    count: number;
+    next: number | null;
+  };
+}
+
+// Pages through the team members endpoint so a member can be resolved by uid,
+// email, or username.
+export default async function getTeamMembers(
+  client: Client,
+  teamId: string
+): Promise<TeamMember[]> {
+  const members: TeamMember[] = [];
+  let until: number | undefined;
+
+  do {
+    const query = new URLSearchParams({ limit: '100' });
+    if (until) {
+      query.set('until', String(until));
+    }
+    const response = await client.fetch<TeamMembersResponse>(
+      `/v2/teams/${encodeURIComponent(teamId)}/members?${query.toString()}`
+    );
+    members.push(...(response.members ?? []));
+    until = response.pagination?.next ?? undefined;
+  } while (until);
+
+  return members;
+}

--- a/packages/cli/src/util/access-group/resolve-member.ts
+++ b/packages/cli/src/util/access-group/resolve-member.ts
@@ -1,0 +1,21 @@
+interface MemberIdentity {
+  uid: string;
+  email?: string;
+  username?: string;
+}
+
+// Resolves a user-supplied identifier (uid, email, or username) to a uid,
+// mirroring how team/project member commands accept flexible identifiers.
+export function resolveMemberId(
+  members: MemberIdentity[],
+  identifier: string
+): string | undefined {
+  const needle = identifier.toLowerCase();
+  const match = members.find(
+    member =>
+      member.uid === identifier ||
+      member.email?.toLowerCase() === needle ||
+      member.username?.toLowerCase() === needle
+  );
+  return match?.uid;
+}

--- a/packages/cli/src/util/access-group/update-access-group.ts
+++ b/packages/cli/src/util/access-group/update-access-group.ts
@@ -4,6 +4,7 @@ import type { AccessGroup } from './types';
 
 export interface UpdateAccessGroupBody {
   name?: string;
+  membersToAdd?: string[];
 }
 
 export default async function updateAccessGroup(

--- a/packages/cli/src/util/telemetry/commands/access-group/members.ts
+++ b/packages/cli/src/util/telemetry/commands/access-group/members.ts
@@ -13,10 +13,26 @@ export class AccessGroupMembersTelemetryClient
     });
   }
 
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
   trackCliArgumentGroup(group: string | undefined) {
     if (group) {
       this.trackCliArgument({
         arg: 'group',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentMember(member: string | undefined) {
+    if (member) {
+      this.trackCliArgument({
+        arg: 'member',
         value: this.redactedValue,
       });
     }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -289,6 +289,35 @@ exports[`help command > access-group help output snapshots > access-group list h
 "
 `;
 
+exports[`help command > access-group help output snapshots > access-group members help output snapshots > access-group members add help column width 120 1`] = `
+"
+  ▲ vercel members add group member
+
+  Add a member to an access group                                                                                       
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Add a member (by id, email, or username) to an access group
+
+    $ vercel access-group members add my-access-group user@example.com
+
+"
+`;
+
 exports[`help command > access-group help output snapshots > access-group members help output snapshots > access-group members help column width 120 1`] = `
 "
   ▲ vercel access-group members [command]
@@ -297,7 +326,8 @@ exports[`help command > access-group help output snapshots > access-group member
 
   Commands:
 
-  list  group  List the members of an access group (default)                                                    
+  list  group         List the members of an access group (default)                                              
+  add   group member  Add a member to an access group                                                            
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/access-group/members-add.test.ts
+++ b/packages/cli/test/unit/commands/access-group/members-add.test.ts
@@ -1,0 +1,112 @@
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+
+describe('access-group members add', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    client.config.currentTeam = 'team_dummy';
+  });
+
+  afterEach(() => {
+    client.config.currentTeam = undefined;
+  });
+
+  function useTeamMembers() {
+    client.scenario.get('/v2/teams/team_dummy/members', (_req, res) => {
+      res.json({
+        members: [
+          { uid: 'usr_1', email: 'jane@example.com', username: 'jane' },
+        ],
+        pagination: { count: 1, next: null },
+      });
+    });
+  }
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('access-group', 'members', 'add', '--help');
+      const exitCodePromise = accessGroup(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:members',
+          value: 'members',
+        },
+        {
+          key: 'flag:help',
+          value: 'access-group members:add',
+        },
+      ]);
+    });
+  });
+
+  it('errors when the member is missing', async () => {
+    client.setArgv('access-group', 'members', 'add', 'ag_1');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Please provide an access group and a member'
+    );
+  });
+
+  it('resolves a member by email and adds it via the update endpoint', async () => {
+    useTeamMembers();
+    let body: unknown;
+    client.scenario.post('/v1/access-groups/ag_1', (req, res) => {
+      body = req.body;
+      res.json({});
+    });
+
+    client.setArgv(
+      'access-group',
+      'members',
+      'add',
+      'ag_1',
+      'jane@example.com'
+    );
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+    expect(body).toEqual({ membersToAdd: ['usr_1'] });
+    await expect(client.stderr).toOutput('added to access group');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:members',
+        value: 'members',
+      },
+      {
+        key: 'subcommand:add',
+        value: 'add',
+      },
+      {
+        key: 'argument:group',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'argument:member',
+        value: '[REDACTED]',
+      },
+    ]);
+  });
+
+  it('errors when the member cannot be resolved', async () => {
+    useTeamMembers();
+    client.setArgv(
+      'access-group',
+      'members',
+      'add',
+      'ag_1',
+      'nobody@example.com'
+    );
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Could not find a team member matching'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -176,6 +176,14 @@ describe('help command', () => {
           })
         ).toMatchSnapshot();
       });
+      it('access-group members add help column width 120', () => {
+        expect(
+          help(accessGroup.membersAddSubcommand, {
+            columns: 120,
+            parent: accessGroup.membersSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `vercel access-group members add <group> <member>` to add a member to an access group by user id, email, or username.

## Notes
- Endpoint (public v1): there is no dedicated member-add endpoint, so the identifier is resolved against team members (`GET /v2/teams/:teamId/members`, requires a team scope) via a shared `resolveMemberId` matching uid/email/username, and applied as `membersToAdd` via the group update endpoint `POST /v1/access-groups/:group`.
- Telemetry redacts the group/member arguments.
- Unit tests assert request method/path/body, usage errors, and resolution failures.
- Help snapshots regenerated; the pre-existing `connex` width-120 snapshot failure is unrelated and left untouched.
- Stack: #17460 (read) → #17464 (add/update) → #17476 (remove) → #17470 (members list) → #17488 (members add) → #17478 (members remove) → #17474 (projects list) → #17493 (projects add) → #17480 (projects update/remove).