### PR TITLE
[cli] upgrade sandbox to 4.0.0

### DIFF
--- a/.changeset/upgrade-sandbox-4.md
+++ b/.changeset/upgrade-sandbox-4.md
@@ -1,0 +1,9 @@
+---
+'vercel': minor
+---
+
+Upgrade the bundled Sandbox CLI from 3.4.0 to 4.0.0.
+
+This changes the default base image for sandboxes created without an explicit `--image` or `--runtime`. The previous default was the `node24` runtime on Amazon Linux 2023; the new default is `vercel/sandbox/universal`, which is based on Ubuntu and includes Node.js 24, Bun, Python 3.14, coding agents, and common development and debugging tools. `--runtime` is deprecated in favor of `--image`, and existing `--runtime` calls continue to work through the legacy v2 API.
+
+The pin had been frozen at 3.4.0 since 2026-07-03 because the `update-sandbox` workflow that bumps it has never run, so `vercel sandbox` and a standalone `sandbox` install of the same vintage booted different operating systems from an identical command.

--- a/.changeset/upgrade-sandbox-4.md
+++ b/.changeset/upgrade-sandbox-4.md
@@ -2,8 +2,14 @@
 'vercel': minor
 ---
 
-Upgrade the bundled Sandbox CLI from 3.4.0 to 4.0.0.
+Upgrade the bundled Sandbox CLI from 3.4.0 to 4.0.0, catching up 10 stable releases. Behavior changes that reach `vercel sandbox` users:
 
