### PR TITLE
[build-utils][next] Replace `prerenderClassification` with `initialMetadata`

### DIFF
--- a/.changeset/prerender-initial-metadata.md
+++ b/.changeset/prerender-initial-metadata.md
@@ -1,0 +1,27 @@
+---
+'@vercel/build-utils': minor
+'@vercel/next': minor
+'vercel': patch
+---
+
+Replace `prerenderClassification` on `Prerender` with `initialMetadata`.
+
+The platform consumes only the request-time compute mode, so the four-field
+taxonomy (`routeType`, `response`, `compute`, `htmlSize`) is reduced to a
+single grouped field:
+
+```ts
+initialMetadata?: {
+  compute: 'blocking' | 'resuming' | 'static';
+}
+```
+
+The group is named `initialMetadata` because the values describe the
+deployment as it was built: revalidation can regenerate a route's output over
+the deployment's lifetime, so readers must treat them as initial values, not
+live state. `@vercel/next` reads `compute` off the v4 prerender-manifest
+taxonomy and deliberately ignores the other fields; the value is still carried
+unvalidated so a compute mode added by a future framework release cannot
+hard-fail a deploy, and it is still set only on the primary output of each
+prerender group. Absence remains legitimate (`notFoundRoutes`, Pages Router
+`fallback: false`, older frameworks).

--- a/.changeset/prerender-initial-metadata.md
+++ b/.changeset/prerender-initial-metadata.md
@@ -6,22 +6,26 @@
 
 Replace `prerenderClassification` on `Prerender` with `initialMetadata`.
 
-The platform consumes only the request-time compute mode, so the four-field
-taxonomy (`routeType`, `response`, `compute`, `htmlSize`) is reduced to a
-single grouped field:
+The platform consumes only the request-time compute mode and the HTML shell
+size, so the flattened four-field taxonomy (`routeType`, `response`,
+`compute`, `htmlSize`) is reduced to a single grouped field:
 
 ```ts
 initialMetadata?: {
   compute: 'blocking' | 'resuming' | 'static';
+  htmlSize?: number;
 }
 ```
 
 The group is named `initialMetadata` because the values describe the
 deployment as it was built: revalidation can regenerate a route's output over
 the deployment's lifetime, so readers must treat them as initial values, not
