### PR TITLE
[cli] Remove --yes from vercel blob delete-store

### DIFF
--- a/.changeset/blob-delete-store-interactive-only.md
+++ b/.changeset/blob-delete-store-interactive-only.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Remove `--yes` from `vercel blob delete-store`. Deleting a Blob store cannot be undone, so it now always requires interactive confirmation and can no longer be run non-interactively (CI, scripts, or agents).

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -500,7 +500,7 @@ export const deleteStoreSubcommand = {
       required: false,
     },
   ],
-  options: [yesOption],
+  options: [],
   examples: [],
 } as const;
 

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -13,7 +13,6 @@ import {
 } from '../../util/blob/confirm';
 import {
   outputAgentError,
-  buildCommandWithYes,
   buildCommandWithGlobalFlags,
 } from '../../util/agent-output';
 
@@ -36,10 +35,35 @@ export default async function removeStore(
 
   const {
     args: [storeIdArg],
-    flags: { '--yes': yes },
   } = parsedArgs;
 
   const interactive = client.stdin.isTTY && !client.nonInteractive;
+
+  // Deleting a store cannot be undone, so it always requires
+  // interactive confirmation and cannot be scripted or run by agents
+  if (!interactive) {
+    outputAgentError(client, {
+      status: 'error',
+      reason: 'dangerous_operation_requires_user',
+      message:
+        'Deleting a blob store cannot be undone and cannot be performed non-interactively. ' +
+        'Agents must not make this change on behalf of a user. ' +
+        'The user must run this command interactively in a terminal to review the impact and confirm.',
+      next: [
+        {
+          command: buildCommandWithGlobalFlags(
+            client.argv,
+            'blob delete-store <storeId>'
+          ),
+          when: 'user runs this command interactively',
+        },
+      ],
+    });
+    output.error(
+      'Deleting a blob store requires interactive confirmation. Run this command in an interactive terminal.'
+    );
+    return 1;
+  }
 
   let storeId: string | undefined = storeIdArg;
 
@@ -48,34 +72,15 @@ export default async function removeStore(
   }
 
   if (!storeId) {
-    if (interactive) {
-      storeId = await client.input.text({
-        message: 'Enter the ID of the blob store you want to remove',
-        validate: value => {
-          if (value.length !== 22) {
-            return 'ID must be 22 characters long';
-          }
-          return true;
-        },
-      });
-    } else {
-      outputAgentError(client, {
-        status: 'error',
-        reason: 'missing_arguments',
-        message: 'Missing required argument: storeId.',
-        next: [
-          {
-            command: buildCommandWithGlobalFlags(
-              client.argv,
-              'blob delete-store <storeId> --yes'
-            ),
-            when: 'delete the blob store',
-          },
-        ],
-      });
-      output.error('Missing required argument: storeId');
-      return 1;
-    }
+    storeId = await client.input.text({
+      message: 'Enter the ID of the blob store you want to remove',
+      validate: value => {
+        if (value.length !== 22) {
+          return 'ID must be 22 characters long';
+        }
+        return true;
+      },
+    });
   }
 
   const link = await getLinkedProject(client);
@@ -103,34 +108,14 @@ export default async function removeStore(
       connectionsResponse.connections
     );
 
-    if (!yes) {
-      if (!interactive) {
-        outputAgentError(client, {
-          status: 'error',
-          reason: 'confirmation_required',
-          message: `Removing ${label} cannot be undone and requires confirmation. Re-run with --yes.`,
-          next: [
-            {
-              command: buildCommandWithYes(client.argv),
-              when: 'remove the blob store without prompting',
-            },
-          ],
-        });
-        output.error(
-          'Confirmation required. Use --yes to skip confirmation in non-interactive environments.'
-        );
-        return 1;
-      }
+    const res = await client.input.confirm(
+      `Are you sure you want to remove ${label}?${projectsInfo} This action cannot be undone.`,
+      false
+    );
 
-      const res = await client.input.confirm(
-        `Are you sure you want to remove ${label}?${projectsInfo} This action cannot be undone.`,
-        false
-      );
-
-      if (!res) {
-        output.success('Blob store not removed');
-        return 0;
-      }
+    if (!res) {
+      output.success('Blob store not removed');
+      return 0;
     }
 
     output.debug('Deleting blob store');

--- a/packages/cli/test/unit/commands/blob/store-remove.test.ts
+++ b/packages/cli/test/unit/commands/blob/store-remove.test.ts
@@ -506,20 +506,21 @@ describe('blob store remove', () => {
     });
   });
 
