### PR TITLE
[1/2] feat(connect): define deployment manifest contract

### DIFF
--- a/.changeset/bright-jars-invent.md
+++ b/.changeset/bright-jars-invent.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Add the versioned Vercel Connect deployment manifest contract.

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -35,3 +35,17 @@ export {
   getConnectorMetadata,
   type ConnectorMetadata,
 } from './connector.js';
+
+export {
+  VERCEL_CONNECT_MANIFEST_KIND,
+  VERCEL_CONNECT_MANIFEST_SCHEMA_VERSION,
+  type VercelConnectAccess,
+  type VercelConnectConnector,
+  type VercelConnectManifest,
+  type VercelConnectManifestGenerator,
+  type VercelConnectRequirement,
+  type VercelConnectResource,
+  type VercelConnectTarget,
+  type VercelConnectTrigger,
+  type VercelConnectUse,
+} from './manifest.js';

--- a/packages/connect/src/manifest.ts
+++ b/packages/connect/src/manifest.ts
@@ -1,0 +1,52 @@
+export const VERCEL_CONNECT_MANIFEST_KIND = 'vercel-connect-manifest';
+export const VERCEL_CONNECT_MANIFEST_SCHEMA_VERSION = 1;
+
+export interface VercelConnectManifest {
+  readonly kind: typeof VERCEL_CONNECT_MANIFEST_KIND;
+  readonly schemaVersion: typeof VERCEL_CONNECT_MANIFEST_SCHEMA_VERSION;
+  readonly generator: VercelConnectManifestGenerator;
+  readonly requirements: readonly VercelConnectRequirement[];
+}
+
+export interface VercelConnectManifestGenerator {
+  readonly name: string;
+  readonly version: string;
+}
+
+export type VercelConnectTarget =
+  | { readonly mode: 'direct'; readonly locator: string }
+  | { readonly mode: 'binding'; readonly reference: string };
+
+export interface VercelConnectRequirement {
+  readonly target: VercelConnectTarget;
+  readonly connector: VercelConnectConnector;
+  readonly resource?: VercelConnectResource;
+  readonly access?: VercelConnectAccess;
+  readonly triggers?: readonly VercelConnectTrigger[];
+  readonly uses: readonly VercelConnectUse[];
+}
+
+export interface VercelConnectConnector {
+  readonly type: string;
+  readonly configuration?: Readonly<Record<string, unknown>>;
+}
+
+export interface VercelConnectResource {
+  readonly protocol: string;
+  readonly url: string;
+}
+
+export interface VercelConnectAccess {
+  readonly principalTypes: readonly ('app' | 'user')[];
+}
+
+export interface VercelConnectTrigger {
+  readonly method: string;
+  readonly path: string;
+}
+
+export interface VercelConnectUse {
+  readonly kind: 'channel' | 'connection';
+  readonly name: string;
+  readonly logicalPath: string;
+}


### PR DESCRIPTION
## Summary

Defines the versioned Connect deployment manifest contract shared by framework build integrations and the Connect control plane. Direct connector locators and project-local bindings are separate target shapes from schema v1.

## Test Plan

Typechecked `@vercel/connect`.
