### PR TITLE
Add fatal error glyph for environment safety

### DIFF
--- a/.changeset/fatal-env-safety-output.md
+++ b/.changeset/fatal-env-safety-output.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a fatal-error glyph for Config and Secret safety failures.

--- a/packages/cli/.agents/skills/cli-ux/SKILL.md
+++ b/packages/cli/.agents/skills/cli-ux/SKILL.md
@@ -112,7 +112,7 @@ A CLI UX change is not done until:
 - resolved target and planned mutation are visible before risky work
 - inferred resource confirmations show the resolved target before asking
 - mutation results show durable remote resources and user-actionable local artifacts changed
-- aligned rows use `printAlignedLabel()` with the shared 16-character label column and correct gutter: `▲` for production rows, `✓` for the primary completed phase, `!` for warnings, blank for previews, progress, and secondary receipt rows
+- aligned rows use `printAlignedLabel()` with the shared 16-character label column and correct gutter: `▲` for production rows, `✓` for the primary completed phase, `!` for warnings, `✗` for fatal errors, blank for previews, progress, and secondary receipt rows
 - every prompt has a flag, argument, or machine-readable action path
 - old vague prompts/output are locked out by tests
 - JSON/agent output remains valid, bounded, and stdout-clean

--- a/packages/cli/.agents/skills/cli-ux/references/command-contracts.md
+++ b/packages/cli/.agents/skills/cli-ux/references/command-contracts.md
@@ -203,6 +203,7 @@ Rules:
 - Use `Name?`, `Store as sensitive?`, `Value?`, `Environments?`, and `Git branch?`.
 - Use `Variable name?` for public-prefix warning choices; use `Value?` for value-warning choices.
 - Public-prefix and value warnings use the warning gutter: `! The NEXT_PUBLIC_ prefix will make API_KEY visible to anyone visiting your site`. Do not use `WARNING!` as a column-0 label.
+- Config/Secret safety hard stops use the fatal-error gutter: `✗ <message>`. Do not print an `!` warning immediately before a fatal error for the same condition; print exactly one fatal message.
 - Keep the sensitive-value explanation as dim inline context on the prompt: `Store as sensitive? Sensitive values cannot be read later`. Do not wrap the hint in parentheses, add trailing punctuation, or print it as a separate row above the prompt.
 - Use checkbox instructions for `Environments?`: `<space> select, <enter> confirm, <a> toggle all, <i> invert` on the prompt line when it fits, with no parentheses.
 - Do not offer Development when the value is sensitive. Do not offer Production/Preview for non-sensitive values when the team policy requires sensitive values there.

