### PR TITLE
[connect] Add branch token resolution

### DIFF
--- a/.changeset/tender-mice-branch-connect.md
+++ b/.changeset/tender-mice-branch-connect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Add opt-in branch connector token resolution for preview deployments.

--- a/packages/connect/src/token.ts
+++ b/packages/connect/src/token.ts
@@ -36,6 +36,15 @@ export interface ConnectTokenExchangeSubject {
 
 export interface ConnectTokenParams {
   subject: ConnectTokenSubject;
+  /**
+   * Resolve this connector to the temporary connector for the current preview
+   * branch. Production requests continue to use the source connector.
+   *
+   * The SDK supplies the current Vercel deployment ID to the dedicated branch
+   * endpoint; Connect validates the deployment against the caller's project
+   * OIDC token and derives the branch server-side.
+   */
+  branch?: boolean;
   installationId?: string;
   audience?: string[];
   /**
@@ -159,7 +168,10 @@ export async function getTokenResponse(
   options?: ConnectOptions
 ): Promise<ConnectTokenResponse> {
   const bufferMs = params.validityBufferMs ?? DEFAULT_VALIDITY_BUFFER_MS;
-  const cacheKey = tokenCacheKey(connector, params);
+  const branchDeploymentId = params.branch
+    ? readRequiredDeploymentId(process.env.VERCEL_DEPLOYMENT_ID)
+    : undefined;
+  const cacheKey = tokenCacheKey(connector, params, branchDeploymentId);
 
   if (options?.forceRefresh) {
     cache.delete(cacheKey);
@@ -176,8 +188,10 @@ export async function getTokenResponse(
   }
 
   const vercelToken = options?.vercelToken ?? (await getVercelOidcToken());
-
-  const endpoint = `https://api.vercel.com/v1/connect/token/${encodeURIComponent(connector)}`;
+  const { branch, ...tokenParams } = params;
+  const endpoint = branch
+    ? `https://api.vercel.com/v1/connect/token/${encodeURIComponent(connector)}/branch`
+    : `https://api.vercel.com/v1/connect/token/${encodeURIComponent(connector)}`;
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -186,7 +200,10 @@ export async function getTokenResponse(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${vercelToken}`,
     },
-    body: JSON.stringify(params),
+    body: JSON.stringify({
+      ...tokenParams,
+      ...(branchDeploymentId ? { deploymentId: branchDeploymentId } : {}),
+    }),
   });
 
   if (!response.ok) {
@@ -255,7 +272,21 @@ export function deleteTokenCacheEntry(
   connector: string,
   params: ConnectTokenParams
 ): void {
-  cache.delete(tokenCacheKey(connector, params));
+  const branchDeploymentId = params.branch
+    ? readRequiredDeploymentId(process.env.VERCEL_DEPLOYMENT_ID)
+    : undefined;
+  cache.delete(tokenCacheKey(connector, params, branchDeploymentId));
+}
+
+function readRequiredDeploymentId(value: string | undefined): string {
+  const deploymentId = value?.trim();
+  if (!deploymentId) {
+    throw new ConnectError(
+      'Branch connector resolution requires VERCEL_DEPLOYMENT_ID',
+      { code: 'branch_deployment_unavailable' }
+    );
+  }
+  return deploymentId;
 }
 
 const DEFAULT_VALIDITY_BUFFER_MS = 30_000;
@@ -273,8 +304,12 @@ const cache = new Map<string, CacheEntry>();
  * equal arguments so {@link getTokenResponse} and
  * {@link deleteTokenCacheEntry} address the same entry.
  */
-function tokenCacheKey(connector: string, params: ConnectTokenParams): string {
-  return JSON.stringify({ connector, ...params });
+function tokenCacheKey(
+  connector: string,
+  params: ConnectTokenParams,
+  branchDeploymentId?: string
+): string {
+  return JSON.stringify({ connector, ...params, branchDeploymentId });
 }
 
 function evictLru(): void {

--- a/packages/connect/test/token.test.ts
+++ b/packages/connect/test/token.test.ts
@@ -117,7 +117,60 @@ describe('getTokenResponse cache', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
+  });
+
+  it('uses the dedicated branch endpoint with the current deployment ID', async () => {
+    vi.stubEnv('VERCEL_DEPLOYMENT_ID', 'dpl_branch');
+    fetchMock.mockResolvedValue(tokenResponse('tok_branch'));
+
+    await getTokenResponse('slack/eve-agent', {
+      subject: { type: 'app' },
+      branch: true,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://api.vercel.com/v1/connect/token/slack%2Feve-agent/branch'
+    );
+    expect(JSON.parse(init.body as string)).toEqual({
+      subject: { type: 'app' },
+      deploymentId: 'dpl_branch',
+    });
+  });
+
+  it('fails closed when branch resolution has no deployment context', async () => {
+    vi.stubEnv('VERCEL_DEPLOYMENT_ID', '');
+
+    await expect(
+      getTokenResponse('slack/eve-agent', {
+        subject: { type: 'app' },
+        branch: true,
+      })
+    ).rejects.toMatchObject({
+      code: 'branch_deployment_unavailable',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps source and branch tokens in separate cache entries', async () => {
+    vi.stubEnv('VERCEL_DEPLOYMENT_ID', 'dpl_branch_cache');
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse('tok_source'))
+      .mockResolvedValueOnce(tokenResponse('tok_branch'));
+
+    const source = await getTokenResponse('slack/eve-agent', {
+      subject: { type: 'app' },
+    });
+    const branch = await getTokenResponse('slack/eve-agent', {
+      subject: { type: 'app' },
+      branch: true,
+    });
+
+    expect(source.token).toBe('tok_source');
+    expect(branch.token).toBe('tok_branch');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('serves a cached, unexpired token without re-fetching', async () => {


### PR DESCRIPTION
### Summary

Eve previews need a way to ask Connect for the temporary Slack connector associated with the branch they are running. This adds an opt-in `branch: true` token parameter that sends `VERCEL_DEPLOYMENT_ID` to a dedicated API endpoint, so callers never choose or supply the branch themselves.

Existing token requests are unchanged. Branch requests fail before making a request when deployment context is missing, and their cached tokens are isolated by deployment.

This is an additive SDK contract and should not be used until the corresponding Connect service support is available.

### Validation

- `pnpm --filter @vercel/connect type-check`
- `pnpm --filter @vercel/connect test` — 92 tests passed
