### PR TITLE
@vercel/next: remove rolled-out flag

### DIFF
--- a/.changeset/next-large-functions-flag-cleanup.md
+++ b/.changeset/next-large-functions-flag-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Clean up the `NEXT_EXPERIMENTAL_LARGE_FUNCTIONS` flag: routes that individually exceed the default packing budget are now always emitted as their own function, no opt-in required.

--- a/packages/next/src/constants.ts
+++ b/packages/next/src/constants.ts
@@ -20,8 +20,7 @@ export const DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE_BUN = 150 * MIB;
 
 /**
  * Uncompressed size ceiling for a "large" function (a single over-budget route
- * emitted on its own). Only applies when large functions are enabled via
- * `NEXT_EXPERIMENTAL_LARGE_FUNCTIONS`; see {@link isLargeFunctionsEnabled}.
+ * emitted on its own).
  */
 export const DEFAULT_MAX_UNCOMPRESSED_LARGE_LAMBDA_SIZE = 5 * 1024 * MIB;
 

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -83,23 +83,6 @@ export function getMaxUncompressedLambdaSize(runtime: string): number {
 }
 
 /**
- * Internal env var enabling experimental large functions: an over-budget route
- * is emitted as its own function under the higher
- * {@link DEFAULT_MAX_UNCOMPRESSED_LARGE_LAMBDA_SIZE} ceiling instead of being
- * bundled. Read at call time (not module load) so the build environment can
- * toggle it without a CLI upgrade, like `VERCEL_CLI_SKIP_MAX_DURATION_LIMIT`.
- *
- * TODO: drop the gate and make this unconditional once the upstream build
- * system fully supports functions above {@link DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE}.
- */
-export const LARGE_FUNCTIONS_ENV = 'NEXT_EXPERIMENTAL_LARGE_FUNCTIONS';
-
-/** Whether large functions are enabled via {@link LARGE_FUNCTIONS_ENV}. */
-export function isLargeFunctionsEnabled(): boolean {
-  return Boolean(process.env[LARGE_FUNCTIONS_ENV]);
-}
-
-/**
  * The uncompressed size ceiling for a lambda group: the higher large-function
  * limit for large groups, otherwise the default per-runtime limit.
  */
