### PR TITLE
[CLI] Add access-group projects add subcommand

### DIFF
--- a/.changeset/access-group-projects-add.md
+++ b/.changeset/access-group-projects-add.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel access-group projects add` subcommand

--- a/packages/cli/src/commands/access-group/command.ts
+++ b/packages/cli/src/commands/access-group/command.ts
@@ -10,6 +10,16 @@ const nameOption = {
   deprecated: false,
 } as const;
 
+const roleOption = {
+  name: 'role',
+  shorthand: null,
+  type: String,
+  argument: 'ROLE',
+  description:
+    'The project role: ADMIN, PROJECT_VIEWER, PROJECT_DEVELOPER, or PROJECT_GUEST',
+  deprecated: false,
+} as const;
+
 export const listSubcommand = {
   name: 'list',
   aliases: ['ls'],
@@ -206,12 +216,35 @@ export const projectsListSubcommand = {
   ],
 } as const;
 
+export const projectsAddSubcommand = {
+  name: 'add',
+  aliases: [],
+  description: 'Add a project to an access group',
+  arguments: [
+    {
+      name: 'group',
+      required: true,
+    },
+    {
+      name: 'project',
+      required: true,
+    },
+  ],
+  options: [roleOption],
+  examples: [
+    {
+      name: 'Add a project to an access group with a role',
+      value: `${packageName} access-group projects add my-access-group my-project --role PROJECT_VIEWER`,
+    },
+  ],
+} as const;
+
 export const projectsSubcommand = {
   name: 'projects',
   aliases: [],
   description: 'Manage the projects of an access group',
   arguments: [],
-  subcommands: [projectsListSubcommand],
+  subcommands: [projectsListSubcommand, projectsAddSubcommand],
   options: [],
   examples: [
     {

--- a/packages/cli/src/commands/access-group/projects-add.ts
+++ b/packages/cli/src/commands/access-group/projects-add.ts
@@ -1,0 +1,95 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getCommandName } from '../../util/pkg-name';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../util/errors-ts';
+import { AccessGroupProjectsTelemetryClient } from '../../util/telemetry/commands/access-group/projects';
+import { createAccessGroupProject } from '../../util/access-group/mutate-access-group-project';
+import { handleAccessGroupError } from '../../util/access-group/error';
+import {
+  ACCESS_GROUP_PROJECT_ROLES,
+  type AccessGroupProjectRole,
+} from '../../util/access-group/types';
+import { projectsAddSubcommand } from './command';
+
+export default async function add(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new AccessGroupProjectsTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    projectsAddSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const [group, project] = parsedArgs.args;
+  if (!group || !project) {
+    output.error(
+      `Please provide an access group and a project. See ${getCommandName(
+        'access-group projects add <group> <project> --role <role>'
+      )}`
+    );
+    return 1;
+  }
+
+  telemetry.trackCliArgumentGroup(group);
+  telemetry.trackCliArgumentProject(project);
+
+  const role = flags['--role'];
+  telemetry.trackCliOptionRole(role);
+
+  if (!role) {
+    output.error(
+      `Please provide a role with \`--role\`. Valid roles: ${ACCESS_GROUP_PROJECT_ROLES.join(
+        ', '
+      )}.`
+    );
+    return 1;
+  }
+  if (!(ACCESS_GROUP_PROJECT_ROLES as readonly string[]).includes(role)) {
+    output.error(
+      `Invalid role "${role}". Valid roles: ${ACCESS_GROUP_PROJECT_ROLES.join(
+        ', '
+      )}.`
+    );
+    return 1;
+  }
+
+  const resolved = await getProjectByNameOrId(client, project);
+  if (resolved instanceof ProjectNotFound) {
+    output.error(`Project ${chalk.bold(project)} not found.`);
+    return 1;
+  }
+
+  try {
+    await createAccessGroupProject(
+      client,
+      group,
+      resolved.id,
+      role as AccessGroupProjectRole
+    );
+  } catch (err) {
+    return handleAccessGroupError(err);
+  }
+
+  output.success(
+    `Project ${chalk.bold(project)} added to access group ${chalk.bold(
+      group
+    )} with role ${chalk.bold(role)}`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/access-group/projects.ts
+++ b/packages/cli/src/commands/access-group/projects.ts
@@ -3,7 +3,12 @@ import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import { type Command, help } from '../help';
 import list from './projects-list';
-import { projectsSubcommand, projectsListSubcommand } from './command';
+import add from './projects-add';
+import {
+  projectsSubcommand,
+  projectsListSubcommand,
+  projectsAddSubcommand,
+} from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
@@ -12,6 +17,7 @@ import { printError } from '../../util/error';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(projectsListSubcommand),
+  add: getCommandAliases(projectsAddSubcommand),
 };
 
 export default async function projects(client: Client): Promise<number> {
@@ -53,11 +59,22 @@ export default async function projects(client: Client): Promise<number> {
     );
   }
 
