### PR TITLE
[CLI] Add project protection trusted-ips set and disable subcommands

### DIFF
--- a/.changeset/project-protection-trusted-ips-set.md
+++ b/.changeset/project-protection-trusted-ips-set.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project protection trusted-ips set|disable` to replace or clear the Trusted IPs allowlist. IPv4/CIDR input is validated locally before any request; IPv6 is rejected; disable requires confirmation (`--yes` in non-interactive mode).

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -571,7 +571,7 @@ export const protectionSubcommand = {
 } as const;
 
 /**
- * `vercel project protection trusted-ips get`.
+ * `vercel project protection trusted-ips get|set|disable`.
  *
  * Nested under `project protection`; the name embeds the middle segment so the
  * help synopsis renders `vercel project protection trusted-ips` with
@@ -581,20 +581,60 @@ export const protectionSubcommand = {
 export const trustedIpsSubcommand = {
   name: 'protection trusted-ips',
   aliases: [],
-  description: 'Show the Trusted IPs allowlist for deployment protection',
+  description:
+    'Show, set, or clear the Trusted IPs allowlist for deployment protection',
   arguments: [
     { name: 'action', required: false },
     { name: 'name', required: false },
   ],
-  options: [formatOption, jsonOption],
+  options: [
+    formatOption,
+    jsonOption,
+    yesOption,
+    {
+      name: 'ip',
+      shorthand: null,
+      type: [String],
+      argument: 'IP',
+      description:
+        'IPv4 address or CIDR to allowlist (repeatable). Append an optional note with "=", e.g. 203.0.113.4=office. IPv6 is not supported.',
+      deprecated: false,
+    },
+    {
+      name: 'deployment-type',
+      shorthand: null,
+      type: String,
+      argument: 'TYPE',
+      description:
+        'Deployment target the allowlist applies to: all, preview, production, prod_deployment_urls_and_all_previews, all_except_custom_domains',
+      deprecated: false,
+    },
+    {
+      name: 'mode',
+      shorthand: null,
+      type: String,
+      argument: 'MODE',
+      description:
+        'Protection mode: additional (IP must match plus another protection) or exclusive (IP match alone bypasses protection)',
+      deprecated: false,
+    },
+  ],
   examples: [
     {
       name: 'Show the Trusted IPs allowlist for the linked project',
       value: `${packageName} project protection trusted-ips get`,
     },
     {
-      name: 'Show the allowlist for a named project as JSON',
-      value: `${packageName} project protection trusted-ips get my-app --json`,
+      name: 'Allowlist IPs for all deployments in additional mode',
+      value: `${packageName} project protection trusted-ips set my-app --ip 203.0.113.4 --ip 198.51.100.0/24 --deployment-type all --mode additional`,
+    },
+    {
+      name: 'Allowlist an IP with a note',
+      value: `${packageName} project protection trusted-ips set --ip "203.0.113.4=office VPN" --deployment-type production --mode exclusive`,
+    },
+    {
+      name: 'Clear the Trusted IPs allowlist',
+      value: `${packageName} project protection trusted-ips disable my-app --yes`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/protection-trusted-ips.ts
+++ b/packages/cli/src/commands/project/protection-trusted-ips.ts
@@ -14,21 +14,27 @@ import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
 import { ProjectTelemetryClient } from '../../util/telemetry/commands/project';
-import type { Project } from '@vercel-internals/types';
+import type { JSONObject, Project } from '@vercel-internals/types';
 
-const TRUSTED_IPS_ACTIONS = ['get'] as const;
+const TRUSTED_IPS_ACTIONS = ['get', 'set', 'disable'] as const;
 type TrustedIpsAction = (typeof TRUSTED_IPS_ACTIONS)[number];
 
 // Verbatim from the public project PATCH schema (trustedIps.deploymentType).
-type DeploymentScope =
-  | 'all'
-  | 'preview'
-  | 'production'
-  | 'prod_deployment_urls_and_all_previews'
-  | 'all_except_custom_domains';
+const DEPLOYMENT_SCOPES = [
+  'all',
+  'preview',
+  'production',
+  'prod_deployment_urls_and_all_previews',
+  'all_except_custom_domains',
+] as const;
+type DeploymentScope = (typeof DEPLOYMENT_SCOPES)[number];
 
 // Verbatim from the public project PATCH schema (trustedIps.protectionMode).
-type ProtectionMode = 'additional' | 'exclusive';
+const PROTECTION_MODES = ['additional', 'exclusive'] as const;
+type ProtectionMode = (typeof PROTECTION_MODES)[number];
+
+// Schema: note has maxLength 20.
+const MAX_NOTE_LENGTH = 20;
 
 interface TrustedIpAddress {
   value: string;
@@ -43,6 +49,79 @@ interface TrustedIpsConfig {
 
 function isTrustedIpsAction(v: string | undefined): v is TrustedIpsAction {
   return !!v && (TRUSTED_IPS_ACTIONS as readonly string[]).includes(v);
+}
+
+/**
+ * Validate an IPv4 address or IPv4 CIDR string locally. IPv6 is intentionally
+ * rejected because the API does not support it. This is a security-critical
+ * gate: never forward unvalidated address strings to the remote PATCH.
+ */
+function isValidIpv4OrCidr(value: string): boolean {
+  const [addr, ...rest] = value.split('/');
+  if (rest.length > 1) return false;
+
+  if (rest.length === 1) {
+    const prefix = rest[0];
+    if (!/^\d{1,2}$/.test(prefix)) return false;
+    const prefixNum = Number(prefix);
+    if (prefixNum < 0 || prefixNum > 32) return false;
+  }
+
+  const octets = addr.split('.');
+  if (octets.length !== 4) return false;
+  for (const octet of octets) {
+    if (!/^\d{1,3}$/.test(octet)) return false;
+    const n = Number(octet);
+    if (n < 0 || n > 255) return false;
+    // Reject non-canonical leading zeros (e.g. "01").
+    if (octet.length > 1 && octet[0] === '0') return false;
+  }
+  return true;
+}
+
+/**
+ * Parse a single `--ip` value into an address plus optional note. Notes are
+ * separated with `=`; an IPv4/CIDR value never contains `=`, so splitting on
+ * the first `=` is unambiguous.
+ */
+function parseIpEntry(
+  raw: string
+): { ok: true; entry: TrustedIpAddress } | { ok: false; message: string } {
+  const trimmed = raw.trim();
+  const eqIndex = trimmed.indexOf('=');
+  const value = (eqIndex === -1 ? trimmed : trimmed.slice(0, eqIndex)).trim();
+  const note =
+    eqIndex === -1 ? undefined : trimmed.slice(eqIndex + 1).trim() || undefined;
+
+  if (value === '') {
+    return {
+      ok: false,
+      message: `Invalid --ip: expected an IPv4 address or CIDR, received an empty value.`,
+    };
+  }
+  if (value.includes(':')) {
+    return {
+      ok: false,
+      message: `Invalid --ip "${value}": IPv6 addresses are not supported.`,
+    };
+  }
+  if (!isValidIpv4OrCidr(value)) {
+    return {
+      ok: false,
+      message: `Invalid --ip "${value}": expected an IPv4 address (e.g. 203.0.113.4) or CIDR (e.g. 198.51.100.0/24).`,
+    };
+  }
+  if (note !== undefined && note.length > MAX_NOTE_LENGTH) {
+    return {
+      ok: false,
+      message: `Invalid note for --ip "${value}": notes must be at most ${MAX_NOTE_LENGTH} characters.`,
+    };
+  }
+
+  return {
+    ok: true,
+    entry: note === undefined ? { value } : { value, note },
+  };
 }
 
 function readTrustedIps(project: Project): TrustedIpsConfig | null {
@@ -85,7 +164,7 @@ export async function projectProtectionTrustedIps(
 
   if (!action) {
     const msg =
-      'Invalid action. Usage: `vercel project protection trusted-ips get [name]`';
+      'Invalid action. Usage: `vercel project protection trusted-ips get|set|disable [name]`';
     outputAgentError(
       client,
       {
@@ -139,7 +218,155 @@ export async function projectProtectionTrustedIps(
   }
   const preferJson = formatResult.jsonOutput || Boolean(client.nonInteractive);
 
+  const scopeFlag = parsedArgs.flags['--deployment-type'] as string | undefined;
+  const modeFlag = parsedArgs.flags['--mode'] as string | undefined;
+  const ipFlags = (parsedArgs.flags['--ip'] as string[] | undefined) ?? [];
+  const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
+
+  // Telemetry: enums verbatim (allowlisted); IPs redacted (sensitive infra).
   telemetry.trackCliArgumentAction(action);
+  telemetry.trackCliOptionDeploymentType(scopeFlag);
+  telemetry.trackCliOptionMode(modeFlag);
+  telemetry.trackCliOptionIp(ipFlags);
+  telemetry.trackCliFlagYes(skipConfirmation);
+
+  // Local validation must happen before any remote lookup or mutation.
+  let trustedIpsBody: TrustedIpsConfig | undefined;
+  if (action === 'set') {
+    if (
+      !scopeFlag ||
+      !DEPLOYMENT_SCOPES.includes(scopeFlag as DeploymentScope)
+    ) {
+      const msg = `\`--deployment-type\` is required and must be one of: ${DEPLOYMENT_SCOPES.join(', ')}`;
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: msg,
+        },
+        1
+      );
+      output.error(msg);
+      return 1;
+    }
+    if (!modeFlag || !PROTECTION_MODES.includes(modeFlag as ProtectionMode)) {
+      const msg = `\`--mode\` is required and must be one of: ${PROTECTION_MODES.join(', ')}`;
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.INVALID_ARGUMENTS,
+          message: msg,
+        },
+        1
+      );
+      output.error(msg);
+      return 1;
+    }
+    if (ipFlags.length === 0) {
+      const msg =
+        'At least one `--ip <address|CIDR>` is required to set Trusted IPs.';
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.MISSING_ARGUMENTS,
+          message: msg,
+        },
+        1
+      );
+      output.error(msg);
+      return 1;
+    }
+
+    const addresses: TrustedIpAddress[] = [];
+    const seen = new Set<string>();
+    for (const raw of ipFlags) {
+      const parsed = parseIpEntry(raw);
+      if (!parsed.ok) {
+        outputAgentError(
+          client,
+          {
+            status: AGENT_STATUS.ERROR,
+            reason: AGENT_REASON.INVALID_ARGUMENTS,
+            message: parsed.message,
+          },
+          1
+        );
+        output.error(parsed.message);
+        return 1;
+      }
+      if (seen.has(parsed.entry.value)) {
+        const msg = `Duplicate IP address "${parsed.entry.value}" in --ip.`;
+        outputAgentError(
+          client,
+          {
+            status: AGENT_STATUS.ERROR,
+            reason: AGENT_REASON.INVALID_ARGUMENTS,
+            message: msg,
+          },
+          1
+        );
+        output.error(msg);
+        return 1;
+      }
+      seen.add(parsed.entry.value);
+      addresses.push(parsed.entry);
+    }
+
+    trustedIpsBody = {
+      deploymentType: scopeFlag as DeploymentScope,
+      addresses,
+      protectionMode: modeFlag as ProtectionMode,
+    };
+  } else if (scopeFlag || modeFlag || ipFlags.length > 0) {
+    const msg = `\`--ip\`, \`--deployment-type\`, and \`--mode\` can only be used with \`project protection trusted-ips set\`.`;
+    outputAgentError(
+      client,
+      {
+        status: AGENT_STATUS.ERROR,
+        reason: AGENT_REASON.INVALID_ARGUMENTS,
+        message: msg,
+      },
+      2
+    );
+    output.error(msg);
+    return 2;
+  }
+
+  // disable requires confirmation before the destructive clear.
+  if (action === 'disable' && !skipConfirmation) {
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: AGENT_STATUS.ERROR,
+          reason: AGENT_REASON.CONFIRMATION_REQUIRED,
+          message:
+            'Confirm clearing the Trusted IPs allowlist by adding --yes.',
+          next: [
+            {
+              command: buildCommandWithGlobalFlags(
+                client.argv,
+                `project protection trusted-ips disable ${parsedArgs.args[1] ?? ''}`.trim() +
+                  ' --yes'
+              ),
+              when: 'confirm and clear the Trusted IPs allowlist',
+            },
+          ],
+        },
+        1
+      );
+      return 1;
+    }
+    if (!client.stdin.isTTY) {
+      output.error(
+        'Missing required flag --yes. Use --yes to skip the confirmation prompt in non-interactive mode.'
+      );
+      return 1;
+    }
+  }
 
   let project: Project;
   try {
@@ -147,7 +374,7 @@ export async function projectProtectionTrustedIps(
       client,
       commandName: 'project protection trusted-ips',
       projectNameOrId: parsedArgs.args[1],
-      forReadOnlyCommand: true,
+      forReadOnlyCommand: action === 'get',
     });
   } catch (err: unknown) {
     exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
@@ -155,14 +382,73 @@ export async function projectProtectionTrustedIps(
     return 1;
   }
 
-  const config = readTrustedIps(project);
+  if (action === 'get') {
+    const config = readTrustedIps(project);
+    if (preferJson) {
+      client.stdout.write(
+        `${JSON.stringify(
+          {
+            projectId: project.id,
+            name: project.name,
+            trustedIps: config,
+          },
+          null,
+          2
+        )}\n`
+      );
+      return 0;
+    }
+    output.log(
+      `${chalk.bold('Trusted IPs')} for ${chalk.cyan(project.name)} (${project.id})`
+    );
+    if (!config) {
+      output.log('Trusted IPs are not configured for this project.');
+      return 0;
+    }
+    output.log(`${chalk.cyan('scope:')} ${config.deploymentType}`);
+    output.log(`${chalk.cyan('mode:')} ${config.protectionMode}`);
+    output.log(`${chalk.cyan('addresses:')}`);
+    for (const addr of config.addresses ?? []) {
+      output.log(`  - ${addr.value}${addr.note ? ` (${addr.note})` : ''}`);
+    }
+    return 0;
+  }
+
+  if (action === 'disable' && !skipConfirmation) {
+    const confirmed = await client.input.confirm(
+      `Clear the Trusted IPs allowlist for ${chalk.bold(project.name)}?`,
+      false
+    );
+    if (!confirmed) {
+      output.log('Aborted');
+      return 0;
+    }
+  }
+
+  const patchBody: JSONObject = {
+    trustedIps:
+      action === 'set' ? (trustedIpsBody as unknown as JSONObject) : null,
+  };
+
+  try {
+    await client.fetch(`/v9/projects/${encodeURIComponent(project.id)}`, {
+      method: 'PATCH',
+      body: patchBody,
+    });
+  } catch (err: unknown) {
+    exitWithNonInteractiveError(client, err, 1, { variant: 'protection' });
+    printError(err);
+    return 1;
+  }
+
   if (preferJson) {
     client.stdout.write(
       `${JSON.stringify(
         {
+          action,
           projectId: project.id,
-          name: project.name,
-          trustedIps: config,
+          projectName: project.name,
+          trustedIps: action === 'set' ? trustedIpsBody : null,
         },
         null,
         2
@@ -170,18 +456,11 @@ export async function projectProtectionTrustedIps(
     );
     return 0;
   }
+
   output.log(
-    `${chalk.bold('Trusted IPs')} for ${chalk.cyan(project.name)} (${project.id})`
+    action === 'set'
+      ? `${chalk.bold('Trusted IPs')} updated for ${chalk.cyan(project.name)}`
+      : `${chalk.bold('Trusted IPs')} cleared for ${chalk.cyan(project.name)}`
   );
-  if (!config) {
-    output.log('Trusted IPs are not configured for this project.');
-    return 0;
-  }
-  output.log(`${chalk.cyan('scope:')} ${config.deploymentType}`);
-  output.log(`${chalk.cyan('mode:')} ${config.protectionMode}`);
-  output.log(`${chalk.cyan('addresses:')}`);
-  for (const addr of config.addresses ?? []) {
-    output.log(`  - ${addr.value}${addr.note ? ` (${addr.note})` : ''}`);
-  }
   return 0;
 }

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -105,7 +105,7 @@ export class ProjectTelemetryClient
   }
 
   /**
-   * `project protection trusted-ips` action (get). Verbatim: these
+   * `project protection trusted-ips` action (get/set/disable). Verbatim: these
    * are a closed, non-sensitive set.
    */
   trackCliArgumentAction(action: string | undefined) {
@@ -113,5 +113,55 @@ export class ProjectTelemetryClient
       arg: 'action',
       value: action,
     });
+  }
+
+  /**
+   * `--deployment-type` deployment target. Value is an allowlisted enum, so it
+   * is safe to record verbatim; anything unexpected is redacted.
+   */
+  trackCliOptionDeploymentType(value: string | undefined) {
+    if (!value) return;
+    const allowed = [
+      'all',
+      'preview',
+      'production',
+      'prod_deployment_urls_and_all_previews',
+      'all_except_custom_domains',
+    ];
+    this.trackCliOption({
+      option: 'deployment-type',
+      value: allowed.includes(value) ? value : this.redactedValue,
+    });
+  }
+
+  /**
+   * `--mode` protection mode. Allowlisted enum recorded verbatim; anything
+   * unexpected is redacted.
+   */
+  trackCliOptionMode(value: string | undefined) {
+    if (!value) return;
+    const allowed = ['additional', 'exclusive'];
+    this.trackCliOption({
+      option: 'mode',
+      value: allowed.includes(value) ? value : this.redactedValue,
+    });
+  }
+
+  /**
+   * `--ip` allowlist entries. IP addresses and their notes are sensitive infra
+   * data, so only the redacted presence is recorded.
+   */
+  trackCliOptionIp(values: string[] | undefined) {
+    if (!values || values.length === 0) return;
+    this.trackCliOption({
+      option: 'ip',
+      value: this.redactedValue,
+    });
+  }
+
+  trackCliFlagYes(present: boolean | undefined) {
+    if (present) {
+      this.trackCliFlag('yes');
+    }
   }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5989,12 +5989,19 @@ exports[`help command > project help output snapshots > project protection trust
 "
   ▲ vercel project protection trusted-ips [action] [name] [options]
 
-  Show the Trusted IPs allowlist for deployment protection                                                              
+  Show, set, or clear the Trusted IPs allowlist for deployment protection                                               
 
   Options:
 
-  -F,  --format <FORMAT>  Specify the output format (json)                                                              
-       --json             Output as JSON                                                                                
+       --deployment-type <TYPE>  Deployment target the allowlist applies to: all, preview, production,                       
+                                 prod_deployment_urls_and_all_previews, all_except_custom_domains                            
+  -F,  --format <FORMAT>         Specify the output format (json)                                                            
+       --ip <IP>                 IPv4 address or CIDR to allowlist (repeatable). Append an optional note with "=", e.g.      
+                                 203.0.113.4=office. IPv6 is not supported.                                                  
+       --json                    Output as JSON                                                                              
+       --mode <MODE>             Protection mode: additional (IP must match plus another protection) or exclusive (IP match  
+                                 alone bypasses protection)                                                                  
+  -y,  --yes                     Accept default value for all prompts                                                        
 
 
   Global Options:
@@ -6017,9 +6024,17 @@ exports[`help command > project help output snapshots > project protection trust
 
     $ vercel project protection trusted-ips get
 
-  - Show the allowlist for a named project as JSON
+  - Allowlist IPs for all deployments in additional mode
 
-    $ vercel project protection trusted-ips get my-app --json
+    $ vercel project protection trusted-ips set my-app --ip 203.0.113.4 --ip 198.51.100.0/24 --deployment-type all --mode additional
+
+  - Allowlist an IP with a note
+
+    $ vercel project protection trusted-ips set --ip "203.0.113.4=office VPN" --deployment-type production --mode exclusive
+
+  - Clear the Trusted IPs allowlist
+
+    $ vercel project protection trusted-ips disable my-app --yes
 
 "
 `;

--- a/packages/cli/test/unit/commands/project/protection-trusted-ips.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-trusted-ips.test.ts
@@ -5,9 +5,20 @@ import { useUser } from '../../../mocks/user';
 import { useTeams } from '../../../mocks/team';
 import { defaultProject, useProject } from '../../../mocks/project';
 
-function setupProject(trustedIps?: unknown) {
+/**
+ * Registers user/team/project mocks. When `onPatch` is provided, a PATCH
+ * handler is registered BEFORE `useProject` so it wins route matching over
+ * the generic `useProject` PATCH mock (first registered route wins).
+ */
+function setupProject(trustedIps?: unknown, onPatch?: (body: unknown) => void) {
   useUser();
   useTeams('team_dummy');
+  if (onPatch) {
+    client.scenario.patch('/v9/projects/prj_123', (req, res) => {
+      onPatch(req.body);
+      res.json({ id: 'prj_123' });
+    });
+  }
   useProject({
     ...defaultProject,
     id: 'prj_123',
@@ -65,48 +76,353 @@ describe('project protection trusted-ips', () => {
         },
       });
     });
+  });
 
-    it('shows scope, mode, and addresses in human output', async () => {
-      setupProject({
-        deploymentType: 'production',
-        addresses: [{ value: '198.51.100.0/24' }],
-        protectionMode: 'exclusive',
+  describe('set', () => {
+    it('replaces trustedIps via PATCH and returns JSON', async () => {
+      let body: unknown;
+      setupProject(null, b => {
+        body = b;
+      });
+
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        'my-project',
+        '--ip',
+        '203.0.113.4',
+        '--ip',
+        '198.51.100.0/24=corp net',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional',
+        '--json'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({
+        trustedIps: {
+          deploymentType: 'all',
+          protectionMode: 'additional',
+          addresses: [
+            { value: '203.0.113.4' },
+            { value: '198.51.100.0/24', note: 'corp net' },
+          ],
+        },
+      });
+    });
+
+    it('requires --deployment-type', async () => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
       });
       client.setArgv(
         'project',
         'protection',
         'trusted-ips',
-        'get',
-        'my-project'
+        'set',
+        '--ip',
+        '203.0.113.4',
+        '--mode',
+        'additional'
       );
       const exitCode = await project(client);
-      expect(exitCode).toBe(0);
-      await expect(client.stderr).toOutput('scope: production');
-      await expect(client.stderr).toOutput('mode: exclusive');
-      await expect(client.stderr).toOutput('198.51.100.0/24');
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('--deployment-type');
     });
 
-    it('tracks the action argument verbatim in telemetry', async () => {
+    it('rejects an invalid --mode', async () => {
       setupProject(null);
       client.setArgv(
         'project',
         'protection',
         'trusted-ips',
-        'get',
+        'set',
+        '--ip',
+        '203.0.113.4',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'bogus'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('--mode');
+    });
+
+    it('requires at least one --ip', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('At least one');
+    });
+
+    it('rejects an invalid IP before any HTTP request', async () => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '999.1.1.1',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('Invalid --ip');
+    });
+
+    it('rejects an invalid CIDR prefix before any HTTP request', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '10.0.0.0/33',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Invalid --ip');
+    });
+
+    it.each([
+      ['leading-zero octet', '01.2.3.4'],
+      ['too few octets', '1.2.3'],
+      ['negative CIDR prefix', '10.0.0.0/-1'],
+    ])('rejects %s before any HTTP request', async (_name, ip) => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        ip,
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('Invalid --ip');
+    });
+
+    it('rejects IPv6 addresses', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '2001:db8::1',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('IPv6');
+    });
+
+    it('rejects a note longer than 20 characters', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '203.0.113.4=this note is way too long to be accepted',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('at most 20');
+    });
+
+    it('rejects duplicate IPs', async () => {
+      setupProject(null);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        '--ip',
+        '203.0.113.4',
+        '--ip',
+        '203.0.113.4',
+        '--deployment-type',
+        'all',
+        '--mode',
+        'additional'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Duplicate');
+    });
+
+    it('redacts IPs but records enums verbatim in telemetry', async () => {
+      setupProject(null, () => {});
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'set',
+        'my-project',
+        '--ip',
+        '203.0.113.4',
+        '--deployment-type',
+        'production',
+        '--mode',
+        'exclusive'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+
+      const events = client.telemetryEventStore.readonlyEvents;
+      const ipEvent = events.find(e => e.key === 'option:ip');
+      expect(ipEvent?.value).toBe('[REDACTED]');
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          key: 'option:deployment-type',
+          value: 'production',
+        })
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({ key: 'option:mode', value: 'exclusive' })
+      );
+      // The raw IP must never appear in any telemetry value.
+      expect(events.every(e => !String(e.value).includes('203.0.113.4'))).toBe(
+        true
+      );
+    });
+  });
+
+  describe('disable', () => {
+    it('clears trustedIps with --yes', async () => {
+      let body: unknown;
+      setupProject(
+        {
+          deploymentType: 'all',
+          addresses: [{ value: '203.0.113.4' }],
+          protectionMode: 'additional',
+        },
+        b => {
+          body = b;
+        }
+      );
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'disable',
+        'my-project',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ trustedIps: null });
+      await expect(client.stderr).toOutput('Trusted IPs cleared');
+    });
+
+    it('requires --yes in non-interactive mode (confirmation_required)', async () => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+        throw new Error('exit');
+      }) as () => never);
+      client.nonInteractive = true;
+      client.input.confirm = vi.fn();
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'disable',
+        'my-project'
+      );
+      await expect(project(client)).rejects.toThrow('exit');
+      expect(patched).toBe(false);
+      expect(client.input.confirm).not.toHaveBeenCalled();
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out.reason).toBe('confirmation_required');
+    });
+
+    it('aborts without mutating when the prompt is declined', async () => {
+      let patched = false;
+      setupProject(null, () => {
+        patched = true;
+      });
+      client.input.confirm = vi.fn().mockResolvedValue(false);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'disable',
         'my-project'
       );
       const exitCode = await project(client);
       expect(exitCode).toBe(0);
-      expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        {
-          key: 'subcommand:protection',
-          value: 'protection trusted-ips',
-        },
-        {
-          key: 'argument:action',
-          value: 'get',
-        },
-      ]);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('Aborted');
+    });
+
+    it('clears trustedIps when the prompt is confirmed', async () => {
+      let body: unknown;
+      setupProject(null, b => {
+        body = b;
+      });
+      client.input.confirm = vi.fn().mockResolvedValue(true);
+      client.setArgv(
+        'project',
+        'protection',
+        'trusted-ips',
+        'disable',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ trustedIps: null });
     });
   });
 
