### PR TITLE
feat(connect): mark eve helper requirements

### DIFF
--- a/.changeset/calm-dodos-connect.md
+++ b/.changeset/calm-dodos-connect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Expose serializable Connect requirement metadata from eve connection and Slack credential helpers.

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -279,7 +279,12 @@ export type EveAuthorizationInput = string | EveAuthorizationOptions;
  * also sent as the managed OAuth UID.
  */
 export interface VercelConnectMetadata {
+  /** Direct connector locator retained for eve runtime authorization behavior. */
   readonly connector: string;
+  /** Connect's connector-type discriminator. */
+  readonly connectorType: string;
+  /** Principals that may receive a token from this helper. */
+  readonly principalTypes: readonly ('app' | 'user')[];
 }
 
 /**
@@ -368,7 +373,11 @@ export function connect(
   InteractiveAuthorizationDefinition | NonInteractiveAuthorizationDefinition
 > {
   const options = normalizeAuthorizationOptions(input);
-  const vercelConnect: VercelConnectMetadata = { connector: options.connector };
+  const vercelConnect: VercelConnectMetadata = {
+    connector: options.connector,
+    connectorType: 'oauth',
+    principalTypes: [options.principalType ?? 'user'],
+  };
   const evict = makeEvict(options);
   if (options.principalType === 'app') {
     return { ...buildNonInteractiveDefinition(options), vercelConnect, evict };

--- a/packages/connect/src/eve/slack-credentials.ts
+++ b/packages/connect/src/eve/slack-credentials.ts
@@ -7,6 +7,8 @@ import {
 } from '../index.js';
 import { vercelOidc } from 'eve/channels/auth';
 
+import type { VercelConnectMetadata } from './connection-authorization.js';
+
 /**
  * Token parameters accepted by {@link connectSlackCredentials}.
  *
@@ -55,10 +57,15 @@ export function connectSlackCredentials(
   connector: string,
   params: ConnectSlackCredentialsParams = {},
   options?: ConnectOptions
-): SlackChannelCredentials {
+): SlackChannelCredentials & { readonly vercelConnect: VercelConnectMetadata } {
   return {
     botToken: () =>
       getToken(connector, { ...params, subject: { type: 'app' } }, options),
     webhookVerifier: vercelOidc(),
+    vercelConnect: {
+      connector,
+      connectorType: 'slack',
+      principalTypes: ['app'],
+    },
   };
 }

--- a/packages/connect/test/eve/channel-credentials.test.ts
+++ b/packages/connect/test/eve/channel-credentials.test.ts
@@ -178,6 +178,11 @@ describe('Eve channel credential helpers', () => {
     );
 
     expect(credentials.webhookVerifier).toEqual(expect.any(Function));
+    expect(credentials.vercelConnect).toEqual({
+      connector: 'oauth/slack',
+      connectorType: 'slack',
+      principalTypes: ['app'],
+    });
     expect(credentials.botToken).toEqual(expect.any(Function));
     await expect(resolveToken(credentials.botToken)).resolves.toBe(
       'slack_token'

--- a/packages/connect/test/eve/connection-authorization.test.ts
+++ b/packages/connect/test/eve/connection-authorization.test.ts
@@ -43,7 +43,13 @@ describe('connect() adapter provisioning', () => {
       .mockResolvedValueOnce(jsonProvisionResponse(connector))
       .mockResolvedValueOnce(jsonTokenResponse('tok_provisioned', connector));
 
-    const definition = connect(connector) as InteractiveAuthorizationDefinition;
+    const definition = connect(connector);
+
+    expect(definition.vercelConnect).toEqual({
+      connector,
+      connectorType: 'oauth',
+      principalTypes: ['user'],
+    });
 
     const result = await definition.getToken({
       principal: PRINCIPAL,


### PR DESCRIPTION
## Summary

Adds helper metadata to the existing eve `connect()` adapter and Slack credential helper: the direct connector locator, Connect connector type, and allowed app/user principals. eve owns the deployment-manifest schema and turns these facts into its build artifact.

Consumed by vercel/eve#2496.

## Test Plan

Updated connection and Slack helper unit tests; `@vercel/connect` typecheck.
