### PR TITLE
Add Config and Secret environment commands

### DIFF
--- a/.changeset/clean-env-type-guidance.md
+++ b/.changeset/clean-env-type-guidance.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add Config and Secret type controls and credential-safety guidance to Environment Variable commands.

--- a/packages/cli/.agents/skills/cli-ux/references/command-contracts.md
+++ b/packages/cli/.agents/skills/cli-ux/references/command-contracts.md
@@ -67,17 +67,17 @@ Current gaps to migrate incrementally:
 
 Link prompt map:
 
-| State                              | Human prompt/output                                                                                                                                                                  | Non-interactive                        |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
-| Multiple teams                     | searchable `Which team?` before project discovery                                                                                                                                    | `action_required: missing_scope` unless explicit signal or single choice |
-| Single team                        | no prompt; aligned `Team` row, then project discovery                                                                                                                                | proceeds with that team                |
-| One folder-name project match      | `Which project?` with the match labeled `(folder name)`, then search/create choices                                                                                                  | link only for explicit/repo-root match |
-| One repository project match       | direct interactive: `Which project?` with the match labeled `(linked by git)`; other paths: `Found existing project`, aligned `Project`/`Source`, then `Link repository to project?` | link only for explicit/repo-root match |
-| No project match                   | `Which project?` with `Search all projects` / `Create a new project`, then `Name?` when creating                                                                                     | require `--yes` or `project_not_found` |
-| Root choices exist                 | `Code directory?`                                                                                                                                                                    | require root flag/config/payload       |
-| Settings differ                    | `Customize settings?`                                                                                                                                                                | require flags/config/payload           |
-| Optional env pull                  | `Pull development environment variables into .env.local?`                                                                                                                            | skip unless explicitly requested       |
-| Stale/deleted link                 | show stale link, then concrete relink choice                                                                                                                                         | `action_required: stale_link`          |
+| State                         | Human prompt/output                                                                                                                                                                  | Non-interactive                                                          |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Multiple teams                | searchable `Which team?` before project discovery                                                                                                                                    | `action_required: missing_scope` unless explicit signal or single choice |
+| Single team                   | no prompt; aligned `Team` row, then project discovery                                                                                                                                | proceeds with that team                                                  |
+| One folder-name project match | `Which project?` with the match labeled `(folder name)`, then search/create choices                                                                                                  | link only for explicit/repo-root match                                   |
+| One repository project match  | direct interactive: `Which project?` with the match labeled `(linked by git)`; other paths: `Found existing project`, aligned `Project`/`Source`, then `Link repository to project?` | link only for explicit/repo-root match                                   |
+| No project match              | `Which project?` with `Search all projects` / `Create a new project`, then `Name?` when creating                                                                                     | require `--yes` or `project_not_found`                                   |
+| Root choices exist            | `Code directory?`                                                                                                                                                                    | require root flag/config/payload                                         |
+| Settings differ               | `Customize settings?`                                                                                                                                                                | require flags/config/payload                                             |
+| Optional env pull             | `Pull development environment variables into .env.local?`                                                                                                                            | skip unless explicitly requested                                         |
+| Stale/deleted link            | show stale link, then concrete relink choice                                                                                                                                         | `action_required: stale_link`                                            |
 
 Link acceptance matrix:
 
@@ -197,6 +197,7 @@ Rules:
 - Show linked `Project` context only when it changes the next decision or prevents real ambiguity. Prefer no preview over a block that repeats already-known values.
 - Never repeat the Environment Variable value after entry in human output, JSON, debug logs, telemetry, warnings, errors, or suggested commands. Sensitive values must not be visible at all.
 - Do not include actual `--value` contents in agent `next` commands. Use quoted `"<value>"` placeholders in shell commands, even if the user provided a value.
+- Human remediation commands run interactively: put each full command on its own indented line and omit `--yes` and templated `--value` arguments. Agent `next[].command` values stay raw and may use `--yes`; when they contain `"<value>"`, state that it must be replaced before running.
 - The environment positional accepts a comma-separated list producing one multi-target entry. Unknown tokens fail locally with `error: invalid_environment` naming valid targets; custom Environment slugs normalize to ids. A Git branch is only allowed when Preview is the only target (`error: branch_requires_preview_only` otherwise). `missing_environment` and `missing_requirements` payloads must include a comma-separated multi-target `next` suggestion (with `--no-sensitive` when Development is included and sensitivity was not explicit).
 - Use masked input for sensitive interactive `Value?` prompts. Use visible text input for non-sensitive `Value?` prompts so users can catch typos before saving.
 - Use `Name?`, `Store as sensitive?`, `Value?`, `Environments?`, and `Git branch?`.
@@ -210,6 +211,10 @@ Rules:
 - Omit timestamps from default success output unless the command family has a support/debug reason to show one.
 - Keep `--force` semantics as overwrite/upsert, not generic confirmation bypass.
 - Keep non-interactive output stdout-clean JSON/action payloads. Human preview/result rows stay on stderr.
+- Behind `env-var-config-secret-ui`, use `Type` with `Config` and `Secret` everywhere in human output; keep the API/JSON field `visibility` for compatibility. Print exactly one `Type` row.
+- Behind the flag, a secret-looking public-prefixed name with no explicit type requires one decision: rename without the prefix and use Secret, keep the public name as Config, or enter another name. `--yes` must not infer browser exposure; fail with both exact next commands instead of prompting. Feature-off keeps the legacy public-prefix flow.
+- Track whether type came from argv, a prompt, inference, or the default. Explicit Config warns and proceeds; inferred public Config can require a later decision when the entered value looks like a credential. Resolve each key/value signal at most once.
+- The feature-on default remains Secret when an explicit type is absent and the flow skips prompts. State the default after the result because Secrets cannot be revealed or pulled. Feature-off keeps the legacy Sensitive/Non-sensitive behavior.
 
 Env add prompt map:
 

--- a/packages/cli/.agents/skills/cli-ux/references/copy.md
+++ b/packages/cli/.agents/skills/cli-ux/references/copy.md
@@ -136,7 +136,7 @@ Use `please` or an apology only when Vercel is at fault, asking an inconvenient 
 - Use sentence case for prompts, help descriptions, errors, warnings, progress, and explanatory prose.
 - Use stable Title Case labels in aligned output: `Project`, `Team`, `Directory`, `Production`, `Request ID`.
 - Omit periods on fragments, labels, statuses, progress lines, and compact result rows. Punctuate full explanations and errors.
