### PR TITLE
chore(@vercel/mcp-adapter): add license metadata

### DIFF
--- a/.changeset/mcp-adapter-license.md
+++ b/.changeset/mcp-adapter-license.md
@@ -1,0 +1,5 @@
+---
+'@vercel/mcp-adapter': patch
+---
+
+Add Apache-2.0 license metadata to the published package.

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -2,6 +2,7 @@
   "name": "@vercel/mcp-adapter",
   "version": "0.3.2",
   "description": "Vercel MCP Adapter for Next.js and other frameworks",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/vercel.git",


### PR DESCRIPTION
## Summary

- add Apache-2.0 license metadata to `@vercel/mcp-adapter`
- add a patch changeset so the metadata is included in the next package release

## Validation

- `npm exec --yes --package=prettier@3.3.3 -- prettier --check packages/mcp-adapter/package.json .changeset/mcp-adapter-license.md`
- `npm pack ./packages/mcp-adapter --dry-run --json`
- parsed `packages/mcp-adapter/package.json` and verified the license value

Fixes #16586