-  if (needHelp) {
-    telemetry.trackCliFlagHelp('access-group projects', subcommandOriginal);
-    printHelp(projectsListSubcommand);
-    return 2;
+  switch (subcommand) {
+    case 'add':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group projects', subcommandOriginal);
+        printHelp(projectsAddSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
+      return add(client, args);
+    default:
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('access-group projects', subcommandOriginal);
+        printHelp(projectsListSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return list(client, args);
   }
-  telemetry.trackCliSubcommandList(subcommandOriginal);
-  return list(client, args);
 }

--- a/packages/cli/src/util/access-group/mutate-access-group-project.ts
+++ b/packages/cli/src/util/access-group/mutate-access-group-project.ts
@@ -1,0 +1,17 @@
+import type Client from '../client';
+import type { AccessGroupProject, AccessGroupProjectRole } from './types';
+
+export function createAccessGroupProject(
+  client: Client,
+  group: string,
+  projectId: string,
+  role: AccessGroupProjectRole
+): Promise<AccessGroupProject> {
+  return client.fetch<AccessGroupProject>(
+    `/v1/access-groups/${encodeURIComponent(group)}/projects`,
+    {
+      method: 'POST',
+      body: { projectId, role },
+    }
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/access-group/projects.ts
+++ b/packages/cli/src/util/telemetry/commands/access-group/projects.ts
@@ -1,6 +1,7 @@
 import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { projectsSubcommand } from '../../../../commands/access-group/command';
+import { ACCESS_GROUP_PROJECT_ROLES } from '../../../access-group/types';
 
 export class AccessGroupProjectsTelemetryClient
   extends TelemetryClient
@@ -13,11 +14,39 @@ export class AccessGroupProjectsTelemetryClient
     });
   }
 
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
   trackCliArgumentGroup(group: string | undefined) {
     if (group) {
       this.trackCliArgument({
         arg: 'group',
         value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentProject(project: string | undefined) {
+    if (project) {
+      this.trackCliArgument({
+        arg: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionRole(role: string | undefined) {
+    if (role) {
+      const known = (ACCESS_GROUP_PROJECT_ROLES as readonly string[]).includes(
+        role
+      );
+      this.trackCliOption({
+        option: 'role',
+        value: known ? role : this.redactedValue,
       });
     }
   }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -429,6 +429,40 @@ exports[`help command > access-group help output snapshots > access-group member
 "
 `;
 
+exports[`help command > access-group help output snapshots > access-group projects help output snapshots > access-group projects add help column width 120 1`] = `
+"
+  ▲ vercel projects add group project [options]
+
+  Add a project to an access group                                                                                      
+
+  Options:
+
+   --role <ROLE>  The project role: ADMIN, PROJECT_VIEWER, PROJECT_DEVELOPER, or PROJECT_GUEST                           
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Add a project to an access group with a role
+
+    $ vercel access-group projects add my-access-group my-project --role PROJECT_VIEWER
+
+"
+`;
+
 exports[`help command > access-group help output snapshots > access-group projects help output snapshots > access-group projects help column width 120 1`] = `
 "
   ▲ vercel access-group projects [command]
@@ -437,7 +471,8 @@ exports[`help command > access-group help output snapshots > access-group projec
 
   Commands:
 
-  list  group  List the projects of an access group (default)                                                   
+  list  group          List the projects of an access group (default)                                            
+  add   group project  Add a project to an access group                                                          
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/access-group/projects-add.test.ts
+++ b/packages/cli/test/unit/commands/access-group/projects-add.test.ts
@@ -1,0 +1,130 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import accessGroup from '../../../../src/commands/access-group';
+import { useUser } from '../../../mocks/user';
+
+describe('access-group projects add', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  function useProjectLookup() {
+    client.scenario.get('/v9/projects/my-project', (_req, res) => {
+      res.json({ id: 'prj_1', name: 'my-project' });
+    });
+  }
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      client.setArgv('access-group', 'projects', 'add', '--help');
+      const exitCodePromise = accessGroup(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:projects',
+          value: 'projects',
+        },
+        {
+          key: 'flag:help',
+          value: 'access-group projects:add',
+        },
+      ]);
+    });
+  });
+
+  it('errors when the project is missing', async () => {
+    client.setArgv('access-group', 'projects', 'add', 'ag_1');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Please provide an access group and a project'
+    );
+  });
+
+  it('errors when --role is missing', async () => {
+    client.setArgv('access-group', 'projects', 'add', 'ag_1', 'my-project');
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Please provide a role');
+  });
+
+  it('errors on an invalid role', async () => {
+    client.setArgv(
+      'access-group',
+      'projects',
+      'add',
+      'ag_1',
+      'my-project',
+      '--role',
+      'SUPERUSER'
+    );
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('Invalid role');
+  });
+
+  it('resolves the project and adds it with a role', async () => {
+    useProjectLookup();
+    let body: unknown;
+    client.scenario.post('/v1/access-groups/ag_1/projects', (req, res) => {
+      body = req.body;
+      res.json({ projectId: 'prj_1', role: 'PROJECT_VIEWER' });
+    });
+
+    client.setArgv(
+      'access-group',
+      'projects',
+      'add',
+      'ag_1',
+      'my-project',
+      '--role',
+      'PROJECT_VIEWER'
+    );
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(0);
+    expect(body).toEqual({ projectId: 'prj_1', role: 'PROJECT_VIEWER' });
+    await expect(client.stderr).toOutput('added to access group');
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:projects',
+        value: 'projects',
+      },
+      {
+        key: 'subcommand:add',
+        value: 'add',
+      },
+      {
+        key: 'argument:group',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'argument:project',
+        value: '[REDACTED]',
+      },
+      {
+        key: 'option:role',
+        value: 'PROJECT_VIEWER',
+      },
+    ]);
+  });
+
+  it('errors when the project is not found', async () => {
+    client.scenario.get('/v9/projects/ghost', (_req, res) => {
+      res.status(404).json({ error: { code: 'not_found', message: 'nope' } });
+    });
+    client.setArgv(
+      'access-group',
+      'projects',
+      'add',
+      'ag_1',
+      'ghost',
+      '--role',
+      'ADMIN'
+    );
+    const exitCode = await accessGroup(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('not found');
+  });
+});

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -210,6 +210,14 @@ describe('help command', () => {
           })
         ).toMatchSnapshot();
       });
+      it('access-group projects add help column width 120', () => {
+        expect(
+          help(accessGroup.projectsAddSubcommand, {
+            columns: 120,
+            parent: accessGroup.projectsSubcommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `vercel access-group projects add <group> <project> --role <role>` to add a project to an access group with a role (ADMIN, PROJECT_VIEWER, PROJECT_DEVELOPER, PROJECT_GUEST).

## Notes
- Endpoint (public v1): `POST /v1/access-groups/:group/projects` (`{projectId, role}`). The `<project>` argument is resolved via `getProjectByNameOrId` (`GET /v9/projects/:idOrName`) first; role is validated client-side against the schema enum.
- Telemetry redacts group/project arguments; the `--role` enum is recorded verbatim (unknown values redacted).
- Unit tests assert request method/path/body, usage errors (missing/invalid role), and project-not-found.
- Help snapshots regenerated; the pre-existing `connex` width-120 snapshot failure is unrelated and left untouched.
- Stack: #17460 (read) → #17464 (add/update) → #17476 (remove) → #17470 (members list) → #17488 (members add) → #17478 (members remove) → #17474 (projects list) → #17493 (projects add) → #17480 (projects update/remove).