### PR TITLE
[CLI] Add project protection options-allowlist subcommand

### DIFF
--- a/.changeset/project-protection-options-allowlist.md
+++ b/.changeset/project-protection-options-allowlist.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project protection options-allowlist get|set|disable` to manage paths exempt from Deployment Protection for CORS preflight (OPTIONS) requests. Paths are validated locally (must start with "/", no duplicates, max 5) before any request.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -682,6 +682,48 @@ export const trustedSourcesSubcommand = {
   ],
 } as const;
 
+/**
+ * `vercel project protection options-allowlist get|set|disable`.
+ */
+export const optionsAllowlistSubcommand = {
+  name: 'protection options-allowlist',
+  aliases: [],
+  description:
+    'Show, set, or clear paths exempt from Deployment Protection for CORS preflight (OPTIONS) requests',
+  arguments: [
+    { name: 'action', required: false },
+    { name: 'name', required: false },
+  ],
+  options: [
+    formatOption,
+    jsonOption,
+    yesOption,
+    {
+      name: 'path',
+      shorthand: null,
+      type: [String],
+      argument: 'PATH',
+      description:
+        'Regex path that should not be protected (repeatable, must start with "/")',
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Show the OPTIONS allowlist for the linked project',
+      value: `${packageName} project protection options-allowlist get`,
+    },
+    {
+      name: 'Allow CORS preflight on API paths',
+      value: `${packageName} project protection options-allowlist set my-app --path /api/.* --path /webhooks/stripe`,
+    },
+    {
+      name: 'Clear the OPTIONS allowlist',
+      value: `${packageName} project protection options-allowlist disable my-app --yes`,
+    },
+  ],
+} as const;
+
 export const accessGroupsSubcommand = {
   name: 'access-groups',
   aliases: ['accessgroups'],

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -27,6 +27,7 @@ import {
   membersSubcommand,
   projectCommand,
   protectionSubcommand,
+  optionsAllowlistSubcommand,
   renameSubcommand,
   removeSubcommand,
   speedInsightsSubcommand,
@@ -173,6 +174,7 @@ export default async function main(client: Client) {
       const nestedProtectionHelp: Record<string, Command> = {
         'trusted-ips': trustedIpsSubcommand,
         'trusted-sources': trustedSourcesSubcommand,
+        'options-allowlist': optionsAllowlistSubcommand,
       };
       const nested = args[0] ? nestedProtectionHelp[args[0]] : undefined;
       if (needHelp) {

--- a/packages/cli/src/commands/project/protection-settings.ts
+++ b/packages/cli/src/commands/project/protection-settings.ts
@@ -10,7 +10,10 @@ import {
   outputAgentError,
 } from '../../util/agent-output';
 import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
-import { trustedSourcesSubcommand } from './command';
+import {
+  optionsAllowlistSubcommand,
+  trustedSourcesSubcommand,
+} from './command';
 import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
@@ -20,15 +23,21 @@ import type { JSONObject, Project } from '@vercel-internals/types';
 const ACTIONS = ['get', 'set', 'disable'] as const;
 type Action = (typeof ACTIONS)[number];
 
+// Schema: optionsAllowlist.paths maxItems — mirror the API's LIMIT (5) so
+// the user gets a clean local error instead of a remote validation failure.
+const MAX_OPTIONS_ALLOWLIST_PATHS = 5;
+
 interface SettingSpec {
   /** Project PATCH body field, verbatim from the public schema. */
-  field: 'trustedSources';
+  field: 'trustedSources' | 'optionsAllowlist';
   /** CLI segment, e.g. `trusted-sources`. */
   slug: string;
   /** Human label used in output. */
   label: string;
   commandName: string;
-  subcommand: typeof trustedSourcesSubcommand;
+  subcommand:
+    | typeof trustedSourcesSubcommand
+    | typeof optionsAllowlistSubcommand;
   /**
    * Build the PATCH value for `set` from parsed flags. Returns an error
    * message when local validation fails (nothing is sent remotely).
@@ -106,8 +115,46 @@ const TRUSTED_SOURCES: SettingSpec = {
   disableValue: null,
 };
 
+const OPTIONS_ALLOWLIST: SettingSpec = {
+  field: 'optionsAllowlist',
+  slug: 'options-allowlist',
+  label: 'OPTIONS Allowlist',
+  commandName: 'project protection options-allowlist',
+  subcommand: optionsAllowlistSubcommand,
+  buildSetValue(flags) {
+    const paths = (flags['--path'] as string[] | undefined) ?? [];
+    if (paths.length === 0) {
+      return fail('At least one `--path </path>` is required for set.');
+    }
+    if (paths.length > MAX_OPTIONS_ALLOWLIST_PATHS) {
+      return fail(
+        `Too many paths (${paths.length}); the maximum is ${MAX_OPTIONS_ALLOWLIST_PATHS}.`
+      );
+    }
+    const seen = new Set<string>();
+    const entries: Array<{ value: string }> = [];
+    for (const raw of paths) {
+      const value = raw.trim();
+      // Schema: pattern '^/.*' — every path must start with '/'.
+      if (!value.startsWith('/')) {
+        return fail(
+          `Invalid --path "${value}": paths must start with "/" (regex paths are allowed, e.g. /api/.*).`
+        );
+      }
+      if (seen.has(value)) {
+        return fail(`Duplicate path "${value}" in --path.`);
+      }
+      seen.add(value);
+      entries.push({ value });
+    }
+    return { ok: true, value: { paths: entries } };
+  },
+  disableValue: null,
+};
+
 const SPECS: Record<string, SettingSpec> = {
   'trusted-sources': TRUSTED_SOURCES,
+  'options-allowlist': OPTIONS_ALLOWLIST,
 };
 
 export function getProtectionSettingSpec(slug: string): SettingSpec | null {
@@ -188,6 +235,7 @@ export async function projectProtectionSetting(
 
   const skipConfirmation = Boolean(parsedArgs.flags['--yes']);
   telemetry.trackCliArgumentAction(action);
+  telemetry.trackCliOptionPath(parsedArgs.flags['--path'] as string[]);
   telemetry.trackCliOptionFile(parsedArgs.flags['--file'] as string);
   telemetry.trackCliFlagYes(skipConfirmation);
 

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -166,6 +166,18 @@ export class ProjectTelemetryClient
   }
 
   /**
+   * `--path` allowlist entries. Paths are sensitive infra data, so only the
+   * redacted presence is recorded.
+   */
+  trackCliOptionPath(values: string[] | undefined) {
+    if (!values || values.length === 0) return;
+    this.trackCliOption({
+      option: 'path',
+      value: this.redactedValue,
+    });
+  }
+
+  /**
    * `--file` config file path. File paths and contents are never recorded;
    * only the redacted presence is tracked.
    */

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5985,6 +5985,50 @@ exports[`help command > project help output snapshots > project list help output
 "
 `;
 
+exports[`help command > project help output snapshots > project protection options-allowlist help output snapshots > project protection options-allowlist help column width 120 1`] = `
+"
+  ▲ vercel project protection options-allowlist [action] [name] [options]
+
+  Show, set, or clear paths exempt from Deployment Protection for CORS preflight (OPTIONS) requests                     
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+       --path <PATH>      Regex path that should not be protected (repeatable, must start with "/")                     
+  -y,  --yes              Accept default value for all prompts                                                          
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Show the OPTIONS allowlist for the linked project
+
+    $ vercel project protection options-allowlist get
+
+  - Allow CORS preflight on API paths
+
+    $ vercel project protection options-allowlist set my-app --path /api/.* --path /webhooks/stripe
+
+  - Clear the OPTIONS allowlist
+
+    $ vercel project protection options-allowlist disable my-app --yes
+
+"
+`;
 
 
 exports[`help command > project help output snapshots > project protection trusted-ips help output snapshots > project protection trusted-ips help column width 120 1`] = `

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -794,6 +794,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('project protection options-allowlist help output snapshots', () => {
+      it('project protection options-allowlist help column width 120', () => {
+        expect(
+          help(project.optionsAllowlistSubcommand, {
+            columns: 120,
+            parent: project.projectCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('promote help output snapshots', () => {

--- a/packages/cli/test/unit/commands/project/protection-settings.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-settings.test.ts
@@ -40,6 +40,168 @@ describe('project protection settings subcommands', () => {
     vi.restoreAllMocks();
   });
 
+  describe('options-allowlist', () => {
+    it('shows the allowlist as JSON on get', async () => {
+      setupProject({ optionsAllowlist: { paths: [{ value: '/api/.*' }] } });
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'get',
+        'my-project',
+        '--json'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toMatchObject({
+        projectId: 'prj_123',
+        optionsAllowlist: { paths: [{ value: '/api/.*' }] },
+      });
+    });
+
+    it('replaces the allowlist via PATCH on set', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        '--path',
+        '/api/.*',
+        '--path',
+        '/webhooks/stripe'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({
+        optionsAllowlist: {
+          paths: [{ value: '/api/.*' }, { value: '/webhooks/stripe' }],
+        },
+      });
+    });
+
+    it('rejects paths not starting with "/" before any HTTP request', async () => {
+      let patched = false;
+      setupProject({}, () => {
+        patched = true;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        '--path',
+        'api/foo'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput('must start with "/"');
+    });
+
+    it('rejects duplicate paths', async () => {
+      setupProject();
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        '--path',
+        '/api',
+        '--path',
+        '/api'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('Duplicate path');
+    });
+
+    it('requires at least one --path on set', async () => {
+      setupProject();
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      await expect(client.stderr).toOutput('At least one');
+    });
+
+    it('rejects more than 5 paths before any HTTP request', async () => {
+      let patched = false;
+      setupProject({}, () => {
+        patched = true;
+      });
+      const pathFlags = Array.from({ length: 6 }, (_, i) => [
+        '--path',
+        `/route-${i}`,
+      ]).flat();
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        ...pathFlags
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(1);
+      expect(patched).toBe(false);
+      await expect(client.stderr).toOutput(
+        'Too many paths (6); the maximum is 5'
+      );
+    });
+
+    it('clears the allowlist (null) on disable --yes', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'disable',
+        'my-project',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ optionsAllowlist: null });
+    });
+
+    it('redacts --path values in telemetry', async () => {
+      setupProject({}, () => {});
+      client.setArgv(
+        'project',
+        'protection',
+        'options-allowlist',
+        'set',
+        'my-project',
+        '--path',
+        '/internal/secret-route'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const events = client.telemetryEventStore.readonlyEvents;
+      const pathEvent = events.find(e => e.key === 'option:path');
+      expect(pathEvent?.value).toBe('[REDACTED]');
+      expect(events.every(e => !String(e.value).includes('secret-route'))).toBe(
+        true
+      );
+    });
+  });
+
   describe('trusted-sources', () => {
     it('shows the config on get', async () => {
       setupProject({
@@ -206,7 +368,7 @@ describe('project protection settings subcommands', () => {
       client.setArgv(
         'project',
         'protection',
-        'trusted-sources',
+        'options-allowlist',
         'disable',
         'my-project'
       );
@@ -242,7 +404,7 @@ describe('project protection settings subcommands', () => {
     client.setArgv(
       'project',
       'protection',
-      'trusted-sources',
+      'options-allowlist',
       'frobnicate',
       'my-project'
     );
@@ -254,6 +416,7 @@ describe('project protection settings subcommands', () => {
   describe('--help', () => {
     it.each([
       'trusted-sources',
+      'options-allowlist',
     ])('prints help and tracks telemetry for %s', async slug => {
       client.setArgv('project', 'protection', slug, '--help');
       const exitCode = await project(client);


### PR DESCRIPTION
## Summary

- Adds `vercel project protection options-allowlist get|set|disable [name]` to manage paths exempt from Deployment Protection for CORS preflight (OPTIONS) requests, via the public project `PATCH /v9/projects/:id` endpoint and the shared get/set/disable runner from the base PR.
- `set` takes repeatable `--path </regex-path>` entries; `disable` clears the allowlist (`optionsAllowlist: null`) behind a confirmation prompt (`--yes` to skip; non-interactive without `--yes` exits 1 with `confirmation_required`).

## Notes

- Schema fields verbatim from the public project PATCH schema: `optionsAllowlist.paths[].value` (pattern `^/.*`, unique, maxItems 5).
- Paths are validated locally before any request: must start with `/`, no duplicates, max 5 entries (matching the API limit) — a clean local error instead of a remote validation failure.
- Telemetry redacts `--path` values (sensitive infra data).
- Stack: #17481 (trusted-ips get) ← #17490 (trusted-ips set/disable) ← #17482 (trusted-sources + shared runner) ← this PR ← protected-sourcemaps PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)