### PR TITLE
[build-utils] Enforce workPath boundary in download()/downloadFile()

### DIFF
--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -85,7 +85,8 @@ async function prepareSymlinkTarget(
 
 export async function downloadFile(
   file: File,
-  fsPath: string
+  fsPath: string,
+  basePath?: string
 ): Promise<FileFsRef> {
   const { mode } = file;
 
@@ -100,6 +101,28 @@ export async function downloadFile(
   // enabled in the group policy. We may want to improve the error message.
   if (isSymbolicLink(mode)) {
     const target = await prepareSymlinkTarget(file, fsPath);
+
+    // Reject symlink targets that escape the build root. The file map comes
+    // from untrusted deployment source, so a symlink such as `/etc/passwd` or
+    // `../../../../etc/passwd` must never be created inside `basePath`.
+    // `isExternalSymlinkTarget` flags absolute and `../` targets, but monorepo
+    // hoisting legitimately uses `../` links whose *resolved* location still
+    // lands inside `basePath` (see #16439), so we only reject once the target
+    // is resolved and shown to point outside the build root. Internal targets
+    // skip the resolve entirely.
+    if (basePath !== undefined && isExternalSymlinkTarget(target)) {
+      const resolvedTarget = path.resolve(path.dirname(fsPath), target);
+      const relative = path.relative(basePath, resolvedTarget);
+      if (
+        relative === '..' ||
+        relative.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relative)
+      ) {
+        throw new Error(
+          `Symlink "${fsPath}" points to "${target}", which resolves outside of the build root and was rejected`
+        );
+      }
+    }
 
     try {
       await symlink(target, fsPath);
@@ -130,6 +153,23 @@ async function removeFile(basePath: string, fileMatched: string) {
   await remove(file);
 }
 
+// Resolve a (untrusted) file map key against `basePath` and reject any name
+// that escapes the build root, e.g. `../../etc/foo` or an absolute path.
+function assertWithinBasePath(basePath: string, name: string): string {
+  const fsPath = path.join(basePath, name);
+  const relative = path.relative(basePath, fsPath);
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(
+      `File "${name}" resolves outside of the build root and was rejected`
+    );
+  }
+  return fsPath;
+}
+
 export default async function download(
   files: Files,
   basePath: string,
@@ -156,6 +196,10 @@ export default async function download(
 
   await Promise.all(
     filenames.map(async name => {
+      // Reject any entry whose resolved path escapes the build root before
+      // touching the filesystem (covers both `removeFile` and `downloadFile`).
+      const fsPath = assertWithinBasePath(basePath, name);
+
       // If the file does not exist anymore, remove it.
       if (Array.isArray(filesRemoved) && filesRemoved.includes(name)) {
         await removeFile(basePath, name);
@@ -188,9 +232,8 @@ export default async function download(
       }
 
       const file = files[name];
-      const fsPath = path.join(basePath, name);
 
-      files2[name] = await downloadFile(file, fsPath);
+      files2[name] = await downloadFile(file, fsPath, basePath);
     })
   );
 

--- a/packages/build-utils/test/unit.download.test.ts
+++ b/packages/build-utils/test/unit.download.test.ts
@@ -190,6 +190,107 @@ describe('download()', () => {
     expect(isExternalSymlink(internalSymlink)).toBe(false);
   });
 
+  it('should reject a symlink whose absolute target escapes the build root', async () => {
+    if (process.platform === 'win32') {
+      console.log('Skipping test on windows');
+      return;
+    }
+    const files = {
+      evil: new FileBlob({
+        mode: S_IFLNK,
+        contentType: undefined,
+        data: '/etc/passwd',
+      }),
+    };
+
+    const outDir = path.join(__dirname, 'symlinks-out');
+    await fs.remove(outDir);
+
+    await expect(download(files, outDir)).rejects.toThrow(
+      /resolves outside of the build root/
+    );
+
+    // The escaping symlink must not have been created.
+    expect(await fs.pathExists(path.join(outDir, 'evil'))).toBe(false);
+  });
+
+  it('should reject a symlink whose ../ target escapes the build root', async () => {
+    if (process.platform === 'win32') {
+      console.log('Skipping test on windows');
+      return;
+    }
+    const files = {
+      evil: new FileBlob({
+        mode: S_IFLNK,
+        contentType: undefined,
+        data: '../../../../../../etc/passwd',
+      }),
+    };
+
+    const outDir = path.join(__dirname, 'symlinks-out');
+    await fs.remove(outDir);
+
+    await expect(download(files, outDir)).rejects.toThrow(
+      /resolves outside of the build root/
+    );
+    expect(await fs.pathExists(path.join(outDir, 'evil'))).toBe(false);
+  });
+
+  it('should still allow a ../ symlink that resolves inside the build root (monorepo hoisting)', async () => {
+    if (process.platform === 'win32') {
+      console.log('Skipping test on windows');
+      return;
+    }
+    const files = {
+      'shared/dep.txt': new FileBlob({
+        mode: 33188,
+        contentType: undefined,
+        data: 'dep text',
+      }),
+      // From app/node_modules this resolves to <outDir>/shared/dep.txt.
+      'app/node_modules/dep.txt': new FileBlob({
+        mode: S_IFLNK,
+        contentType: undefined,
+        data: '../../shared/dep.txt',
+      }),
+    };
+
+    const outDir = path.join(__dirname, 'symlinks-out');
+    await fs.remove(outDir);
+
+    const files2 = await download(files, outDir);
+    strictEqual(Object.keys(files2).length, 2);
+
+    const linkStat = await fs.lstat(
+      path.join(outDir, 'app/node_modules/dep.txt')
+    );
+    assert(linkStat.isSymbolicLink());
+    strictEqual(
+      await readlink(path.join(outDir, 'app/node_modules/dep.txt')),
+      '../../shared/dep.txt'
+    );
+  });
+
+  it('should reject a file name that escapes the build root', async () => {
+    const files = {
+      '../evil.txt': new FileBlob({
+        mode: 33188,
+        contentType: undefined,
+        data: 'escaped',
+      }),
+    };
+
+    const outDir = path.join(__dirname, 'symlinks-out');
+    await fs.remove(outDir);
+
+    await expect(download(files, outDir)).rejects.toThrow(
+      /resolves outside of the build root/
+    );
+    expect(await fs.pathExists(path.join(path.dirname(outDir), 'evil.txt'))).toBe(
+      false
+    );
+  });
+
   it('should not fail when symlink already exists with same target', async () => {
     if (process.platform === 'win32') {
       console.log('Skipping test on windows');

--- a/packages/cli/src/commands/build/manifest.ts
+++ b/packages/cli/src/commands/build/manifest.ts
@@ -95,7 +95,8 @@ export async function writeManifests(
   ops.push(
     downloadFile(
       projectManifestBlob,
-      join(outputDir, 'diagnostics', 'project-manifest.json')
+      join(outputDir, 'diagnostics', 'project-manifest.json'),
+      join(outputDir, 'diagnostics')
     ).then(
       () => undefined,
       err => err
@@ -113,7 +114,8 @@ export async function writeManifests(
   ops.push(
     downloadFile(
       deployManifestBlob,
-      join(outputDir, 'diagnostics', 'deploy-manifest.json')
+      join(outputDir, 'diagnostics', 'deploy-manifest.json'),
+      join(outputDir, 'diagnostics')
     ).then(
       () => undefined,
       err => err

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -654,7 +654,7 @@ async function writeStaticFile(
       // if link fails we continue attempting to copy
     }
   }
-  await downloadFile(file, dest);
+  await downloadFile(file, dest, join(outputDir, 'static'));
 }
 
 /**

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -639,8 +639,16 @@ async function writeStaticFile(
   const dest = join(outputDir, 'static', fsPath);
   await fs.mkdirp(dirname(dest));
 
-  // if already on disk hard link instead of copying
-  if ('fsPath' in file) {
+  // if already on disk hard link instead of copying.
+  // Symlinks deliberately skip this fast-path: `fs.link()` would copy the
+  // entry into the output directory without ever consulting the build-root
+  // boundary check, so a symlink such as `../../secret` committed to the
+  // source would land in `.vercel/output/static`. (Platforms differ on
+  // whether `link()` dereferences — Linux preserves the symlink, macOS/BSD
+  // hard-links the resolved target — but both escape the build root.)
+  // Falling through to `downloadFile()` routes them through the single
+  // `basePath` check below instead.
+  if ('fsPath' in file && !isSymbolicLink(file.mode)) {
     // If source and destination resolve to the same path (e.g. local builds
     // where a builder writes static files directly into outputDir/static/ and
     // then returns FileFsRef objects pointing to those same paths), the file

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -236,6 +236,136 @@ describe('writeBuildResult()', () => {
   });
 });
 
+describe('writeBuildResult() static symlink boundary', () => {
+  // Regression coverage for the `fs.link()` fast-path in `writeStaticFile()`.
+  // That fast-path used to run for every `File` carrying an `fsPath`, which
+  // meant a symlink was hard-linked straight into `.vercel/output/static`
+  // without ever reaching the `basePath` boundary check inside
+  // `downloadFile()`. Symlinks now skip the fast-path so the check applies.
+
+  /** Build a V2 static-only build result for a single output file. */
+  async function writeStatic(
+    workPath: string,
+    outputDir: string,
+    outputPath: string,
+    file: FileFsRef
+  ) {
+    const build = { src: 'index.html', use: '@vercel/static' };
+    const staticBuilder: BuilderV2 = {
+      version: 2,
+      build: async () => {
+        throw new Error('not used by writeBuildResult');
+      },
+    };
+    return writeBuildResult({
+      repoRootPath: workPath,
+      outputDir,
+      buildResult: { output: { [outputPath]: file } },
+      build,
+      builder: staticBuilder,
+      builderPkg: { name: '@vercel/static' },
+      vercelConfig: null,
+      standalone: false,
+      workPath,
+    });
+  }
+
+  /** Create a symlink on disk and wrap it in a `FileFsRef` the way `glob()` does. */
+  async function symlinkRef(fsPath: string, target: string) {
+    await fs.mkdirp(join(fsPath, '..'));
+    await fs.symlink(target, fsPath);
+    // `glob()` uses `lstat`, so the mode carries the symlink type bits.
+    const stat = await fs.lstat(fsPath);
+    return new FileFsRef({ mode: stat.mode, fsPath });
+  }
+
+  it('rejects a relative symlink that escapes the build root', async () => {
+    if (process.platform === 'win32') return;
+    const workPath = await getWriteableDirectory();
+    const outputDir = join(workPath, '.vercel', 'output');
+    // The secret sits outside `.vercel/output/static`, which is the build root
+    // enforced by `downloadFile()`.
+    await fs.writeFile(join(workPath, 'secret.txt'), 'SECRET');
+    // The source symlink is nested one level deeper so that `../../secret.txt`
+    // resolves to a real file *from the source location*. That matters: a
+    // dangling symlink would make `fs.link()` fail with ENOENT and fall
+    // through to the guard on its own, so this test would still pass with the
+    // fast-path bug present and would not be a regression test at all.
+    const file = await symlinkRef(
+      join(workPath, 'dist', 'nested', 'leak.txt'),
+      '../../secret.txt'
+    );
+    expect(await fs.readFile(file.fsPath, 'utf8')).toBe('SECRET');
+
+    await expect(
+      writeStatic(workPath, outputDir, 'leak.txt', file)
+    ).rejects.toThrow(/resolves outside of the build root/);
+
+    // Nothing may be materialized at the destination — in particular the
+    // `fs.link()` fast-path must not have copied the entry in first.
+    expect(
+      await fs.pathExists(join(outputDir, 'static', 'leak.txt'))
+    ).toBe(false);
+
+    await fs.remove(workPath);
+  });
+
+  it('rejects an absolute symlink that escapes the build root', async () => {
+    if (process.platform === 'win32') return;
+    const workPath = await getWriteableDirectory();
+    const outputDir = join(workPath, '.vercel', 'output');
+    const file = await symlinkRef(join(workPath, 'dist', 'passwd'), '/etc/passwd');
+
+    await expect(
+      writeStatic(workPath, outputDir, 'passwd', file)
+    ).rejects.toThrow(/resolves outside of the build root/);
+
+    expect(await fs.pathExists(join(outputDir, 'static', 'passwd'))).toBe(false);
+
+    await fs.remove(workPath);
+  });
+
+  it('still writes a symlink whose target stays inside the build root', async () => {
+    if (process.platform === 'win32') return;
+    const workPath = await getWriteableDirectory();
+    const outputDir = join(workPath, '.vercel', 'output');
+    // Monorepo hoisting legitimately uses `../` links that resolve back
+    // inside the output directory (see #16439) — those must keep working.
+    await fs.mkdirp(join(outputDir, 'static'));
+    await fs.writeFile(join(outputDir, 'static', 'real.txt'), 'in-root');
+    const file = await symlinkRef(join(workPath, 'dist', 'link.txt'), '../real.txt');
+
+    await writeStatic(workPath, outputDir, 'sub/link.txt', file);
+
+    const dest = join(outputDir, 'static', 'sub', 'link.txt');
+    expect((await fs.lstat(dest)).isSymbolicLink()).toBe(true);
+    expect(await fs.readlink(dest)).toBe('../real.txt');
+    expect(await fs.readFile(dest, 'utf8')).toBe('in-root');
+
+    await fs.remove(workPath);
+  });
+
+  it('keeps the hard-link fast-path for regular files', async () => {
+    if (process.platform === 'win32') return;
+    const workPath = await getWriteableDirectory();
+    const outputDir = join(workPath, '.vercel', 'output');
+    const src = join(workPath, 'dist', 'index.html');
+    await fs.mkdirp(join(workPath, 'dist'));
+    await fs.writeFile(src, '<h1>hello</h1>');
+    const file = new FileFsRef({ mode: (await fs.lstat(src)).mode, fsPath: src });
+
+    await writeStatic(workPath, outputDir, 'index.html', file);
+
+    const dest = join(outputDir, 'static', 'index.html');
+    expect(await fs.readFile(dest, 'utf8')).toBe('<h1>hello</h1>');
+    // A hard link shares the inode with the source; this asserts the
+    // optimization was not lost when symlinks were carved out of it.
+    expect((await fs.stat(dest)).ino).toBe((await fs.stat(src)).ino);
+
+    await fs.remove(workPath);
+  });
+});
+
 describe('filesWithoutFsRefs()', () => {
   it('should create `filePathMap` with normalized POSIX paths', async () => {
     const repoRootPath = join(


### PR DESCRIPTION
### Summary

`download()` and `downloadFile()` in `@vercel/build-utils` write files and create symlinks from an untrusted file map (the deployment source), but they never check that the resulting path stays inside the build root. A symlink in a repo like `evil -> /etc/passwd` or `evil -> ../../../../etc/x` survives upload unchanged and gets recreated as is in the build workspace. The module already has an `isExternalSymlinkTarget()` helper, but it was never used on the write path.

This is a defense in depth change on the filesystem boundary. Build steps already run untrusted code, so the point here is just to stop `download()` from placing links or paths outside `basePath`. It is not claiming a sandbox escape.

### Changes

- `downloadFile()` now takes an optional `basePath`. When a symlink target is external (absolute or `../`), it resolves the target and rejects it only if it lands outside `basePath`. Internal targets and monorepo `../` hoists that resolve back inside the root (see #16439) are still allowed, so this does not regress that behavior.
- `download()` validates every file map key against the build root before touching the filesystem (covers both `removeFile` and `downloadFile`) and passes `basePath` through. The CLI already rejects `..` keys at collection time in `client/src/utils/index.ts`, so this mainly closes the same gap for any non CLI caller of the library.
- Passes `basePath` into the other direct `downloadFile()` callers (`write-build-result.ts` and `manifest.ts`) so the check is applied everywhere.

### Tests

New cases in `unit.download.test.ts`: absolute target escape (rejected), `../` target escape (rejected), a monorepo `../` symlink that resolves inside the root (still allowed), and a file name that escapes the root (rejected).

### Verification

```
pnpm --filter @vercel/build-utils test unit.download
```