@@ -1970,8 +1953,7 @@ export type LambdaGroup = {
   isApiLambda: boolean;
   /**
    * Whether this group is a single over-budget route emitted on its own and
-   * measured against {@link DEFAULT_MAX_UNCOMPRESSED_LARGE_LAMBDA_SIZE}. Only
-   * set when large functions are enabled (see {@link isLargeFunctionsEnabled}).
+   * measured against {@link DEFAULT_MAX_UNCOMPRESSED_LARGE_LAMBDA_SIZE}.
    */
   isLargeFunctions?: boolean;
   pseudoLayer: PseudoLayer;
@@ -2037,8 +2019,6 @@ export async function getPageLambdaGroups({
   nodeVersion: { runtime: string };
 }) {
   const groups: Array<LambdaGroup> = [];
-
-  const largeFunctionsEnabled = isLargeFunctionsEnabled();
 
   for (const page of pages) {
     const newPages = [...internalPages, page];
@@ -2137,7 +2117,7 @@ export async function getPageLambdaGroups({
     // manifests, etc.), so it can't be guaranteed to fit a normal function.
     // `experimentalAllowBundling` defers bundling upstream, so the split is moot.
     let isLargeFunction = false;
-    if (largeFunctionsEnabled && !experimentalAllowBundling) {
+    if (!experimentalAllowBundling) {
       let standaloneUncompressedSize = initialPseudoLayerUncompressed;
       const countedFiles = new Set<string>(
         Object.keys(initialPseudoLayer.pseudoLayer)

--- a/packages/next/test/unit/utils.test.ts
+++ b/packages/next/test/unit/utils.test.ts
@@ -10,8 +10,6 @@ import {
   normalizePrefetches,
   getMaxUncompressedLambdaSize,
   getGroupMaxUncompressedLambdaSize,
-  isLargeFunctionsEnabled,
-  LARGE_FUNCTIONS_ENV,
   getPageLambdaGroups,
   detectLambdaLimitExceeding,
   type LambdaGroup,
@@ -498,7 +496,8 @@ function groupPagesBySize(
   runtime = 'nodejs22.x',
   functionsConfigManifest?: Parameters<
     typeof getPageLambdaGroups
-  >[0]['functionsConfigManifest']
+  >[0]['functionsConfigManifest'],
+  experimentalAllowBundling?: boolean
 ) {
   const pages = Object.keys(pageSizes);
   const compressedPages: Record<string, PseudoFile> = {};
@@ -520,6 +519,7 @@ function groupPagesBySize(
     initialPseudoLayerUncompressed: 0,
     internalPages: [],
     nodeVersion: { runtime },
+    experimentalAllowBundling,
   });
 }
 
@@ -579,52 +579,32 @@ describe('getGroupMaxUncompressedLambdaSize', () => {
   });
 });
 
-describe('isLargeFunctionsEnabled', () => {
-  afterEach(() => {
-    delete process.env[LARGE_FUNCTIONS_ENV];
-  });
-
-  it('defaults to disabled', () => {
-    delete process.env[LARGE_FUNCTIONS_ENV];
-    expect(isLargeFunctionsEnabled()).toBe(false);
-  });
-
-  it('is enabled when the env var is set', () => {
-    process.env[LARGE_FUNCTIONS_ENV] = '1';
-    expect(isLargeFunctionsEnabled()).toBe(true);
-  });
-});
-
 describe('getPageLambdaGroups large functions', () => {
-  afterEach(() => {
-    delete process.env[LARGE_FUNCTIONS_ENV];
-  });
+  it('never marks a route large when experimentalAllowBundling defers bundling', async () => {
+    const groups = await groupPagesBySize(
+      {
+        'big-a.js': 300 * MiB,
+        'small-1.js': 10 * MiB,
+        'small-2.js': 10 * MiB,
+        'big-b.js': 300 * MiB,
+      },
+      'nodejs22.x',
+      undefined,
+      true
+    );
 
-  it('keeps existing bundling unchanged when the flag is disabled', async () => {
-    delete process.env[LARGE_FUNCTIONS_ENV];
-
-    const groups = await groupPagesBySize({
-      'big-a.js': 300 * MiB,
-      'small-1.js': 10 * MiB,
-      'small-2.js': 10 * MiB,
-      'big-b.js': 300 * MiB,
-    });
-
-    // No group is flagged large, and the two oversized routes are NOT merged
-    // together — each oversized route gets its own (over-limit) group, exactly
-    // as before this feature existed.
+    // Bundling is deferred upstream, so the split is moot: nothing is measured
+    // against the large ceiling, and every route stands alone as before.
     expect(groups.every(g => !g.isLargeFunctions)).toBe(true);
-    const byPages = groups.map(g => g.pages.slice().sort()).sort();
-    expect(byPages).toEqual([
+    expect(groups.map(g => g.pages).sort()).toEqual([
       ['big-a.js'],
       ['big-b.js'],
-      ['small-1.js', 'small-2.js'],
+      ['small-1.js'],
+      ['small-2.js'],
     ]);
   });
 
   it('emits each over-budget route as its own individual large function', async () => {
-    process.env[LARGE_FUNCTIONS_ENV] = '1';
-
     const groups = await groupPagesBySize({
       'big-a.js': 300 * MiB,
       'small-1.js': 10 * MiB,
@@ -651,8 +631,6 @@ describe('getPageLambdaGroups large functions', () => {
   });
 
   it('does not bundle large routes together even when they would fit the ceiling', async () => {
-    process.env[LARGE_FUNCTIONS_ENV] = '1';
-
     const groups = await groupPagesBySize({
       // Together only 600 MiB (well under the 5 GiB ceiling), yet each large
       // route is still emitted as its own function rather than bundled.
@@ -666,8 +644,6 @@ describe('getPageLambdaGroups large functions', () => {
   });
 
   it('never mixes large and normal routes in the same group', async () => {
-    process.env[LARGE_FUNCTIONS_ENV] = '1';
-
     const groups = await groupPagesBySize({
       'big.js': 260 * MiB,
       'small.js': 50 * MiB,
@@ -681,8 +657,6 @@ describe('getPageLambdaGroups large functions', () => {
   });
 
   it('treats a route within the normal packing budget as normal', async () => {
-    process.env[LARGE_FUNCTIONS_ENV] = '1';
-
     const groups = await groupPagesBySize({
       // 200 MiB is under the 225 MiB budget (250 MiB limit − 25 MiB reserved).
       'within-budget.js': 200 * MiB,
@@ -693,8 +667,6 @@ describe('getPageLambdaGroups large functions', () => {
   });
 
   it('treats a route over the packing budget but under the hard limit as large', async () => {
-    process.env[LARGE_FUNCTIONS_ENV] = '1';
-
     const groups = await groupPagesBySize({
       // 240 MiB is under the 250 MiB limit but over the 225 MiB packing budget,
       // so it cannot be guaranteed to fit a normal function (once post-build


### PR DESCRIPTION
Removing the rolled-out `NEXT_EXPERIMENTAL_LARGE_FUNCTIONS` flag reference from the codebase