### PR TITLE
[CLI] Add project protection protected-sourcemaps subcommand

### DIFF
--- a/.changeset/project-protection-sourcemaps.md
+++ b/.changeset/project-protection-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel project protection protected-sourcemaps get|set|disable` to show or toggle whether sourcemaps require authentication to access.

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -724,6 +724,35 @@ export const optionsAllowlistSubcommand = {
   ],
 } as const;
 
+/**
+ * `vercel project protection protected-sourcemaps get|set|disable`.
+ */
+export const protectedSourcemapsSubcommand = {
+  name: 'protection protected-sourcemaps',
+  aliases: [],
+  description:
+    'Show or toggle whether sourcemaps require authentication to access',
+  arguments: [
+    { name: 'action', required: false },
+    { name: 'name', required: false },
+  ],
+  options: [formatOption, jsonOption, yesOption],
+  examples: [
+    {
+      name: 'Show the Protected Sourcemaps setting for the linked project',
+      value: `${packageName} project protection protected-sourcemaps get`,
+    },
+    {
+      name: 'Protect sourcemaps behind authentication',
+      value: `${packageName} project protection protected-sourcemaps set my-app`,
+    },
+    {
+      name: 'Disable sourcemap protection',
+      value: `${packageName} project protection protected-sourcemaps disable my-app --yes`,
+    },
+  ],
+} as const;
+
 export const accessGroupsSubcommand = {
   name: 'access-groups',
   aliases: ['accessgroups'],

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -28,6 +28,7 @@ import {
   projectCommand,
   protectionSubcommand,
   optionsAllowlistSubcommand,
+  protectedSourcemapsSubcommand,
   renameSubcommand,
   removeSubcommand,
   speedInsightsSubcommand,
@@ -175,6 +176,7 @@ export default async function main(client: Client) {
         'trusted-ips': trustedIpsSubcommand,
         'trusted-sources': trustedSourcesSubcommand,
         'options-allowlist': optionsAllowlistSubcommand,
+        'protected-sourcemaps': protectedSourcemapsSubcommand,
       };
       const nested = args[0] ? nestedProtectionHelp[args[0]] : undefined;
       if (needHelp) {

--- a/packages/cli/src/commands/project/protection-settings.ts
+++ b/packages/cli/src/commands/project/protection-settings.ts
@@ -12,6 +12,7 @@ import {
 import { AGENT_REASON, AGENT_STATUS } from '../../util/agent-output-constants';
 import {
   optionsAllowlistSubcommand,
+  protectedSourcemapsSubcommand,
   trustedSourcesSubcommand,
 } from './command';
 import { validateJsonOutput } from '../../util/output-format';
@@ -29,7 +30,7 @@ const MAX_OPTIONS_ALLOWLIST_PATHS = 5;
 
 interface SettingSpec {
   /** Project PATCH body field, verbatim from the public schema. */
-  field: 'trustedSources' | 'optionsAllowlist';
+  field: 'trustedSources' | 'optionsAllowlist' | 'protectedSourcemaps';
   /** CLI segment, e.g. `trusted-sources`. */
   slug: string;
   /** Human label used in output. */
@@ -37,7 +38,8 @@ interface SettingSpec {
   commandName: string;
   subcommand:
     | typeof trustedSourcesSubcommand
-    | typeof optionsAllowlistSubcommand;
+    | typeof optionsAllowlistSubcommand
+    | typeof protectedSourcemapsSubcommand;
   /**
    * Build the PATCH value for `set` from parsed flags. Returns an error
    * message when local validation fails (nothing is sent remotely).
@@ -152,9 +154,23 @@ const OPTIONS_ALLOWLIST: SettingSpec = {
   disableValue: null,
 };
 
+const PROTECTED_SOURCEMAPS: SettingSpec = {
+  field: 'protectedSourcemaps',
+  slug: 'protected-sourcemaps',
+  label: 'Protected Sourcemaps',
+  commandName: 'project protection protected-sourcemaps',
+  subcommand: protectedSourcemapsSubcommand,
+  // Boolean setting: `set` turns it on, `disable` turns it off.
+  buildSetValue() {
+    return { ok: true, value: true };
+  },
+  disableValue: false,
+};
+
 const SPECS: Record<string, SettingSpec> = {
   'trusted-sources': TRUSTED_SOURCES,
   'options-allowlist': OPTIONS_ALLOWLIST,
+  'protected-sourcemaps': PROTECTED_SOURCEMAPS,
 };
 
 export function getProtectionSettingSpec(slug: string): SettingSpec | null {

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -6030,6 +6030,49 @@ exports[`help command > project help output snapshots > project protection optio
 "
 `;
 
+exports[`help command > project help output snapshots > project protection protected-sourcemaps help output snapshots > project protection protected-sourcemaps help column width 120 1`] = `
+"
+  ▲ vercel project protection protected-sourcemaps [action] [name] [options]
+
+  Show or toggle whether sourcemaps require authentication to access                                                    
+
+  Options:
+
+  -F,  --format <FORMAT>  Specify the output format (json)                                                              
+       --json             Output as JSON                                                                                
+  -y,  --yes              Accept default value for all prompts                                                          
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Show the Protected Sourcemaps setting for the linked project
+
+    $ vercel project protection protected-sourcemaps get
+
+  - Protect sourcemaps behind authentication
+
+    $ vercel project protection protected-sourcemaps set my-app
+
+  - Disable sourcemap protection
+
+    $ vercel project protection protected-sourcemaps disable my-app --yes
+
+"
+`;
 
 exports[`help command > project help output snapshots > project protection trusted-ips help output snapshots > project protection trusted-ips help column width 120 1`] = `
 "

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -804,6 +804,16 @@ describe('help command', () => {
         ).toMatchSnapshot();
       });
     });
