### PR TITLE
[CLI] Add env shared unlink subcommand

### DIFF
--- a/.changeset/env-shared-unlink.md
+++ b/.changeset/env-shared-unlink.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel env shared unlink` to remove a single project link from a team Shared Environment Variable without deleting it, with TTY confirmation, `--yes`, and a non-interactive `confirmation_required` contract.

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -619,6 +619,39 @@ export const sharedRemoveSubcommand = {
   ],
 } as const;
 
+export const sharedUnlinkSubcommand = {
+  name: 'unlink',
+  aliases: [],
+  description:
+    'Unlink a project from a team Shared Environment Variable without deleting it',
+  arguments: [
+    {
+      name: 'name-or-id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'project',
+      description: 'Project to unlink by name or ID (required)',
+      shorthand: null,
+      type: String,
+      argument: 'NAME_OR_ID',
+      deprecated: false,
+    },
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when unlinking the project',
+    },
+  ],
+  examples: [
+    {
+      name: 'Unlink a project from a Shared Environment Variable',
+      value: `${packageName} env shared unlink API_URL --project my-project`,
+    },
+  ],
+} as const;
+
 export const sharedSubcommand = {
   name: 'shared',
   aliases: [],
@@ -630,6 +663,7 @@ export const sharedSubcommand = {
     sharedAddSubcommand,
     sharedUpdateSubcommand,
     sharedRemoveSubcommand,
+    sharedUnlinkSubcommand,
   ],
   options: [],
   examples: [

--- a/packages/cli/src/commands/env/shared-unlink.ts
+++ b/packages/cli/src/commands/env/shared-unlink.ts
@@ -1,0 +1,152 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { unlinkSharedEnvProject } from '../../util/env/shared-env-mutations';
+import resolveSharedEnvVariable from '../../util/env/resolve-shared-env';
+import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import stamp from '../../util/output/stamp';
+import output from '../../output-manager';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import { isAPIError } from '../../util/errors-ts';
+import {
+  outputActionRequired,
+  buildCommandWithYes,
+} from '../../util/agent-output';
+import { EnvSharedUnlinkTelemetryClient } from '../../util/telemetry/commands/env/shared-unlink';
+import { sharedUnlinkSubcommand } from './command';
+
+export default async function unlink(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new EnvSharedUnlinkTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    sharedUnlinkSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { args, flags } = parsedArgs;
+  const [nameOrId] = args;
+  const project = flags['--project'];
+
+  telemetry.trackCliArgumentNameOrId(nameOrId);
+  telemetry.trackCliOptionProject(project);
+  telemetry.trackCliFlagYes(flags['--yes']);
+
+  if (args.length !== 1) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        `${getCommandName('env shared unlink <name-or-id> --project <name-or-id>')}`
+      )}`
+    );
+    return 1;
+  }
+
+  if (!project) {
+    output.error(
+      `Provide the project to unlink with ${chalk.cyan('--project')}.`
+    );
+    return 1;
+  }
+
+  const { contextName } = await getScope(client);
+
+  output.spinner(
+    `Resolving Shared Environment Variable under ${chalk.bold(contextName)}`
+  );
+
+  let resolved;
+  try {
+    resolved = await resolveSharedEnvVariable(client, nameOrId);
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+  output.stopSpinner();
+
+  if (resolved.status === 'not_found') {
+    output.error(
+      `No Shared Environment Variable ${chalk.bold(
+        nameOrId
+      )} found under ${chalk.bold(contextName)}.`
+    );
+    return 1;
+  }
+  if (resolved.status === 'ambiguous') {
+    output.error(
+      `Multiple Shared Environment Variables named ${chalk.bold(
+        nameOrId
+      )} were found. Unlink one by ID instead:`
+    );
+    for (const env of resolved.matches) {
+      output.print(
+        `  ${env.id}  ${chalk.gray(env.target?.join(', ') || '-')}\n`
+      );
+    }
+    return 1;
+  }
+
+  const record = resolved.record;
+
+  if (!flags['--yes']) {
+    if (client.nonInteractive) {
+      outputActionRequired(
+        client,
+        {
+          status: 'action_required',
+          reason: 'confirmation_required',
+          message: `Unlinking project ${project} from Shared Environment Variable ${record.key ?? record.id}. Use --yes to confirm.`,
+          next: [{ command: buildCommandWithYes(client.argv) }],
+        },
+        1
+      );
+    }
+    const confirmed = await client.input.confirm(
+      `Unlink project ${chalk.bold(project)} from Shared Environment Variable ${chalk.bold(
+        record.key ?? record.id
+      )}?`,
+      true
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
+  }
+
+  const unlinkStamp = stamp();
+  output.spinner('Unlinking');
+
+  try {
+    await unlinkSharedEnvProject(client, record.id, project);
+  } catch (err) {
+    output.stopSpinner();
+    if (isAPIError(err) && err.serverMessage) {
+      output.error(err.serverMessage);
+      return 1;
+    }
+    printError(err);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  printAlignedLabel('Unlinked', `${project} ${chalk.gray(unlinkStamp())}`, {
+    gutter: '✓',
+  });
+  printAlignedLabel('Variable', record.key ?? record.id);
+  printAlignedLabel('Team', contextName);
+
+  return 0;
+}

--- a/packages/cli/src/commands/env/shared.ts
+++ b/packages/cli/src/commands/env/shared.ts
@@ -9,6 +9,7 @@ import inspect from './shared-inspect';
 import add from './shared-add';
 import update from './shared-update';
 import remove from './shared-remove';
+import unlink from './shared-unlink';
 import {
   envCommand,
   sharedSubcommand,
@@ -17,6 +18,7 @@ import {
   sharedAddSubcommand,
   sharedUpdateSubcommand,
   sharedRemoveSubcommand,
+  sharedUnlinkSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -29,6 +31,7 @@ const COMMAND_CONFIG = {
   add: getCommandAliases(sharedAddSubcommand),
   update: getCommandAliases(sharedUpdateSubcommand),
   rm: getCommandAliases(sharedRemoveSubcommand),
+  unlink: getCommandAliases(sharedUnlinkSubcommand),
 };
 
 export default async function shared(client: Client): Promise<number> {
@@ -118,6 +121,14 @@ export default async function shared(client: Client): Promise<number> {
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return remove(client, args);
+    case 'unlink':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('env shared', subcommandOriginal);
+        printHelp(sharedUnlinkSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandUnlink(subcommandOriginal);
+      return unlink(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(

--- a/packages/cli/src/util/env/shared-env-mutations.ts
+++ b/packages/cli/src/util/env/shared-env-mutations.ts
@@ -108,3 +108,25 @@ export async function deleteSharedEnvRecord(
     body: { ids: [id] },
   });
 }
+
+/**
+ * Removes a project link from a Shared Environment Variable without deleting
+ * the variable, via `PATCH /v1/env/:id/unlink/:projectId`. The project is
+ * resolved by name or ID server-side.
+ */
+export async function unlinkSharedEnvProject(
+  client: Client,
+  id: string,
+  projectIdOrName: string
+): Promise<{ id: string }> {
+  output.debug(`Unlinking project ${projectIdOrName} from ${id}`);
+
+  return client.fetch<{ id: string }>(
+    `/v1/env/${encodeURIComponent(id)}/unlink/${encodeURIComponent(
+      projectIdOrName
+    )}`,
+    {
+      method: 'PATCH',
+    }
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/env/shared-unlink.ts
+++ b/packages/cli/src/util/telemetry/commands/env/shared-unlink.ts
@@ -1,0 +1,26 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { sharedUnlinkSubcommand } from '../../../../commands/env/command';
+
+export class EnvSharedUnlinkTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof sharedUnlinkSubcommand>
+{
+  trackCliArgumentNameOrId(nameOrId: string | undefined) {
+    if (nameOrId) {
+      this.trackCliArgument({ arg: 'name-or-id', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionProject(project: string | undefined) {
+    if (project) {
+      this.trackCliOption({ option: 'project', value: this.redactedValue });
+    }
+  }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/env/shared.ts
+++ b/packages/cli/src/util/telemetry/commands/env/shared.ts
@@ -40,4 +40,11 @@ export class EnvSharedTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandUnlink(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'unlink',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3170,6 +3170,7 @@ exports[`help command > env help output snapshots > env shared help output snaps
   add      name [value]        Add a team Shared Environment Variable                                            
   update   name-or-id [value]  Update a team Shared Environment Variable                                         
   remove   name-or-id          Remove a team Shared Environment Variable                                         
+  unlink   name-or-id          Unlink a project from a team Shared Environment Variable without deleting it      
 
 
   Global Options:
@@ -3314,6 +3315,41 @@ exports[`help command > env help output snapshots > env shared help output snaps
   - Remove a Shared Environment Variable without confirmation
 
     $ vercel env shared rm env_XCG7t7AIHuO2SBA8667zNUiM --yes
+
+"
+`;
+
+exports[`help command > env help output snapshots > env shared help output snapshots > env shared unlink help column width 120 1`] = `
+"
+  ▲ vercel shared unlink name-or-id [options]
+
+  Unlink a project from a team Shared Environment Variable without deleting it                                          
+
+  Options:
+
+       --project <NAME_OR_ID>  Project to unlink by name or ID (required)                                                    
+  -y,  --yes                   Skip the confirmation prompt when unlinking the project                                       
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Unlink a project from a Shared Environment Variable
+
+    $ vercel env shared unlink API_URL --project my-project
 
 "
 `;

--- a/packages/cli/test/unit/commands/env/shared-unlink.test.ts
+++ b/packages/cli/test/unit/commands/env/shared-unlink.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import env from '../../../../src/commands/env';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+
+const record = {
+  id: 'env_1',
+  key: 'API_URL',
+  type: 'encrypted',
+  target: ['production'],
+  projectId: ['prj_a'],
+};
+
+function useResolve(data: unknown[] = [record]) {
+  client.scenario.get('/v1/env', (_req, res) => {
+    res.json({
+      data,
+      pagination: { count: data.length, next: null, prev: null },
+    });
+  });
+}
+
+function useUnlink() {
+  let called = false;
+  let path: string | undefined;
+  client.scenario.patch('/v1/env/:id/unlink/:projectId', (req, res) => {
+    called = true;
+    path = req.path;
+    res.json({ id: 'env_1' });
+  });
+  return { wasCalled: () => called, getPath: () => path };
+}
+
+describe('env shared unlink', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('--help', () => {
+    it('renders help and tracks telemetry', async () => {
+      client.setArgv('env', 'shared', 'unlink', '--help');
+      const exitCode = await env(client);
+      expect(exitCode).toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'subcommand:shared', value: 'shared' },
+        { key: 'flag:help', value: 'env shared:unlink' },
+      ]);
+    });
+  });
+
+  it('unlinks a project from the variable', async () => {
+    useResolve();
+    const mock = useUnlink();
+    client.setArgv(
+      'env',
+      'shared',
+      'unlink',
+      'API_URL',
+      '--project',
+      'my-project',
+      '--yes'
+    );
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(0);
+    expect(mock.wasCalled()).toBe(true);
+    expect(mock.getPath()).toContain('/v1/env/env_1/unlink/my-project');
+    await expect(client.stderr).toOutput('Unlinked');
+  });
+
+  it('cancels when the confirmation is declined and does not unlink', async () => {
+    useResolve();
+    const mock = useUnlink();
+    client.setArgv(
+      'env',
+      'shared',
+      'unlink',
+      'API_URL',
+      '--project',
+      'my-project'
+    );
+
+    const exitCodePromise = env(client);
+    await expect(client.stderr).toOutput('Unlink project');
+    client.stdin.write('n\n');
+
+    await expect(client.stderr).toOutput('Canceled');
+    expect(await exitCodePromise).toEqual(0);
+    expect(mock.wasCalled()).toBe(false);
+  });
+
+  it('emits confirmation_required and exits 1 in non-interactive mode', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as never);
+
+    useResolve();
+    const mock = useUnlink();
+    client.nonInteractive = true;
+    client.setArgv(
+      'env',
+      'shared',
+      'unlink',
+      'API_URL',
+      '--project',
+      'my-project',
+      '--non-interactive'
+    );
+
+    await expect(env(client)).rejects.toThrow('exit');
+    expect(mock.wasCalled()).toBe(false);
+    const payload = JSON.parse(client.stdout.getFullOutput());
+    expect(payload.reason).toEqual('confirmation_required');
+
+    exitSpy.mockRestore();
+  });
+
+  it('errors when multiple variables share the name', async () => {
+    useResolve([
+      { ...record, id: 'env_1' },
+      { ...record, id: 'env_2' },
+    ]);
+    const mock = useUnlink();
+    client.setArgv(
+      'env',
+      'shared',
+      'unlink',
+      'API_URL',
+      '--project',
+      'my-project',
+      '--yes'
+    );
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    expect(mock.wasCalled()).toBe(false);
+    const stderr = client.stderr.getFullOutput();
+    expect(stderr).toContain('Multiple Shared Environment Variables');
+    expect(stderr).toContain('env_1');
+    expect(stderr).toContain('env_2');
+  });
+
+  it('requires the --project flag', async () => {
+    const mock = useUnlink();
+    client.setArgv('env', 'shared', 'unlink', 'API_URL', '--yes');
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    expect(mock.wasCalled()).toBe(false);
+    await expect(client.stderr).toOutput('--project');
+  });
+
+  it('errors when the variable is not found', async () => {
+    useResolve([]);
+    const mock = useUnlink();
+    client.setArgv(
+      'env',
+      'shared',
+      'unlink',
+      'MISSING',
+      '--project',
+      'my-project',
+      '--yes'
+    );
+
+    const exitCode = await env(client);
+    expect(exitCode).toEqual(1);
+    expect(mock.wasCalled()).toBe(false);
+    await expect(client.stderr).toOutput(
+      'No Shared Environment Variable MISSING found'
+    );
+  });
+
+  it('tracks telemetry with redacted argument and project', async () => {
+    useResolve();
+    useUnlink();
+    client.setArgv(
+      'env',
+      'shared',
+      'unlink',
+      'API_URL',
+      '--project',
+      'my-project',
+      '--yes'
+    );
+    await env(client);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      { key: 'subcommand:shared', value: 'shared' },
+      { key: 'subcommand:unlink', value: 'unlink' },
+      { key: 'argument:name-or-id', value: '[REDACTED]' },
+      { key: 'option:project', value: '[REDACTED]' },
+      { key: 'flag:yes', value: 'TRUE' },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -447,6 +447,14 @@ describe('help command', () => {
           })
         ).toMatchSnapshot();
       });
+      it('env shared unlink help column width 120', () => {
+        expect(
+          help(env.sharedUnlinkSubcommand, {
+            columns: 120,
+            parent: env.sharedSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `vercel env shared unlink <name-or-id> --project <name-or-id>` to remove a single project link from a team Shared Environment Variable without deleting the variable. Confirms in TTY; `--yes` skips; non-interactive without `--yes` exits 1 with a `confirmation_required` agent payload and never fires the PATCH.
- Telemetry client, unit tests (non-interactive contract, decline path asserting the PATCH is not fired, ambiguous name, missing `--project`), and help snapshots.

## Notes
- Endpoint: `PATCH /v1/env/:id/unlink/:projectId`. The dedicated unlink endpoint removes one project link and leaves the variable intact; it resolves the project by name or ID server-side, so `--project` accepts either. Incremental link/unlink via the PATCH `projectIdUpdates` array is available separately on `env shared update`.
- `<name-or-id>` resolves through the list endpoint (never the get-by-id endpoint), so the secret value is never fetched; ambiguous names error with the matching ids.
- TTY confirmation defaults to Yes since unlinking is reversible (relink via `env shared update --link-project`); the non-interactive path still requires explicit `--yes`.
- Stack: #17483 (`ls`) → #17487 (`inspect`) → #17484 (`add`) → #17486 (`update`) → #17485 (`remove`) → this PR.