### PR TITLE
@vercel/python: remove rolled out flag

### DIFF
--- a/.changeset/python-large-functions-flag-cleanup.md
+++ b/.changeset/python-large-functions-flag-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Clean up the `VERCEL_SUPPORT_LARGE_FUNCTIONS` flag, now that large functions are fully rolled out.

--- a/packages/python/src/dependency-externalizer.ts
+++ b/packages/python/src/dependency-externalizer.ts
@@ -23,7 +23,6 @@ import {
   UV_BUNDLE_DIR,
 } from './uv';
 import { detectTargetPlatform } from './platform-info';
-import { isLargeFunctionsEnabled } from './large-functions';
 import { InstalledPythonDistributions } from './installed-distributions';
 import type { PythonVersion } from './version';
 
@@ -171,13 +170,10 @@ export class PythonDependencyExternalizer {
     ) {
       return false;
     }
-    // Over the threshold with a lock to defer from. Large functions skip
-    // runtime install once deps exceed ephemeral storage (bundled for Hive);
-    // below that, runtime install still keeps it on Lambda.
-    if (
-      isLargeFunctionsEnabled() &&
-      this.totalBundleSize > LAMBDA_EPHEMERAL_STORAGE_BYTES
-    ) {
+    // Over the threshold with a lock to defer from. Skip runtime install once
+    // deps exceed ephemeral storage (bundled for Hive instead); below that,
+    // runtime install still keeps it on Lambda.
+    if (this.totalBundleSize > LAMBDA_EPHEMERAL_STORAGE_BYTES) {
       return false;
     }
     return true;
@@ -209,8 +205,6 @@ export class PythonDependencyExternalizer {
 
     const runtimeInstallEnabled = this.shouldEnableRuntimeInstall();
 
-    const largeFunctionsEnabled = isLargeFunctionsEnabled();
-
     // Surface the size BEFORE the size-limit checks below, which may throw.
     // Otherwise oversized bundles would never report their size, biasing any
     // size telemetry toward builds that fit the limit.
@@ -219,34 +213,9 @@ export class PythonDependencyExternalizer {
       runtimeInstallEnabled,
     });
 
-    // Custom install commands can't use runtime install; enforced only when
-    // not bundling everything directly (large functions).
-    if (
-      this.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES &&
-      this.hasCustomCommand &&
-      !largeFunctionsEnabled
-    ) {
-      const limitMB = (LAMBDA_SIZE_THRESHOLD_BYTES / (1024 * 1024)).toFixed(0);
-      throw new NowBuildError({
-        code: 'LAMBDA_SIZE_EXCEEDED',
-        message:
-          `Total bundle size (${totalBundleSizeMB} MB) exceeds the maximum function size (${limitMB} MB).\n\n` +
-          `A custom install command prevents Vercel from optimizing your\n` +
-          `function bundle size automatically. To fix this, you can:\n` +
-          `  1. Remove unused dependencies from your project, or\n` +
-          `  2. Remove the custom install command so Vercel can optimize\n` +
-          `     the function bundle automatically.`,
-        link: BUNDLING_DOCS_LINK,
-        action: 'Learn More',
-      });
-    }
-
     // Enforce the large-function size limit up front (faster than failing at
     // ZIP time). `>=` matches the platform's uncompressed-size check.
-    if (
-      largeFunctionsEnabled &&
-      this.totalBundleSize >= MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE
-    ) {
+    if (this.totalBundleSize >= MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE) {
       const limitMB = (
         MAX_LARGE_FUNCTION_UNCOMPRESSED_SIZE /
         (1024 * 1024)
@@ -275,9 +244,9 @@ export class PythonDependencyExternalizer {
    * public), runtime config, and uv binary.
    * Must be called after analyze().
    *
-   * If large functions are allowed and the bundle can't fit AWS Lambda, falls
-   * back to bundling everything for Hive and returns `fellBackToFullBundle:
-   * true` so the caller can apply the same compileall handling.
+   * If the bundle can't fit AWS Lambda, falls back to bundling everything for
+   * Hive and returns `fellBackToFullBundle: true` so the caller can apply the
+   * same compileall handling.
    */
   async generateBundle(
     files: Files,
@@ -299,27 +268,10 @@ export class PythonDependencyExternalizer {
 
     const totalBundleSizeMB = (this.totalBundleSize / (1024 * 1024)).toFixed(2);
 
-    // When set, a bundle that can't fit AWS Lambda is bundled for Hive instead
-    // of failing the build.
-    const largeFunctionsEnabled = isLargeFunctionsEnabled();
-
-    // Verify total deps won't exceed Lambda ephemeral storage (512 MB)
+    // Deps that won't fit Lambda ephemeral storage (512 MB) can't be installed
+    // at cold start, so bundle everything for Hive instead.
     if (this.totalBundleSize > LAMBDA_EPHEMERAL_STORAGE_BYTES) {
-      if (largeFunctionsEnabled) {
-        return this.bundleAllForHive(files);
-      }
-      const limitMB = (LAMBDA_EPHEMERAL_STORAGE_BYTES / (1024 * 1024)).toFixed(
-        0
-      );
-      throw new NowBuildError({
-        code: 'LAMBDA_SIZE_EXCEEDED',
-        message:
-          `Total bundle size (${totalBundleSizeMB} MB) exceeds the maximum function size (${limitMB} MB).\n\n` +
-          `Reduce the size of your dependencies or split your application into\n` +
-          `smaller functions.`,
-        link: BUNDLING_DOCS_LINK,
-        action: 'Learn More',
-      });
+      return this.bundleAllForHive(files);
     }
 
     // Read and parse the uv.lock file. Use a project-relative path in
@@ -399,20 +351,9 @@ export class PythonDependencyExternalizer {
       name => !forceBundledSet.has(normalizePackageName(name))
     );
 
+    // Nothing left to defer to runtime install, so bundle everything for Hive.
     if (externalizablePublic.length === 0) {
-      if (largeFunctionsEnabled) {
-        return this.bundleAllForHive(files);
-      }
-      throw new NowBuildError({
-        code: 'RUNTIME_DEPENDENCY_INSTALLATION_FAILED',
-        message:
-          `Total bundle size (${totalBundleSizeMB} MB) exceeds the maximum function size and\n` +
-          `can't be optimized automatically because some dependencies don't\n` +
-          `provide a compatible pre-built wheel.\n\n` +
-          `To fix this, either:\n` +
-          `  1. Regenerate your lock file with: uv lock --upgrade, or\n` +
-          `  2. Replace the packages that don't provide a pre-built wheel.`,
-      });
+      return this.bundleAllForHive(files);
     }
 
     // Calculate per-package sizes for public packages
@@ -497,9 +438,8 @@ export class PythonDependencyExternalizer {
 
     // The non-deferrable footprint (source + private/wheel-less packages +
     // tooling) alone exceeds the threshold, so runtime install can't shrink the
-    // zip enough. Large functions bundle everything for Hive; otherwise the
-    // final-size check below throws.
-    if (largeFunctionsEnabled && remainingCapacity < 0) {
+    // zip enough. Bundle everything for Hive.
+    if (remainingCapacity < 0) {
       return this.bundleAllForHive(files);
     }
 
@@ -624,23 +564,8 @@ export class PythonDependencyExternalizer {
     // target 225 MB, so a slight overshoot here is safe.
     const finalBundleSize = await calculateBundleSize(files);
     if (finalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES + 100 * 1024) {
-      if (largeFunctionsEnabled) {
-        // Estimation overshoot past the threshold; bundle everything for Hive.
-        return this.bundleAllForHive(files);
-      }
-      const finalSizeMB = (finalBundleSize / (1024 * 1024)).toFixed(2);
-      const limitMB = (LAMBDA_SIZE_THRESHOLD_BYTES / (1024 * 1024)).toFixed(0);
-      throw new NowBuildError({
-        code: 'LAMBDA_SIZE_EXCEEDED',
-        message:
-          `Total bundle size (${finalSizeMB} MB) exceeds the maximum function size (${limitMB} MB) even after\n` +
-          `optimizing dependencies.\n\n` +
-          `This usually means your source code or private packages are too\n` +
-          `large. Reduce their size or split your application into smaller\n` +
-          `functions.`,
-        link: BUNDLING_DOCS_LINK,
-        action: 'Learn More',
-      });
+      // Estimation overshoot past the threshold; bundle everything for Hive.
+      return this.bundleAllForHive(files);
     }
 
     return {

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -70,7 +70,6 @@ import {
   RUNTIME_DEPS_DIR,
   type GenerateBundleResult,
 } from './dependency-externalizer';
-import { isLargeFunctionsEnabled } from './large-functions';
 import {
   UvRunner,
   UV_LINUX_TARGET,
@@ -1835,13 +1834,11 @@ export const build: BuildVX = async ({
         }
       } else {
         // Bundle all deps directly. Either it fits the standard size limit, or
-        // large functions are enabled and the whole bundle ships.
+        // it exceeds it and the whole bundle ships on Hive.
         addFiles(files, depAnalysis.allVendorFiles);
         if (depAnalysis.totalBundleSize > LAMBDA_SIZE_THRESHOLD_BYTES) {
           packingMode = 'hive';
-          if (isLargeFunctionsEnabled()) {
-            announceLargeFunction();
-          }
+          announceLargeFunction();
           if (compileAllEnabled) {
             await runAdjacentCompileAndFill(LARGE_FUNCTION_FILL_CEILING_BYTES);
           }

--- a/packages/python/src/large-functions.ts
+++ b/packages/python/src/large-functions.ts
@@ -1,8 +1,0 @@
-/**
- * Whether large functions are enabled (via `VERCEL_SUPPORT_LARGE_FUNCTIONS`).
- * When enabled, functions exceeding the AWS Lambda size limits run on Hive.
- */
-export function isLargeFunctionsEnabled(): boolean {
-  const value = process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-  return value === '1' || value === 'true';
-}

--- a/packages/python/test/fixtures/51-litellm/vercel.json
+++ b/packages/python/test/fixtures/51-litellm/vercel.json
@@ -1,7 +1,0 @@
-{
-  "build": {
-    "env": {
-      "VERCEL_SUPPORT_LARGE_FUNCTIONS": "1"
-    }
-  }
-}

--- a/packages/python/test/fixtures/64-hive-compileall/vercel.json
+++ b/packages/python/test/fixtures/64-hive-compileall/vercel.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "env": {
-      "VERCEL_SUPPORT_LARGE_FUNCTIONS": "1",
       "VERCEL_PYTHON_COMPILEALL": "1"
     }
   }

--- a/packages/python/test/unit.compileall.test.ts
+++ b/packages/python/test/unit.compileall.test.ts
@@ -34,7 +34,6 @@ import {
 
 const mockedExeca = vi.mocked(execa);
 const originalCompileAllEnv = process.env.VERCEL_PYTHON_COMPILEALL;
-const originalLargeFnEnv = process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
 const tmpDirs: string[] = [];
 
 afterEach(() => {
@@ -46,11 +45,6 @@ afterEach(() => {
     delete process.env.VERCEL_PYTHON_COMPILEALL;
   } else {
     process.env.VERCEL_PYTHON_COMPILEALL = originalCompileAllEnv;
-  }
-  if (originalLargeFnEnv === undefined) {
-    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-  } else {
-    process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = originalLargeFnEnv;
   }
 });
 
@@ -67,15 +61,6 @@ describe('shouldCompileAll', () => {
     );
 
     process.env.VERCEL_PYTHON_COMPILEALL = 'TRUE';
-    expect(shouldCompileAll({ isDev: false, hasCustomCommand: false })).toBe(
-      true
-    );
-  });
-
-  it('does not require VERCEL_SUPPORT_LARGE_FUNCTIONS', () => {
-    delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-    process.env.VERCEL_PYTHON_COMPILEALL = '1';
-
     expect(shouldCompileAll({ isDev: false, hasCustomCommand: false })).toBe(
       true
     );

--- a/packages/python/test/unit.dependency-externalizer.test.ts
+++ b/packages/python/test/unit.dependency-externalizer.test.ts
@@ -45,17 +45,6 @@ function createInstalledDistributions() {
 
 describe('dependency externalizer support', () => {
   describe('shouldEnableRuntimeInstall', () => {
-    const originalLargeFunctionsEnv =
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
-    afterEach(() => {
-      if (originalLargeFunctionsEnv === undefined) {
-        delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-      } else {
-        process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = originalLargeFunctionsEnv;
-      }
-    });
-
     const oversized = LAMBDA_SIZE_THRESHOLD_BYTES + 1;
     const undersized = LAMBDA_SIZE_THRESHOLD_BYTES - 1;
     // Exceeds even the ephemeral-storage budget, so runtime installation can't
@@ -83,54 +72,24 @@ describe('dependency externalizer support', () => {
     }
 
     it('returns true when bundle exceeds threshold and uvLockPath is present', () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
+      // Deferrable bundles stay on Lambda via runtime install; Hive is only
+      // used when the deps can't fit ephemeral storage.
       const ext = createExternalizer({ totalBundleSize: oversized });
       expect(ext.shouldEnableRuntimeInstall()).toBe(true);
     });
 
-    it('still attempts runtime install under VERCEL_SUPPORT_LARGE_FUNCTIONS when the bundle fits ephemeral storage', () => {
-      // Large functions keep deferrable bundles on Lambda via runtime install;
-      // Hive is only used when the deps can't fit ephemeral storage.
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-      const ext = createExternalizer({ totalBundleSize: oversized });
-      expect(ext.shouldEnableRuntimeInstall()).toBe(true);
-    });
-
-    it('skips runtime install under VERCEL_SUPPORT_LARGE_FUNCTIONS when the bundle exceeds ephemeral storage', () => {
+    it('returns false when the bundle exceeds ephemeral storage', () => {
       // Too big for /tmp: bundle everything and serve on Hive instead.
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
       const ext = createExternalizer({ totalBundleSize: ephemeralOversized });
       expect(ext.shouldEnableRuntimeInstall()).toBe(false);
-    });
-
-    it('skips runtime install under VERCEL_SUPPORT_LARGE_FUNCTIONS when the bundle is under threshold', () => {
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-      const ext = createExternalizer({ totalBundleSize: undersized });
-      expect(ext.shouldEnableRuntimeInstall()).toBe(false);
-    });
-
-    it('attempts runtime install when VERCEL_SUPPORT_LARGE_FUNCTIONS is an unrecognised value', () => {
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = 'yes';
-      const ext = createExternalizer({ totalBundleSize: oversized });
-      expect(ext.shouldEnableRuntimeInstall()).toBe(true);
-    });
-
-    it('still attempts runtime install when the bundle exceeds ephemeral storage without large functions enabled', () => {
-      // Without large functions the ephemeral short-circuit does not apply, so
-      // it still attempts the hack (generateBundle later throws).
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-      const ext = createExternalizer({ totalBundleSize: ephemeralOversized });
-      expect(ext.shouldEnableRuntimeInstall()).toBe(true);
     });
 
     it('returns false when bundle is under threshold', () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({ totalBundleSize: undersized });
       expect(ext.shouldEnableRuntimeInstall()).toBe(false);
     });
 
     it('returns false when uvLockPath is null', () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({
         totalBundleSize: oversized,
         uvLockPath: null,
@@ -139,7 +98,6 @@ describe('dependency externalizer support', () => {
     });
 
     it('returns false when hasCustomCommand is true even with oversized bundle and uvLockPath', () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({
         totalBundleSize: oversized,
         hasCustomCommand: true,
@@ -148,7 +106,6 @@ describe('dependency externalizer support', () => {
     });
 
     it('returns false when hasCustomCommand is true and bundle is under threshold', () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
       const ext = createExternalizer({
         totalBundleSize: undersized,
         hasCustomCommand: true,
@@ -1049,20 +1006,7 @@ version = "8.1.7"
   });
 
   describe('analyze', () => {
-    const originalLargeFunctionsEnv =
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
-    afterEach(() => {
-      if (originalLargeFunctionsEnv === undefined) {
-        delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-      } else {
-        process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = originalLargeFunctionsEnv;
-      }
-    });
-
     it('uses the injected installed distributions when sizing the bundle', async () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
       const installedDistributions = createInstalledDistributions();
       const mirrorPackagesIntoVendor = vi
         .spyOn(installedDistributions, 'mirrorPackagesIntoVendor')
@@ -1089,67 +1033,7 @@ version = "8.1.7"
       expect(Object.keys(result.allVendorFiles)).toEqual(['_vendor/pkg.py']);
     });
 
-    it('throws user-friendly error for custom install command with oversized bundle', async () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
-      const tempDir = path.join(tmpdir(), `dep-ext-analyze-${Date.now()}`);
-      fs.mkdirSync(tempDir, { recursive: true });
-
-      // Create a sparse file that reports > 225 MB without using real disk space
-      const bigFilePath = path.join(tempDir, 'big-file.dat');
-      const fd = fs.openSync(bigFilePath, 'w');
-      fs.ftruncateSync(fd, LAMBDA_SIZE_THRESHOLD_BYTES + 1024 * 1024);
-      fs.closeSync(fd);
-
-      const ext = new PythonDependencyExternalizer({
-        installedDistributions: createInstalledDistributions(),
-        vendorDir: '_vendor',
-        workPath: tempDir,
-        uvLockPath: path.join(tempDir, 'uv.lock'),
-        uvProjectDir: tempDir,
-        projectName: 'test-project',
-        pythonVersion: TEST_PYTHON_VERSION,
-        hasCustomCommand: true,
-      });
-
-      const files = {
-        'big-file.dat': new FileFsRef({ fsPath: bigFilePath }),
-      };
-
-      try {
-        await expect(ext.analyze(files)).rejects.toThrow(
-          'exceeds the maximum function size'
-        );
-
-        // Re-create the externalizer since the previous one may have mutated state
-        const ext2 = new PythonDependencyExternalizer({
-          installedDistributions: createInstalledDistributions(),
-          vendorDir: '_vendor',
-          workPath: tempDir,
-          uvLockPath: path.join(tempDir, 'uv.lock'),
-          uvProjectDir: tempDir,
-          projectName: 'test-project',
-          pythonVersion: TEST_PYTHON_VERSION,
-          hasCustomCommand: true,
-        });
-
-        try {
-          await ext2.analyze(files);
-          expect.fail('Expected analyze() to throw');
-        } catch (error: unknown) {
-          const message = (error as Error).message;
-          expect(message).toContain('custom install command');
-          expect(message).not.toContain('Lambda size limit');
-          expect(message).not.toContain('runtime dependency installation');
-        }
-      } finally {
-        fs.removeSync(tempDir);
-      }
-    });
-
     it('does not throw for custom install command when bundle is under threshold', async () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
       const tempDir = path.join(tmpdir(), `dep-ext-analyze-ok-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
 
@@ -1180,8 +1064,6 @@ version = "8.1.7"
     });
 
     it('invokes onSized with the size even when the bundle exceeds the large-function limit and throws', async () => {
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
       const tempDir = path.join(
         tmpdir(),
         `dep-ext-onsized-large-${Date.now()}`
@@ -1227,11 +1109,9 @@ version = "8.1.7"
       }
     });
 
-    it('attempts runtime install under supportLargeFunctions when the bundle fits ephemeral storage', async () => {
+    it('attempts runtime install when the bundle fits ephemeral storage', async () => {
       // Over the 225 MB Lambda threshold but within /tmp: keep it on Lambda via
       // runtime install rather than sending it to Hive.
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
       const tempDir = path.join(tmpdir(), `dep-ext-large-defer-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
 
@@ -1265,11 +1145,9 @@ version = "8.1.7"
       }
     });
 
-    it('skips runtime install under supportLargeFunctions when the bundle exceeds ephemeral storage', async () => {
+    it('skips runtime install when the bundle exceeds ephemeral storage', async () => {
       // Too big for /tmp: bundle everything (no runtime install) and let the
       // platform route it to Hive.
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
       const tempDir = path.join(tmpdir(), `dep-ext-large-hive-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
 
@@ -1303,9 +1181,7 @@ version = "8.1.7"
       }
     });
 
-    it('throws the extended limit error under supportLargeFunctions when the bundle exceeds 5 GB', async () => {
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
+    it('throws the extended limit error when the bundle exceeds 5 GB', async () => {
       const tempDir = path.join(tmpdir(), `dep-ext-large-over-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
 
@@ -1339,9 +1215,7 @@ version = "8.1.7"
       }
     });
 
-    it('throws under supportLargeFunctions when the bundle is exactly at the 5 GB limit', async () => {
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
+    it('throws when the bundle is exactly at the 5 GB limit', async () => {
       const tempDir = path.join(tmpdir(), `dep-ext-large-eq-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
 
@@ -1376,14 +1250,12 @@ version = "8.1.7"
       }
     });
 
-    it('does not throw the custom-install-command error under supportLargeFunctions', async () => {
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
+    it('bundles an oversized custom-install-command build for Hive instead of throwing', async () => {
       const tempDir = path.join(tmpdir(), `dep-ext-large-custom-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
 
-      // Over the AWS Lambda threshold; with a custom command this throws on the
-      // standard path, but direct-bundle mode bundles it for Hive instead.
+      // Over the AWS Lambda threshold. A custom install command rules out
+      // runtime install, so the whole bundle ships to Hive.
       const bigFilePath = path.join(tempDir, 'big-file.dat');
       const fd = fs.openSync(bigFilePath, 'w');
       fs.ftruncateSync(fd, LAMBDA_SIZE_THRESHOLD_BYTES + 1024 * 1024);
@@ -1413,8 +1285,6 @@ version = "8.1.7"
     });
 
     it('invokes onSized on the under-threshold success path', async () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
       const tempDir = path.join(tmpdir(), `dep-ext-onsized-ok-${Date.now()}`);
       fs.mkdirSync(tempDir, { recursive: true });
 
@@ -1452,17 +1322,6 @@ version = "8.1.7"
   });
 
   describe('generateBundle Hive fallback', () => {
-    const originalLargeFunctionsEnv =
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
-    afterEach(() => {
-      if (originalLargeFunctionsEnv === undefined) {
-        delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-      } else {
-        process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = originalLargeFunctionsEnv;
-      }
-    });
-
     // Build an externalizer in the post-analyze() state without a real venv:
     // the ephemeral-storage check runs before any uv.lock work, so the fallback
     // it triggers can be exercised by setting the analyzed fields directly.
@@ -1489,9 +1348,7 @@ version = "8.1.7"
       return ext;
     }
 
-    it('bundles all dependencies for Hive and discards runtime-install artifacts when deps exceed ephemeral storage under supportLargeFunctions', async () => {
-      process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS = '1';
-
+    it('bundles all dependencies for Hive and discards runtime-install artifacts when deps exceed ephemeral storage', async () => {
       const allVendorFiles: Files = {
         '_vendor/pkg/__init__.py': new FileBlob({ data: 'a' }),
         '_vendor/pkg/module.py': new FileBlob({ data: 'b' }),
@@ -1528,19 +1385,6 @@ version = "8.1.7"
       expect(files['_uv/uv']).toBeUndefined();
       expect(files['_uv/pyproject.toml']).toBeUndefined();
       expect(files['_uv/uv.lock']).toBeUndefined();
-    });
-
-    it('throws when deps exceed ephemeral storage without supportLargeFunctions', async () => {
-      delete process.env.VERCEL_SUPPORT_LARGE_FUNCTIONS;
-
-      const ext = createAnalyzedExternalizer({
-        totalBundleSize: LAMBDA_EPHEMERAL_STORAGE_BYTES + 1,
-        allVendorFiles: {},
-      });
-
-      await expect(ext.generateBundle({})).rejects.toThrow(
-        'exceeds the maximum function size'
-      );
     });
   });
 });


### PR DESCRIPTION
Removing the rolled-out `VERCEL_SUPPORT_LARGE_FUNCTIONS` flag reference from the codebase