-live state. `@vercel/next` reads `compute` off the v4 prerender-manifest
-taxonomy and deliberately ignores the other fields; the value is still carried
-unvalidated so a compute mode added by a future framework release cannot
-hard-fail a deploy, and it is still set only on the primary output of each
-prerender group. Absence remains legitimate (`notFoundRoutes`, Pages Router
+live state. `@vercel/next` reads `compute` and `htmlSize` off the v4
+prerender-manifest taxonomy and deliberately ignores `routeType` and
+`response`; the values are still carried unvalidated so a compute mode added
+by a future framework release cannot hard-fail a deploy, and they are still
+set only on the primary output of each prerender group. `htmlSize: 0` is a
+real size (a shell that postponed everything); `htmlSize` is absent when
+there is no HTML shell to measure (route handlers, Pages Router). Absence of
+the whole group remains legitimate (`notFoundRoutes`, Pages Router
 `fallback: false`, older frameworks).

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -8,7 +8,7 @@ import {
   sanitizeConsumerName,
 } from './lambda';
 import { NodejsLambda, type NodejsLambdaOptions } from './nodejs-lambda';
-import { Prerender, type PrerenderClassification } from './prerender';
+import { Prerender, type PrerenderInitialMetadata } from './prerender';
 import download, {
   downloadFile,
   DownloadedFiles,
@@ -69,7 +69,7 @@ import { cloneEnv } from './clone-env';
 import { hardLinkDir } from './hard-link-dir';
 import { validateNpmrc } from './validate-npmrc';
 
-export type { NodejsLambdaOptions, PrerenderClassification };
+export type { NodejsLambdaOptions, PrerenderInitialMetadata };
 
 export {
   FileBlob,

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -16,6 +16,12 @@ export interface PrerenderInitialMetadata {
    * start the response until request-time compute starts.
    */
   compute: 'blocking' | 'resuming' | 'static';
+  /**
+   * Byte size of the prerendered HTML shell, when the entry has one. `0` is
+   * a real size — a shell that postponed everything — and `undefined` means
+   * there is no HTML shell to measure (route handlers, Pages Router).
+   */
+  htmlSize?: number;
 }
 
 interface PrerenderOptions {

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -2,18 +2,20 @@ import type { File, HasField, Chain } from './types';
 import { Lambda } from './lambda';
 
 /**
- * The framework's own description of what it prerendered, mirroring the
- * Next.js prerender taxonomy rather than re-deriving it from build artifacts.
+ * The framework's own description of what it prerendered at build time,
+ * rather than re-deriving it from build artifacts. These are *initial*
+ * values: revalidation can regenerate a route's output over the lifetime of
+ * a deployment, so readers must treat them as the state as of the build,
+ * not as live state.
  */
-export interface PrerenderClassification {
-  /** What kind of entry this is within its route group. */
-  routeType: 'route' | 'page' | 'shell' | 'fallback';
-  /** How much of the response the prerender contains. */
-  response: 'empty' | 'initial' | 'complete';
-  /** What has to happen at request time to finish the response. */
+export interface PrerenderInitialMetadata {
+  /**
+   * What has to happen at request time to finish the response, as of build
+   * time: `static` needs no server compute, `resuming` streams the static
+   * response while the server resumes postponed work, and `blocking` cannot
+   * start the response until request-time compute starts.
+   */
   compute: 'blocking' | 'resuming' | 'static';
-  /** Byte size of the prerendered HTML shell, when the entry has one. */
-  htmlSize?: number;
 }
 
 interface PrerenderOptions {
@@ -34,7 +36,7 @@ interface PrerenderOptions {
   chain?: Chain;
   exposeErrBody?: boolean;
   partialFallback?: boolean;
-  prerenderClassification?: PrerenderClassification;
+  initialMetadata?: PrerenderInitialMetadata;
 }
 
 export class Prerender {
@@ -66,11 +68,12 @@ export class Prerender {
   public exposeErrBody?: boolean;
   public partialFallback?: boolean;
   /**
-   * The framework's classification of this prerender. `undefined` when the
-   * framework did not provide one, which is legitimate: not-found routes and
-   * Pages Router `fallback: false` templates have no classification.
+   * The framework's build-time serving metadata for this prerender.
+   * `undefined` when the framework did not provide it, which is legitimate:
+   * not-found routes, Pages Router `fallback: false` templates, and builds
+   * from frameworks that predate the field carry none.
    */
-  public prerenderClassification?: PrerenderClassification;
+  public initialMetadata?: PrerenderInitialMetadata;
 
   constructor({
     expiration,
@@ -90,17 +93,17 @@ export class Prerender {
     chain,
     exposeErrBody,
     partialFallback,
-    prerenderClassification,
+    initialMetadata,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
     this.staleExpiration = staleExpiration;
     this.sourcePath = sourcePath;
     // Deliberately unvalidated: producers in this repo are trusted, and a
-    // taxonomy value added by a future Next.js release must not hard-fail a
+    // compute mode added by a future framework release must not hard-fail a
     // deploy. Untrusted input — a `.prerender-config.json` supplied by
     // `vercel deploy --prebuilt` — is sanitized by the platform instead.
-    this.prerenderClassification = prerenderClassification;
+    this.initialMetadata = initialMetadata;
 
     this.lambda = lambda;
     if (this.lambda) {

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -631,10 +631,27 @@ it('should round-trip initialMetadata', async () => {
     bypassToken: 'some-long-bypass-token-to-make-it-work',
     initialMetadata: {
       compute: 'resuming',
+      htmlSize: 5491,
     },
   });
   expect(resuming.initialMetadata).toEqual({
     compute: 'resuming',
+    htmlSize: 5491,
+  });
+
+  // `htmlSize` is optional within the group — route handlers and Pages
+  // Router entries have no HTML shell to measure.
+  const withoutShell = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    initialMetadata: {
+      compute: 'static',
+    },
+  });
+  expect(withoutShell.initialMetadata).toEqual({
+    compute: 'static',
   });
 
   const withoutMetadata = new Prerender({

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -623,55 +623,31 @@ it('should support experimentalBypassFor correctly', async () => {
   );
 });
 
-it('should round-trip prerenderClassification', async () => {
-  const shell = new Prerender({
+it('should round-trip initialMetadata', async () => {
+  const resuming = new Prerender({
     expiration: 1,
     fallback: null,
     group: 1,
     bypassToken: 'some-long-bypass-token-to-make-it-work',
-    prerenderClassification: {
-      routeType: 'shell',
-      response: 'initial',
+    initialMetadata: {
       compute: 'resuming',
-      htmlSize: 5491,
     },
   });
-  expect(shell.prerenderClassification).toEqual({
-    routeType: 'shell',
-    response: 'initial',
+  expect(resuming.initialMetadata).toEqual({
     compute: 'resuming',
-    htmlSize: 5491,
   });
 
-  // `htmlSize` is optional within the group — route handlers have no HTML.
-  const route = new Prerender({
-    expiration: 1,
-    fallback: null,
-    group: 1,
-    bypassToken: 'some-long-bypass-token-to-make-it-work',
-    prerenderClassification: {
-      routeType: 'route',
-      response: 'complete',
-      compute: 'static',
-    },
-  });
-  expect(route.prerenderClassification).toEqual({
-    routeType: 'route',
-    response: 'complete',
-    compute: 'static',
-  });
-
-  const unclassified = new Prerender({
+  const withoutMetadata = new Prerender({
     expiration: 1,
     fallback: null,
     group: 1,
     bypassToken: 'some-long-bypass-token-to-make-it-work',
   });
-  expect(unclassified.prerenderClassification).toBeUndefined();
+  expect(withoutMetadata.initialMetadata).toBeUndefined();
 });
 
-it('should not validate prerenderClassification enum values', async () => {
-  // Deliberately unvalidated: a taxonomy value added by a future Next.js
+it('should not validate initialMetadata enum values', async () => {
+  // Deliberately unvalidated: a compute mode added by a future framework
   // release must not hard-fail a deploy. Untrusted `.prerender-config.json`
   // input is sanitized by the platform instead.
   const future = new Prerender({
@@ -679,14 +655,12 @@ it('should not validate prerenderClassification enum values', async () => {
     fallback: null,
     group: 1,
     bypassToken: 'some-long-bypass-token-to-make-it-work',
-    prerenderClassification: {
-      // @ts-expect-error - a value Next.js has not shipped yet
-      routeType: 'something-new',
-      response: 'complete',
-      compute: 'static',
+    initialMetadata: {
+      // @ts-expect-error - a value no framework has shipped yet
+      compute: 'something-new',
     },
   });
-  expect(future.prerenderClassification?.routeType).toBe('something-new');
+  expect(future.initialMetadata?.compute).toBe('something-new');
 });
 
 it('should support passQuery correctly', async () => {

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -160,7 +160,7 @@ describe('writeBuildResult()', () => {
     }
   });
 
-  it('writes prerenderClassification to .prerender-config.json', async () => {
+  it('writes initialMetadata to .prerender-config.json', async () => {
     const workPath = await getWriteableDirectory();
     const outputDir = join(workPath, '.vercel', 'output');
     const build = {
@@ -181,11 +181,8 @@ describe('writeBuildResult()', () => {
       handler: 'index.handler',
       runtime: 'nodejs22.x',
     });
-    const prerenderClassification = {
-      routeType: 'shell',
-      response: 'initial',
+    const initialMetadata = {
       compute: 'resuming',
-      htmlSize: 5491,
     } as const;
 
     try {
@@ -199,10 +196,10 @@ describe('writeBuildResult()', () => {
               fallback: null,
               lambda,
               bypassToken: 'some-long-bypass-token-to-make-it-work',
-              prerenderClassification,
+              initialMetadata,
             }),
-            // A route Next.js declined to classify (`notFoundRoutes`, Pages
-            // Router `fallback: false`) must not gain an empty group.
+            // A route the framework supplied no metadata for (`notFoundRoutes`,
+            // Pages Router `fallback: false`) must not gain an empty object.
             unclassified: new Prerender({
               expiration: 1,
               fallback: null,
@@ -222,14 +219,12 @@ describe('writeBuildResult()', () => {
       const classified = await fs.readJSON(
         join(outputDir, 'functions/classified.prerender-config.json')
       );
-      expect(classified.prerenderClassification).toEqual(
-        prerenderClassification
-      );
+      expect(classified.initialMetadata).toEqual(initialMetadata);
 
       const unclassified = await fs.readJSON(
         join(outputDir, 'functions/unclassified.prerender-config.json')
       );
-      expect(unclassified).not.toHaveProperty('prerenderClassification');
+      expect(unclassified).not.toHaveProperty('initialMetadata');
     } finally {
       await fs.remove(workPath);
     }

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -183,6 +183,9 @@ describe('writeBuildResult()', () => {
     });
     const initialMetadata = {
       compute: 'resuming',
+      // Zero is a real shell size — a shell that postponed everything — and
+      // must survive serialization.
+      htmlSize: 0,
     } as const;
 
     try {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -18,7 +18,7 @@ import {
   File,
   FlagDefinitions,
   Chain,
-  PrerenderClassification,
+  PrerenderInitialMetadata,
 } from '@vercel/build-utils';
 import { NodeFileTraceReasons } from '@vercel/nft';
 import type {
@@ -1193,32 +1193,31 @@ export enum RenderingMode {
 }
 
 /**
- * The prerender taxonomy as it appears on a v4 prerender-manifest entry, where
- * each field is independently optional because older Next.js versions omit the
- * group entirely.
+ * The prerender taxonomy fields as they appear on a v4 prerender-manifest
+ * entry. Next.js also emits `routeType`, `response` and `htmlSize`, but the
+ * platform consumes only `compute`, so the rest are deliberately left
+ * untyped and unread. Optional because older Next.js versions omit the
+ * taxonomy entirely.
  */
-type RawPrerenderClassification = Partial<PrerenderClassification>;
+type RawPrerenderTaxonomy = {
+  compute?: PrerenderInitialMetadata['compute'];
+};
 
 /**
- * Read the prerender taxonomy off a manifest entry, but only when Next.js
- * supplied the complete group: it throws an `InvariantError` on a partial one,
- * and absence is legitimate (`notFoundRoutes`, Pages Router `fallback: false`).
- * Values are carried through verbatim — Next.js owns this vocabulary, and one
- * it adds later must reach the platform rather than fail the build.
+ * Read the build-time serving metadata off a manifest entry. Absence is
+ * legitimate (`notFoundRoutes`, Pages Router `fallback: false`, older
+ * Next.js). The value is carried through verbatim — Next.js owns this
+ * vocabulary, and a compute mode it adds later must reach the platform
+ * rather than fail the build.
  */
-function toPrerenderClassification(
-  entry: RawPrerenderClassification
-): PrerenderClassification | undefined {
-  const { routeType, response, compute, htmlSize } = entry;
-  if (!routeType || !response || !compute) {
+function toInitialMetadata(
+  entry: RawPrerenderTaxonomy
+): PrerenderInitialMetadata | undefined {
+  const { compute } = entry;
+  if (!compute) {
     return undefined;
   }
-  return {
-    routeType,
-    response,
-    compute,
-    ...(htmlSize !== undefined ? { htmlSize } : {}),
-  };
+  return { compute };
 }
 
 export type NextPrerenderedRoutes = {
@@ -1226,7 +1225,7 @@ export type NextPrerenderedRoutes = {
 
   staticRoutes: {
     [route: string]: {
-      prerenderClassification?: PrerenderClassification;
+      initialMetadata?: PrerenderInitialMetadata;
       initialRevalidate: number | false;
       initialExpire?: number;
       dataRoute: string | null;
@@ -1242,7 +1241,7 @@ export type NextPrerenderedRoutes = {
 
   blockingFallbackRoutes: {
     [route: string]: {
-      prerenderClassification?: PrerenderClassification;
+      initialMetadata?: PrerenderInitialMetadata;
       routeRegex: string;
       dataRoute: string | null;
       fallback: string | boolean | null;
@@ -1258,7 +1257,7 @@ export type NextPrerenderedRoutes = {
 
   fallbackRoutes: {
     [route: string]: {
-      prerenderClassification?: PrerenderClassification;
+      initialMetadata?: PrerenderInitialMetadata;
       fallback: string;
       fallbackStatus?: number;
       fallbackHeaders?: Record<string, string>;
@@ -1283,7 +1282,7 @@ export type NextPrerenderedRoutes = {
    */
   omittedRoutes: {
     [route: string]: {
-      prerenderClassification?: PrerenderClassification;
+      initialMetadata?: PrerenderInitialMetadata;
       routeRegex: string;
       dataRoute: string | null;
       dataRouteRegex: string | null;
@@ -1483,7 +1482,7 @@ export async function getPrerenderManifest(
     | {
         version: 4;
         routes: {
-          [route: string]: RawPrerenderClassification & {
+          [route: string]: RawPrerenderTaxonomy & {
             initialRevalidateSeconds: number | false;
             initialExpireSeconds?: number;
             srcRoute: string | null;
@@ -1498,7 +1497,7 @@ export async function getPrerenderManifest(
           };
         };
         dynamicRoutes: {
-          [route: string]: RawPrerenderClassification & {
+          [route: string]: RawPrerenderTaxonomy & {
             routeRegex: string;
             fallback: string | false;
             fallbackStatus?: number;
@@ -1618,12 +1617,10 @@ export async function getPrerenderManifest(
         let prefetchDataRoute: undefined | string | null;
         let allowHeader: undefined | string[];
         let renderingMode: RenderingMode;
-        let prerenderClassification: PrerenderClassification | undefined;
+        let initialMetadata: PrerenderInitialMetadata | undefined;
 
         if (manifest.version === 4) {
-          prerenderClassification = toPrerenderClassification(
-            manifest.routes[route]
-          );
+          initialMetadata = toInitialMetadata(manifest.routes[route]);
           initialExpireSeconds = manifest.routes[route].initialExpireSeconds;
           initialStatus = manifest.routes[route].initialStatus;
           initialHeaders = manifest.routes[route].initialHeaders;
@@ -1641,7 +1638,7 @@ export async function getPrerenderManifest(
         }
 
         ret.staticRoutes[route] = {
-          prerenderClassification,
+          initialMetadata,
           initialRevalidate:
             initialRevalidateSeconds === false
               ? false
@@ -1672,9 +1669,9 @@ export async function getPrerenderManifest(
         let fallbackRootParams: undefined | string[];
         let allowHeader: undefined | string[];
         let fallbackSourceRoute: undefined | string;
-        let prerenderClassification: PrerenderClassification | undefined;
+        let initialMetadata: PrerenderInitialMetadata | undefined;
         if (manifest.version === 4) {
-          prerenderClassification = toPrerenderClassification(
+          initialMetadata = toInitialMetadata(
             manifest.dynamicRoutes[lazyRoute]
           );
           experimentalBypassFor =
@@ -1704,7 +1701,7 @@ export async function getPrerenderManifest(
 
         if (typeof fallback === 'string') {
           ret.fallbackRoutes[lazyRoute] = {
-            prerenderClassification,
+            initialMetadata,
             experimentalBypassFor,
             routeRegex,
             fallback,
@@ -1723,7 +1720,7 @@ export async function getPrerenderManifest(
           };
         } else if (fallback === null) {
           ret.blockingFallbackRoutes[lazyRoute] = {
-            prerenderClassification,
+            initialMetadata,
             experimentalBypassFor,
             routeRegex,
             dataRoute,
@@ -1737,7 +1734,7 @@ export async function getPrerenderManifest(
           };
         } else {
           ret.omittedRoutes[lazyRoute] = {
-            prerenderClassification,
+            initialMetadata,
             experimentalBypassFor,
             routeRegex,
             dataRoute,
@@ -2693,13 +2690,13 @@ export const onPrerenderRoute =
     let allowHeader: string[] | undefined;
     // Next.js' own description of what it prerendered, read off the manifest
     // rather than inferred from the emitted build artifacts.
-    let prerenderClassification: PrerenderClassification | undefined;
+    let initialMetadata: PrerenderInitialMetadata | undefined;
 
     if (isFallback || isBlocking) {
       const pr = isFallback
         ? prerenderManifest.fallbackRoutes[routeKey]
         : prerenderManifest.blockingFallbackRoutes[routeKey];
-      prerenderClassification = pr.prerenderClassification;
+      initialMetadata = pr.initialMetadata;
       initialRevalidate = 1; // TODO: should Next.js provide this default?
       // @ts-ignore
       if (initialRevalidate === false) {
@@ -2716,8 +2713,8 @@ export const onPrerenderRoute =
       renderingMode = pr.renderingMode;
       prefetchDataRoute = pr.prefetchDataRoute;
     } else if (isOmitted) {
-      prerenderClassification =
-        prerenderManifest.omittedRoutes[routeKey].prerenderClassification;
+      initialMetadata =
+        prerenderManifest.omittedRoutes[routeKey].initialMetadata;
       initialRevalidate = false;
       srcRoute = routeKey;
       dataRoute = prerenderManifest.omittedRoutes[routeKey].dataRoute;
@@ -2729,7 +2726,7 @@ export const onPrerenderRoute =
         prerenderManifest.omittedRoutes[routeKey].prefetchDataRoute;
     } else {
       const pr = prerenderManifest.staticRoutes[routeKey];
-      prerenderClassification = pr.prerenderClassification;
+      initialMetadata = pr.initialMetadata;
       ({
         initialRevalidate,
         initialExpire,
@@ -3257,11 +3254,11 @@ export const onPrerenderRoute =
           chain,
           allowHeader,
           partialFallback: partialFallback || undefined,
-          // The classification goes on the primary output only, so each route
-          // group has exactly one classified entry; the sibling data and
+          // The metadata goes on the primary output only, so each route
+          // group has exactly one carrying entry; the sibling data and
           // segment prerenders below are grouped back to it by `sourcePath`
           // downstream.
-          prerenderClassification,
+          initialMetadata,
 
           ...(isNotFound
             ? {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1194,30 +1194,36 @@ export enum RenderingMode {
 
 /**
  * The prerender taxonomy fields as they appear on a v4 prerender-manifest
- * entry. Next.js also emits `routeType`, `response` and `htmlSize`, but the
- * platform consumes only `compute`, so the rest are deliberately left
+ * entry. Next.js also emits `routeType` and `response`, but the platform
+ * consumes only `compute` and `htmlSize`, so the rest are deliberately left
  * untyped and unread. Optional because older Next.js versions omit the
  * taxonomy entirely.
  */
 type RawPrerenderTaxonomy = {
   compute?: PrerenderInitialMetadata['compute'];
+  htmlSize?: number;
 };
 
 /**
  * Read the build-time serving metadata off a manifest entry. Absence is
  * legitimate (`notFoundRoutes`, Pages Router `fallback: false`, older
- * Next.js). The value is carried through verbatim — Next.js owns this
+ * Next.js). The values are carried through verbatim — Next.js owns this
  * vocabulary, and a compute mode it adds later must reach the platform
  * rather than fail the build.
  */
 function toInitialMetadata(
   entry: RawPrerenderTaxonomy
 ): PrerenderInitialMetadata | undefined {
-  const { compute } = entry;
+  const { compute, htmlSize } = entry;
   if (!compute) {
     return undefined;
   }
-  return { compute };
+  return {
+    compute,
+    // Zero is a real shell size — a shell that postponed everything — so
+    // this tests for presence, not truthiness.
+    ...(htmlSize !== undefined ? { htmlSize } : {}),
+  };
 }
 
 export type NextPrerenderedRoutes = {

--- a/packages/next/test/integration/segment-cache-cc.test.js
+++ b/packages/next/test/integration/segment-cache-cc.test.js
@@ -52,16 +52,22 @@ describe('clientSegmentCache prerender headers', () => {
       expect(output[key].type).toBe('Prerender');
       return output[key];
     };
+    // `htmlSize` is a byte count that shifts with every Next.js release, so
+    // assert on its presence rather than its value.
     const initialMetadata = key => {
       const actual = prerender(key).initialMetadata;
       expect(actual, `expected initialMetadata on ${key}`).toBeDefined();
-      return actual;
+      const { htmlSize, ...rest } = actual;
+      return { ...rest, htmlSize: typeof htmlSize };
     };
 
     // `cacheComponents: true` app routes that fully prerender: the whole
     // response is in the shell and nothing is left to compute per-request.
     for (const key of ['index', 'careers', 'careers/foobar-1']) {
-      expect(initialMetadata(key)).toEqual({ compute: 'static' });
+      expect(initialMetadata(key)).toEqual({
+        compute: 'static',
+        htmlSize: 'number',
+      });
     }
 
     // Suspense around an async component reading `headers()`: the shell is
@@ -69,23 +75,32 @@ describe('clientSegmentCache prerender headers', () => {
     // the response on the server.
     expect(initialMetadata('dynamic-suspense')).toEqual({
       compute: 'resuming',
+      htmlSize: 'number',
     });
 
     // `[slug]` is a dynamic template with a prerendered fallback shell that
     // postponed work, so serving it resumes on the server too.
     expect(initialMetadata('careers/[slug]')).toEqual({
       compute: 'resuming',
+      htmlSize: 'number',
     });
 
-    // Pages-router ISR route: fully static per request.
-    expect(initialMetadata('legacy')).toEqual({ compute: 'static' });
+    // Pages-router ISR route: fully static per request, and there is no app
+    // HTML shell to measure.
+    expect(initialMetadata('legacy')).toEqual({
+      compute: 'static',
+      htmlSize: 'undefined',
+    });
 
-    // Next.js emits the full taxonomy (`routeType`, `response`, `htmlSize`),
-    // but the platform consumes `compute` only — the rest must not ride
+    // Next.js also emits `routeType` and `response`, but the platform
+    // consumes `compute` and `htmlSize` only — the rest must not ride
     // along into the Prerender output.
-    expect(initialMetadata('careers/[slug]')).not.toHaveProperty('routeType');
-    expect(initialMetadata('careers/[slug]')).not.toHaveProperty('response');
-    expect(initialMetadata('careers/[slug]')).not.toHaveProperty('htmlSize');
+    expect(prerender('careers/[slug]').initialMetadata).not.toHaveProperty(
+      'routeType'
+    );
+    expect(prerender('careers/[slug]').initialMetadata).not.toHaveProperty(
+      'response'
+    );
 
     // A route in the manifest's `notFoundRoutes` gets no taxonomy from
     // Next.js, and must not be given a synthesized one.

--- a/packages/next/test/integration/segment-cache-cc.test.js
+++ b/packages/next/test/integration/segment-cache-cc.test.js
@@ -40,7 +40,7 @@ describe('clientSegmentCache prerender headers', () => {
     }
   });
 
-  it('should surface prerenderClassification on Prerender outputs', async () => {
+  it('should surface initialMetadata on Prerender outputs', async () => {
     const fixturePath = path.join(__dirname, 'segment-cache-cc');
 
     const {
@@ -52,61 +52,48 @@ describe('clientSegmentCache prerender headers', () => {
       expect(output[key].type).toBe('Prerender');
       return output[key];
     };
-    // `htmlSize` is a byte count that shifts with every Next.js release, so
-    // assert on its presence rather than its value.
-    const classification = key => {
-      const actual = prerender(key).prerenderClassification;
-      expect(actual, `expected a classification on ${key}`).toBeDefined();
-      const { htmlSize, ...rest } = actual;
-      return { ...rest, htmlSize: typeof htmlSize };
+    const initialMetadata = key => {
+      const actual = prerender(key).initialMetadata;
+      expect(actual, `expected initialMetadata on ${key}`).toBeDefined();
+      return actual;
     };
 
     // `cacheComponents: true` app routes that fully prerender: the whole
     // response is in the shell and nothing is left to compute per-request.
     for (const key of ['index', 'careers', 'careers/foobar-1']) {
-      expect(classification(key)).toEqual({
-        routeType: 'page',
-        response: 'complete',
-        compute: 'static',
-        htmlSize: 'number',
-      });
+      expect(initialMetadata(key)).toEqual({ compute: 'static' });
     }
 
     // Suspense around an async component reading `headers()`: the shell is
-    // prerendered and the dynamic hole is postponed, so the response is only
-    // the initial part and the request resumes it.
-    expect(classification('dynamic-suspense')).toEqual({
-      routeType: 'page',
-      response: 'initial',
+    // prerendered and the dynamic hole is postponed, so the request resumes
+    // the response on the server.
+    expect(initialMetadata('dynamic-suspense')).toEqual({
       compute: 'resuming',
-      htmlSize: 'number',
     });
 
-    // `[slug]` is a dynamic template with a prerendered fallback shell. It
-    // still has unprerendered params, so it is a fallback rather than a shell.
-    expect(classification('careers/[slug]')).toEqual({
-      routeType: 'fallback',
-      response: 'initial',
+    // `[slug]` is a dynamic template with a prerendered fallback shell that
+    // postponed work, so serving it resumes on the server too.
+    expect(initialMetadata('careers/[slug]')).toEqual({
       compute: 'resuming',
-      htmlSize: 'number',
     });
 
-    // Pages-router ISR route: classified, but there is no app HTML shell to
-    // measure.
-    expect(classification('legacy')).toEqual({
-      routeType: 'page',
-      response: 'complete',
-      compute: 'static',
-      htmlSize: 'undefined',
-    });
+    // Pages-router ISR route: fully static per request.
+    expect(initialMetadata('legacy')).toEqual({ compute: 'static' });
 
-    // A route in the manifest's `notFoundRoutes` gets no classification from
+    // Next.js emits the full taxonomy (`routeType`, `response`, `htmlSize`),
+    // but the platform consumes `compute` only — the rest must not ride
+    // along into the Prerender output.
+    expect(initialMetadata('careers/[slug]')).not.toHaveProperty('routeType');
+    expect(initialMetadata('careers/[slug]')).not.toHaveProperty('response');
+    expect(initialMetadata('careers/[slug]')).not.toHaveProperty('htmlSize');
+
+    // A route in the manifest's `notFoundRoutes` gets no taxonomy from
     // Next.js, and must not be given a synthesized one.
-    expect(prerender('missing').prerenderClassification).toBeUndefined();
+    expect(prerender('missing').initialMetadata).toBeUndefined();
 
-    // Only the primary output of a route group is classified — the sibling
-    // data, prefetch and segment prerenders are grouped back to it downstream
-    // via `sourcePath`, and must not each contribute a classified row.
+    // Only the primary output of a route group carries the metadata — the
+    // sibling data, prefetch and segment prerenders are grouped back to it
+    // downstream via `sourcePath`, and must not each contribute a row.
     for (const key of [
       'index.rsc',
       'dynamic-suspense.rsc',
@@ -116,8 +103,8 @@ describe('clientSegmentCache prerender headers', () => {
       '_next/data/' + buildId(output) + '/legacy.json',
     ]) {
       expect(
-        prerender(key).prerenderClassification,
-        `expected no classification on ${key}`
+        prerender(key).initialMetadata,
+        `expected no initialMetadata on ${key}`
       ).toBeUndefined();
     }
   });


### PR DESCRIPTION
## Why

- The platform consumes only the request-time compute mode and the HTML shell size of a prerender — the dashboard badge and the `staticHint` derivation need `compute`, the shell size is surfaced for support tooling, while `routeType` and `response` have no consumer. Carrying unused fields in a customer-visible artifact is a contract we would have to honor forever.
- The consumed values are grouped under a single `initialMetadata` key to signal their semantics: they describe the deployment **as it was built**. Revalidation can regenerate a route's output over the deployment's lifetime, so readers must treat them as initial values, not live state.
- Nesting under one key also removes the platform-side risk class of a taxonomy field colliding with a `serverlessFunctions` entry's own `path`/`type`/`size` when the build container flattens prerender configs into `deploy_metadata.json`.
- The vendored CLI in vercel/api is already writing the old flattened vocabulary into version-1 `deploy_metadata.json` artifacts in production, so this builder is where the emission actually changes; downstream vercel/api PRs (#85659, #85660, #85661) will be updated to read `initialMetadata`.

## What

```ts
// @vercel/build-utils
export interface PrerenderInitialMetadata {
  compute: 'blocking' | 'resuming' | 'static';
  htmlSize?: number;
}
// PrerenderOptions / Prerender
initialMetadata?: PrerenderInitialMetadata;
```

- `@vercel/next` reads `compute` and `htmlSize` off the v4 prerender-manifest taxonomy and deliberately ignores `routeType` and `response`.
- `htmlSize` keeps its presence semantics: `0` is a real size (a shell that postponed everything), absence means there is no HTML shell to measure (route handlers, Pages Router).
- Unchanged invariants: values are carried **unvalidated** (a compute mode added by a future framework release must not hard-fail a deploy; untrusted `--prebuilt` input is sanitized by the platform), the field is set **only on the primary output** of each prerender group, and absence of the whole group is legitimate (`notFoundRoutes`, Pages Router `fallback: false`, older frameworks).
- The CLI serializes `Prerender` wholesale into `.prerender-config.json`, so the config key renames with no CLI src change; only its test moved.

## Validation

- `packages/next/test/integration/segment-cache-cc.test.js` now asserts `initialMetadata` on primary outputs across static, resuming and pages-router routes (including `htmlSize` presence on App Router HTML and absence on Pages Router), asserts `routeType`/`response` do **not** ride along into the Prerender output, and keeps the absence assertions for `notFoundRoutes` and sibling RSC/data/segment outputs (CI runs this; it needs a full Next.js fixture build).
- build-utils round-trip (incl. shell-less metadata) + no-validation unit tests and the CLI `.prerender-config.json` serialization test (incl. `htmlSize: 0` surviving) pass locally.

## CI status (pre-existing failures, none from this diff)

- **Lint GitHub Actions**: zizmor `ref-version-mismatch` findings in workflows this PR does not touch (`validate-binary.yml` etc.) — upstream action tags moved out from under their hash-pin comments, so every fresh lint run fails (e.g. #17521, which also touches no workflow files, fails identically). Needs a separate pin-comment fix.
- **Unit / CLI [3/7] mac + win**: `help.test.ts` › connex create help snapshot (width 120). Reproduced on **unmodified main** on macOS — fails identically there; linux shards pass here and on main. Platform-specific snapshot breakage on main, unrelated to this change.
- **Vercel preview deploys** (`vercel-vercel-*`): failing on every currently open PR (#17523, #17524, …).

The jobs that exercise this diff — build-utils unit, `@vercel/next` unit/typecheck, CLI linux shards — are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