@@ -116,6 +432,31 @@ describe('project protection trusted-ips', () => {
     const exitCode = await project(client);
     expect(exitCode).toBe(2);
     await expect(client.stderr).toOutput('Invalid action');
+  });
+
+  it.each([
+    ['get', ['--ip', '203.0.113.4'] as string[]],
+    ['get', ['--deployment-type', 'all'] as string[]],
+    ['disable', ['--mode', 'additional', '--yes'] as string[]],
+  ])('rejects set-only flags with %s (exit 2, no mutation)', async (action, flags) => {
+    let patched = false;
+    setupProject(null, () => {
+      patched = true;
+    });
+    client.setArgv(
+      'project',
+      'protection',
+      'trusted-ips',
+      action,
+      'my-project',
+      ...flags
+    );
+    const exitCode = await project(client);
+    expect(exitCode).toBe(2);
+    expect(patched).toBe(false);
+    await expect(client.stderr).toOutput(
+      'can only be used with `project protection trusted-ips set`'
+    );
   });
 
   describe('--help', () => {


### PR DESCRIPTION
## Summary

- Adds `vercel project protection trusted-ips set|disable [name]` on top of the get-only base PR, replacing or clearing the Trusted IPs allowlist via the public project `PATCH /v9/projects/:id` endpoint.
- `set` takes repeatable `--ip <IPv4|CIDR>[=note]`, `--deployment-type <enum>`, and `--mode additional|exclusive`; `disable` sends `trustedIps: null` behind a confirmation prompt (`--yes` to skip; non-interactive without `--yes` exits 1 with `confirmation_required`).

## Notes

- IP input is validated locally before any request: IPv4 addresses and IPv4 CIDRs only (octet range, prefix 0-32, no leading zeros), duplicates rejected, IPv6 rejected explicitly; notes max 20 chars per the schema.
- Telemetry redacts `--ip` values; `--deployment-type`/`--mode` recorded verbatim only when they match schema enums.
- `set`/`disable` were split out of #17481 to keep that PR read-only; set+disable stay together because disable alone is ~30 lines and meaningless without set.
- Stack: #17481 (trusted-ips get) ← this PR ← #17482 (trusted-sources + shared runner) ← options-allowlist PR ← protected-sourcemaps PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)