### PR TITLE
Add Config and Secret environment foundations

### DIFF
--- a/.changeset/fresh-env-secret-foundations.md
+++ b/.changeset/fresh-env-secret-foundations.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add shared Config and Secret Environment Variable safety utilities.

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -75,6 +75,8 @@ export interface Team {
    * Preview Environment Variables to `sensitive` on create.
    */
   sensitiveEnvironmentVariablePolicy?: 'default' | 'on' | 'off';
+  /** Require Production Secret values to be stored separately. */
+  disjunctiveProductionSecretPolicy?: 'default' | 'on' | 'off';
 }
 
 export type Domain = {

--- a/packages/cli/src/util/env/env-var-config-secret-ui.ts
+++ b/packages/cli/src/util/env/env-var-config-secret-ui.ts
@@ -1,12 +1,13 @@
 import type { ProjectEnvType } from '@vercel-internals/types';
-import { getPublicPrefix } from './validate-env';
+import { getApiPublicPrefix } from './validate-env';
 
 export type EnvVariableVisibility = 'config' | 'secret';
 
 /**
  * Opt-in CLI support for the config/secret env var model (dashboard flag:
  * `env-var-config-secret-ui`). When enabled, the CLI skips legacy Sensitive
- * Environment Variables Policy coercion. Development still disallows secrets.
+ * Environment Variables Policy coercion. The API allows Secret variables in
+ * Development while this model is enabled.
  */
 export function isEnvVarConfigSecretUiEnabled(): boolean {
   const raw = process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
@@ -19,7 +20,7 @@ export function shouldEnforceSensitiveEnvVarPolicy(policyOn: boolean): boolean {
   return policyOn && !isEnvVarConfigSecretUiEnabled();
 }
 
-/** Human-readable visibility for CLI output. */
+/** Human-readable type for CLI output. */
 export function formatVisibilityLabel(
   visibility: EnvVariableVisibility | undefined,
   type: ProjectEnvType
@@ -47,10 +48,6 @@ export function visibilityFromEnvType(
   return undefined;
 }
 
-function hasNonDevelopmentTarget(envTargets: string[]): boolean {
-  return envTargets.some(target => target !== 'development');
-}
-
 /**
  * Returns a client-side error when a public-prefixed key cannot use secret
  * visibility (matches API `getConfigSecretValidationError` rules).
@@ -60,10 +57,10 @@ export function getPublicPrefixSecretVisibilityError(
   options: {
     visibility?: EnvVariableVisibility;
     type: ProjectEnvType;
-    envTargets: string[];
+    context?: 'add' | 'update';
   }
 ): string | null {
-  const publicPrefix = getPublicPrefix(key);
+  const publicPrefix = getApiPublicPrefix(key);
   if (!publicPrefix) {
     return null;
   }
@@ -74,60 +71,11 @@ export function getPublicPrefixSecretVisibilityError(
     return null;
   }
 
-  const prefixLabel = publicPrefix.replace(/_$/, '');
-  if (hasNonDevelopmentTarget(options.envTargets)) {
-    return `Environment variables with a public framework prefix (${prefixLabel}) cannot use secret visibility on Production or Preview. Target Development only, rename to remove the public prefix, or use \`--visibility config\` with \`--no-sensitive\` on Development.`;
+  const privateKey = key.slice(publicPrefix.length);
+  if (options.context === 'update') {
+    return `\`${publicPrefix}\` exposes this value to anyone visiting your site, so \`${key}\` cannot be a Secret. To keep it private, add \`${privateKey}\` as a Secret, then remove \`${key}\`. If the value is safe to expose, keep it as Config.`;
   }
-
-  return `Environment variables with a public framework prefix (${prefixLabel}) cannot use secret visibility. Rename to remove the public prefix or use \`--visibility config\` with \`--no-sensitive\`.`;
-}
-
-/**
- * Returns a client-side error when secrets are requested for Development.
- */
-export function getDevelopmentSecretVisibilityError(
-  envTargets: string[],
-  options: {
-    type: ProjectEnvType;
-    visibility?: EnvVariableVisibility;
-  }
-): string | null {
-  if (!envTargets.includes('development')) {
-    return null;
-  }
-
-  const wouldBeSecret =
-    options.type === 'sensitive' || options.visibility === 'secret';
-  if (!wouldBeSecret) {
-    return null;
-  }
-
-  const hasNonDevelopment = envTargets.some(target => target !== 'development');
-  if (hasNonDevelopment) {
-    return `Sensitive Environment Variables are not supported on the Development Environment. Add --no-sensitive to store a non-sensitive value for all selected Environments, or run \`vercel env add\` separately for Development.`;
-  }
-
-  return `--sensitive is not allowed with the Development Environment. Sensitive Environment Variables are only supported on Production and Preview.`;
-}
-
-/**
- * Omits inferred visibility for public-prefixed keys only when the API team
- * policy will force-coerce type to sensitive (cannot safely set visibility).
- */
-function shouldOmitInferredVisibility(
-  key: string,
-  envTargets: string[],
-  teamSensitivePolicyOn: boolean
-): boolean {
-  if (!getPublicPrefix(key)) {
-    return false;
-  }
-
-  if (!hasNonDevelopmentTarget(envTargets)) {
-    return false;
-  }
-
-  return teamSensitivePolicyOn;
+  return `\`${publicPrefix}\` exposes this value to anyone visiting your site, so \`${key}\` cannot be a Secret. To keep it private, rename the variable to \`${privateKey}\` and keep the Secret type. If the value is safe to expose, use \`--type config\`.`;
 }
 
 export interface ResolveEnvVarVisibilityOptions {
@@ -145,7 +93,7 @@ export interface ResolveEnvVarVisibilityResult {
 }
 
 /**
- * Resolves `visibility` for API requests. Uses `--visibility` when set;
+ * Resolves `visibility` for API requests. Uses `--type` when set;
  * otherwise infers from `type` unless that would fail for public-prefixed keys.
  */
 export function resolveEnvVarVisibility(
@@ -161,7 +109,13 @@ export function resolveEnvVarVisibility(
       options.explicitVisibility !== 'secret'
     ) {
       return {
-        error: 'The `--visibility` flag must be either `config` or `secret`.',
+        error:
+          options.explicitVisibility === 'sensitive'
+            ? 'The `--type` flag accepts `config` or `secret`. Use `--type secret` or the legacy `--sensitive` flag.'
+            : options.explicitVisibility === 'plain' ||
+                options.explicitVisibility === 'encrypted'
+              ? 'The `--type` flag accepts `config` or `secret`. Use `--type config` for readable values.'
+              : 'The `--type` flag must be either `config` or `secret`.',
       };
     }
 
@@ -170,22 +124,10 @@ export function resolveEnvVarVisibility(
       {
         visibility: options.explicitVisibility,
         type: options.type,
-        envTargets: options.envTargets,
       }
     );
     if (publicPrefixError) {
       return { error: publicPrefixError };
-    }
-
-    const developmentError = getDevelopmentSecretVisibilityError(
-      options.envTargets,
-      {
-        type: options.type,
-        visibility: options.explicitVisibility,
-      }
-    );
-    if (developmentError) {
-      return { error: developmentError };
     }
 
     return { visibility: options.explicitVisibility };
@@ -196,31 +138,9 @@ export function resolveEnvVarVisibility(
     return {};
   }
 
-  const developmentError = getDevelopmentSecretVisibilityError(
-    options.envTargets,
-    {
-      type: options.type,
-      visibility: inferred,
-    }
-  );
-  if (developmentError) {
-    return { error: developmentError };
-  }
-
-  if (
-    shouldOmitInferredVisibility(
-      options.key,
-      options.envTargets,
-      options.teamSensitivePolicyOn
-    )
-  ) {
-    return {};
-  }
-
   const publicPrefixError = getPublicPrefixSecretVisibilityError(options.key, {
     visibility: inferred,
     type: options.type,
-    envTargets: options.envTargets,
   });
   if (publicPrefixError) {
     return { error: publicPrefixError };

--- a/packages/cli/src/util/env/secret-detection.ts
+++ b/packages/cli/src/util/env/secret-detection.ts
@@ -1,0 +1,232 @@
+import type { ProjectEnvType } from '@vercel-internals/types';
+
+// Keep these heuristics aligned with the dashboard's secret-key-detection.ts.
+const SERVER_ONLY_KEY_PATTERNS = [
+  'access_token',
+  'refresh_token',
+  'client_secret',
+  'webhook_secret',
+  'api_key',
+  'private_key',
+  'service_account',
+  'service_role',
+  'database_url',
+  'database_uri',
+  'db_url',
+  'postgres_url',
+  'postgres_uri',
+  'mysql_url',
+  'mongo_url',
+  'mongo_uri',
+  'redis_url',
+  'redis_uri',
+  'amqp_url',
+  'kafka_url',
+  'elasticsearch_url',
+  'password',
+  'passwd',
+  'pwd',
+  'secret',
+  'private',
+  'key',
+  'apikey',
+  'auth',
+  'token',
+  'jwt',
+  'signature',
+  'cert',
+  'pem',
+  'salt',
+  'bearer',
+  'credential',
+  'credentials',
+  'creds',
+] as const;
+
+const SAFE_KEY_HINT_TOKENS = ['public', 'publishable', 'anon'];
+
+const WELL_KNOWN_SECRET_NAMES = new Set([
+  'DATABASE_URL',
+  'DATABASE_URL_UNPOOLED',
+  'POSTGRES_URL',
+  'POSTGRES_URL_NON_POOLING',
+  'POSTGRES_URL_NO_SSL',
+  'POSTGRES_URL_UNPOOLED',
+  'POSTGRES_PRISMA_URL',
+  'MONGODB_URI',
+  'MONGODB_URL',
+  'MONGO_URI',
+  'MONGO_URL',
+  'MYSQL_URL',
+  'MYSQL_URI',
+  'REDIS_URL',
+  'REDIS_TLS_URL',
+  'KV_URL',
+  'KV_REST_API_URL',
+  'UPSTASH_REDIS_REST_URL',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'AWS_ACCESS_KEY_ID',
+]);
+
+const SECRET_SEGMENT_PATTERN =
+  /(?:^|[_-])(SECRET|PASSWORD|PASSWD|PASSPHRASE|PWD|PGPASSWORD|TOKEN|CREDENTIAL|JWT|DSN|APIKEY|PRIVATEKEY|SALT|PEPPER|MNEMONIC|PEM|CIPHER)S?(?:[_-]|$)/i;
+const EXPLICIT_SECRET_TOKEN_PATTERN =
+  /(?:^|[_-])(SECRET|PASSWORD|PASSWD|PASSPHRASE|PWD|PGPASSWORD|TOKEN|CREDENTIAL|MNEMONIC|PRIVATEKEY|APIKEY)S?(?:[_-]|$)/i;
+const SECRET_COMPOUND_PATTERNS = [
+  /(?:^|[_-])(?:API|PRIVATE|SIGNING|ENCRYPTION|SESSION|COOKIE|CSRF|HMAC|ACCESS|APP|WRITE)[_-]?(?:KEY|SECRET)S?(?:[_-]|$)/i,
+  /(?:^|[_-])(?:ACCESS|REFRESH|BEARER|AUTH)[_-]?TOKENS?(?:[_-]|$)/i,
+  /(?:^|[_-])(?:WEBHOOK|SIGNING)[_-]?SECRETS?(?:[_-]|$)/i,
+  /(?:^|[_-])SERVICE[_-]?(?:ROLE(?:[_-]?KEYS?)?|ACCOUNTS?)(?:[_-]|$)/i,
+];
+const NON_CREDENTIAL_KEY_TOKENS = new Set([
+  'PUBLIC',
+  'PUBLISHABLE',
+  'ANON',
+  'PRIMARY',
+  'PARTITION',
+  'FOREIGN',
+  'SORT',
+  'HASH',
+  'COMPOSITE',
+  'INDEX',
+  'UNIQUE',
+  'NATURAL',
+  'SURROGATE',
+  'CACHE',
+  'IDEMPOTENCY',
+  'LOOKUP',
+  'ROW',
+  'SHARD',
+  'CLUSTER',
+  'LICENSE',
+  'LICENCE',
+  'PRODUCT',
+  'TRANSLATION',
+  'TRANSLATIONS',
+  'I18N',
+  'LOCALE',
+  'RBAC',
+  'ACL',
+  'ROLE',
+  'ROLES',
+  'PERMISSION',
+  'PERMISSIONS',
+  'SCOPE',
+  'SCOPES',
+  'POLICY',
+  'POLICIES',
+]);
+const GENERIC_KEY_SUFFIX_PATTERN = /(?:^|[_-])([A-Z0-9]+)[_-]KEYS?$/i;
+const DB_URL_PATTERN =
+  /(?:^|_)(?:DATABASE|POSTGRES|MONGO|MONGODB|MYSQL|REDIS|NEON|PLANETSCALE|TURSO|RDS)(?:_[A-Z0-9_]*)?_(?:URL|URI)(?:_[A-Z0-9_]+)?$/i;
+
+const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
+  /gh[opsru]_[A-Za-z0-9_]{20,}/,
+  /github_pat_[A-Za-z0-9_]{20,}/,
+  /glpat-[A-Za-z0-9_-]{20,}/,
+  /(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{20,}/,
+  /whsec_[A-Za-z0-9]{20,}/,
+  /xox[abprs]-[A-Za-z0-9-]{20,}/,
+  /xapp-[A-Za-z0-9-]{20,}/,
+  /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/,
+  /\bAIza[A-Za-z0-9_-]{30,}/,
+  /sk-ant-[A-Za-z0-9_-]{20,}/,
+  /sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}/,
+  /\bsk-[A-Za-z0-9]{32,}\b/,
+  /shp(?:at|ss|ca)_[a-fA-F0-9]{32}/,
+  /npm_[A-Za-z0-9]{30,}/,
+  /\bhf_[A-Za-z0-9]{30,}/,
+  /nvapi-[A-Za-z0-9_-]{40,}/,
+  /SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/,
+  /key-[a-f0-9]{32}/,
+  /glsa_[A-Za-z0-9_]{32}_[a-f0-9]{8}/,
+  /pscale_pw_[A-Za-z0-9_-]{20,}/,
+  /\bre_[A-Za-z0-9_]{30,}/,
+  /dop_v1_[a-f0-9]{64}/,
+  /sntrys_[A-Za-z0-9_-]{30,}/,
+  /FlyV1 [A-Za-z0-9_-]{20,}/,
+  /AccountKey=[A-Za-z0-9+/]{40,}=*/,
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----/,
+  /-----BEGIN PGP MESSAGE-----/,
+  /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{8,}\b/,
+  /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[A-Za-z0-9_.%-]*:[^@\s/]+(?<!\.\.)@/,
+  /\bBearer\s+[A-Za-z0-9_+=/.-]{20,}/i,
+  /(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|auth)\s*[=:]\s*["']?[A-Za-z0-9_+=/.-]{12,}/i,
+];
+
+function tokenize(key: string): Set<string> {
+  return new Set(
+    key
+      .split(/(?<=[a-z])(?=[A-Z])/)
+      .flatMap(part => part.split(/[_\-.]+/))
+      .map(token => token.toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+function hasSafeKeyHint(key: string): boolean {
+  const tokens = tokenize(key);
+  return SAFE_KEY_HINT_TOKENS.some(token => tokens.has(token));
+}
+
+function hasGenericKeySuffix(key: string): boolean {
+  const precedingToken =
+    GENERIC_KEY_SUFFIX_PATTERN.exec(key)?.[1]?.toUpperCase();
+  return Boolean(
+    precedingToken && !NON_CREDENTIAL_KEY_TOKENS.has(precedingToken)
+  );
+}
+
+export function getMatchingServerOnlyKey(key: string): string | null {
+  const normalized = key
+    .replace(/(?<=[a-z])(?=[A-Z])/g, '_')
+    .toLowerCase()
+    .replace(/[-.]+/g, '_');
+  for (const pattern of SERVER_ONLY_KEY_PATTERNS) {
+    if (pattern.includes('_') && normalized.includes(pattern)) return pattern;
+  }
+  const tokens = tokenize(key);
+  return (
+    SERVER_ONLY_KEY_PATTERNS.find(
+      pattern => !pattern.includes('_') && tokens.has(pattern)
+    ) ?? null
+  );
+}
+
+export function looksLikeSecret(key: string): boolean {
+  if (!key || hasSafeKeyHint(key)) return false;
+  if (WELL_KNOWN_SECRET_NAMES.has(key.toUpperCase())) return true;
+  if (SECRET_SEGMENT_PATTERN.test(key)) return true;
+  if (SECRET_COMPOUND_PATTERNS.some(pattern => pattern.test(key))) return true;
+  if (DB_URL_PATTERN.test(key)) return true;
+  return hasGenericKeySuffix(key);
+}
+
+export function looksLikeSecretValue(value: string): boolean {
+  const trimmed = value.trim();
+  return Boolean(
+    trimmed && SECRET_VALUE_PATTERNS.some(pattern => pattern.test(trimmed))
+  );
+}
+
+export function shouldConfirmRotationBeforeDelete(env: {
+  key: string;
+  type: ProjectEnvType;
+  hasPublicPrefix: boolean;
+}): boolean {
+  if (env.type === 'system') return false;
+  if (EXPLICIT_SECRET_TOKEN_PATTERN.test(env.key)) return true;
+  if (env.hasPublicPrefix || hasSafeKeyHint(env.key)) return false;
+  return looksLikeSecret(env.key);
+}
+
+export function isFlagsSecretNeedingSplit(env: {
+  key: string;
+  type: ProjectEnvType;
+  targets: string[];
+  customEnvironmentIds?: string[];
+}): boolean {
+  if (env.key !== 'FLAGS_SECRET') return false;
+  if (env.type !== 'plain' && env.type !== 'encrypted') return false;
+  return env.targets.length + (env.customEnvironmentIds?.length ?? 0) > 1;
+}

--- a/packages/cli/src/util/env/validate-env.ts
+++ b/packages/cli/src/util/env/validate-env.ts
@@ -1,4 +1,7 @@
 import { frameworkList } from '@vercel/frameworks';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getMatchingServerOnlyKey, looksLikeSecret } from './secret-detection';
 
 export interface EnvWarning {
   message: string;
@@ -81,16 +84,39 @@ export function formatWarnings(warnings: EnvWarning[]): string | null {
   return `Value ${messages.join(', ')}, and ${last}`;
 }
 
-/** Framework prefixes that expose variables to the browser. */
-const PUBLIC_PREFIXES = [
+/** Prefixes the API currently rejects for Secret variables. */
+const API_PUBLIC_PREFIXES = [
+  'NEXT_PUBLIC_',
+  'VUE_APP_',
+  'REACT_APP_',
+  'GATSBY_',
+  'GRIDSOME_',
+  'NUXT_PUBLIC_',
+  'STORYBOOK_',
+  'VITE_',
+  'PUBLIC_',
+  'EXPO_PUBLIC_',
+  'NG_APP_',
+  'REDWOOD_ENV_',
+] as const;
+
+const LEGACY_PUBLIC_PREFIXES = [
   ...new Set(
     frameworkList.map(f => f.envPrefix).filter((p): p is string => !!p)
   ),
 ];
 
-// Require word boundaries: pattern must be preceded/followed by _ or string boundary
-// Matches: _PASSWORD_, _SECRET, KEY_, etc. but not KEYBOARD, ACCESSIBLE
-const SENSITIVE_PATTERN =
+/** All known framework prefixes used for Config/Secret advisory guidance. */
+const PUBLIC_PREFIXES = [
+  ...new Set([
+    ...API_PUBLIC_PREFIXES,
+    ...frameworkList
+      .map(f => f.envPrefix)
+      .filter((prefix): prefix is string => !!prefix),
+  ]),
+];
+
+const LEGACY_SENSITIVE_PATTERN =
   /(?:^|_)(password|secret|private|token|key|auth|jwt|signature)(?:_|$)/i;
 
 /**
@@ -159,17 +185,67 @@ export function normalizeStdinEnvValue(
 /**
  * Returns the public prefix if the key starts with one, null otherwise.
  */
-export function getPublicPrefix(key: string): string | null {
+export function getPublicPrefix(
+  key: string,
+  includeDashboardPrefixes = false
+): string | null {
   const upperKey = key.toUpperCase();
-  return PUBLIC_PREFIXES.find(p => upperKey.startsWith(p)) || null;
+  const prefixes = includeDashboardPrefixes
+    ? PUBLIC_PREFIXES
+    : LEGACY_PUBLIC_PREFIXES;
+  return prefixes.find(p => upperKey.startsWith(p)) || null;
+}
+
+export function getApiPublicPrefix(key: string): string | null {
+  const upperKey = key.toUpperCase();
+  return (
+    API_PUBLIC_PREFIXES.find(prefix => upperKey.startsWith(prefix)) ?? null
+  );
+}
+
+export function parseSvelteKitPublicEnvVarPrefix(
+  config: string
+): { status: 'ready'; prefix: string | null } | { status: 'unavailable' } {
+  if (!config.includes('publicPrefix')) {
+    return { status: 'ready', prefix: null };
+  }
+  const match =
+    /publicPrefix:\s*(?:'(?<single>[^']*)'|"(?<double>[^"]*)"|`(?<template>[^`$]*)`)/.exec(
+      config
+    );
+  const prefix =
+    match?.groups?.single ?? match?.groups?.double ?? match?.groups?.template;
+  return prefix === undefined
+    ? { status: 'unavailable' }
+    : { status: 'ready', prefix };
+}
+
+/** Reads the same static SvelteKit publicPrefix syntax supported by Dashboard. */
+export async function getLocalSvelteKitPublicPrefixes(
+  cwd: string,
+  rootDirectory?: string | null
+): Promise<string[] | undefined> {
+  const projectRoot = rootDirectory ? join(cwd, rootDirectory) : cwd;
+  let config: string;
+  try {
+    config = await readFile(join(projectRoot, 'svelte.config.js'), 'utf8');
+  } catch {
+    return undefined;
+  }
+  const parsed = parseSvelteKitPublicEnvVarPrefix(config);
+  if (parsed.status === 'unavailable') return undefined;
+  return [parsed.prefix ?? 'PUBLIC_', 'VITE_'];
 }
 
 /**
  * Removes the public prefix from a key.
  * e.g. "NEXT_PUBLIC_API_KEY" -> "API_KEY"
  */
-export function removePublicPrefix(key: string): string {
-  const prefix = getPublicPrefix(key);
+export function removePublicPrefix(
+  key: string,
+  includeDashboardPrefixes = false
+): string {
+  const prefix = getPublicPrefix(key, includeDashboardPrefixes);
   if (!prefix) return key;
   return key.slice(prefix.length);
 }
@@ -249,21 +325,31 @@ export async function validateEnvValue(
   return { finalValue, alreadyConfirmed };
 }
 
-export function getEnvKeyWarnings(key: string): EnvWarning[] {
+export function getEnvKeyWarnings(
+  key: string,
+  options: { configSecretUiEnabled?: boolean } = {}
+): EnvWarning[] {
   const warnings: EnvWarning[] = [];
-  const matchingPrefix = getPublicPrefix(key);
+  const matchingPrefix = getPublicPrefix(key, options.configSecretUiEnabled);
 
   if (matchingPrefix) {
-    const sensitiveMatch = SENSITIVE_PATTERN.exec(key);
     const nameWithoutPrefix = key.slice(matchingPrefix.length);
+    const sensitiveMatch = options.configSecretUiEnabled
+      ? looksLikeSecret(nameWithoutPrefix) &&
+        getMatchingServerOnlyKey(nameWithoutPrefix)
+      : LEGACY_SENSITIVE_PATTERN.exec(key);
     if (sensitiveMatch) {
       warnings.push({
-        message: `The ${matchingPrefix} prefix will make ${nameWithoutPrefix} visible to anyone visiting your site`,
+        message: options.configSecretUiEnabled
+          ? `\`${matchingPrefix}\` exposes \`${key}\` to anyone visiting your site`
+          : `The ${matchingPrefix} prefix will make ${nameWithoutPrefix} visible to anyone visiting your site`,
         requiresConfirmation: true,
       });
     } else {
       warnings.push({
-        message: `${matchingPrefix} variables can be seen by anyone visiting your site`,
+        message: options.configSecretUiEnabled
+          ? `\`${matchingPrefix}\` exposes this value to anyone visiting your site`
+          : `${matchingPrefix} variables can be seen by anyone visiting your site`,
         requiresConfirmation: false,
       });
     }

--- a/packages/cli/test/unit/util/env/env-var-config-secret-ui.test.ts
+++ b/packages/cli/test/unit/util/env/env-var-config-secret-ui.test.ts
@@ -80,14 +80,15 @@ describe('visibilityFromEnvType', () => {
 });
 
 describe('getPublicPrefixSecretVisibilityError', () => {
-  it('returns an error for secret visibility on public-prefixed production keys', () => {
+  it('returns an error for Secret on public-prefixed keys', () => {
     expect(
       getPublicPrefixSecretVisibilityError('NEXT_PUBLIC_API_URL', {
         visibility: 'secret',
         type: 'encrypted',
-        envTargets: ['production'],
       })
-    ).toMatch(/cannot use secret visibility on Production or Preview/);
+    ).toBe(
+      '`NEXT_PUBLIC_` exposes this value to anyone visiting your site, so `NEXT_PUBLIC_API_URL` cannot be a Secret. To keep it private, rename the variable to `API_URL` and keep the Secret type. If the value is safe to expose, use `--type config`.'
+    );
   });
 
   it('returns null for config visibility on public-prefixed keys', () => {
@@ -95,9 +96,20 @@ describe('getPublicPrefixSecretVisibilityError', () => {
       getPublicPrefixSecretVisibilityError('NEXT_PUBLIC_API_URL', {
         visibility: 'config',
         type: 'encrypted',
-        envTargets: ['production'],
       })
     ).toBeNull();
+  });
+
+  it('uses add-and-remove recovery for updates', () => {
+    expect(
+      getPublicPrefixSecretVisibilityError('NEXT_PUBLIC_API_KEY', {
+        visibility: 'secret',
+        type: 'encrypted',
+        context: 'update',
+      })
+    ).toBe(
+      '`NEXT_PUBLIC_` exposes this value to anyone visiting your site, so `NEXT_PUBLIC_API_KEY` cannot be a Secret. To keep it private, add `API_KEY` as a Secret, then remove `NEXT_PUBLIC_API_KEY`. If the value is safe to expose, keep it as Config.'
+    );
   });
 });
 
@@ -126,7 +138,7 @@ describe('resolveEnvVarVisibility', () => {
     ).toEqual({});
   });
 
-  it('uses explicit --visibility when provided', () => {
+  it('uses explicit --type when provided', () => {
     expect(
       resolveEnvVarVisibility({
         configSecretUiEnabled: true,
@@ -139,7 +151,7 @@ describe('resolveEnvVarVisibility', () => {
     ).toEqual({ visibility: 'config' });
   });
 
-  it('errors on invalid explicit visibility values', () => {
+  it('errors on invalid explicit type values', () => {
     expect(
       resolveEnvVarVisibility({
         configSecretUiEnabled: true,
@@ -162,7 +174,7 @@ describe('resolveEnvVarVisibility', () => {
         envTargets: ['production'],
         teamSensitivePolicyOn: false,
       }).error
-    ).toMatch(/cannot use secret visibility/);
+    ).toMatch(/cannot be a Secret/);
   });
 
   it('infers visibility from type when not explicitly provided', () => {
@@ -177,7 +189,7 @@ describe('resolveEnvVarVisibility', () => {
     ).toEqual({ visibility: 'config' });
   });
 
-  it('omits inferred visibility for public-prefixed keys when team policy force-coerces type', () => {
+  it('keeps Config visibility for public-prefixed keys when the legacy team policy is on', () => {
     expect(
       resolveEnvVarVisibility({
         configSecretUiEnabled: true,
@@ -186,7 +198,7 @@ describe('resolveEnvVarVisibility', () => {
         envTargets: ['production'],
         teamSensitivePolicyOn: true,
       })
-    ).toEqual({});
+    ).toEqual({ visibility: 'config' });
   });
 
   it('does not omit inferred visibility for public-prefixed keys when only type is sensitive', () => {
@@ -198,7 +210,7 @@ describe('resolveEnvVarVisibility', () => {
         envTargets: ['production'],
         teamSensitivePolicyOn: false,
       }).error
-    ).toMatch(/cannot use secret visibility/);
+    ).toMatch(/cannot be a Secret/);
   });
 
   it('errors when sensitive type is requested on public-prefixed production keys', () => {
@@ -210,10 +222,10 @@ describe('resolveEnvVarVisibility', () => {
         envTargets: ['production'],
         teamSensitivePolicyOn: false,
       }).error
-    ).toMatch(/cannot use secret visibility/);
+    ).toMatch(/cannot be a Secret/);
   });
 
-  it('rejects secrets on Development when flag is enabled', () => {
+  it('allows secrets on Development when flag is enabled', () => {
     expect(
       resolveEnvVarVisibility({
         configSecretUiEnabled: true,
@@ -221,7 +233,7 @@ describe('resolveEnvVarVisibility', () => {
         key: 'API_KEY',
         envTargets: ['development'],
         teamSensitivePolicyOn: false,
-      }).error
-    ).toMatch(/not allowed with the Development Environment/);
+      })
+    ).toEqual({ visibility: 'secret' });
   });
 });

--- a/packages/cli/test/unit/util/env/secret-detection.test.ts
+++ b/packages/cli/test/unit/util/env/secret-detection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getMatchingServerOnlyKey,
+  isFlagsSecretNeedingSplit,
+  looksLikeSecret,
+  looksLikeSecretValue,
+  shouldConfirmRotationBeforeDelete,
+} from '../../../../src/util/env/secret-detection';
+
+describe('secret detection', () => {
+  it.each([
+    ['DATABASE_URL', true],
+    ['STRIPE_API_KEY', true],
+    ['STRIPE_PUBLISHABLE_KEY', false],
+    ['CACHE_KEY', false],
+    ['MONKEY_NAME', false],
+  ])('classifies key %s', (key, expected) => {
+    expect(looksLikeSecret(key)).toBe(expected);
+  });
+
+  it('matches server-only compound names before generic tokens', () => {
+    expect(getMatchingServerOnlyKey('DATABASE_ACCESS_TOKEN')).toBe(
+      'access_token'
+    );
+  });
+
+  it('detects credential formats without exposing their value', () => {
+    expect(looksLikeSecretValue(`ghp_${'a'.repeat(30)}`)).toBe(true);
+    expect(looksLikeSecretValue('ordinary-config-value')).toBe(false);
+  });
+
+  it('requires rotation guidance for credential-like deletes', () => {
+    expect(
+      shouldConfirmRotationBeforeDelete({
+        key: 'STRIPE_SECRET_KEY',
+        type: 'sensitive',
+        hasPublicPrefix: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldConfirmRotationBeforeDelete({
+        key: 'NEXT_PUBLIC_API_URL',
+        type: 'encrypted',
+        hasPublicPrefix: true,
+      })
+    ).toBe(false);
+  });
+
+  it('recommends splitting readable FLAGS_SECRET outside Development', () => {
+    expect(
+      isFlagsSecretNeedingSplit({
+        key: 'FLAGS_SECRET',
+        type: 'encrypted',
+        targets: ['production', 'preview'],
+      })
+    ).toBe(true);
+    expect(
+      isFlagsSecretNeedingSplit({
+        key: 'FLAGS_SECRET',
+        type: 'encrypted',
+        targets: ['production'],
+      })
+    ).toBe(false);
+    expect(
+      isFlagsSecretNeedingSplit({
+        key: 'FLAGS_SECRET',
+        type: 'encrypted',
+        targets: ['development'],
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/cli/test/unit/util/env/validate-env.test.ts
+++ b/packages/cli/test/unit/util/env/validate-env.test.ts
@@ -5,6 +5,7 @@ import {
   formatWarnings,
   hasOnlyWhitespaceWarnings,
   normalizeStdinEnvValue,
+  parseSvelteKitPublicEnvVarPrefix,
   trimValue,
   getPublicPrefix,
   removePublicPrefix,
@@ -677,6 +678,35 @@ describe('validate-env', () => {
         value: 'line1\nline2\n',
         strippedTrailingNewline: false,
       });
+    });
+  });
+
+  describe('parseSvelteKitPublicEnvVarPrefix', () => {
+    it.each([
+      ["kit: { env: { publicPrefix: 'BROWSER_' } }", 'BROWSER_'],
+      ['kit: { env: { publicPrefix: "CLIENT_" } }', 'CLIENT_'],
+      ['kit: { env: { publicPrefix: `WEB_` } }', 'WEB_'],
+      ["kit: { env: { publicPrefix: '' } }", ''],
+    ])('reads a static prefix from %s', (config, prefix) => {
+      expect(parseSvelteKitPublicEnvVarPrefix(config)).toEqual({
+        status: 'ready',
+        prefix,
+      });
+    });
+
+    it('uses the SvelteKit default when publicPrefix is absent', () => {
+      expect(parseSvelteKitPublicEnvVarPrefix('export default {}')).toEqual({
+        status: 'ready',
+        prefix: null,
+      });
+    });
+
+    it('does not guess a dynamic prefix', () => {
+      expect(
+        parseSvelteKitPublicEnvVarPrefix(
+          'export default { kit: { env: { publicPrefix } } }'
+        )
+      ).toEqual({ status: 'unavailable' });
     });
   });
 });


### PR DESCRIPTION
Adds the shared foundations for Config and Secret Environment Variables.

- Defines API type support and visibility resolution.
- Adds credential detection and framework public-prefix parsing.
- Adds focused utility coverage.

Stack 1/3. Followed by #17519 and #17513.