-  describe('--yes flag', () => {
-    it('should skip confirmation prompt when --yes is passed', async () => {
+  describe('confirmation is always required', () => {
+    it('should reject --yes as an unknown option', async () => {
       const exitCode = await removeStore(
         client,
         ['store_1234567890123456', '--yes'],
         noToken
       );
 
-      expect(exitCode).toBe(0);
+      expect(exitCode).toBe(1);
       expect(confirmInputMock).not.toHaveBeenCalled();
-      expect(mockedOutput.success).toHaveBeenCalledWith('Blob store deleted');
+      expect(client.fetch).not.toHaveBeenCalled();
+      expect(mockedOutput.success).not.toHaveBeenCalled();
     });
 
-    it('should still prompt without --yes', async () => {
+    it('should always prompt for confirmation', async () => {
       const exitCode = await removeStore(
         client,
         ['store_1234567890123456'],
@@ -530,7 +531,7 @@ describe('blob store remove', () => {
       expect(confirmInputMock).toHaveBeenCalled();
     });
 
-    it('should error in non-TTY without --yes', async () => {
+    it('should error in non-TTY environments', async () => {
       (client.stdin as any).isTTY = false;
 
       const exitCode = await removeStore(
@@ -541,9 +542,10 @@ describe('blob store remove', () => {
 
       expect(exitCode).toBe(1);
       expect(mockedOutput.error).toHaveBeenCalledWith(
-        'Confirmation required. Use --yes to skip confirmation in non-interactive environments.'
+        'Deleting a blob store requires interactive confirmation. Run this command in an interactive terminal.'
       );
       expect(confirmInputMock).not.toHaveBeenCalled();
+      expect(client.fetch).not.toHaveBeenCalled();
     });
   });
 
@@ -708,48 +710,50 @@ describe('blob store remove', () => {
       }) as () => never);
     });
 
-    it('requires --yes and emits confirmation_required instead of prompting', async () => {
+    it('emits dangerous_operation_requires_user instead of prompting', async () => {
       await removeStore(client, ['store_1234567890123456'], noToken).catch(
         () => {}
       );
 
       expect(vi.mocked(process.exit)).toHaveBeenCalledWith(1);
       expect(confirmInputMock).not.toHaveBeenCalled();
+      expect(client.fetch).not.toHaveBeenCalled();
       const payload = JSON.parse(client.stdout.getFullOutput());
       expect(payload).toMatchObject({
         status: 'error',
-        reason: 'confirmation_required',
-        message: expect.stringMatching(/--yes/),
+        reason: 'dangerous_operation_requires_user',
+        message: expect.stringContaining('interactively'),
         next: expect.arrayContaining([
           expect.objectContaining({
-            command: expect.stringContaining('--yes'),
+            when: 'user runs this command interactively',
           }),
         ]),
       });
+      expect(client.stdout.getFullOutput()).not.toContain('--yes');
     });
 
-    it('emits missing_arguments when no store id is available', async () => {
+    it('emits dangerous_operation_requires_user even when no store id is given', async () => {
       await removeStore(client, [], noToken).catch(() => {});
 
       expect(vi.mocked(process.exit)).toHaveBeenCalledWith(1);
       const payload = JSON.parse(client.stdout.getFullOutput());
       expect(payload).toMatchObject({
         status: 'error',
-        reason: 'missing_arguments',
-        message: expect.stringContaining('storeId'),
+        reason: 'dangerous_operation_requires_user',
       });
     });
 
-    it('deletes without prompting when --yes is passed', async () => {
+    it('does not delete when --yes is passed', async () => {
       const exitCode = await removeStore(
         client,
         ['store_1234567890123456', '--yes'],
         noToken
-      );
+      ).catch(() => 1);
 
-      expect(exitCode).toBe(0);
+      expect(exitCode).toBe(1);
       expect(confirmInputMock).not.toHaveBeenCalled();
-      expect(mockedOutput.success).toHaveBeenCalledWith('Blob store deleted');
+      expect(mockedOutput.success).not.toHaveBeenCalled();
+      expect(client.fetch).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# Problem

`vercel blob delete-store --yes` allowed permanently deleting a Blob store with no confirmation, from scripts, CI, or agents. Store deletion cannot be undone, so a single-flag bypass is too easy to trigger accidentally (or for an agent to run autonomously).

# Solution

Make `blob delete-store` interactive-only, following the CLI's established pattern for severe destructive operations (`firewall attack-mode enable/disable`):

- Remove the `--yes` option from the subcommand; it is now rejected as an unknown option.
- The confirmation prompt (defaulting to No) is now unconditional.
- In non-interactive contexts (`--non-interactive`, agents, non-TTY), the command fails immediately with the `dangerous_operation_requires_user` agent-error payload instructing that a user must run the command interactively.

This aligns with the CLI UX guideline that `--yes` must not bypass severe destructive confirmation by itself.

**Breaking behavior note:** existing scripts using `blob delete-store <id> --yes` will start failing with an unknown-option error. This is the intended migration — store deletion must be performed interactively by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)