-- Use straight quotes and backticks for commands, paths, IDs, and copyable literals. CLI source strings may use ASCII apostrophes. Do not import the dashboard's curly-quote rule.
+- Use straight quotes and backticks for command names, flags, paths, IDs, and copyable literals in prose. Put full runnable commands on their own indented lines without backticks or a shell prompt so the line is safely copyable. CLI source strings may use ASCII apostrophes. Do not import the dashboard's curly-quote rule.
 - Use `…`, never `...`, for ongoing prose or progress. Preserve `...` only in literal syntax.
 - Use decimal units by default and the spacing rules in [`core.md`](core.md#data-mechanics).
 - Respect singular/plural interpolation. Never use `item(s)`.

--- a/packages/cli/.agents/skills/cli-ux/references/core.md
+++ b/packages/cli/.agents/skills/cli-ux/references/core.md
@@ -19,7 +19,7 @@ This is the cross-cutting baseline because most CLI UX work touches strings. For
 - Do not use `Unable to`.
 - Do not use `successfully`; name the completed action.
 - Do not use `Oops`, `Uh-oh`, `Whoops`, `Heads up`, `please`, or apologies unless Vercel is at fault or asking the user for an inconvenient favor.
-- CLI command/path/code output uses straight quotes/backticks for copyability. Dashboard UI may prefer curly quotes; CLI source strings may use ASCII apostrophes.
+- Command names, flags, paths, and code literals in prose use straight quotes/backticks for copyability. Put full runnable commands on their own indented lines without backticks or a shell prompt; literal backticks invoke command substitution when pasted into a shell. Dashboard UI may prefer curly quotes; CLI source strings may use ASCII apostrophes.
 - Use `…`, not `...`, in prose/progress text. Keep `...` only when syntax requires it.
 
 Use:
@@ -440,6 +440,7 @@ Rules:
 - Use existing `AGENT_REASON` / `AGENT_STATUS` before inventing strings.
 - Include `argv: string[]` with copy-pasteable `command` when feasible.
 - Use angle-bracket placeholders: `<name>`, `<slug>`, `<file>`.
+- Keep `next[].command` raw, without display delimiters. When it contains a placeholder, say what must be replaced in `when` or another structured field; do not describe a templated command as directly executable.
 - Preserve safe context flags; strip or redact secret values.
 - Do not suggest pipes, redirects, command substitution, or shell-specific syntax unless labeled for that shell.
 - Fully qualify suggested subcommands: `teams switch <slug>`, not `switch <slug>`.

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -15,6 +15,8 @@ import param from '../../util/output/param';
 import { isKnownError } from '../../util/env/known-error';
 import {
   getEnvKeyWarnings,
+  getLocalSvelteKitPublicPrefixes,
+  getPublicPrefix,
   normalizeStdinEnvValue,
   removePublicPrefix,
   validateEnvValue,
@@ -33,6 +35,7 @@ import { determineAgent } from '@vercel/detect-agent';
 import { suggestNextCommands } from '../../util/suggest-next-commands';
 import getTeamById from '../../util/teams/get-team-by-id';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import {
   outputActionRequired,
   outputAgentError,
@@ -41,14 +44,28 @@ import {
   getPreservedArgsForEnvAdd,
 } from '../../util/agent-output';
 import {
+  getPublicPrefixSecretVisibilityError,
   isEnvVarConfigSecretUiEnabled,
   resolveEnvVarVisibility,
   shouldEnforceSensitiveEnvVarPolicy,
   type EnvVariableVisibility,
   formatVisibilityLabel,
 } from '../../util/env/env-var-config-secret-ui';
+import {
+  isFlagsSecretNeedingSplit,
+  looksLikeSecret,
+  looksLikeSecretValue,
+} from '../../util/env/secret-detection';
 
 type EnvType = 'encrypted' | 'sensitive';
+type TypeSource = 'argv' | 'prompt' | 'inferred' | 'default';
+
+function looksLikeCredentialName(
+  key: string,
+  publicPrefix: string | null | undefined = getPublicPrefix(key, true)
+): boolean {
+  return looksLikeSecret(publicPrefix ? key.slice(publicPrefix.length) : key);
+}
 
 type EnvChoice = {
   name: string;
@@ -66,9 +83,10 @@ function filterEnvChoicesForSensitivity(
   opts: {
     isSensitive: boolean;
     policyOn: boolean;
+    configSecretUiEnabled: boolean;
   }
 ): EnvChoice[] {
-  if (opts.isSensitive) {
+  if (opts.isSensitive && !opts.configSecretUiEnabled) {
     return choices.filter(c => c.value !== 'development');
   }
   if (opts.policyOn) {
@@ -80,12 +98,13 @@ function filterEnvChoicesForSensitivity(
 function getTargetCompatibilityError(
   envTargets: string[],
   isSensitive: boolean,
-  policyOn: boolean
+  policyOn: boolean,
+  configSecretUiEnabled: boolean
 ): string | null {
   const hasDevelopment = envTargets.includes('development');
   const hasSensitiveCapable = envTargets.some(t => t !== 'development');
 
-  if (isSensitive && hasDevelopment) {
+  if (isSensitive && hasDevelopment && !configSecretUiEnabled) {
     return `Sensitive Environment Variables are not supported on the Development Environment. Add --no-sensitive to store a non-sensitive value for all selected Environments, or run ${getCommandName(
       'env add'
     )} separately for Development.`;
@@ -107,10 +126,11 @@ function resolveFinalType(
     forceSensitive: boolean;
     forceEncrypted: boolean;
     policyOn: boolean;
+    configSecretUiEnabled: boolean;
   }
 ): EnvType {
   const hasDevelopment = envTargets.includes('development');
-  if (hasDevelopment) {
+  if (hasDevelopment && !opts.configSecretUiEnabled) {
     return 'encrypted';
   }
   if (opts.forceEncrypted && !opts.policyOn) {
@@ -179,9 +199,11 @@ function filterSensitiveMultiTargetSuggestionTargets(
   opts: {
     forceSensitive: boolean;
     policyOn: boolean;
+    configSecretUiEnabled: boolean;
   }
 ): string[] {
-  const excludeDevelopment = opts.forceSensitive || opts.policyOn;
+  const excludeDevelopment =
+    (opts.forceSensitive && !opts.configSecretUiEnabled) || opts.policyOn;
 
   return excludeDevelopment
     ? targets.filter(target => target !== 'development')
@@ -241,12 +263,13 @@ function printEnvAddResult(
   if (envGitBranch) {
     printAlignedLabel('Branch', envGitBranch);
   }
-  printAlignedLabel('Type', typeLabel(finalType));
   if (isEnvVarConfigSecretUiEnabled()) {
     const visibilityLabel = formatVisibilityLabel(visibility, finalType);
     if (visibilityLabel) {
-      printAlignedLabel('Visibility', visibilityLabel);
+      printAlignedLabel('Type', visibilityLabel);
     }
+  } else {
+    printAlignedLabel('Type', typeLabel(finalType));
   }
 }
 
@@ -264,6 +287,17 @@ function promptEnvValue(
       ? { transformer: (value: string) => '*'.repeat(value.length) }
       : {}),
   });
+}
+
+function buildHumanEnvAddCommand(
+  argv: string[],
+  commandTemplate: string
+): string {
+  const globalFlags = getGlobalFlagsFromArgs(argv.slice(2), {
+    preserveProject: true,
+  }).filter(flag => !flag.startsWith('--non-interactive'));
+  const suffix = globalFlags.length > 0 ? ` ${globalFlags.join(' ')}` : '';
+  return getCommandNamePlain(`${commandTemplate}${suffix}`);
 }
 
 export default async function add(client: Client, argv: string[]) {
@@ -294,6 +328,12 @@ export default async function add(client: Client, argv: string[]) {
   const valueFromFlag =
     typeof opts['--value'] === 'string' ? opts['--value'] : undefined;
   let [envName, envTargetArg, envGitBranch] = args;
+  const forceSensitive = Boolean(opts['--sensitive']);
+  const forceEncrypted = Boolean(opts['--no-sensitive']);
+  let explicitType =
+    typeof opts['--type'] === 'string' ? opts['--type'] : undefined;
+  let typeSource: TypeSource | undefined =
+    explicitType || forceSensitive || forceEncrypted ? 'argv' : undefined;
 
   const telemetryClient = new EnvAddTelemetryClient({
     opts: {
@@ -311,8 +351,8 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliFlagForce(opts['--force']);
   telemetryClient.trackCliFlagGuidance(opts['--guidance']);
   telemetryClient.trackCliFlagYes(opts['--yes']);
-  telemetryClient.trackCliOptionVisibility(
-    typeof opts['--visibility'] === 'string' ? opts['--visibility'] : undefined
+  telemetryClient.trackCliOptionType(
+    typeof opts['--type'] === 'string' ? opts['--type'] : undefined
   );
   telemetryClient.trackCliOptionProject(opts['--project']);
 
@@ -390,9 +430,9 @@ export default async function add(client: Client, argv: string[]) {
         {
           status: 'error',
           reason: 'not_linked',
-          message: `Your codebase isn't linked to a project on Vercel. Run ${getCommandNamePlain(
+          message: `Your codebase isn't linked to a project on Vercel. Run \`${getCommandNamePlain(
             'link'
-          )} to begin. Use --yes for non-interactive; use --scope or --project to specify team or project. Then run your env add command.`,
+          )}\` to begin. Use \`--yes\` for non-interactive; use \`--scope\` or \`--project\` to specify team or project. Then run your env add command.`,
           next: [
             { command: buildCommandWithYes(linkArgv) },
             { command: buildCommandWithYes(envAddRetryArgv) },
@@ -515,6 +555,7 @@ export default async function add(client: Client, argv: string[]) {
           {
             forceSensitive: Boolean(opts['--sensitive']),
             policyOn: false,
+            configSecretUiEnabled,
           }
         );
         if (multiTargets.length > 1) {
@@ -523,7 +564,9 @@ export default async function add(client: Client, argv: string[]) {
               client.argv,
               envName || '<name>',
               multiTargets,
-              multiTargets.includes('development') && !opts['--no-sensitive']
+              !configSecretUiEnabled &&
+                multiTargets.includes('development') &&
+                !opts['--no-sensitive']
             )
           );
         }
@@ -549,13 +592,37 @@ export default async function add(client: Client, argv: string[]) {
     });
   }
 
-  // Validate key name early (before value entry) with re-entry option
+  if (configSecretUiEnabled && (explicitType === 'secret' || forceSensitive)) {
+    const publicPrefixError = getPublicPrefixSecretVisibilityError(envName, {
+      visibility: explicitType === 'secret' ? 'secret' : undefined,
+      type: 'sensitive',
+    });
+    if (publicPrefixError) {
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: 'invalid_type',
+            message: publicPrefixError,
+          },
+          1
+        );
+      }
+      output.error(publicPrefixError);
+      return 1;
+    }
+  }
+
+  // Validate key name early (before value entry) with re-entry option.
   const skipConfirm =
     opts['--yes'] || !!stdInput || valueFromFlag !== undefined;
-  if (!skipConfirm) {
+  if (configSecretUiEnabled) {
     let keyAccepted = false;
     while (!keyAccepted) {
-      const keyWarnings = getEnvKeyWarnings(envName);
+      const keyWarnings = getEnvKeyWarnings(envName, {
+        configSecretUiEnabled,
+      });
       const sensitiveWarning = keyWarnings.find(w => w.requiresConfirmation);
 
       if (!sensitiveWarning) {
@@ -567,8 +634,128 @@ export default async function add(client: Client, argv: string[]) {
         break;
       }
 
+      const nameWithoutPrefix = removePublicPrefix(
+        envName,
+        configSecretUiEnabled
+      );
+      const publicPrefix = getPublicPrefix(envName, true);
+
+      if (typeSource === 'argv') {
+        for (const w of keyWarnings) {
+          printEnvAddWarning(w.message);
+        }
+        keyAccepted = true;
+        break;
+      }
+
+      const privateCommand = buildEnvAddCommandWithPreservedArgs(
+        client.argv,
+        `env add ${nameWithoutPrefix} ${
+          envTargetArg ?? getEnvTargetPlaceholder()
+        } --type secret --value "<value>" --yes`
+      );
+      const publicCommand = buildEnvAddCommandWithPreservedArgs(
+        client.argv,
+        `env add ${envName} ${
+          envTargetArg ?? getEnvTargetPlaceholder()
+        } --type config --value "<value>" --yes`
+      );
+      const humanTargetArg = envTargetArg ? ` ${envTargetArg}` : '';
+      const privateHumanCommand = buildHumanEnvAddCommand(
+        client.argv,
+        `env add ${nameWithoutPrefix}${humanTargetArg} --type secret`
+      );
+      const publicHumanCommand = buildHumanEnvAddCommand(
+        client.argv,
+        `env add ${envName}${humanTargetArg} --type config`
+      );
+      const message = `${envName} looks like a credential, and ${publicPrefix} exposes its value to anyone visiting your site. Choose explicitly: rename to ${nameWithoutPrefix} with --type secret to keep it private, or keep the name with --type config to expose it.`;
+
+      if (client.nonInteractive || opts['--yes'] || !!stdInput) {
+        if (client.nonInteractive) {
+          outputActionRequired(client, {
+            status: 'action_required',
+            reason: 'public_prefix_requires_type',
+            message,
+            choices: [
+              {
+                id: 'private',
+                name: `Keep private: rename to ${nameWithoutPrefix} and use Secret`,
+              },
+              {
+                id: 'public',
+                name: `Expose publicly: keep ${envName} as Config`,
+              },
+            ],
+            next: [
+              {
+                command: privateCommand,
+                when: 'Keep it private; replace <value> before running',
+              },
+              {
+                command: publicCommand,
+                when: 'Expose it publicly; replace <value> before running',
+              },
+            ],
+          });
+        }
+        output.error(message);
+        output.print(`  Keep it private:\n    ${privateHumanCommand}\n`);
+        output.print(`  Expose it publicly:\n    ${publicHumanCommand}\n`);
+        return 1;
+      }
+
+      for (const w of keyWarnings) {
+        printEnvAddWarning(w.message);
+      }
+
+      const action = await client.input.select({
+        message: 'How should this variable be stored?',
+        choices: [
+          {
+            name: `Keep private: rename to ${nameWithoutPrefix} and use Secret`,
+            value: 'p',
+          },
+          {
+            name: `Expose to anyone visiting your site: keep ${envName} as Config`,
+            value: 'c',
+          },
+          { name: 'Enter a different name', value: 'r' },
+        ],
+      });
+
+      if (action === 'p') {
+        envName = nameWithoutPrefix;
+        explicitType = 'secret';
+        typeSource = 'prompt';
+        output.log(`Renamed to ${envName}`);
+      } else if (action === 'c') {
+        explicitType = 'config';
+        typeSource = 'prompt';
+        keyAccepted = true;
+      } else {
+        envName = await client.input.text({
+          message: `Name?`,
+          validate: val => (val ? true : 'Name cannot be empty'),
+        });
+      }
+    }
+  } else if (!skipConfirm) {
+    let keyAccepted = false;
+    while (!keyAccepted) {
+      const keyWarnings = getEnvKeyWarnings(envName);
+      const sensitiveWarning = keyWarnings.find(w => w.requiresConfirmation);
+
+      if (!sensitiveWarning) {
+        for (const w of keyWarnings) {
+          printEnvAddWarning(w.message);
+        }
+        keyAccepted = true;
+        break;
+      }
+
       if (client.nonInteractive) {
-        const nameWithoutPrefix = removePublicPrefix(envName);
+        const nameWithoutPrefix = removePublicPrefix(envName, false);
         outputActionRequired(client, {
           status: 'action_required',
           reason: 'env_key_sensitive',
@@ -601,7 +788,7 @@ export default async function add(client: Client, argv: string[]) {
         printEnvAddWarning(w.message);
       }
 
-      const nameWithoutPrefix = removePublicPrefix(envName);
+      const nameWithoutPrefix = removePublicPrefix(envName, false);
       const choices = [
         { name: `Keep ${envName}`, value: 'c' },
         { name: `Rename to ${nameWithoutPrefix}`, value: 'p' },
@@ -627,13 +814,14 @@ export default async function add(client: Client, argv: string[]) {
       }
     }
   } else {
-    // Non-interactive: just show warnings
+    // Legacy non-interactive/explicit-value flow: show warnings and continue.
     const keyWarnings = getEnvKeyWarnings(envName);
     for (const w of keyWarnings) {
       printEnvAddWarning(w.message);
     }
   }
 
+  let customSveltePublicPrefix: string | undefined;
   const link = await resolveProjectContext({
     client,
     projectNameOrId: opts['--project'],
@@ -684,9 +872,9 @@ export default async function add(client: Client, argv: string[]) {
         {
           status: 'error',
           reason: 'not_linked',
-          message: `Your codebase isn't linked to a project on Vercel. Run ${getCommandNamePlain(
+          message: `Your codebase isn't linked to a project on Vercel. Run \`${getCommandNamePlain(
             'link'
-          )} to begin. Use --yes for non-interactive; use --scope or --project to specify team or project. Then run your env add command.`,
+          )}\` to begin. Use \`--yes\` for non-interactive; use \`--scope\` or \`--project\` to specify team or project. Then run your env add command.`,
           next: [
             { command: buildCommandWithYes(linkArgv) },
             { command: buildCommandWithYes(envAddRetryArgv) },
@@ -706,6 +894,46 @@ export default async function add(client: Client, argv: string[]) {
   client.config.currentTeam =
     link.org.type === 'team' ? link.org.id : undefined;
   const { project } = link;
+  if (
+    configSecretUiEnabled &&
+    (project.framework === 'sveltekit' ||
+      project.framework === 'sveltekit-1' ||
+      project.framework === 'sveltekit-2')
+  ) {
+    const localPublicPrefixes = await getLocalSvelteKitPublicPrefixes(
+      link.repoRoot ?? client.cwd,
+      (project as { rootDirectory?: string | null }).rootDirectory
+    );
+    const matchingLocalPrefix = localPublicPrefixes?.find(prefix =>
+      envName.startsWith(prefix)
+    );
+    if (matchingLocalPrefix !== undefined && !getPublicPrefix(envName, true)) {
+      customSveltePublicPrefix = matchingLocalPrefix;
+      printEnvAddWarning(
+        matchingLocalPrefix === ''
+          ? 'This SvelteKit project uses an empty publicPrefix, so every Environment Variable is exposed to the browser.'
+          : `${matchingLocalPrefix} variables are exposed to the browser by this SvelteKit project.`
+      );
+    }
+  }
+  if (
+    customSveltePublicPrefix !== undefined &&
+    (explicitType === 'secret' || forceSensitive)
+  ) {
+    const message =
+      customSveltePublicPrefix === ''
+        ? 'This SvelteKit project uses an empty `publicPrefix`, so every Environment Variable is exposed to the browser and cannot be kept private as a Secret. Change the SvelteKit `publicPrefix`, or use `--type config` only if the value is safe to expose.'
+        : `\`${customSveltePublicPrefix}\` exposes this value to anyone visiting your site, so \`${envName}\` cannot be kept private as a Secret. Rename the variable without the configured public prefix, or use \`--type config\` only if the value is safe to expose.`;
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        { status: 'error', reason: 'invalid_type', message },
+        1
+      );
+    }
+    output.error(message);
+    return 1;
+  }
   const [{ envs }, customEnvironments] = await Promise.all([
     getEnvRecords(client, project.id, 'vercel-cli:env:add'),
     getCustomEnvironments(client, project.id),
@@ -805,9 +1033,6 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
-  const forceSensitive = Boolean(opts['--sensitive']);
-  const forceEncrypted = Boolean(opts['--no-sensitive']);
-
   if (forceSensitive && forceEncrypted) {
     output.error(
       `--sensitive and --no-sensitive cannot be used together. Pick one.`
@@ -815,17 +1040,21 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
-  const explicitVisibility =
-    typeof opts['--visibility'] === 'string' ? opts['--visibility'] : undefined;
-  if (explicitVisibility === 'secret' && forceEncrypted) {
+  if (explicitType && !configSecretUiEnabled) {
     output.error(
-      '`--visibility secret` cannot be used with `--no-sensitive`. Pick one.'
+      '`--type` is only available while Config and Secret Environment Variables are enabled.'
     );
     return 1;
   }
-  if (explicitVisibility === 'config' && forceSensitive) {
+  if (explicitType === 'secret' && forceEncrypted) {
     output.error(
-      '`--visibility config` cannot be used with `--sensitive`. Pick one.'
+      '`--type secret` cannot be used with `--no-sensitive`. Pick one.'
+    );
+    return 1;
+  }
+  if (explicitType === 'config' && forceSensitive) {
+    output.error(
+      '`--type config` cannot be used with `--sensitive`. Pick one.'
     );
     return 1;
   }
@@ -834,10 +1063,13 @@ export default async function add(client: Client, argv: string[]) {
   // (cached). Only relevant when the linked org is a team.
   let policyOn = false;
   let teamSensitivePolicyOn = false;
+  let disjunctiveProductionSecretPolicyOn = false;
   if (link.org.type === 'team') {
     try {
       const team = await getTeamById(client, link.org.id);
       teamSensitivePolicyOn = team?.sensitiveEnvironmentVariablePolicy === 'on';
+      disjunctiveProductionSecretPolicyOn =
+        team?.disjunctiveProductionSecretPolicy === 'on';
       policyOn = shouldEnforceSensitiveEnvVarPolicy(teamSensitivePolicyOn);
     } catch {
       // Non-fatal — policy detection is best-effort.
@@ -846,22 +1078,52 @@ export default async function add(client: Client, argv: string[]) {
 
   const isDevelopmentOnlyTarget =
     envTargets.length === 1 && envTargets[0] === 'development';
-  const userWasExplicit = forceSensitive || forceEncrypted;
+  const userWasExplicit = forceSensitive || forceEncrypted || !!explicitType;
   const skipSensitivePrompt =
     userWasExplicit ||
     client.nonInteractive ||
     skipConfirm ||
-    isDevelopmentOnlyTarget;
+    (isDevelopmentOnlyTarget && !configSecretUiEnabled);
 
   let isSensitive: boolean;
   if (forceSensitive) {
     isSensitive = true;
   } else if (forceEncrypted) {
     isSensitive = false;
-  } else if (isDevelopmentOnlyTarget) {
+  } else if (explicitType) {
+    isSensitive = explicitType === 'secret';
+  } else if (
+    configSecretUiEnabled &&
+    (getPublicPrefix(envName, true) || customSveltePublicPrefix !== undefined)
+  ) {
+    isSensitive = false;
+    explicitType = 'config';
+    typeSource = 'inferred';
+  } else if (isDevelopmentOnlyTarget && !configSecretUiEnabled) {
     isSensitive = false;
   } else if (skipSensitivePrompt) {
     isSensitive = true;
+    if (configSecretUiEnabled) {
+      typeSource = 'default';
+    }
+  } else if (configSecretUiEnabled) {
+    const selectedType = await client.input.select({
+      message: 'Environment Variable type?',
+      choices: [
+        {
+          name: `Secret (cannot be revealed after saving${
+            looksLikeCredentialName(envName)
+              ? '; recommended because this name looks like a credential'
+              : ''
+          })`,
+          value: 'secret',
+        },
+        { name: 'Config (can be revealed after saving)', value: 'config' },
+      ],
+    });
+    isSensitive = selectedType === 'secret';
+    explicitType = selectedType;
+    typeSource = 'prompt';
   } else {
     isSensitive = await client.input.confirm(SENSITIVE_SECRET_PROMPT, true);
     if (policyOn && !isSensitive) {
@@ -887,7 +1149,11 @@ export default async function add(client: Client, argv: string[]) {
     );
   }
 
-  if (forceSensitive && envTargets.includes('development')) {
+  if (
+    !configSecretUiEnabled &&
+    forceSensitive &&
+    envTargets.includes('development')
+  ) {
     const msg = `--sensitive is not allowed with the Development Environment. Sensitive Environment Variables are only supported on Production and Preview.`;
     if (client.nonInteractive) {
       const nonDev = envTargets.filter(t => t !== 'development');
@@ -922,7 +1188,8 @@ export default async function add(client: Client, argv: string[]) {
     const compatibilityError = getTargetCompatibilityError(
       envTargets,
       isSensitive,
-      policyOn
+      policyOn,
+      configSecretUiEnabled
     );
     if (compatibilityError) {
       if (client.nonInteractive) {
@@ -973,6 +1240,7 @@ export default async function add(client: Client, argv: string[]) {
   const envChoices = filterEnvChoicesForSensitivity(choices, {
     isSensitive,
     policyOn,
+    configSecretUiEnabled,
   });
 
   if (policyOn && isSensitive) {
@@ -1017,7 +1285,7 @@ export default async function add(client: Client, argv: string[]) {
         status: 'action_required',
         reason: 'missing_value',
         message:
-          'In non-interactive mode provide the value via --value or stdin. Example: vercel env add <name> <environment> --value "<value>" --yes',
+          'In non-interactive mode provide the value via `--value` or stdin. Example: `vercel env add <name> <environment> --value "<value>" --yes`',
         next: [
           {
             command: buildEnvAddCommandWithPreservedArgs(
@@ -1031,7 +1299,7 @@ export default async function add(client: Client, argv: string[]) {
     envValue = await promptEnvValue(client, { isSensitive });
   }
 
-  const { finalValue } = await validateEnvValue({
+  let { finalValue } = await validateEnvValue({
     envName,
     initialValue: envValue,
     skipConfirm,
@@ -1052,6 +1320,7 @@ export default async function add(client: Client, argv: string[]) {
         {
           forceSensitive,
           policyOn,
+          configSecretUiEnabled,
         }
       );
       const next: Array<{ command: string; when?: string }> = [];
@@ -1061,7 +1330,9 @@ export default async function add(client: Client, argv: string[]) {
             client.argv,
             envName,
             multiTargets,
-            multiTargets.includes('development') && !forceEncrypted
+            !configSecretUiEnabled &&
+              multiTargets.includes('development') &&
+              !forceEncrypted
           )
         );
       }
@@ -1101,7 +1372,8 @@ export default async function add(client: Client, argv: string[]) {
   const postSelectionError = getTargetCompatibilityError(
     envTargets,
     isSensitive,
-    policyOn
+    policyOn,
+    configSecretUiEnabled
   );
   if (postSelectionError) {
     output.error(postSelectionError);
@@ -1156,6 +1428,7 @@ export default async function add(client: Client, argv: string[]) {
     forceSensitive,
     forceEncrypted,
     policyOn,
+    configSecretUiEnabled,
   });
 
   if (policyOn && !hasDevelopment) {
@@ -1170,10 +1443,220 @@ export default async function add(client: Client, argv: string[]) {
     }
   }
 
+  while (
+    configSecretUiEnabled &&
+    finalType === 'encrypted' &&
+    (typeSource === 'argv'
+      ? looksLikeCredentialName(envName, customSveltePublicPrefix) ||
+        looksLikeSecretValue(finalValue)
+      : (customSveltePublicPrefix !== undefined &&
+          looksLikeCredentialName(envName, customSveltePublicPrefix)) ||
+        looksLikeSecretValue(finalValue))
+  ) {
+    printEnvAddWarning(
+      'This name or value looks like a credential. Config values can be revealed after saving.'
+    );
+    const publicPrefix =
+      getPublicPrefix(envName, true) ?? customSveltePublicPrefix;
+    if (publicPrefix !== undefined && typeSource !== 'argv') {
+      const privateName = envName.slice(publicPrefix.length);
+      const privateCommand = buildEnvAddCommandWithPreservedArgs(
+        client.argv,
+        `env add ${privateName} ${envTargets.join(
+          ','
+        )} --type secret --value "<value>" --yes`
+      );
+      const publicCommand = buildEnvAddCommandWithPreservedArgs(
+        client.argv,
+        `env add ${envName} ${envTargets.join(
+          ','
+        )} --type config --value "<value>" --yes`
+      );
+      const privateHumanCommand = buildHumanEnvAddCommand(
+        client.argv,
+        `env add ${privateName} ${envTargets.join(',')} --type secret`
+      );
+      const publicHumanCommand = buildHumanEnvAddCommand(
+        client.argv,
+        `env add ${envName} ${envTargets.join(',')} --type config`
+      );
+      const message =
+        publicPrefix === ''
+          ? `${envName} looks like a credential, and this SvelteKit project exposes every Environment Variable to the browser. Change the SvelteKit publicPrefix to keep it private, or use --type config only if the value is safe to expose.`
+          : `${envName} looks like a credential, and ${publicPrefix} exposes its value to anyone visiting your site. Choose explicitly: rename to ${privateName} with --type secret to keep it private, or keep the name with --type config to expose it.`;
+      if (client.nonInteractive) {
+        outputActionRequired(client, {
+          status: 'action_required',
+          reason: 'public_prefix_requires_type',
+          message,
+          next: [
+            ...(publicPrefix === ''
+              ? []
+              : [
+                  {
+                    command: privateCommand,
+                    when: 'Keep it private; replace <value> before running',
+                  },
+                ]),
+            {
+              command: publicCommand,
+              when: 'Expose it publicly; replace <value> before running',
+            },
+          ],
+        });
+      }
+      if (opts['--yes']) {
+        output.error(message);
+        if (publicPrefix !== '') {
+          output.print(`  Keep it private:\n    ${privateHumanCommand}\n`);
+        }
+        output.print(`  Expose it publicly:\n    ${publicHumanCommand}\n`);
+        return 1;
+      }
+      const selectedAction = await client.input.select({
+        message: 'How should this variable be stored?',
+        choices: [
+          ...(publicPrefix === ''
+            ? []
+            : [
+                {
+                  name: `Keep private: rename to ${privateName} and use Secret`,
+                  value: 'private',
+                },
+              ]),
+          {
+            name: `Expose to anyone visiting your site: keep ${envName} as Config`,
+            value: 'public',
+          },
+          { name: 'Enter a different value', value: 'reenter' },
+        ],
+      });
+      if (selectedAction === 'private') {
+        envName = privateName;
+        finalType = 'sensitive';
+        explicitType = 'secret';
+        typeSource = 'prompt';
+        output.log(`Renamed to ${envName}`);
+        break;
+      }
+      if (selectedAction === 'reenter') {
+        const reenteredValue = await promptEnvValue(client, {
+          isSensitive: false,
+        });
+        const validated = await validateEnvValue({
+          envName,
+          initialValue: reenteredValue,
+          skipConfirm: false,
+          promptForValue: () => promptEnvValue(client, { isSensitive: false }),
+          selectAction: choices =>
+            client.input.select({ message: 'Value?', choices }),
+          showWarning: msg => printEnvAddWarning(msg),
+          showLog: msg => output.log(msg),
+        });
+        finalValue = validated.finalValue;
+        continue;
+      }
+    } else if (
+      typeSource !== 'argv' &&
+      !opts['--yes'] &&
+      !client.nonInteractive
+    ) {
+      const selectedType = await client.input.select({
+        message: 'Store this value as?',
+        choices: [
+          {
+            name: 'Secret (cannot be revealed after saving; recommended)',
+            value: 'secret',
+          },
+          {
+            name: 'Config (can be revealed after saving)',
+            value: 'config',
+          },
+        ],
+      });
+      if (selectedType === 'secret') {
+        finalType = 'sensitive';
+        explicitType = 'secret';
+        typeSource = 'prompt';
+      }
+    }
+    break;
+  }
+
+  if (
+    configSecretUiEnabled &&
+    finalType === 'sensitive' &&
+    customSveltePublicPrefix !== undefined
+  ) {
+    printEnvAddWarning(
+      'This SvelteKit project exposes this variable to the browser; the Secret type does not prevent that. Rename the variable without the configured public prefix to keep it private.'
+    );
+  }
+
+  if (
+    configSecretUiEnabled &&
+    isFlagsSecretNeedingSplit({
+      key: envName,
+      type: finalType,
+      targets: envTargets.filter(isValidEnvTarget),
+      customEnvironmentIds: envTargets.filter(
+        target => !isValidEnvTarget(target)
+      ),
+    })
+  ) {
+    printEnvAddWarning(
+      'FLAGS_SECRET should use a separate value for each environment so Development overrides cannot affect Preview or Production.'
+    );
+  }
+
+  const hasProduction = envTargets.includes('production');
+  const hasNonProduction = envTargets.some(target => target !== 'production');
+  if (
+    configSecretUiEnabled &&
+    finalType === 'sensitive' &&
+    disjunctiveProductionSecretPolicyOn &&
+    hasProduction &&
+    hasNonProduction
+  ) {
+    const message =
+      'Your team requires Production Secret values to be stored separately. Run one command for Production and another for the remaining environments.';
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'production_secret_must_be_separate',
+          message,
+          next: [
+            {
+              command: buildEnvAddCommandWithPreservedArgs(
+                client.argv,
+                `env add ${envName} production --type secret --value "<value>" --yes`
+              ),
+              when: 'Set the Production Secret',
+            },
+            {
+              command: buildEnvAddCommandWithPreservedArgs(
+                client.argv,
+                `env add ${envName} ${envTargets
+                  .filter(target => target !== 'production')
+                  .join(',')} --type secret --value "<value>" --yes`
+              ),
+              when: 'Set the non-Production Secret',
+            },
+          ],
+        },
+        1
+      );
+    }
+    output.error(message);
+    return 1;
+  }
+
   const upsert = opts['--force'] ? 'true' : '';
   const { visibility, error: visibilityError } = resolveEnvVarVisibility({
     configSecretUiEnabled,
-    explicitVisibility,
+    explicitVisibility: explicitType,
     type: finalType,
     key: envName,
     envTargets,
@@ -1185,7 +1668,7 @@ export default async function add(client: Client, argv: string[]) {
         client,
         {
           status: 'error',
-          reason: 'invalid_visibility',
+          reason: 'invalid_type',
           message: visibilityError,
         },
         1
@@ -1210,17 +1693,22 @@ export default async function add(client: Client, argv: string[]) {
     );
   } catch (err: unknown) {
     if (client.nonInteractive && isAPIError(err)) {
-      const reason =
-        (err as { slug?: string }).slug ||
-        (err.serverMessage?.toLowerCase().includes('branch')
-          ? 'branch_not_found'
-          : 'api_error');
+      const requiresSeparateProductionSecret =
+        /production.*separate|separate.*production/i.test(err.serverMessage);
+      const reason = requiresSeparateProductionSecret
+        ? 'production_secret_must_be_separate'
+        : (err as { slug?: string }).slug ||
+          (err.serverMessage?.toLowerCase().includes('branch')
+            ? 'branch_not_found'
+            : 'api_error');
       outputAgentError(
         client,
         {
           status: 'error',
           reason,
-          message: err.serverMessage,
+          message: requiresSeparateProductionSecret
+            ? `${err.serverMessage} Run separate commands for Production and non-Production environments.`
+            : err.serverMessage,
         },
         1
       );
@@ -1242,6 +1730,14 @@ export default async function add(client: Client, argv: string[]) {
     Boolean(opts['--force']),
     visibility
   );
+
+  if (configSecretUiEnabled && typeSource === 'default') {
+    output.print(
+      `  ${chalk.dim(
+        'Stored as Secret by default. Secrets cannot be revealed or pulled; use --type config for values you need to read later.'
+      )}\n`
+    );
+  }
 
   const { isAgent } = await determineAgent();
   const guidanceMode = parsedArgs.flags['--guidance'] ?? isAgent;

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -61,7 +61,7 @@ export const addSubcommand = {
     projectOption,
     {
       name: 'sensitive',
-      description: 'Store the value as sensitive for Production or Preview',
+      description: 'Prevent the value from being read after saving',
       shorthand: null,
       type: Boolean,
       deprecated: false,
@@ -74,12 +74,12 @@ export const addSubcommand = {
       deprecated: false,
     },
     {
-      name: 'visibility',
+      name: 'type',
       description:
-        'Set config/secret visibility (`config` or `secret`). Inferred from type when omitted and VERCEL_ENV_VAR_CONFIG_SECRET_UI is set',
+        'Set the type to `config` (value can be revealed after saving) or `secret` (value cannot be revealed after saving)',
       shorthand: null,
       type: String,
-      argument: 'VISIBILITY',
+      argument: 'TYPE',
       deprecated: false,
     },
     {
@@ -338,12 +338,12 @@ export const updateSubcommand = {
       deprecated: false,
     },
     {
-      name: 'visibility',
+      name: 'type',
       description:
-        'Set config/secret visibility (`config` or `secret`). Inferred from type when omitted and VERCEL_ENV_VAR_CONFIG_SECRET_UI is set',
+        'Set the type to `config` (value can be revealed after saving) or `secret` (value cannot be revealed after saving)',
       shorthand: null,
       type: String,
-      argument: 'VISIBILITY',
+      argument: 'TYPE',
       deprecated: false,
     },
     {

--- a/packages/cli/src/commands/env/ls.ts
+++ b/packages/cli/src/commands/env/ls.ts
@@ -26,6 +26,10 @@ import { resolveProjectContext } from '../../util/projects/resolve-project-conte
 import { determineAgent } from '@vercel/detect-agent';
 import { suggestNextCommands } from '../../util/suggest-next-commands';
 import { validateLsArgs } from '../../util/validate-ls-args';
+import {
+  formatVisibilityLabel,
+  isEnvVarConfigSecretUiEnabled,
+} from '../../util/env/env-var-config-secret-ui';
 
 export default async function ls(client: Client, argv: string[]) {
   const telemetryClient = new EnvLsTelemetryClient({
@@ -64,6 +68,7 @@ export default async function ls(client: Client, argv: string[]) {
     return 1;
   }
   const asJson = formatResult.jsonOutput;
+  const configSecretUiEnabled = isEnvVarConfigSecretUiEnabled();
 
   telemetryClient.trackCliArgumentEnvironment(envTarget);
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
@@ -110,6 +115,7 @@ export default async function ls(client: Client, argv: string[]) {
         key: env.key,
         value: env.type === 'plain' ? env.value : undefined,
         type: env.type,
+        ...(configSecretUiEnabled ? { visibility: env.visibility } : {}),
         target: env.target,
         gitBranch: env.gitBranch,
         configurationId: env.configurationId,
@@ -126,7 +132,9 @@ export default async function ls(client: Client, argv: string[]) {
     output.log(
       `Environment Variables found for ${projectSlugLink} ${chalk.gray(lsStamp())}`
     );
-    client.stdout.write(`${getTable(link, envs, customEnvs)}\n`);
+    client.stdout.write(
+      `${getTable(link, envs, customEnvs, configSecretUiEnabled)}\n`
+    );
   }
 
   if (!asJson) {
@@ -148,18 +156,24 @@ export default async function ls(client: Client, argv: string[]) {
 function getTable(
   link: ProjectLinked,
   records: ProjectEnvVariable[],
-  customEnvironments: CustomEnvironment[]
+  customEnvironments: CustomEnvironment[],
+  configSecretUiEnabled: boolean
 ) {
   const label = records.some(env => env.gitBranch)
     ? 'environments (git branch)'
     : 'environments';
+  const headers = configSecretUiEnabled
+    ? ['name', 'value', 'type', label, 'created']
+    : ['name', 'value', label, 'created'];
   return formatTable(
-    ['name', 'value', label, 'created'],
-    ['l', 'l', 'l', 'l', 'l'],
+    headers,
+    headers.map(() => 'l' as const),
     [
       {
         name: '',
-        rows: records.map(row => getRow(link, row, customEnvironments)),
+        rows: records.map(row =>
+          getRow(link, row, customEnvironments, configSecretUiEnabled)
+        ),
       },
     ]
   );
@@ -168,7 +182,8 @@ function getTable(
 function getRow(
   link: ProjectLinked,
   env: ProjectEnvVariable,
-  customEnvironments: CustomEnvironment[]
+  customEnvironments: CustomEnvironment[],
+  configSecretUiEnabled: boolean
 ) {
   let value: string;
   if (env.type === 'plain') {
@@ -184,10 +199,13 @@ function getRow(
   }
 
   const now = Date.now();
-  return [
-    chalk.bold(env.key),
-    value,
+  const row = [chalk.bold(env.key), value];
+  if (configSecretUiEnabled) {
+    row.push(formatVisibilityLabel(env.visibility, env.type) ?? '—');
+  }
+  row.push(
     formatEnvironments(link, env, customEnvironments),
-    env.createdAt ? `${ms(now - env.createdAt)} ago` : '',
-  ];
+    env.createdAt ? `${ms(now - env.createdAt)} ago` : ''
+  );
+  return row;
 }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -36,6 +36,7 @@ import {
   outputAgentError,
 } from '../../util/agent-output';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
+import { isEnvVarConfigSecretUiEnabled } from '../../util/env/env-var-config-secret-ui';
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
 
@@ -169,9 +170,9 @@ export default async function pull(
         {
           status: 'error',
           reason: 'not_linked',
-          message: `Your codebase isn't linked to a project on Vercel. Run ${getCommandNamePlain(
+          message: `Your codebase isn't linked to a project on Vercel. Run \`${getCommandNamePlain(
             'link'
-          )} to begin. Use --yes for non-interactive; use --scope or --project to specify team or project.`,
+          )}\` to begin. Use \`--yes\` for non-interactive; use \`--scope\` or \`--project\` to specify team or project.`,
           next: [
             { command: buildCommandWithYes(linkArgv) },
             { command: buildCommandWithYes(client.argv) },
@@ -315,6 +316,7 @@ export async function envPullCommandLogic(
   let contents: string;
   let fileChanged = true;
   const keptLocalKeys: string[] = [];
+  let redactedSecretCount = 0;
 
   if (oidcTokenOnly) {
     const existingContents = exists ? await readFile(fullPath, 'utf8') : '';
@@ -332,6 +334,7 @@ export async function envPullCommandLogic(
       gitBranch,
       records
     );
+    redactedSecretCount = sensitiveKeys.size;
 
     const mergedRecords: Record<string, string | undefined> = { ...records };
     for (const key of sensitiveKeys) {
@@ -385,6 +388,18 @@ export async function envPullCommandLogic(
         .join(', ')} (defined locally, not found in the ${chalk.cyan(
         environment
       )} Environment)`
+    );
+  }
+
+  if (isEnvVarConfigSecretUiEnabled() && redactedSecretCount > 0) {
+    output.warn(
+      `${redactedSecretCount} Secret ${
+        redactedSecretCount === 1 ? 'value' : 'values'
+      } cannot be pulled because ${
+        redactedSecretCount === 1 ? 'a Secret cannot' : 'Secrets cannot'
+      } be revealed. Wrote "${SENSITIVE_PLACEHOLDER}" ${
+        redactedSecretCount === 1 ? 'placeholder' : 'placeholders'
+      }; replace ${redactedSecretCount === 1 ? 'it' : 'them'} with local-only values.`
     );
   }
 

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -25,6 +25,9 @@ import {
   buildEnvRmCommandWithPreservedArgs,
   getPreservedArgsForEnvRm,
 } from '../../util/agent-output';
+import { getPublicPrefix } from '../../util/env/validate-env';
+import { shouldConfirmRotationBeforeDelete } from '../../util/env/secret-detection';
+import { isEnvVarConfigSecretUiEnabled } from '../../util/env/env-var-config-secret-ui';
 
 export default async function rm(client: Client, argv: string[]) {
   const telemetryClient = new EnvRmTelemetryClient({
@@ -61,9 +64,9 @@ export default async function rm(client: Client, argv: string[]) {
         {
           status: 'error',
           reason: 'invalid_arguments',
-          message: `Invalid number of arguments. Usage: ${getCommandNamePlain(
+          message: `Invalid number of arguments. Usage: \`${getCommandNamePlain(
             `env rm <name> ${getEnvTargetPlaceholder()} <gitbranch>`
-          )}`,
+          )}\``,
         },
         1
       );
@@ -106,9 +109,9 @@ export default async function rm(client: Client, argv: string[]) {
         {
           status: 'error',
           reason: 'not_linked',
-          message: `Your codebase isn't linked to a project on Vercel. Run ${getCommandNamePlain(
+          message: `Your codebase isn't linked to a project on Vercel. Run \`${getCommandNamePlain(
             'link'
-          )} to begin. Use --yes for non-interactive; use --scope or --project to specify team or project.`,
+          )}\` to begin. Use \`--yes\` for non-interactive; use \`--scope\` or \`--project\` to specify team or project.`,
           next: [
             { command: buildCommandWithYes(linkArgv) },
             { command: buildCommandWithYes(client.argv) },
@@ -137,7 +140,7 @@ export default async function rm(client: Client, argv: string[]) {
           status: 'action_required',
           reason: 'missing_name',
           message:
-            'Provide the variable name as an argument. Example: vercel env rm <name> --yes',
+            'Provide the variable name as an argument. Example: `vercel env rm <name> --yes`',
           next: [
             {
               command: buildEnvRmCommandWithPreservedArgs(
@@ -216,6 +219,19 @@ export default async function rm(client: Client, argv: string[]) {
     envs = envs.filter(env => env.id === id);
   }
   const env = envs[0];
+  const configSecretUiEnabled = isEnvVarConfigSecretUiEnabled();
+  const shouldWarnAboutRotation =
+    configSecretUiEnabled &&
+    shouldConfirmRotationBeforeDelete({
+      key: env.key,
+      type: env.type,
+      hasPublicPrefix: getPublicPrefix(env.key, true) !== null,
+    });
+  const rotationWarning =
+    'Removing this variable from Vercel does not revoke the credential. Rotate or disable it at its provider.';
+  if (shouldWarnAboutRotation) {
+    output.warn(rotationWarning);
+  }
 
   const skipConfirmation = opts['--yes'];
   if (!skipConfirmation) {
@@ -225,22 +241,28 @@ export default async function rm(client: Client, argv: string[]) {
         {
           status: 'action_required',
           reason: 'confirmation_required',
-          message: `Removing Environment Variable ${env.key}. Use --yes to confirm.`,
+          message: `Removing Environment Variable ${env.key}. ${
+            shouldWarnAboutRotation ? `${rotationWarning} ` : ''
+          }Use --yes to confirm.`,
           next: [{ command: buildCommandWithYes(client.argv) }],
         },
         1
       );
     }
-    if (
-      !(await client.input.confirm(
-        `Removing Environment Variable ${param(env.key)} from ${formatEnvironments(
+    const confirmationMessage = configSecretUiEnabled
+      ? `Remove ${param(env.key)} from ${formatEnvironments(
           link,
           env,
           customEnvironments
-        )} in Project ${chalk.bold(project.name)}. Are you sure?`,
-        false
-      ))
-    ) {
+        )} in Project ${chalk.bold(project.name)}?`
+      : `Removing Environment Variable ${param(
+          env.key
+        )} from ${formatEnvironments(
+          link,
+          env,
+          customEnvironments
+        )} in Project ${chalk.bold(project.name)}. Are you sure?`;
+    if (!(await client.input.confirm(confirmationMessage, false))) {
       output.log('Canceled');
       return 0;
     }

--- a/packages/cli/src/commands/env/run.ts
+++ b/packages/cli/src/commands/env/run.ts
@@ -7,10 +7,11 @@ import { runSubcommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { resolveProjectContext } from '../../util/projects/resolve-project-context';
-import { pullEnvRecords } from '../../util/env/get-env-records';
+import getEnvRecords, { pullEnvRecords } from '../../util/env/get-env-records';
 import parseTarget from '../../util/parse-target';
 import { getCommandName } from '../../util/pkg-name';
 import type { EnvTelemetryClient } from '../../util/telemetry/commands/env';
+import { isEnvVarConfigSecretUiEnabled } from '../../util/env/env-var-config-secret-ui';
 
 /**
  * Parses argv for the run subcommand, splitting on `--` to separate
@@ -121,6 +122,38 @@ export default async function run(
     localEnv = loadEnvConfig(client.cwd, true).combinedEnv;
   } catch (err) {
     output.debug(`Failed to load local env files: ${err}`);
+  }
+
+  if (isEnvVarConfigSecretUiEnabled()) {
+    const emptyKeys = new Set(
+      Object.entries(records.env)
+        .filter(([key, value]) => !value && !localEnv[key] && !process.env[key])
+        .map(([key]) => key)
+    );
+    if (emptyKeys.size > 0) {
+      try {
+        const { envs } = await getEnvRecords(
+          client,
+          link.project.id,
+          'vercel-cli:env:run',
+          { target: environment, gitBranch }
+        );
+        const unavailableSecretKeys = envs.filter(
+          env => env.type === 'sensitive' && emptyKeys.has(env.key)
+        );
+        if (unavailableSecretKeys.length > 0) {
+          output.warn(
+            `${unavailableSecretKeys.length} Secret ${
+              unavailableSecretKeys.length === 1 ? 'value is' : 'values are'
+            } not available to vercel env run. Define ${
+              unavailableSecretKeys.length === 1 ? 'it' : 'them'
+            } in a local .env file.`
+          );
+        }
+      } catch {
+        // The command can still run with the values returned by the pull API.
+      }
+    }
   }
 
   try {

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -9,6 +9,8 @@ import param from '../../util/output/param';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { isKnownError } from '../../util/env/known-error';
 import {
+  getLocalSvelteKitPublicPrefixes,
+  getPublicPrefix,
   normalizeStdinEnvValue,
   validateEnvValue,
 } from '../../util/env/validate-env';
@@ -28,11 +30,23 @@ import type { ProjectEnvVariable } from '@vercel-internals/types';
 import { getGlobalFlagsFromArgs } from '../../util/arg-common';
 import { printAlignedLabel } from '../../util/output/print-aligned-label';
 import {
+  getPublicPrefixSecretVisibilityError,
   isEnvVarConfigSecretUiEnabled,
   resolveEnvVarVisibility,
   shouldEnforceSensitiveEnvVarPolicy,
   formatVisibilityLabel,
 } from '../../util/env/env-var-config-secret-ui';
+import {
+  looksLikeSecret,
+  looksLikeSecretValue,
+} from '../../util/env/secret-detection';
+
+function looksLikeCredentialName(
+  key: string,
+  publicPrefix: string | null | undefined = getPublicPrefix(key, true)
+): boolean {
+  return looksLikeSecret(publicPrefix ? key.slice(publicPrefix.length) : key);
+}
 
 function selectedEnvTargetsDevelopment(env: ProjectEnvVariable): boolean {
   if (typeof env.target === 'string') return env.target === 'development';
@@ -74,6 +88,9 @@ export default async function update(client: Client, argv: string[]) {
     typeof opts['--value'] === 'string' ? opts['--value'] : undefined;
   const stdInput = await readStandardInput(client.stdin);
   let [envName, envTargetArg, envGitBranch] = args;
+  let explicitType =
+    typeof opts['--type'] === 'string' ? opts['--type'] : undefined;
+  const typeWasExplicit = explicitType !== undefined || opts['--sensitive'];
 
   const telemetryClient = new EnvUpdateTelemetryClient({
     opts: {
@@ -86,8 +103,8 @@ export default async function update(client: Client, argv: string[]) {
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
   telemetryClient.trackCliFlagYes(opts['--yes']);
   telemetryClient.trackCliOptionValue(valueFromFlag);
-  telemetryClient.trackCliOptionVisibility(
-    typeof opts['--visibility'] === 'string' ? opts['--visibility'] : undefined
+  telemetryClient.trackCliOptionType(
+    typeof opts['--type'] === 'string' ? opts['--type'] : undefined
   );
 
   if (args.length > 3) {
@@ -97,9 +114,9 @@ export default async function update(client: Client, argv: string[]) {
         {
           status: 'error',
           reason: 'invalid_arguments',
-          message: `Invalid number of arguments. Usage: ${getCommandNamePlain(
+          message: `Invalid number of arguments. Usage: \`${getCommandNamePlain(
             `env update <name> ${getEnvTargetPlaceholder()} <gitbranch>`
-          )}`,
+          )}\``,
         },
         1
       );
@@ -143,7 +160,7 @@ export default async function update(client: Client, argv: string[]) {
           status: 'action_required',
           reason: 'missing_requirements',
           missing,
-          message: `Provide all required inputs for non-interactive mode: ${parts.join('; ')}. Example: ${getCommandNamePlain(template)}`,
+          message: `Provide all required inputs for non-interactive mode: ${parts.join('; ')}. Example: \`${getCommandNamePlain(template)}\``,
           next: [
             {
               command: buildEnvUpdateCommandWithPreservedArgs(
@@ -171,7 +188,7 @@ export default async function update(client: Client, argv: string[]) {
           status: 'action_required',
           reason: 'missing_name',
           message:
-            'Provide the variable name as an argument. Example: vercel env update <name>',
+            'Provide the variable name as an argument. Example: `vercel env update <name>`',
           next: [
             {
               command: buildEnvUpdateCommandWithPreservedArgs(
@@ -216,9 +233,9 @@ export default async function update(client: Client, argv: string[]) {
         {
           status: 'error',
           reason: 'not_linked',
-          message: `Your codebase isn't linked to a project on Vercel. Run ${getCommandNamePlain(
+          message: `Your codebase isn't linked to a project on Vercel. Run \`${getCommandNamePlain(
             'link'
-          )} to begin. Use --yes for non-interactive; use --scope or --project to specify team or project.`,
+          )}\` to begin. Use \`--yes\` for non-interactive; use \`--scope\` or \`--project\` to specify team or project.`,
           next: [
             { command: buildCommandWithYes(linkArgv) },
             { command: buildCommandWithYes(client.argv) },
@@ -259,7 +276,7 @@ export default async function update(client: Client, argv: string[]) {
         {
           status: 'error',
           reason: 'env_not_found',
-          message: `The variable ${envName} was not found. Run ${getCommandNamePlain(listArgs)} to see all available Environment Variables.`,
+          message: `The variable ${envName} was not found. Run \`${getCommandNamePlain(listArgs)}\` to see all available Environment Variables.`,
         },
         1
       );
@@ -381,14 +398,209 @@ export default async function update(client: Client, argv: string[]) {
     selectedEnv = matchingEnvs[selectedIndex];
   }
 
-  // Detect team-level sensitive env var policy. Cached in getTeamById.
   const configSecretUiEnabled = isEnvVarConfigSecretUiEnabled();
+  let customSveltePublicPrefix: string | undefined;
+  if (
+    configSecretUiEnabled &&
+    (project.framework === 'sveltekit' ||
+      project.framework === 'sveltekit-1' ||
+      project.framework === 'sveltekit-2')
+  ) {
+    const localPublicPrefixes = await getLocalSvelteKitPublicPrefixes(
+      link.repoRoot ?? client.cwd,
+      (project as { rootDirectory?: string | null }).rootDirectory
+    );
+    const matchingLocalPrefix = localPublicPrefixes?.find(prefix =>
+      envName.startsWith(prefix)
+    );
+    if (matchingLocalPrefix !== undefined && !getPublicPrefix(envName, true)) {
+      customSveltePublicPrefix = matchingLocalPrefix;
+      output.warn(
+        matchingLocalPrefix === ''
+          ? 'This SvelteKit project uses an empty publicPrefix, so every Environment Variable is exposed to the browser.'
+          : `${matchingLocalPrefix} variables are exposed to the browser by this SvelteKit project.`
+      );
+    }
+  }
+
+  if (explicitType && !configSecretUiEnabled) {
+    output.error(
+      '`--type` is only available while Config and Secret Environment Variables are enabled.'
+    );
+    return 1;
+  }
+  if (explicitType === 'config' && opts['--sensitive']) {
+    output.error(
+      '`--type config` cannot be used with `--sensitive`. Pick one.'
+    );
+    return 1;
+  }
+
+  const targets = Array.isArray(selectedEnv.target)
+    ? selectedEnv.target
+    : [selectedEnv.target].filter((r): r is NonNullable<typeof r> =>
+        Boolean(r)
+      );
+  const allTargets = [...targets, ...(selectedEnv.customEnvironmentIds || [])];
+
+  if (explicitType === 'config' && selectedEnv.type === 'sensitive') {
+    const targetArg = envTargetArg || targets[0] || getEnvTargetPlaceholder();
+    const branchArg = selectedEnv.gitBranch ? ` ${selectedEnv.gitBranch}` : '';
+    const globalFlags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+      preserveProject: true,
+    });
+    const humanGlobalFlags = globalFlags.filter(
+      flag => !flag.startsWith('--non-interactive')
+    );
+    const globalSuffix =
+      globalFlags.length > 0 ? ` ${globalFlags.join(' ')}` : '';
+    const humanGlobalSuffix =
+      humanGlobalFlags.length > 0 ? ` ${humanGlobalFlags.join(' ')}` : '';
+    const removeCommand = getCommandNamePlain(
+      `env rm ${envName} ${targetArg}${branchArg} --yes${globalSuffix}`
+    );
+    const addCommand = getCommandNamePlain(
+      `env add ${envName} ${targetArg}${branchArg} --type config --value "<value>" --yes${globalSuffix}`
+    );
+    const removeHumanCommand = getCommandNamePlain(
+      `env rm ${envName} ${targetArg}${branchArg}${humanGlobalSuffix}`
+    );
+    const addHumanCommand = getCommandNamePlain(
+      `env add ${envName} ${targetArg}${branchArg} --type config${humanGlobalSuffix}`
+    );
+    const message =
+      'A Secret cannot be changed to Config. To store this value as Config, remove the variable and add it again with `--type config`.';
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'secret_cannot_become_config',
+          message,
+          next: [
+            {
+              command: removeCommand,
+              when: 'Remove the Secret variable',
+            },
+            {
+              command: addCommand,
+              when: 'Add it again as Config; replace <value> before running',
+            },
+          ],
+        },
+        1
+      );
+    }
+    output.error(
+      `A Secret cannot be changed to Config. Remove the variable, then add it again as Config. ${param(envName)} will be unavailable to new builds between these commands.`
+    );
+    output.print(`  Remove:\n    ${removeHumanCommand}\n`);
+    output.print(
+      `  Add as Config (prompts for the value):\n    ${addHumanCommand}\n`
+    );
+    return 1;
+  }
+
+  if (
+    configSecretUiEnabled &&
+    (explicitType === 'secret' || opts['--sensitive'])
+  ) {
+    const apiPublicPrefix = getPublicPrefix(envName, true);
+    const publicPrefix = apiPublicPrefix ?? customSveltePublicPrefix;
+    const publicPrefixError = apiPublicPrefix
+      ? getPublicPrefixSecretVisibilityError(envName, {
+          visibility: explicitType === 'secret' ? 'secret' : undefined,
+          type: 'sensitive',
+          context: 'update',
+        })
+      : customSveltePublicPrefix === ''
+        ? 'This SvelteKit project uses an empty `publicPrefix`, so every Environment Variable is exposed to the browser and cannot be kept private as a Secret. Change the SvelteKit `publicPrefix`, or keep this variable as Config only if the value is safe to expose.'
+        : customSveltePublicPrefix !== undefined
+          ? `\`${customSveltePublicPrefix}\` exposes this value to anyone visiting your site, so \`${envName}\` cannot be kept private as a Secret. Add a new Secret without the configured public prefix, then remove this Config.`
+          : null;
+    if (publicPrefixError) {
+      const privateName =
+        publicPrefix === undefined
+          ? envName
+          : envName.slice(publicPrefix.length);
+      const targetArg = envTargetArg || targets[0] || getEnvTargetPlaceholder();
+      const branchArg = selectedEnv.gitBranch
+        ? ` ${selectedEnv.gitBranch}`
+        : '';
+      const globalFlags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+        preserveProject: true,
+      });
+      const humanGlobalFlags = globalFlags.filter(
+        flag => !flag.startsWith('--non-interactive')
+      );
+      const globalSuffix =
+        globalFlags.length > 0 ? ` ${globalFlags.join(' ')}` : '';
+      const humanGlobalSuffix =
+        humanGlobalFlags.length > 0 ? ` ${humanGlobalFlags.join(' ')}` : '';
+      const addCommand =
+        publicPrefix === ''
+          ? undefined
+          : getCommandNamePlain(
+              `env add ${privateName} ${targetArg}${branchArg} --type secret --value "<value>" --yes${globalSuffix}`
+            );
+      const removeCommand = getCommandNamePlain(
+        `env rm ${envName} ${targetArg}${branchArg} --yes${globalSuffix}`
+      );
+      const addHumanCommand =
+        publicPrefix === ''
+          ? undefined
+          : getCommandNamePlain(
+              `env add ${privateName} ${targetArg}${branchArg} --type secret${humanGlobalSuffix}`
+            );
+      const removeHumanCommand = getCommandNamePlain(
+        `env rm ${envName} ${targetArg}${branchArg}${humanGlobalSuffix}`
+      );
+      if (client.nonInteractive) {
+        outputAgentError(
+          client,
+          {
+            status: 'error',
+            reason: 'invalid_type',
+            message: publicPrefixError,
+            next: addCommand
+              ? [
+                  {
+                    command: addCommand,
+                    when: 'Add the private Secret; replace <value> before running',
+                  },
+                  {
+                    command: removeCommand,
+                    when: 'Remove the public Config after the Secret is available',
+                  },
+                ]
+              : [],
+          },
+          1
+        );
+      }
+      output.error(publicPrefixError);
+      if (addHumanCommand) {
+        output.print(
+          `  Add the private Secret (prompts for the value):\n    ${addHumanCommand}\n`
+        );
+        output.print(
+          `  Remove the public Config:\n    ${removeHumanCommand}\n`
+        );
+      }
+      return 1;
+    }
+  }
+
+  // Detect team-level sensitive env var policy. Cached in getTeamById.
   let policyOn = false;
   let teamSensitivePolicyOn = false;
+  let disjunctiveProductionSecretPolicyOn = false;
   if (link.org.type === 'team') {
     try {
       const team = await getTeamById(client, link.org.id);
       teamSensitivePolicyOn = team?.sensitiveEnvironmentVariablePolicy === 'on';
+      disjunctiveProductionSecretPolicyOn =
+        team?.disjunctiveProductionSecretPolicy === 'on';
       policyOn = shouldEnforceSensitiveEnvVarPolicy(teamSensitivePolicyOn);
     } catch {
       // Non-fatal — policy detection is best-effort.
@@ -414,7 +626,7 @@ export default async function update(client: Client, argv: string[]) {
     return 1;
   }
 
-  if (opts['--sensitive'] && selectedIsDevelopment) {
+  if (!configSecretUiEnabled && opts['--sensitive'] && selectedIsDevelopment) {
     const msg = `--sensitive is not allowed with the Development Environment. Sensitive Environment Variables are only supported on Production and Preview.`;
     if (client.nonInteractive) {
       outputAgentError(
@@ -454,7 +666,7 @@ export default async function update(client: Client, argv: string[]) {
           status: 'action_required',
           reason: 'missing_value',
           message:
-            "In non-interactive mode provide the new value via --value or stdin. Example: vercel env update <name> <environment> --value 'value' --yes",
+            "In non-interactive mode provide the new value via `--value` or stdin. Example: `vercel env update <name> <environment> --value 'value' --yes`",
           next: [
             {
               command: buildEnvUpdateCommandWithPreservedArgs(
@@ -486,8 +698,8 @@ export default async function update(client: Client, argv: string[]) {
     showLog: msg => output.log(msg),
   });
 
-  // Confirm the update unless --yes flag is provided or already confirmed from validation
-  if (!opts['--yes'] && !alreadyConfirmed) {
+  // Preserve the legacy confirmation order while the new type model is off.
+  if (!configSecretUiEnabled && !opts['--yes'] && !alreadyConfirmed) {
     if (client.nonInteractive) {
       outputActionRequired(
         client,
@@ -516,25 +728,135 @@ export default async function update(client: Client, argv: string[]) {
     }
   }
 
-  const type = opts['--sensitive'] ? 'sensitive' : selectedEnv.type;
-  const explicitVisibility =
-    typeof opts['--visibility'] === 'string' ? opts['--visibility'] : undefined;
-  if (explicitVisibility === 'config' && opts['--sensitive']) {
-    output.error(
-      '`--visibility config` cannot be used with `--sensitive`. Pick one.'
+  let type =
+    opts['--sensitive'] || explicitType === 'secret'
+      ? 'sensitive'
+      : explicitType === 'config'
+        ? 'encrypted'
+        : selectedEnv.type;
+
+  if (
+    configSecretUiEnabled &&
+    (type === 'plain' || type === 'encrypted') &&
+    (looksLikeCredentialName(envName, customSveltePublicPrefix) ||
+      looksLikeSecretValue(finalValue))
+  ) {
+    output.warn(
+      'This name or value looks like a credential. Config values can be revealed after saving.'
     );
+    const publicPrefix = getPublicPrefix(envName, true);
+    if (publicPrefix) {
+      const privateName = envName.slice(publicPrefix.length);
+      const targetArg = envTargetArg || targets[0] || getEnvTargetPlaceholder();
+      const branchArg = selectedEnv.gitBranch
+        ? ` ${selectedEnv.gitBranch}`
+        : '';
+      const humanGlobalFlags = getGlobalFlagsFromArgs(client.argv.slice(2), {
+        preserveProject: true,
+      }).filter(flag => !flag.startsWith('--non-interactive'));
+      const humanGlobalSuffix =
+        humanGlobalFlags.length > 0 ? ` ${humanGlobalFlags.join(' ')}` : '';
+      const addPrivateCommand = getCommandNamePlain(
+        `env add ${privateName} ${targetArg}${branchArg} --type secret${humanGlobalSuffix}`
+      );
+      const removePublicCommand = getCommandNamePlain(
+        `env rm ${envName} ${targetArg}${branchArg}${humanGlobalSuffix}`
+      );
+      output.warn(
+        `${publicPrefix} exposes this value to anyone visiting your site. Keep Config only if the value is safe to expose.`
+      );
+      if (!typeWasExplicit && !opts['--yes'] && !client.nonInteractive) {
+        const selectedAction = await client.input.select({
+          message: 'How should this variable be stored?',
+          choices: [
+            {
+              name: `Keep private: add ${privateName} as Secret, then remove ${envName}`,
+              value: 'private',
+            },
+            {
+              name: `Expose to anyone visiting your site: keep ${envName} as Config`,
+              value: 'config',
+            },
+          ],
+        });
+        if (selectedAction === 'private') {
+          output.print(`  Add the private Secret (prompts for the value):\n`);
+          output.print(`    ${addPrivateCommand}\n`);
+          output.print(`  Remove the public Config:\n`);
+          output.print(`    ${removePublicCommand}\n`);
+          return 1;
+        }
+      }
+    } else if (!typeWasExplicit && !opts['--yes'] && !client.nonInteractive) {
+      const selectedType = await client.input.select({
+        message: 'Store this value as?',
+        choices: [
+          {
+            name: 'Secret (cannot be revealed after saving; recommended)',
+            value: 'secret',
+          },
+          {
+            name: 'Config (can be revealed after saving)',
+            value: 'config',
+          },
+        ],
+      });
+      if (selectedType === 'secret') {
+        type = 'sensitive';
+        explicitType = 'secret';
+      }
+    } else if (!typeWasExplicit) {
+      output.warn('Re-run with `--type secret` to protect it.');
+    }
+  }
+
+  if (
+    configSecretUiEnabled &&
+    type === 'sensitive' &&
+    selectedEnv.type !== 'sensitive'
+  ) {
+    output.warn(
+      'The previous value was readable as Config and may have been exposed. If this variable still holds the same credential, rotate it at its provider and update this variable again.'
+    );
+  }
+
+  if (
+    configSecretUiEnabled &&
+    type === 'sensitive' &&
+    customSveltePublicPrefix !== undefined
+  ) {
+    output.warn(
+      'This SvelteKit project exposes this variable to the browser; the Secret type does not prevent that. Rename the variable without the configured public prefix to keep it private.'
+    );
+  }
+
+  if (
+    configSecretUiEnabled &&
+    type === 'sensitive' &&
+    disjunctiveProductionSecretPolicyOn &&
+    targets.includes('production') &&
+    allTargets.some(target => target !== 'production')
+  ) {
+    const message =
+      'Your team requires Production Secret values to be stored separately. Create separate Production and non-Production variables before converting this one.';
+    if (client.nonInteractive) {
+      outputAgentError(
+        client,
+        {
+          status: 'error',
+          reason: 'production_secret_must_be_separate',
+          message,
+        },
+        1
+      );
+    }
+    output.error(message);
     return 1;
   }
-  const targets = Array.isArray(selectedEnv.target)
-    ? selectedEnv.target
-    : [selectedEnv.target].filter((r): r is NonNullable<typeof r> =>
-        Boolean(r)
-      );
-  const allTargets = [...targets, ...(selectedEnv.customEnvironmentIds || [])];
 
   const { visibility, error: visibilityError } = resolveEnvVarVisibility({
     configSecretUiEnabled,
-    explicitVisibility,
+    explicitVisibility: explicitType,
     type,
     key: envName,
     envTargets: allTargets,
@@ -546,7 +868,7 @@ export default async function update(client: Client, argv: string[]) {
         client,
         {
           status: 'error',
-          reason: 'invalid_visibility',
+          reason: 'invalid_type',
           message: visibilityError,
         },
         1
@@ -554,6 +876,46 @@ export default async function update(client: Client, argv: string[]) {
     }
     output.error(visibilityError);
     return 1;
+  }
+
+  if (configSecretUiEnabled && !opts['--yes']) {
+    if (client.nonInteractive) {
+      outputActionRequired(
+        client,
+        {
+          status: 'action_required',
+          reason: 'confirmation_required',
+          message: `Update ${envName} as ${formatVisibilityLabel(
+            visibility,
+            type
+          )} in ${formatEnvironments(
+            link,
+            selectedEnv,
+            customEnvironments
+          )}? Use --yes to confirm.`,
+          next: [{ command: buildCommandWithYes(client.argv) }],
+        },
+        1
+      );
+    }
+    output.print('\n');
+    printAlignedLabel('Project', `${link.org.slug}/${project.name}`);
+    printAlignedLabel(
+      'Environments',
+      formatEnvironments(link, selectedEnv, customEnvironments)
+    );
+    const visibilityLabel = formatVisibilityLabel(visibility, type);
+    if (visibilityLabel) {
+      printAlignedLabel('Type', visibilityLabel);
+    }
+    const confirmed = await client.input.confirm(
+      'Update this Environment Variable?',
+      false
+    );
+    if (!confirmed) {
+      output.log('Canceled');
+      return 0;
+    }
   }
 
   const updateStamp = stamp();
@@ -573,17 +935,22 @@ export default async function update(client: Client, argv: string[]) {
     );
   } catch (err: unknown) {
     if (client.nonInteractive && isAPIError(err)) {
-      const reason =
-        (err as { slug?: string }).slug ||
-        (err.serverMessage?.toLowerCase().includes('branch')
-          ? 'branch_not_found'
-          : 'api_error');
+      const requiresSeparateProductionSecret =
+        /production.*separate|separate.*production/i.test(err.serverMessage);
+      const reason = requiresSeparateProductionSecret
+        ? 'production_secret_must_be_separate'
+        : (err as { slug?: string }).slug ||
+          (err.serverMessage?.toLowerCase().includes('branch')
+            ? 'branch_not_found'
+            : 'api_error');
       outputAgentError(
         client,
         {
           status: 'error',
           reason,
-          message: err.serverMessage,
+          message: requiresSeparateProductionSecret
+            ? `${err.serverMessage} Create separate Production and non-Production variables.`
+            : err.serverMessage,
         },
         1
       );
@@ -607,7 +974,7 @@ export default async function update(client: Client, argv: string[]) {
   if (configSecretUiEnabled) {
     const visibilityLabel = formatVisibilityLabel(visibility, type);
     if (visibilityLabel) {
-      printAlignedLabel('Visibility', visibilityLabel);
+      printAlignedLabel('Type', visibilityLabel);
     }
   }
 

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -48,14 +48,12 @@ export class EnvAddTelemetryClient
     }
   }
 
-  trackCliOptionVisibility(visibility: string | undefined) {
-    if (visibility) {
-      const validVisibilities = ['config', 'secret'];
+  trackCliOptionType(type: string | undefined) {
+    if (type) {
+      const validTypes = ['config', 'secret'];
       this.trackCliOption({
-        option: 'visibility',
-        value: validVisibilities.includes(visibility)
-          ? visibility
-          : this.redactedValue,
+        option: 'type',
+        value: validTypes.includes(type) ? type : this.redactedValue,
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/env/update.ts
+++ b/packages/cli/src/util/telemetry/commands/env/update.ts
@@ -60,14 +60,12 @@ export class EnvUpdateTelemetryClient
     }
   }
 
-  trackCliOptionVisibility(visibility: string | undefined) {
-    if (visibility) {
-      const validVisibilities = ['config', 'secret'];
+  trackCliOptionType(type: string | undefined) {
+    if (type) {
+      const validTypes = ['config', 'secret'];
       this.trackCliOption({
-        option: 'visibility',
-        value: validVisibilities.includes(visibility)
-          ? visibility
-          : this.redactedValue,
+        option: 'type',
+        value: validTypes.includes(type) ? type : this.redactedValue,
       });
     }
   }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2690,15 +2690,15 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
   Options:
 
-       --force                    Overwrite an existing variable for the same target                                         
-       --guidance                 Show command suggestions after completion                                                  
-       --no-sensitive             Store the value as non-sensitive when policy allows                                        
-       --project <NAME_OR_ID>     Project name or ID (defaults to the linked project)                                        
-       --sensitive                Store the value as sensitive for Production or Preview                                     
-       --value <VALUE>            Set the variable value for non-interactive use; otherwise use stdin or the prompt          
-       --visibility <VISIBILITY>  Set config/secret visibility (\`config\` or \`secret\`). Inferred from type when omitted and   
-                                  VERCEL_ENV_VAR_CONFIG_SECRET_UI is set                                                     
-  -y,  --yes                      Skip the confirmation prompt when adding an Environment Variable                           
+       --force                 Overwrite an existing variable for the same target                                            
+       --guidance              Show command suggestions after completion                                                     
+       --no-sensitive          Store the value as non-sensitive when policy allows                                           
+       --project <NAME_OR_ID>  Project name or ID (defaults to the linked project)                                           
+       --sensitive             Prevent the value from being read after saving                                                
+       --type <TYPE>           Set the type to \`config\` (value can be revealed after saving) or \`secret\` (value cannot be    
+                               revealed after saving)                                                                        
+       --value <VALUE>         Set the variable value for non-interactive use; otherwise use stdin or the prompt             
+  -y,  --yes                   Skip the confirmation prompt when adding an Environment Variable                              
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import stripAnsi from 'strip-ansi';
 import env from '../../../../src/commands/env';
 import {
@@ -508,7 +510,7 @@ describe('env add', () => {
         }
       });
 
-      it('prints visibility in the result when the flag is enabled', async () => {
+      it('prints Type in the result when the flag is enabled', async () => {
         const addEnvRecordModule = await import(
           '../../../../src/util/env/add-env-record'
         );
@@ -528,32 +530,43 @@ describe('env add', () => {
             '--yes'
           );
           const exitCodePromise = env(client);
-          await expect(client.stderr).toOutput('Visibility      Config');
+          await expect(client.stderr).toOutput('Type            Config');
           await expect(exitCodePromise).resolves.toBe(0);
+          const output = stripAnsi(client.stderr.getFullOutput());
+          expect(output.match(/Type\s+Config/g)).toHaveLength(1);
+          expect(output).not.toContain('Type            Non-sensitive');
         } finally {
           addSpy.mockRestore();
         }
       });
 
-      it('rejects --sensitive on Development', async () => {
-        client.setArgv(
-          'env',
-          'add',
-          'DEV_SECRET',
-          'development',
-          '--sensitive',
-          '--value',
-          'foo',
-          '--yes'
+      it('allows --sensitive on Development', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
         );
-        const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput(
-          'not allowed with the Development Environment'
-        );
-        await expect(exitCodePromise).resolves.toBe(1);
+        const addSpy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+        try {
+          client.setArgv(
+            'env',
+            'add',
+            'DEV_SECRET',
+            'development',
+            '--sensitive',
+            '--value',
+            'foo',
+            '--yes'
+          );
+          await expect(env(client)).resolves.toBe(0);
+          expect(addSpy.mock.calls[0]?.[3]).toBe('sensitive');
+          expect(addSpy.mock.calls[0]?.[8]).toBe('secret');
+        } finally {
+          addSpy.mockRestore();
+        }
       });
 
-      it('omits visibility for public-prefixed keys on Production when team policy is on', async () => {
+      it('keeps Config visibility for public-prefixed keys when legacy team policy is on', async () => {
         const teamModule = await import(
           '../../../../src/util/teams/get-team-by-id'
         );
@@ -584,7 +597,7 @@ describe('env add', () => {
 
           expect(addSpy).toHaveBeenCalled();
           const call = addSpy.mock.calls[0] as unknown[];
-          expect(call[8]).toBeUndefined();
+          expect(call[8]).toBe('config');
         } finally {
           teamSpy.mockRestore();
           addSpy.mockRestore();
@@ -602,29 +615,110 @@ describe('env add', () => {
           'my-secret',
           '--yes'
         );
-        const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('cannot use secret visibility');
-        await expect(exitCodePromise).resolves.toBe(1);
+        await expect(env(client)).resolves.toBe(1);
+        const output = client.stderr.getFullOutput();
+        expect(output).toContain('cannot be a Secret');
+        expect(output).toContain(
+          'rename the variable to `API_KEY` and keep the Secret type'
+        );
+        expect(output).toContain(
+          'If the value is safe to expose, use `--type config`'
+        );
       });
 
-      it('rejects secret visibility on public-prefixed production keys', async () => {
+      it('rejects the Secret type on public-prefixed production keys', async () => {
         client.setArgv(
           'env',
           'add',
           'NEXT_PUBLIC_API_URL',
           'production',
-          '--visibility',
+          '--type',
           'secret',
           '--value',
           'https://example.com',
           '--yes'
         );
         const exitCodePromise = env(client);
-        await expect(client.stderr).toOutput('cannot use secret visibility');
+        await expect(client.stderr).toOutput('cannot be a Secret');
         await expect(exitCodePromise).resolves.toBe(1);
       });
 
-      it('uses explicit --visibility when provided', async () => {
+      it('requires an explicit safe path for a credential-like public key with --yes', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'NEXT_PUBLIC_API_KEY',
+          'production',
+          '--value',
+          'my-secret',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Choose explicitly');
+        await expect(client.stderr).toOutput(
+          '    vercel env add API_KEY production --type secret'
+        );
+        await expect(client.stderr).toOutput(
+          '    vercel env add NEXT_PUBLIC_API_KEY production --type config'
+        );
+        await expect(exitCodePromise).resolves.toBe(1);
+      });
+
+      it('still prompts for the public-prefix decision when only --value is provided', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const addSpy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+        try {
+          client.setArgv(
+            'env',
+            'add',
+            'NEXT_PUBLIC_API_KEY',
+            'production',
+            '--value',
+            'my-secret'
+          );
+          const exitCodePromise = env(client);
+          await expect(client.stderr).toOutput(
+            'How should this variable be stored?'
+          );
+          client.stdin.write('\x1B[B\n');
+          await expect(exitCodePromise).resolves.toBe(0);
+          expect(addSpy.mock.calls[0]?.[3]).toBe('encrypted');
+          expect(addSpy.mock.calls[0]?.[8]).toBe('config');
+        } finally {
+          addSpy.mockRestore();
+        }
+      });
+
+      it('renames a public variable in-flow when its value looks like a credential', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const addSpy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+        try {
+          client.setArgv('env', 'add', 'NEXT_PUBLIC_URL', 'production');
+          const exitCodePromise = env(client);
+          await expect(client.stderr).toOutput('Value?');
+          client.stdin.write(`ghp_${'a'.repeat(30)}\n`);
+          await expect(client.stderr).toOutput(
+            'How should this variable be stored?'
+          );
+          client.stdin.write('\n');
+          await expect(exitCodePromise).resolves.toBe(0);
+          expect(addSpy.mock.calls[0]?.[3]).toBe('sensitive');
+          expect(addSpy.mock.calls[0]?.[4]).toBe('URL');
+          expect(addSpy.mock.calls[0]?.[8]).toBe('secret');
+        } finally {
+          addSpy.mockRestore();
+        }
+      });
+
+      it('uses explicit --type when provided', async () => {
         const addEnvRecordModule = await import(
           '../../../../src/util/env/add-env-record'
         );
@@ -638,7 +732,7 @@ describe('env add', () => {
             'add',
             'API_KEY',
             'production',
-            '--visibility',
+            '--type',
             'config',
             '--no-sensitive',
             '--value',
@@ -650,9 +744,105 @@ describe('env add', () => {
 
           const call = addSpy.mock.calls[0] as unknown[];
           expect(call[8]).toBe('config');
+          expect(client.telemetryEventStore.readonlyEvents).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                key: 'option:type',
+                value: 'config',
+              }),
+            ])
+          );
         } finally {
           addSpy.mockRestore();
         }
+      });
+
+      it('maps --type secret to sensitive API storage in Development', async () => {
+        const addEnvRecordModule = await import(
+          '../../../../src/util/env/add-env-record'
+        );
+        const addSpy = vi
+          .spyOn(addEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+
+        try {
+          client.setArgv(
+            'env',
+            'add',
+            'API_KEY',
+            'development',
+            '--type',
+            'secret',
+            '--value',
+            'foo',
+            '--yes'
+          );
+          await expect(env(client)).resolves.toBe(0);
+
+          const call = addSpy.mock.calls[0] as unknown[];
+          expect(call[3]).toBe('sensitive');
+          expect(call[8]).toBe('secret');
+        } finally {
+          addSpy.mockRestore();
+        }
+      });
+
+      it.each([
+        {
+          name: 'custom public prefix',
+          publicPrefix: 'BROWSER_',
+          envName: 'BROWSER_API_KEY',
+          expected:
+            '`BROWSER_` exposes this value to anyone visiting your site',
+        },
+        {
+          name: 'empty public prefix',
+          publicPrefix: '',
+          envName: 'API_KEY',
+          expected: 'every Environment Variable is exposed to the browser',
+        },
+      ])('blocks the Secret type for a SvelteKit $name', async ({
+        publicPrefix,
+        envName,
+        expected,
+      }) => {
+        const projectName = publicPrefix
+          ? 'svelte-add-custom'
+          : 'svelte-add-empty';
+        client.cwd = setupTmpDir();
+        client.config.currentTeam = 'team_dummy';
+        await writeFile(
+          join(client.cwd, 'svelte.config.js'),
+          `export default { kit: { env: { publicPrefix: '${publicPrefix}' } } };\n`
+        );
+        useProject({
+          ...defaultProject,
+          id: projectName,
+          name: projectName,
+          accountId: 'team_dummy',
+          framework: 'sveltekit',
+        });
+        client.setArgv(
+          'env',
+          'add',
+          envName,
+          'production',
+          '--type',
+          'secret',
+          '--value',
+          'secret-value',
+          '--yes',
+          '--project',
+          projectName
+        );
+
+        await expect(env(client)).resolves.toBe(1);
+        const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toContain(expected);
+        expect(output).toContain('cannot be kept private as a Secret');
+        expect(output).toContain(
+          'use `--type config` only if the value is safe to expose'
+        );
       });
     });
 
@@ -1884,7 +2074,7 @@ describe('env add', () => {
         logSpy.mockRestore();
       });
 
-      it('excludes Development from the multi-target suggestion when --sensitive is set and flag is enabled', async () => {
+      it('includes Development in the multi-target suggestion when --sensitive is set and flag is enabled', async () => {
         const originalFlag = process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
         process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = '1';
 
@@ -1916,9 +2106,8 @@ describe('env add', () => {
           expect(
             commands.some(
               (c: string) =>
-                c.includes('production,preview') &&
-                c.includes('--sensitive') &&
-                !c.includes('development')
+                c.includes('production,preview,development') &&
+                c.includes('--sensitive')
             )
           ).toBe(true);
         } finally {

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -194,6 +194,59 @@ describe('env ls', () => {
       expect(stderrOutput).not.toContain('environments');
       expect(stderrOutput).not.toContain('created');
     });
+
+    it('includes API visibility while retaining legacy type when Config/Secret is enabled', async () => {
+      const originalFlag = process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+      process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = '1';
+      client.cwd = setupTmpDir();
+      client.config.currentTeam = 'team_dummy';
+      useProject(
+        {
+          ...defaultProject,
+          id: 'explicit-env-ls-visibility',
+          name: 'explicit-env-ls-visibility',
+          accountId: 'team_dummy',
+        },
+        [
+          {
+            id: 'env_secret',
+            key: 'API_KEY',
+            value: '',
+            type: 'sensitive',
+            visibility: 'secret',
+            target: ['production'],
+            gitBranch: undefined,
+            configurationId: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ]
+      );
+      try {
+        client.setArgv(
+          'env',
+          'ls',
+          '--format',
+          'json',
+          '--project',
+          'explicit-env-ls-visibility'
+        );
+        await expect(env(client)).resolves.toBe(0);
+        expect(JSON.parse(client.stdout.getFullOutput()).envs[0]).toMatchObject(
+          {
+            key: 'API_KEY',
+            type: 'sensitive',
+            visibility: 'secret',
+          }
+        );
+      } finally {
+        if (originalFlag === undefined) {
+          delete process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+        } else {
+          process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = originalFlag;
+        }
+      }
+    });
   });
 
   describe('--project', () => {

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -416,6 +416,67 @@ describe('env pull', () => {
   });
 
   it('writes a placeholder for redacted sensitive env vars', async () => {
+    const originalFlag = process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+    process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = '1';
+    try {
+      useUser();
+      useTeams('team_dummy');
+      useProject(
+        {
+          ...defaultProject,
+          id: 'vercel-env-pull',
+          name: 'vercel-env-pull',
+        },
+        [
+          ...envs,
+          {
+            type: 'sensitive',
+            id: 'sens1234sens5678',
+            key: 'SENSITIVE_SECRET',
+            value: '',
+            target: ['production'],
+            gitBranch: undefined,
+            configurationId: null,
+            updatedAt: 1557241361455,
+            createdAt: 1557241361455,
+          },
+          {
+            type: 'encrypted',
+            id: 'empt1234empt5678',
+            key: 'ACTUALLY_EMPTY',
+            value: '',
+            target: ['production'],
+            gitBranch: undefined,
+            configurationId: null,
+            updatedAt: 1557241361455,
+            createdAt: 1557241361455,
+          },
+        ]
+      );
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', '--yes', '--environment', 'production');
+      const exitCode = await env(client);
+      expect(exitCode, 'exit code for "env"').toEqual(0);
+
+      const rawProdEnv = await fs.readFile(
+        path.join(cwd, '.env.local'),
+        'utf8'
+      );
+      expect(rawProdEnv).toContain('SENSITIVE_SECRET="[SENSITIVE]"');
+      expect(rawProdEnv).not.toContain('SENSITIVE_SECRET=""');
+      expect(rawProdEnv).toContain('ACTUALLY_EMPTY=""');
+    } finally {
+      if (originalFlag === undefined) {
+        delete process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+      } else {
+        process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = originalFlag;
+      }
+    }
+  });
+
+  it('keeps redacted sensitive placeholders when Config/Secret is disabled', async () => {
+    delete process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
     useUser();
     useTeams('team_dummy');
     useProject(
@@ -425,22 +486,10 @@ describe('env pull', () => {
         name: 'vercel-env-pull',
       },
       [
-        ...envs,
         {
           type: 'sensitive',
-          id: 'sens1234sens5678',
+          id: 'legacy-sensitive-id',
           key: 'SENSITIVE_SECRET',
-          value: '',
-          target: ['production'],
-          gitBranch: undefined,
-          configurationId: null,
-          updatedAt: 1557241361455,
-          createdAt: 1557241361455,
-        },
-        {
-          type: 'encrypted',
-          id: 'empt1234empt5678',
-          key: 'ACTUALLY_EMPTY',
           value: '',
           target: ['production'],
           gitBranch: undefined,
@@ -453,13 +502,14 @@ describe('env pull', () => {
     const cwd = setupUnitFixture('vercel-env-pull');
     client.cwd = cwd;
     client.setArgv('env', 'pull', '--yes', '--environment', 'production');
-    const exitCode = await env(client);
-    expect(exitCode, 'exit code for "env"').toEqual(0);
 
-    const rawProdEnv = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
-    expect(rawProdEnv).toContain('SENSITIVE_SECRET="[SENSITIVE]"');
-    expect(rawProdEnv).not.toContain('SENSITIVE_SECRET=""');
-    expect(rawProdEnv).toContain('ACTUALLY_EMPTY=""');
+    await expect(env(client)).resolves.toBe(0);
+
+    const contents = await fs.readFile(path.join(cwd, '.env.local'), 'utf8');
+    expect(contents).toContain('SENSITIVE_SECRET="[SENSITIVE]"');
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Secret value cannot be pulled'
+    );
   });
 
   it('should handle pulling from specific Git branch', async () => {

--- a/packages/cli/test/unit/commands/env/rm.test.ts
+++ b/packages/cli/test/unit/commands/env/rm.test.ts
@@ -92,6 +92,94 @@ describe('env rm', () => {
     await expect(env(client)).resolves.toEqual(0);
   });
 
+  it('warns that deleting a credential-like variable does not revoke it', async () => {
+    const originalFlag = process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+    process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = '1';
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject(
+      {
+        ...defaultProject,
+        id: 'explicit-secret-rm',
+        name: 'explicit-secret-rm',
+        accountId: 'team_dummy',
+      },
+      [
+        {
+          type: 'sensitive',
+          visibility: 'secret',
+          id: 'secret-rm-id',
+          key: 'STRIPE_SECRET_KEY',
+          value: '',
+          target: ['production'],
+          gitBranch: undefined,
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    try {
+      client.setArgv(
+        'env',
+        'rm',
+        'STRIPE_SECRET_KEY',
+        '--yes',
+        '--project',
+        'explicit-secret-rm'
+      );
+      const exitCodePromise = env(client);
+      await expect(client.stderr).toOutput(
+        'Removing this variable from Vercel does not revoke the credential'
+      );
+      await expect(exitCodePromise).resolves.toBe(0);
+    } finally {
+      if (originalFlag === undefined) {
+        delete process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+      } else {
+        process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = originalFlag;
+      }
+    }
+  });
+
+  it('does not add credential-rotation guidance when Config/Secret is disabled', async () => {
+    client.cwd = setupTmpDir();
+    client.config.currentTeam = 'team_dummy';
+    useProject(
+      {
+        ...defaultProject,
+        id: 'explicit-legacy-rm',
+        name: 'explicit-legacy-rm',
+        accountId: 'team_dummy',
+      },
+      [
+        {
+          type: 'sensitive',
+          id: 'legacy-rm-id',
+          key: 'STRIPE_SECRET_KEY',
+          value: '',
+          target: ['production'],
+          gitBranch: undefined,
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    client.setArgv(
+      'env',
+      'rm',
+      'STRIPE_SECRET_KEY',
+      '--yes',
+      '--project',
+      'explicit-legacy-rm'
+    );
+    await expect(env(client)).resolves.toBe(0);
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'does not revoke the credential'
+    );
+  });
+
   describe('non-interactive', () => {
     it('outputs action_required with missing_name when name not provided', async () => {
       const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {

--- a/packages/cli/test/unit/commands/env/run.test.ts
+++ b/packages/cli/test/unit/commands/env/run.test.ts
@@ -343,5 +343,115 @@ describe('env run', () => {
 
       expect(exitCode).toEqual(42);
     });
+
+    describe('VERCEL_ENV_VAR_CONFIG_SECRET_UI', () => {
+      const originalFlag = process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+      const originalRunOnlySecret = process.env.RUN_ONLY_SECRET;
+
+      beforeEach(() => {
+        process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = '1';
+        delete process.env.RUN_ONLY_SECRET;
+      });
+
+      afterEach(() => {
+        if (originalFlag === undefined) {
+          delete process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+        } else {
+          process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI = originalFlag;
+        }
+        if (originalRunOnlySecret === undefined) {
+          delete process.env.RUN_ONLY_SECRET;
+        } else {
+          process.env.RUN_ONLY_SECRET = originalRunOnlySecret;
+        }
+      });
+
+      function setupSensitiveRun() {
+        useUser();
+        useTeams('team_dummy');
+        useProject(
+          {
+            ...defaultProject,
+            id: 'env-run-sensitive',
+            name: 'env-run-sensitive',
+            accountId: 'team_dummy',
+          },
+          [
+            {
+              type: 'sensitive',
+              id: 'sensitive-run-id',
+              key: 'RUN_ONLY_SECRET',
+              value: '',
+              target: ['development'],
+              gitBranch: undefined,
+              configurationId: null,
+              updatedAt: 1557241361455,
+              createdAt: 1557241361455,
+            },
+          ]
+        );
+        client.cwd = setupTmpDir();
+        client.config.currentTeam = 'team_dummy';
+        client.setArgv(
+          'env',
+          'run',
+          '--project',
+          'env-run-sensitive',
+          '--',
+          'echo',
+          'hello'
+        );
+      }
+
+      it('warns when a Secret value is unavailable', async () => {
+        setupSensitiveRun();
+
+        await expect(env(client)).resolves.toBe(0);
+        expect(client.stderr.getFullOutput()).toContain(
+          '1 Secret value is not available to vercel env run. Define it in a local .env file.'
+        );
+      });
+
+      it('does not warn when the Secret is already defined locally', async () => {
+        setupSensitiveRun();
+        process.env.RUN_ONLY_SECRET = 'local-secret';
+
+        await expect(env(client)).resolves.toBe(0);
+        expect(client.stderr.getFullOutput()).not.toContain(
+          'Secret value is not available'
+        );
+      });
+
+      it('continues running when Secret metadata cannot be loaded', async () => {
+        const getEnvRecordsModule = await import(
+          '../../../../src/util/env/get-env-records'
+        );
+        const getEnvRecordsSpy = vi
+          .spyOn(getEnvRecordsModule, 'default')
+          .mockRejectedValueOnce(new Error('metadata unavailable'));
+        setupSensitiveRun();
+
+        try {
+          await expect(env(client)).resolves.toBe(0);
+          expect(execa).toHaveBeenCalledWith(
+            'echo',
+            ['hello'],
+            expect.objectContaining({ cwd: client.cwd })
+          );
+        } finally {
+          getEnvRecordsSpy.mockRestore();
+        }
+      });
+
+      it('preserves legacy behavior when the feature flag is disabled', async () => {
+        delete process.env.VERCEL_ENV_VAR_CONFIG_SECRET_UI;
+        setupSensitiveRun();
+
+        await expect(env(client)).resolves.toBe(0);
+        expect(client.stderr.getFullOutput()).not.toContain(
+          'Secret value is not available'
+        );
+      });
+    });
   });
 });

--- a/packages/cli/test/unit/commands/env/update.test.ts
+++ b/packages/cli/test/unit/commands/env/update.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import env from '../../../../src/commands/env';
 import {
   setupTmpDir,
@@ -9,6 +11,7 @@ import { defaultProject, envs, useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 import type { ProjectEnvVariable } from '@vercel-internals/types';
+import stripAnsi from 'strip-ansi';
 
 describe('env update', () => {
   beforeEach(() => {
@@ -554,23 +557,308 @@ describe('env update', () => {
         updateSpy.mockRestore();
       });
 
-      it('rejects --sensitive on a Development record when flag is enabled', async () => {
+      it('allows --sensitive on a Development record when flag is enabled', async () => {
+        const updateEnvRecordModule = await import(
+          '../../../../src/util/env/update-env-record'
+        );
+        const updateSpy = vi
+          .spyOn(updateEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+        const cwd = setupUnitFixture('vercel-env-pull');
+        client.cwd = cwd;
+        try {
+          client.setArgv(
+            'env',
+            'update',
+            'TEST_VAR_DEV',
+            '--sensitive',
+            '--value',
+            'new-value',
+            '--yes'
+          );
+          await expect(env(client)).resolves.toBe(0);
+          expect(updateSpy.mock.calls[0]?.[3]).toBe('sensitive');
+          expect(updateSpy.mock.calls[0]?.[8]).toBe('secret');
+        } finally {
+          updateSpy.mockRestore();
+        }
+      });
+
+      it('resolves the Secret type before confirming the update', async () => {
         const cwd = setupUnitFixture('vercel-env-pull');
         client.cwd = cwd;
         client.setArgv(
           'env',
           'update',
-          'TEST_VAR_DEV',
-          '--sensitive',
+          'TEST_VAR',
+          'production',
+          '--type',
+          'secret',
           '--value',
-          'new-value',
-          '--yes'
+          'new-value'
         );
+
         const exitCodePromise = env(client);
         await expect(client.stderr).toOutput(
-          'not allowed with the Development Environment'
+          'The previous value was readable as Config'
         );
-        await expect(exitCodePromise).resolves.toBe(1);
+        await expect(client.stderr).toOutput('Type            Secret');
+        await expect(client.stderr).toOutput(
+          'Update this Environment Variable?'
+        );
+        const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output.indexOf('Type            Secret')).toBeLessThan(
+          output.indexOf('Update this Environment Variable?')
+        );
+        client.stdin.write('n\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+        expect(client.telemetryEventStore.readonlyEvents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              key: 'option:type',
+              value: 'secret',
+            }),
+          ])
+        );
+      });
+
+      it('warns when a plain Config value looks like a credential', async () => {
+        const updateEnvRecordModule = await import(
+          '../../../../src/util/env/update-env-record'
+        );
+        const updateSpy = vi
+          .spyOn(updateEnvRecordModule, 'default')
+          .mockResolvedValue(undefined);
+        client.cwd = setupTmpDir();
+        client.config.currentTeam = 'team_dummy';
+        useProject(
+          {
+            ...defaultProject,
+            id: 'explicit-plain-update',
+            name: 'explicit-plain-update',
+            accountId: 'team_dummy',
+          },
+          [
+            {
+              type: 'plain',
+              id: 'plain-env-id',
+              key: 'PUBLIC_VALUE',
+              value: 'old-value',
+              target: ['production'],
+              gitBranch: undefined,
+              configurationId: null,
+              updatedAt: 1557241361455,
+              createdAt: 1557241361455,
+            },
+          ]
+        );
+        try {
+          client.setArgv(
+            'env',
+            'update',
+            'PUBLIC_VALUE',
+            'production',
+            '--type',
+            'config',
+            '--value',
+            `ghp_${'a'.repeat(30)}`,
+            '--yes',
+            '--project',
+            'explicit-plain-update'
+          );
+
+          await expect(env(client)).resolves.toBe(0);
+          expect(client.stderr.getFullOutput()).toContain(
+            'This name or value looks like a credential'
+          );
+          expect(updateSpy).toHaveBeenCalled();
+        } finally {
+          updateSpy.mockRestore();
+        }
+      });
+
+      it('gives add-and-remove recovery for a public Config that cannot become Secret', async () => {
+        client.cwd = setupTmpDir();
+        client.config.currentTeam = 'team_dummy';
+        useProject(
+          {
+            ...defaultProject,
+            id: 'explicit-public-update',
+            name: 'explicit-public-update',
+            accountId: 'team_dummy',
+          },
+          [
+            {
+              type: 'encrypted',
+              visibility: 'config',
+              id: 'public-env-id',
+              key: 'NEXT_PUBLIC_API_KEY',
+              value: 'old-value',
+              target: ['production'],
+              gitBranch: undefined,
+              configurationId: null,
+              updatedAt: 1557241361455,
+              createdAt: 1557241361455,
+            },
+          ]
+        );
+        client.setArgv(
+          'env',
+          'update',
+          'NEXT_PUBLIC_API_KEY',
+          'production',
+          '--type',
+          'secret',
+          '--value',
+          'new-value',
+          '--yes',
+          '--project',
+          'explicit-public-update'
+        );
+
+        await expect(env(client)).resolves.toBe(1);
+        const output = client.stderr.getFullOutput();
+        expect(output).toContain('cannot be a Secret');
+        expect(output).toContain(
+          'vercel env add API_KEY production --type secret --project explicit-public-update'
+        );
+        expect(output).toContain(
+          'vercel env rm NEXT_PUBLIC_API_KEY production --project explicit-public-update'
+        );
+      });
+
+      it.each([
+        {
+          name: 'custom public prefix',
+          publicPrefix: 'BROWSER_',
+          envName: 'BROWSER_API_KEY',
+          expected:
+            '`BROWSER_` exposes this value to anyone visiting your site',
+          expectedCommand:
+            'vercel env add API_KEY production --type secret --project svelte-update-custom',
+        },
+        {
+          name: 'empty public prefix',
+          publicPrefix: '',
+          envName: 'API_KEY',
+          expected: 'every Environment Variable is exposed to the browser',
+          expectedCommand: undefined,
+        },
+      ])('blocks changing a SvelteKit $name Config to Secret', async ({
+        publicPrefix,
+        envName,
+        expected,
+        expectedCommand,
+      }) => {
+        const projectName = publicPrefix
+          ? 'svelte-update-custom'
+          : 'svelte-update-empty';
+        client.cwd = setupTmpDir();
+        client.config.currentTeam = 'team_dummy';
+        await writeFile(
+          join(client.cwd, 'svelte.config.js'),
+          `export default { kit: { env: { publicPrefix: '${publicPrefix}' } } };\n`
+        );
+        useProject(
+          {
+            ...defaultProject,
+            id: projectName,
+            name: projectName,
+            accountId: 'team_dummy',
+            framework: 'sveltekit',
+          },
+          [
+            {
+              type: 'encrypted',
+              visibility: 'config',
+              id: 'svelte-config-id',
+              key: envName,
+              value: 'old-value',
+              target: ['production'],
+              gitBranch: undefined,
+              configurationId: null,
+              updatedAt: 1557241361455,
+              createdAt: 1557241361455,
+            },
+          ]
+        );
+        client.setArgv(
+          'env',
+          'update',
+          envName,
+          'production',
+          '--type',
+          'secret',
+          '--value',
+          'new-value',
+          '--yes',
+          '--project',
+          projectName
+        );
+
+        await expect(env(client)).resolves.toBe(1);
+        const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toContain(expected);
+        expect(output).toContain('cannot be kept private as a Secret');
+        if (expectedCommand) {
+          expect(output).toContain(expectedCommand);
+        } else {
+          expect(output).not.toContain('Add the private Secret');
+        }
+      });
+
+      it('explains the remove-and-add path when a Secret cannot become Config', async () => {
+        client.cwd = setupTmpDir();
+        client.config.currentTeam = 'team_dummy';
+        useProject(
+          {
+            ...defaultProject,
+            id: 'explicit-secret-update',
+            name: 'explicit-secret-update',
+            accountId: 'team_dummy',
+          },
+          [
+            {
+              type: 'sensitive',
+              visibility: 'secret',
+              id: 'secret-env-id',
+              key: 'API_KEY',
+              value: '',
+              target: ['production'],
+              gitBranch: undefined,
+              configurationId: null,
+              updatedAt: 1557241361455,
+              createdAt: 1557241361455,
+              customEnvironmentIds: [],
+            },
+          ]
+        );
+        client.setArgv(
+          'env',
+          'update',
+          'API_KEY',
+          'production',
+          '--type',
+          'config',
+          '--value',
+          'new-value',
+          '--yes',
+          '--project',
+          'explicit-secret-update'
+        );
+
+        await expect(env(client)).resolves.toBe(1);
+        const output = stripAnsi(client.stderr.getFullOutput());
+        expect(output).toContain('A Secret cannot be changed to Config');
+        expect(output).toContain(
+          'API_KEY" will be unavailable to new builds between these commands'
+        );
+        expect(output).toContain(
+          '    vercel env rm API_KEY production --project explicit-secret-update'
+        );
+        expect(output).toContain(
+          '    vercel env add API_KEY production --type config --project explicit-secret-update'
+        );
       });
     });
   });


### PR DESCRIPTION
Adopts Config and Secret behavior across the environment commands.

- Adds `--type config|secret` flows for add and update while preserving feature-off behavior.
- Carries visibility through list, pull, remove, run, telemetry, and help.
- Adds command coverage and user-facing safety guidance.

Stack 2/3. Depends on #17518; followed by #17513.