### PR TITLE
ci: remove GitHub Actions-level test retry loops

### DIFF
--- a/.changeset/no-ci-layer-test-retries.md
+++ b/.changeset/no-ci-layer-test-retries.md
@@ -1,0 +1,4 @@
+---
+---
+
+Removed the GitHub Actions-level test retry loops from the unit and E2E test jobs so a failing test suite fails on its first attempt. Retries do not belong in the CI layer; any retrying should live in source code.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -347,33 +347,17 @@ jobs:
       - name: Test ${{matrix.packageName}}
         timeout-minutes: 25
         run: |
-          attempt=1
-          max_attempts=2
           export NODE_OPTIONS="--require=${GITHUB_WORKSPACE}/utils/dd-trace-ci-init.js"
 
-          while [ "$attempt" -le "$max_attempts" ]; do
-            echo "Running tests (attempt $attempt/$max_attempts): ${{matrix.testScript}} ${{matrix.packageName}}"
+          echo "Running tests: ${{matrix.testScript}} ${{matrix.packageName}}"
 
-            # When VITEST_TEST_FILES is set, the test script reads paths from that env var
-            # instead of CLI args, avoiding the Windows cmd.exe ~8191 char arg limit.
-            if [ -n "$VITEST_TEST_FILES" ]; then
-              run_cmd="node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir='.turbo' --log-order=stream --filter=${{matrix.packageName}}"
-            else
-              run_cmd="node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir='.turbo' --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}"
-            fi
-
-            if eval "$run_cmd"; then
-              exit 0
-            fi
-
-            if [ "$attempt" -eq "$max_attempts" ]; then
-              echo "Tests failed after $max_attempts attempts."
-              exit 1
-            fi
-
-            echo "Tests failed; retrying once..."
-            attempt=$((attempt+1))
-          done
+          # When VITEST_TEST_FILES is set, the test script reads paths from that env var
+          # instead of CLI args, avoiding the Windows cmd.exe ~8191 char arg limit.
+          if [ -n "$VITEST_TEST_FILES" ]; then
+            node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir='.turbo' --log-order=stream --filter=${{matrix.packageName}}
+          else
+            node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir='.turbo' --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}
+          fi
         shell: bash
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -541,25 +525,10 @@ jobs:
       - name: Test ${{matrix.packageName}}
         timeout-minutes: 35
         run: |
-          attempt=1
-          max_attempts=2
           export NODE_OPTIONS="--require=${GITHUB_WORKSPACE}/utils/dd-trace-ci-init.js"
 
-          while [ "$attempt" -le "$max_attempts" ]; do
-            echo "Running tests (attempt $attempt/$max_attempts): ${{matrix.testScript}} ${{matrix.packageName}}"
-
-            if node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}; then
-              exit 0
-            fi
-
-            if [ "$attempt" -eq "$max_attempts" ]; then
-              echo "Tests failed after $max_attempts attempts."
-              exit 1
-            fi
-
-            echo "Tests failed; retrying once..."
-            attempt=$((attempt+1))
-          done
+          echo "Running tests: ${{matrix.testScript}} ${{matrix.packageName}}"
+          node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}
         shell: bash
         env:
           # Per-package pip install specs (e.g. VERCEL_RUNTIME_PYTHON,


### PR DESCRIPTION
## Why

Both test jobs in `.github/workflows/test.yml` wrapped their test command in a bash retry loop and ran the suite up to twice:

```
Running tests (attempt 1/2): test @vercel/fs-detectors
...
Tests failed; retrying once...
Running tests (attempt 2/2): test @vercel/fs-detectors
```

A first-attempt failure was swallowed and the step only went red if the second run also failed. That is the wrong layer for this behavior:

- it hides flakes from the exact signal we use to gate merges, so a test that fails half the time reads as green;
- it doubles the wall-clock cost of a job that is genuinely broken (a 25-minute unit chunk becomes 50, a 35-minute E2E chunk becomes 70);
- the retry is unscoped — it re-runs the whole chunk, not the one operation that was actually flaky.

If retrying is necessary, it belongs in source code, scoped to the operation that is actually unreliable (as `utils/determine-release.mjs` already does for its `npm view` lookup).

## What changed

- **`unit-test` → `Test <package>`**: dropped the `attempt`/`max_attempts` `while` loop and the `run_cmd` + `eval` indirection it required. The `VITEST_TEST_FILES` branch (which avoids the Windows `cmd.exe` ~8191-char arg limit) is preserved and now invokes `turbo` directly.
- **`e2e-test` → `Test <package>`**: dropped the same loop; the step runs the suite once.

Both steps keep their `NODE_OPTIONS` Datadog preload, `env` blocks, and `timeout-minutes` unchanged, and now match the single-run shape already used by the equivalent steps in `.github/workflows/nightly-test-no-cache.yml`.

These were the only two occurrences of Actions-level retry in the repo — `grep -rni 'retry\|retries\|max_attempts' .github/` comes back clean, and no third-party retry actions (`nick-fields/retry`, `Wandalen/wretry`) are in use.

## Deliberately left alone

The `for attempt in {1..120}` loops in the E2E jobs (`test.yml`, `nightly-test-no-cache.yml`) that poll for `\$DPL_URL/tarballs/vercel.tgz`. Those are a wait-for-readiness barrier on an asynchronous deployment, not a retry of a failed command — they don't mask a failure, and removing them would leave the E2E jobs with no way to wait for the tarball they install. Happy to move them into a Node helper under `utils/` in a follow-up if you'd rather have zero polling loops in YAML.

Note that the `Run attempt=1` line in the reported log is emitted by the GitHub runner itself for the job's run attempt; it isn't produced by anything in this repo.

## Verification

- All `.github/workflows/*.yml` still parse under `js-yaml` (same parse CI's `lint-actions` job does with `pyyaml`).
- Both rewritten step scripts pass `bash -n` with the `${{ }}` expressions substituted.
- Simulated exit-code propagation under the runner's `bash --noprofile --norc -eo pipefail`: the step exits 0 only when both `node utils/gen.js` and `turbo run` succeed, and exits 1 otherwise — in both the `VITEST_TEST_FILES` and CLI-args branches.
- `prettier --check` on `.github/workflows/test.yml` was already failing on `main` and is unchanged here; CI's format check (`biome`) does not cover `.github/`.

## Expected effect

Flaky tests that were previously papered over will now turn CI red. That's the point — the fix for each one is a source-level fix (or a targeted, in-code retry), not a blanket re-run of the chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)