+    describe('project protection protected-sourcemaps help output snapshots', () => {
+      it('project protection protected-sourcemaps help column width 120', () => {
+        expect(
+          help(project.protectedSourcemapsSubcommand, {
+            columns: 120,
+            parent: project.projectCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('promote help output snapshots', () => {

--- a/packages/cli/test/unit/commands/project/protection-settings.test.ts
+++ b/packages/cli/test/unit/commands/project/protection-settings.test.ts
@@ -202,6 +202,62 @@ describe('project protection settings subcommands', () => {
     });
   });
 
+  describe('protected-sourcemaps', () => {
+    it('shows the current setting on get', async () => {
+      setupProject({ protectedSourcemaps: true });
+      client.setArgv(
+        'project',
+        'protection',
+        'protected-sourcemaps',
+        'get',
+        'my-project',
+        '--json'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      const out = JSON.parse(client.stdout.getFullOutput().trim());
+      expect(out).toMatchObject({
+        projectId: 'prj_123',
+        protectedSourcemaps: true,
+      });
+    });
+
+    it('sends true on set', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'protected-sourcemaps',
+        'set',
+        'my-project'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ protectedSourcemaps: true });
+    });
+
+    it('sends false on disable --yes', async () => {
+      let body: unknown;
+      setupProject({}, b => {
+        body = b;
+      });
+      client.setArgv(
+        'project',
+        'protection',
+        'protected-sourcemaps',
+        'disable',
+        'my-project',
+        '--yes'
+      );
+      const exitCode = await project(client);
+      expect(exitCode).toBe(0);
+      expect(body).toEqual({ protectedSourcemaps: false });
+    });
+  });
+
   describe('trusted-sources', () => {
     it('shows the config on get', async () => {
       setupProject({
@@ -417,6 +473,7 @@ describe('project protection settings subcommands', () => {
     it.each([
       'trusted-sources',
       'options-allowlist',
+      'protected-sourcemaps',
     ])('prints help and tracks telemetry for %s', async slug => {
       client.setArgv('project', 'protection', slug, '--help');
       const exitCode = await project(client);


### PR DESCRIPTION
## Summary

- Adds `vercel project protection protected-sourcemaps get|set|disable [name]` to show or toggle whether sourcemaps require authentication to access, via the public project `PATCH /v9/projects/:id` endpoint and the shared get/set/disable runner.
- `get` prints the current boolean; `set` enables protection (`protectedSourcemaps: true`); `disable` turns it off (`false`) behind a confirmation prompt (`--yes` to skip; non-interactive without `--yes` exits 1 with `confirmation_required`).

## Notes

- Schema field verbatim from the public project PATCH schema: `protectedSourcemaps` (boolean).
- The setting is feature-flagged server-side; the API rejects updates for teams without the feature.
- Stack: #17481 (trusted-ips get) ← #17490 (trusted-ips set/disable) ← #17482 (trusted-sources + shared runner) ← #17491 (options-allowlist) ← this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)