-This changes the default base image for sandboxes created without an explicit `--image` or `--runtime`. The previous default was the `node24` runtime on Amazon Linux 2023; the new default is `vercel/sandbox/universal`, which is based on Ubuntu and includes Node.js 24, Bun, Python 3.14, coding agents, and common development and debugging tools. `--runtime` is deprecated in favor of `--image`, and existing `--runtime` calls continue to work through the legacy v2 API.
+- **`fork` now copies the source sandbox's environment variables.** 3.4.0 documented the opposite ("env vars are NOT copied and must be re-supplied via `--env`"); `Sandbox.fork()` now calls `POST /v2/sandboxes/:name/fork`, which copies env and image server-side (SDK 2.9.0, sandbox#259). Anything secret in a source sandbox propagates into forks by default. Flags passed to `fork` override the copied values.
+- **The default base image changes.** Sandboxes created without `--image` or `--runtime` previously used the `node24` runtime on Amazon Linux 2023; they now use `vercel/sandbox/universal`, based on Ubuntu with Node.js 24, Bun, Python 3.14, coding agents, and common development and debugging tools. `--runtime` is deprecated in favor of `--image` and existing `--runtime` calls keep working through the legacy v2 API. Pass `--image vercel/sandbox/node:24` for an Ubuntu-based equivalent of the old default.
+- **`sandbox list` renames the `RUNTIME` column to `RUNTIME/IMAGE`**, falling back to the image reference for image-based sandboxes (3.5.0, sandbox#253). This breaks anything parsing that output.
+- **`sandbox sh` is no longer deprecated** (3.4.1, sandbox#241).
+- **Default API call retries are reduced** (SDK 2.7.1, sandbox#254).
+- Transient authorization failures are retried after refreshing a stored access token (3.4.3, sandbox#247).
+- Help examples use the invoked app name, so `vercel sandbox --help` shows `vercel sandbox ...` rather than the standalone `sandbox ...` form that is not on PATH for Vercel CLI users (sandbox#269).
 
-The pin had been frozen at 3.4.0 since 2026-07-03 because the `update-sandbox` workflow that bumps it has never run, so `vercel sandbox` and a standalone `sandbox` install of the same vintage booted different operating systems from an identical command.
+The pin had been frozen at 3.4.0 since 2026-07-03 because the `update-sandbox` workflow that bumps it has never run, so `vercel sandbox` and a current standalone `sandbox` install booted different operating systems from an identical command.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,7 +77,7 @@
     "jose": "5.9.6",
     "jsonc-parser": "3.3.1",
     "luxon": "^3.4.0",
-    "sandbox": "3.4.0",
+    "sandbox": "4.0.0",
     "smol-toml": "1.5.2",
     "undici": "5.29.0",
     "zod": "4.1.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,8 +576,8 @@ importers:
         specifier: ^3.4.0
         version: 3.7.2
       sandbox:
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 4.0.0
+        version: 4.0.0
       smol-toml:
         specifier: 1.5.2
         version: 1.5.2
@@ -6772,8 +6772,8 @@ packages:
   '@vercel/sandbox@1.10.2':
     resolution: {integrity: sha512-rWhYfIyW0Va0gFxtz434LhVirV+eQs+AK0QQWtsOPw2oTvOSA4iogQqemRqvRPPbqI8nfZOz6kbCsytVa20gdw==}
 
-  '@vercel/sandbox@2.4.0':
-    resolution: {integrity: sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==}
+  '@vercel/sandbox@3.0.0':
+    resolution: {integrity: sha512-1pF3id7LIG2GfjkEAZW+ZngMDdywJw7aFLOyIlry/lj8v3b4GMn3WCuBbvG4N4wTmYUfFzHaVHfdwVpqALEFkw==}
 
   '@vercel/sdk@1.21.8':
     resolution: {integrity: sha512-6qWQdWk/DaC24m2krcHUtdqCKn5/6mEgW5vVsHPxQj5MPNh9lftw5VnwlAgmKO+6kh2Tazd9JnqDqbZM/X5jkg==}
@@ -9694,9 +9694,6 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  jose@5.10.0:
-    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
-
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
 
@@ -11541,8 +11538,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sandbox@3.4.0:
-    resolution: {integrity: sha512-JPdADikobt6zFuuCRhl6whNrCJlLPxpUmT/hNxLij70mkpeejHKDN+HeVlrdHI8snDTzRIiF3Ye8KyMIyVWA+A==}
+  sandbox@4.0.0:
+    resolution: {integrity: sha512-3fNfxSmRJpoCGF3wBncPjxypKYmgtleaAYgyhMrowBpp83388gIELSQ4evIPt1sP+fa6gnn0wRr8CBnUneFzRQ==}
     hasBin: true
 
   scheduler@0.23.2:
@@ -12998,10 +12995,6 @@ packages:
   xdg-app-paths@5.1.0:
     resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
     engines: {node: '>=6'}
-
-  xdg-app-paths@5.5.1:
-    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
-    engines: {node: '>= 6.0'}
 
   xdg-portable@7.3.0:
     resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
@@ -17122,7 +17115,7 @@ snapshots:
 
   '@vercel/cli-config@0.2.1':
     dependencies:
-      xdg-app-paths: 5.5.1
+      xdg-app-paths: 5.1.0
       zod: 4.1.11
     optional: true
 
@@ -17209,7 +17202,7 @@ snapshots:
     dependencies:
       '@vercel/cli-config': 0.2.1
       '@vercel/cli-exec': 1.0.0
-      jose: 5.10.0
+      jose: 5.9.6
     optional: true
 
   '@vercel/prepare-flags-definitions@0.3.0': {}
@@ -17230,7 +17223,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vercel/sandbox@2.4.0':
+  '@vercel/sandbox@3.0.0':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@workflow/serde': 4.1.0-beta.2
@@ -20706,9 +20699,6 @@ snapshots:
 
   jju@1.4.0: {}
 
-  jose@5.10.0:
-    optional: true
-
   jose@5.9.6: {}
 
   jose@6.2.3: {}
@@ -22814,9 +22804,9 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sandbox@3.4.0:
+  sandbox@4.0.0:
     dependencies:
-      '@vercel/sandbox': 2.4.0
+      '@vercel/sandbox': 3.0.0
       async-retry: 1.3.3
       debug: 4.4.3(supports-color@8.1.1)
       ws: 8.21.0
@@ -24641,12 +24631,6 @@ snapshots:
   xdg-app-paths@5.1.0:
     dependencies:
       xdg-portable: 7.3.0
-
-  xdg-app-paths@5.5.1:
-    dependencies:
-      os-paths: 4.4.0
-      xdg-portable: 7.3.0
-    optional: true
 
   xdg-portable@7.3.0:
     dependencies:


### PR DESCRIPTION
## summary

The bundled `sandbox` pin has been frozen at `3.4.0` since it was published on 2026-07-03. `sandbox@4.0.0` is latest and 10 stable releases have shipped past the pin (3.4.1, 3.4.2, 3.4.3, 3.5.0–3.5.5, 4.0.0).

Because the pin is exact and `packages/cli/src/commands/sandbox/index.ts` does `await import('sandbox')`, `vercel sandbox` and a current standalone `sandbox` install boot **different operating systems from an identical command**. Measured on `vercel` 58.9.0, same account and project, no `--image` and no `--runtime` so each used its own default:

| | `vercel sandbox run` (bundled 3.4.0) | `sandbox run` (4.0.0) |
| --- | --- | --- |
| OS | Amazon Linux 2023.12.20260727 | Ubuntu 26.04 LTS |
| node | v24.14.1 | v24.19.0 |
| bun | absent | 1.3.14 |
| python | 3.9.25 | 3.14.4 |

The bundled CLI also can't show you which you got: `vercel sandbox list` still has the pre-3.5.0 `RUNTIME` column, so it prints `node24` where `sandbox ls` prints `vercel/sandbox/universal@sha256:0e3e3617e824…`.

## changes

- `packages/cli/package.json`: `sandbox` `3.4.0` → `4.0.0`
- `pnpm-lock.yaml`: see the lockfile section below
- changeset marked `minor`, and it enumerates the behavior changes rather than describing this as a routine bump — see below

## behavior changes that reach users

Full list is in the changeset. The one worth a reviewer's attention:

**`fork` now copies the source sandbox's environment variables.** 3.4.0's own help text says the opposite — "env vars are NOT copied and must be re-supplied via `--env`" — while 4.0.0 says "Copies config (cpu, timeout, network policy, tags, env vars, etc.)". `Sandbox.fork()` now calls `POST /v2/sandboxes/:name/fork`, which copies env and image server-side (SDK 2.9.0, vercel/sandbox#259). So anything secret in a source sandbox propagates into forks by default, where previously it deliberately did not.

Also: the default base image changes to `vercel/sandbox/universal` (Ubuntu) from the `node24` runtime (Amazon Linux 2023); `sandbox list` renames `RUNTIME` to `RUNTIME/IMAGE`, which breaks output parsing; `sandbox sh` is un-deprecated; default API retries are reduced.

Since this changes what `vercel sandbox create` produces by default and how `fork` handles secrets, it wants an explicit ack from whoever owns the CLI's sandbox surface rather than treating it as a dep bump.

## lockfile

The committed diff is 38 lines / 11 hunks. A clean `pnpm install --lockfile-only` today produces 296 lines / 62 hunks. **This is not byte-reproducible — if you regenerate it you will get a different file.** Why, and why I kept the smaller one:

- The extra churn is a `minimumReleaseAge: 2880` (2-day) window in `pnpm-workspace.yaml:9`. `minimumReleaseAgeExclude` lists `sandbox` and `@vercel/*`, so the packages this PR actually bumps resolve deterministically, while unrelated peer chains resolve differently depending on when you run it. It re-resolved `@emnapi/runtime` 1.10.0 → 1.11.3 across the oxc/rolldown/tsdown wasm bindings and downgraded `vite` 7.1.7 → 5.1.8 under `@react-router/dev`. None of that belongs in a pin bump, so I dropped those hunks.
- Beyond the sandbox packages, the committed diff also contains two dedupes onto versions already in the tree: `jose` 5.10.0 → 5.9.6 under `@vercel/oidc@3.8.1` (legal under `^5.9.6`) and `xdg-app-paths` 5.5.1 → 5.1.0 under `@vercel/cli-config@0.2.1` (legal under `"5"`), plus deletion of the two orphaned entries. Both are optional subtrees.
- `pnpm install --lockfile-only` against the committed lockfile is a 0-diff no-op, so CI's non-frozen install won't rewrite it and the `--frozen-lockfile` release jobs won't fail.
- Integrity was checked against the real tarballs: computed sha512 for `sandbox@4.0.0` and `@vercel/sandbox@3.0.0` both match the committed values. (Noting for anyone reusing the technique: `pnpm install --frozen-lockfile` exiting 0 does **not** validate integrity hashes — it only checks package.json/lockfile agreement. A deliberately corrupted hash still passes it.)

Happy to replace this with a clean regen if you'd rather have reproducibility than a reviewable diff.

## verification

- A real full `pnpm install --frozen-lockfile` succeeds and installs `sandbox` 4.0.0 and `@vercel/sandbox` 3.0.0.
- End-to-end: swapping the bundled 3.4.0 → 4.0.0 into an installed `vercel` 58.9.0 gives `vercel sandbox --version` → `4.0.0` (exit 0), and `vercel sandbox --help` now prints `$ vercel sandbox sh` where 3.4.0 printed `$ sandbox create --connect`, so the vercel/sandbox#269 fix lands.
- Not tested: a build from monorepo source. `scripts/build.mjs` needs unbuilt `@vercel/build-utils`, and `turbo build --filter=vercel...` fails at `@vercel/python-analysis#build`, unrelated to this change.
- Current CI failures on this PR are pre-existing on main, not caused by it: the `connex` help snapshot drift under `Unit / CLI (win/node22)` fails identically on #17502 and #17499, and `Lint GitHub Actions` fails zizmor `ref-version-mismatch` on `dtolnay/rust-toolchain` pins, also failing on #17513. This PR touches no workflow files. It can't go green until the snapshot drift is fixed on main.

## root cause, not fixed here

`.github/workflows/update-sandbox.yml` should have kept this current. It is `workflow_dispatch`-only and **has never run** — `GET /repos/vercel/vercel/actions/workflows/update-sandbox.yml/runs` returns `total_count: 0`. #16991 restores it and has been open since 2026-07-09.

**This PR is a one-time catch-up. Without that, the pin drifts again.** A scheduled CI check that fails when the pin trails npm latest looks like the better companion fix than ranging the pin: a range makes builds non-reproducible, and it needs no bot secret and no auto-merge, so it routes around what's blocking #16991. Separately, `update-sandbox.yml:58` hardcodes `'vercel': patch` for every bump, including majors like this one.

Also flagging #16982 and #16990 — if a native `vercel sandbox` lands, the bundled-dep approach may go away and this bump becomes moot.