--- a/packages/cli/.agents/skills/cli-ux/references/copy.md
+++ b/packages/cli/.agents/skills/cli-ux/references/copy.md
@@ -101,12 +101,13 @@ The canonical product terms in [`core.md`](core.md#voice--copy) override adjacen
 
 Errors include what failed, the constraint or cause when known, and the recovery step when one exists.
 
+- New or touched fatal human errors use the `✗` gutter without an additional `Error:` label. The glyph carries the error state; the sentence carries the meaning.
 - Use `Failed to` or `{Noun} failed` for system, API, build, deploy, network, and infrastructure failures.
 - Use `Couldn't` or `Can't` for validation, permission, and user-state failures.
 - Never use `Unable to`, `An error occurred`, or raw upstream error objects.
 - Preserve an actionable marketplace-partner message with attribution when exact partner wording helps supportability; otherwise translate upstream errors into Vercel voice.
 - Pair platform/system failures with the correctly labeled stable `Request ID`, `Deployment ID`, `Build ID`, `Run ID`, or `Trace ID` when available. Do not add IDs to ordinary validation or permission errors.
-- Warnings state the nonfatal condition, why it matters, and the fix when one exists. Do not warn when the command should fail or stay silent.
+- Warnings use the `!` gutter and state the nonfatal condition, why it matters, and the fix when one exists. Do not warn when the command should fail or stay silent.
 - Never use humor, exclamation marks, or apology preambles in errors.
 
 ## Banned + Avoided Language

--- a/packages/cli/.agents/skills/cli-ux/references/core.md
+++ b/packages/cli/.agents/skills/cli-ux/references/core.md
@@ -182,7 +182,8 @@ Use existing helpers before adding formatting:
 
 - `output.print()` for designed rows
 - `output.log()` only when the gray `> ` prefix is intended
-- `output.warn()` / `output.error()` for warnings/errors when their format matches the target surface; if a warning helper emits a non-target label such as `WARNING!`, use or add a scoped formatted warning row and test it
+- `output.fatal()` for new or touched fatal human errors; it prints the error but does not exit, so the caller still owns the exit code
+- `output.warn()` / `output.error()` for legacy warnings/errors when their format must remain compatible; if a warning helper emits a non-target label such as `WARNING!`, use or add a scoped formatted warning row and test it
 - `output.spinner()` for long-running work
 - `printAlignedLabel()` for target aligned label-value result blocks
 - `table()` for tabular data
@@ -201,7 +202,7 @@ Target aligned result rows:
 
 Rules:
 
-- The first 2 columns are the gutter: either two spaces (`"  "`) or a semantic glyph plus space (`"▲ "`, `"✓ "`, `"! "`).
+- The first 2 columns are the gutter: either two spaces (`"  "`) or a semantic glyph plus space (`"▲ "`, `"✓ "`, `"! "`, `"✗ "`).
 - The gutter is not decoration. Use a glyph only when it carries state; otherwise keep the two-space gutter.
 - label width: 16 chars
 - value column: 18
@@ -215,6 +216,7 @@ Rules:
 - Production rows and production alias rows use `▲`: `▲ Production`, `▲ Aliased`.
 - Primary completed-phase rows use `✓`: `✓ Added`, `✓ Created`, `✓ Linked`, `✓ Removed`, `✓ Updated`, `✓ Overrode`, `✓ Ready`.
 - Warning rows use `!` in the gutter: `! --scope is deprecated. Use --team.` Do not render `WARNING!` starting at column 0; if a command must keep a text warning label for compatibility, indent it after the blank gutter.
+- Fatal error rows use `✗` in the gutter: `✗ Can't add this Secret because the name exposes it to the browser.` Do not also prefix the message with `Error:`.
 - Preview, setup, discovery, progress, settings, local file, and secondary receipt rows keep the blank two-space gutter.
 - Body section headings and detail blocks such as `Changes:`, diff rows, and local file summaries keep the blank two-space gutter. Do not let section headings or `+`/`-` diff markers occupy column 0.
 - URLs are cyan in human output and plain strings in JSON.
@@ -259,9 +261,12 @@ Allowed primary glyphs:
 - `?` active prompt
 - `✓` primary completed phase: completed action, deployment readiness, or terminal wait-state completion
 - `!` warning or nonfatal risk notice
+- `✗` fatal error or failed terminal state
 - `·` inline separator
 - `→` relationship/transition
 - `…` continuing work
+
+Legacy `✘` per-item failure markers may remain where compatibility requires them. `×` is a deletion/diff marker, not a fatal-error glyph. Do not add new meanings for either glyph.
 
 Banned in primary result and progress rows:
 
@@ -276,7 +281,7 @@ Color:
 - dim: paths, hints, metadata, durations
 - green: success only; color the `✓` gutter green when color is enabled, but do not turn secondary receipt rows green
 - yellow: warnings only; color the `!` gutter yellow when color is enabled
-- red: errors only
+- red: errors only; color the `✗` gutter red when color is enabled
 - Target: respect `--no-color` and standard `NO_COLOR`; current handling is narrower, so widen rather than narrow support when touching color handling.
 - Machine output is colorless regardless of color settings.
 - never rely on color, emoji width, or ANSI for required meaning
@@ -341,6 +346,9 @@ Provide --team explicitly. No default is applied in non-interactive mode.
 
 Rules:
 
+- New or touched fatal human errors use `output.fatal()` and the `✗` gutter. Keep legacy `output.error()` output unchanged for incremental migration.
+- `output.fatal()` does not terminate the process. The command must still return or exit with the correct nonzero code.
+- Indent explicit continuation lines after a fatal error with the blank gutter. Terminal wrapping does not need manual indentation.
 - Put the most actionable line last in multi-line errors.
 - Group repeated failures under one explanation.
 - Do not dump stack traces unless `--debug`.

--- a/packages/cli/.agents/skills/cli-ux/references/verification.md
+++ b/packages/cli/.agents/skills/cli-ux/references/verification.md
@@ -21,7 +21,7 @@ When changing CLI UX behavior:
 - cover internal local state files through tests, debug output, machine output, or help text instead of default human success output when they are not user-actionable
 - cover prompt/action separation: values appear in preview rows, then prompts ask for the action
 - cover vertical rhythm: phase breaks use at most one blank line, and related rows remain contiguous
-- cover raw gutter glyphs, not only stripped output: `▲` for production rows, `✓` for the primary completed phase, `!` for warnings, and blank gutter for previews, progress, and secondary receipt rows
+- cover raw gutter glyphs, not only stripped output: `▲` for production rows, `✓` for the primary completed phase, `!` for warnings, `✗` for fatal errors, and blank gutter for previews, progress, and secondary receipt rows
 - cover `--no-color`, `NO_COLOR`, and no ANSI where machine output is involved
 - cover `--yes`, `--force`, typed confirmation, and `--dry-run` when the command family supports them
 - cover retry/no-duplicate behavior for remote mutations
@@ -44,6 +44,7 @@ Before editing shared prompt/output/link helpers, inspect call sites and tests f
 - `setupAndLink()` changes affect direct setup callers and unlinked flows reached through `ensureLink()`, including `vc dev`.
 - `linkFolderToProject()` changes affect any command that links before continuing work, including deploy, dev, pull/env, git connect/disconnect, open, target, and other project-scoped commands.
 - `printAlignedLabel()` changes affect deploy result rows and every command adopting aligned rows.
+- `Output.fatal()` changes affect every command adopting fatal-error rows. Test the helper directly, then test at least one command path for the raw glyph, unchanged nonzero exit, and absence of human output in its machine/JSON path.
 
 Use `rg` before editing and testing:
 
@@ -75,6 +76,15 @@ When warning output changes:
 expect(stripAnsi(output)).toMatch(/^! .+/m);
 expect(stripAnsi(output)).not.toContain('WARNING!');
 ```
+
+When fatal error output changes:
+
+```ts
+expect(stripAnsi(output)).toMatch(/^✗ .+/m);
+expect(stripAnsi(output)).not.toContain('Error:');
+```
+
+Also lock legacy `output.error()` output where untouched so gradual adoption does not become an accidental global change.
 
 For exact blank-gutter spacing, prefer `printAlignedLabel()` unit tests or a direct `output.print` mock:
 
@@ -116,6 +126,7 @@ Reject or fix changes that:
 - put `▲` on preview/setup/link/local file rows, or omit it from production rows
 - use `✓` as decoration, on every row, or on discovery/progress rows instead of only the primary completed phase
 - print warnings with a column-0 `WARNING!` label instead of the warning gutter
+- print a new or touched fatal human error with a column-0 `Error:` label instead of the fatal-error gutter
 - use `scope` where `team` works
 - add emoji to primary result or progress rows
 - put timing on URL rows

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -609,7 +609,7 @@ export default async function add(client: Client, argv: string[]) {
           1
         );
       }
-      output.error(publicPrefixError);
+      output.fatal(publicPrefixError);
       return 1;
     }
   }
@@ -699,7 +699,7 @@ export default async function add(client: Client, argv: string[]) {
             ],
           });
         }
-        output.error(message);
+        output.fatal(message);
         output.print(`  Keep it private:\n    ${privateHumanCommand}\n`);
         output.print(`  Expose it publicly:\n    ${publicHumanCommand}\n`);
         return 1;
@@ -909,11 +909,6 @@ export default async function add(client: Client, argv: string[]) {
     );
     if (matchingLocalPrefix !== undefined && !getPublicPrefix(envName, true)) {
       customSveltePublicPrefix = matchingLocalPrefix;
-      printEnvAddWarning(
-        matchingLocalPrefix === ''
-          ? 'This SvelteKit project uses an empty publicPrefix, so every Environment Variable is exposed to the browser.'
-          : `${matchingLocalPrefix} variables are exposed to the browser by this SvelteKit project.`
-      );
     }
   }
   if (
@@ -931,8 +926,15 @@ export default async function add(client: Client, argv: string[]) {
         1
       );
     }
-    output.error(message);
+    output.fatal(message);
     return 1;
+  }
+  if (customSveltePublicPrefix !== undefined) {
+    printEnvAddWarning(
+      customSveltePublicPrefix === ''
+        ? 'This SvelteKit project uses an empty publicPrefix, so every Environment Variable is exposed to the browser.'
+        : `${customSveltePublicPrefix} variables are exposed to the browser by this SvelteKit project.`
+    );
   }
   const [{ envs }, customEnvironments] = await Promise.all([
     getEnvRecords(client, project.id, 'vercel-cli:env:add'),
@@ -1047,13 +1049,13 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
   if (explicitType === 'secret' && forceEncrypted) {
-    output.error(
+    output.fatal(
       '`--type secret` cannot be used with `--no-sensitive`. Pick one.'
     );
     return 1;
   }
   if (explicitType === 'config' && forceSensitive) {
-    output.error(
+    output.fatal(
       '`--type config` cannot be used with `--sensitive`. Pick one.'
     );
     return 1;
@@ -1506,7 +1508,7 @@ export default async function add(client: Client, argv: string[]) {
         });
       }
       if (opts['--yes']) {
-        output.error(message);
+        output.fatal(message);
         if (publicPrefix !== '') {
           output.print(`  Keep it private:\n    ${privateHumanCommand}\n`);
         }
@@ -1649,7 +1651,7 @@ export default async function add(client: Client, argv: string[]) {
         1
       );
     }
-    output.error(message);
+    output.fatal(message);
     return 1;
   }
 
@@ -1674,7 +1676,7 @@ export default async function add(client: Client, argv: string[]) {
         1
       );
     }
-    output.error(visibilityError);
+    output.fatal(visibilityError);
     return 1;
   }
 

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -48,6 +48,10 @@ function looksLikeCredentialName(
   return looksLikeSecret(publicPrefix ? key.slice(publicPrefix.length) : key);
 }
 
+function printEnvUpdateWarning(message: string): void {
+  output.print(`${chalk.yellow('!')} ${message}\n`);
+}
+
 function selectedEnvTargetsDevelopment(env: ProjectEnvVariable): boolean {
   if (typeof env.target === 'string') return env.target === 'development';
   if (Array.isArray(env.target)) return env.target.includes('development');
@@ -415,11 +419,6 @@ export default async function update(client: Client, argv: string[]) {
     );
     if (matchingLocalPrefix !== undefined && !getPublicPrefix(envName, true)) {
       customSveltePublicPrefix = matchingLocalPrefix;
-      output.warn(
-        matchingLocalPrefix === ''
-          ? 'This SvelteKit project uses an empty publicPrefix, so every Environment Variable is exposed to the browser.'
-          : `${matchingLocalPrefix} variables are exposed to the browser by this SvelteKit project.`
-      );
     }
   }
 
@@ -430,7 +429,7 @@ export default async function update(client: Client, argv: string[]) {
     return 1;
   }
   if (explicitType === 'config' && opts['--sensitive']) {
-    output.error(
+    output.fatal(
       '`--type config` cannot be used with `--sensitive`. Pick one.'
     );
     return 1;
@@ -491,7 +490,7 @@ export default async function update(client: Client, argv: string[]) {
         1
       );
     }
-    output.error(
+    output.fatal(
       `A Secret cannot be changed to Config. Remove the variable, then add it again as Config. ${param(envName)} will be unavailable to new builds between these commands.`
     );
     output.print(`  Remove:\n    ${removeHumanCommand}\n`);
@@ -578,7 +577,7 @@ export default async function update(client: Client, argv: string[]) {
           1
         );
       }
-      output.error(publicPrefixError);
+      output.fatal(publicPrefixError);
       if (addHumanCommand) {
         output.print(
           `  Add the private Secret (prompts for the value):\n    ${addHumanCommand}\n`
@@ -589,6 +588,14 @@ export default async function update(client: Client, argv: string[]) {
       }
       return 1;
     }
+  }
+
+  if (customSveltePublicPrefix !== undefined) {
+    printEnvUpdateWarning(
+      customSveltePublicPrefix === ''
+        ? 'This SvelteKit project uses an empty publicPrefix, so every Environment Variable is exposed to the browser.'
+        : `${customSveltePublicPrefix} variables are exposed to the browser by this SvelteKit project.`
+    );
   }
 
   // Detect team-level sensitive env var policy. Cached in getTeamById.
@@ -850,7 +857,7 @@ export default async function update(client: Client, argv: string[]) {
         1
       );
     }
-    output.error(message);
+    output.fatal(message);
     return 1;
   }
 
@@ -874,7 +881,7 @@ export default async function update(client: Client, argv: string[]) {
         1
       );
     }
-    output.error(visibilityError);
+    output.fatal(visibilityError);
     return 1;
   }
 

--- a/packages/cli/src/util/output/chars.ts
+++ b/packages/cli/src/util/output/chars.ts
@@ -1,6 +1,7 @@
 const chars = {
   tick: process.platform === 'win32' ? '√' : '✔',
   cross: process.platform === 'win32' ? '☓' : '✘',
+  fatal: process.platform === 'win32' ? 'x' : '✗',
 } as const;
 
 export default chars;

--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -7,6 +7,7 @@ import { errorToString } from '@vercel/error-utils';
 import { removeEmoji } from '../emoji';
 import type * as tty from 'tty';
 import { inspect } from 'util';
+import chars from './chars';
 
 const IS_TEST = process.env.NODE_ENV === 'test';
 
@@ -134,6 +135,13 @@ export class Output {
     if (details) {
       this.print(`${chalk.bold(action)}: ${renderLink(details)}\n`);
     }
+  };
+
+  /**
+   * Prints a fatal error. This does not exit; the caller owns the exit code.
+   */
+  fatal = (str: string) => {
+    this.print(`${chalk.red(chars.fatal)} ${str.replace(/\n/g, '\n  ')}\n`);
   };
 
   prettyError = (err: unknown) => {

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -616,7 +616,9 @@ describe('env add', () => {
           '--yes'
         );
         await expect(env(client)).resolves.toBe(1);
-        const output = client.stderr.getFullOutput();
+        const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toMatch(/^✗ /m);
+        expect(output).not.toContain('Error:');
         expect(output).toContain('cannot be a Secret');
         expect(output).toContain(
           'rename the variable to `API_KEY` and keep the Secret type'
@@ -643,6 +645,43 @@ describe('env add', () => {
         await expect(exitCodePromise).resolves.toBe(1);
       });
 
+      it('keeps the fatal glyph out of non-interactive JSON errors', async () => {
+        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('exit');
+        });
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        try {
+          client.nonInteractive = true;
+          client.setArgv(
+            'env',
+            'add',
+            'NEXT_PUBLIC_API_KEY',
+            'production',
+            '--type',
+            'secret',
+            '--value',
+            'my-secret',
+            '--yes',
+            '--non-interactive'
+          );
+
+          await expect(env(client)).rejects.toThrow('exit');
+          const payload = JSON.parse(
+            logSpy.mock.calls[logSpy.mock.calls.length - 1][0]
+          );
+          expect(payload).toMatchObject({
+            status: 'error',
+            reason: 'invalid_type',
+          });
+          expect(JSON.stringify(payload)).not.toContain('✗');
+          expect(client.stderr.getFullOutput()).not.toContain('✗');
+        } finally {
+          exitSpy.mockRestore();
+          logSpy.mockRestore();
+        }
+      });
+
       it('requires an explicit safe path for a credential-like public key with --yes', async () => {
         client.setArgv(
           'env',
@@ -662,6 +701,9 @@ describe('env add', () => {
           '    vercel env add NEXT_PUBLIC_API_KEY production --type config'
         );
         await expect(exitCodePromise).resolves.toBe(1);
+        const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toMatch(/^✗ /m);
+        expect(output).not.toContain('Error:');
       });
 
       it('still prompts for the public-prefix decision when only --value is provided', async () => {
@@ -838,6 +880,9 @@ describe('env add', () => {
 
         await expect(env(client)).resolves.toBe(1);
         const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toMatch(/^✗ /m);
+        expect(output).not.toMatch(/^! /m);
+        expect(output).not.toContain('Error:');
         expect(output).toContain(expected);
         expect(output).toContain('cannot be kept private as a Secret');
         expect(output).toContain(

--- a/packages/cli/test/unit/commands/env/update.test.ts
+++ b/packages/cli/test/unit/commands/env/update.test.ts
@@ -717,7 +717,9 @@ describe('env update', () => {
         );
 
         await expect(env(client)).resolves.toBe(1);
-        const output = client.stderr.getFullOutput();
+        const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toMatch(/^✗ /m);
+        expect(output).not.toContain('Error:');
         expect(output).toContain('cannot be a Secret');
         expect(output).toContain(
           'vercel env add API_KEY production --type secret --project explicit-public-update'
@@ -798,6 +800,9 @@ describe('env update', () => {
 
         await expect(env(client)).resolves.toBe(1);
         const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toMatch(/^✗ /m);
+        expect(output).not.toMatch(/^! /m);
+        expect(output).not.toContain('Error:');
         expect(output).toContain(expected);
         expect(output).toContain('cannot be kept private as a Secret');
         if (expectedCommand) {
@@ -805,6 +810,61 @@ describe('env update', () => {
         } else {
           expect(output).not.toContain('Add the private Secret');
         }
+      });
+
+      it('does not print a SvelteKit warning before a conflicting type error', async () => {
+        client.cwd = setupTmpDir();
+        client.config.currentTeam = 'team_dummy';
+        await writeFile(
+          join(client.cwd, 'svelte.config.js'),
+          "export default { kit: { env: { publicPrefix: 'BROWSER_' } } };\n"
+        );
+        useProject(
+          {
+            ...defaultProject,
+            id: 'svelte-update-conflict',
+            name: 'svelte-update-conflict',
+            accountId: 'team_dummy',
+            framework: 'sveltekit',
+          },
+          [
+            {
+              type: 'encrypted',
+              visibility: 'config',
+              id: 'svelte-config-id',
+              key: 'BROWSER_API_KEY',
+              value: 'old-value',
+              target: ['production'],
+              gitBranch: undefined,
+              configurationId: null,
+              updatedAt: 1557241361455,
+              createdAt: 1557241361455,
+            },
+          ]
+        );
+        client.setArgv(
+          'env',
+          'update',
+          'BROWSER_API_KEY',
+          'production',
+          '--type',
+          'config',
+          '--sensitive',
+          '--value',
+          'new-value',
+          '--yes',
+          '--project',
+          'svelte-update-conflict'
+        );
+
+        await expect(env(client)).resolves.toBe(1);
+        const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toMatch(/^✗ /m);
+        expect(output).toContain(
+          '`--type config` cannot be used with `--sensitive`'
+        );
+        expect(output).not.toMatch(/^! /m);
+        expect(output).not.toContain('Error:');
       });
 
       it('explains the remove-and-add path when a Secret cannot become Config', async () => {
@@ -849,6 +909,8 @@ describe('env update', () => {
 
         await expect(env(client)).resolves.toBe(1);
         const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toMatch(/^✗ /m);
+        expect(output).not.toContain('Error:');
         expect(output).toContain('A Secret cannot be changed to Config');
         expect(output).toContain(
           'API_KEY" will be unavailable to new builds between these commands'

--- a/packages/cli/test/unit/util/output/create-output.test.ts
+++ b/packages/cli/test/unit/util/output/create-output.test.ts
@@ -1,8 +1,71 @@
-import { describe, expect, it } from 'vitest';
+import { PassThrough } from 'stream';
+import type * as tty from 'tty';
+import chalk from 'chalk';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import stripAnsi from 'strip-ansi';
 import output from '../../../../src/output-manager';
+import { Output } from '../../../../src/util/output/create-output';
+
+afterEach(() => {
+  chalk.level = 0;
+});
+
+function createTestOutput(options: { noColor?: boolean } = {}) {
+  const stream = new PassThrough();
+  const testOutput = new Output(stream as unknown as tty.WriteStream, options);
+  return {
+    output: testOutput,
+    read: () => stream.read()?.toString() ?? '',
+  };
+}
 
 describe('Output', () => {
+  describe('fatal()', () => {
+    it('prints a red fatal glyph and indents explicit continuation lines', () => {
+      chalk.level = 1;
+      const testOutput = createTestOutput();
+
+      testOutput.output.fatal('Failed to save.\nRun `vercel env add` again.');
+
+      const value = testOutput.read();
+      expect(value).toContain('\u001b[31m✗\u001b[39m');
+      expect(stripAnsi(value)).toBe(
+        '✗ Failed to save.\n  Run `vercel env add` again.\n'
+      );
+    });
+
+    it('keeps the fatal glyph and removes ANSI when color is disabled', () => {
+      chalk.level = 1;
+      const testOutput = createTestOutput({ noColor: true });
+
+      testOutput.output.fatal('Failed to save.');
+
+      expect(testOutput.read()).toBe('✗ Failed to save.\n');
+    });
+
+    it('does not terminate the process', () => {
+      const exit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation(() => undefined as never);
+      const testOutput = createTestOutput({ noColor: true });
+
+      testOutput.output.fatal('Failed to save.');
+
+      expect(exit).not.toHaveBeenCalled();
+      exit.mockRestore();
+    });
+  });
+
+  describe('error()', () => {
+    it('preserves the legacy Error label', () => {
+      const testOutput = createTestOutput({ noColor: true });
+
+      testOutput.output.error('Failed to save.');
+
+      expect(testOutput.read()).toBe('Error: Failed to save.\n');
+    });
+  });
+
   describe('link()', () => {
     it('should return hyperlink ANSI codes when `supportsHyperlink=true`', () => {
       output.initialize({ supportsHyperlink: true });


### PR DESCRIPTION
Introduces incremental fatal-error UX for the new environment safety hard stops.

- Adds `output.fatal()` with `✗` and a Windows fallback.
- Removes duplicate warnings before fatal SvelteKit public-prefix errors.
- Updates CLI UX guidance and regression tests while preserving legacy `output.error()` and machine JSON.

Stack 3/3. Depends on #17519.