### PR TITLE
fix(connect): resolve Eve Slack installations by workspace

### DIFF
--- a/.changeset/fuzzy-carpets-connect.md
+++ b/.changeset/fuzzy-carpets-connect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Allow Eve Slack credentials to resolve a Connect installation from the inbound Slack installation workspace.

--- a/packages/connect/src/eve/index.ts
+++ b/packages/connect/src/eve/index.ts
@@ -44,5 +44,7 @@ export {
 } from './photon-credentials.js';
 export {
   connectSlackCredentials,
+  type ConnectSlackCredentialsContext,
   type ConnectSlackCredentialsParams,
+  type ConnectSlackInstallationIdResolver,
 } from './slack-credentials.js';

--- a/packages/connect/src/eve/slack-credentials.ts
+++ b/packages/connect/src/eve/slack-credentials.ts
@@ -15,16 +15,35 @@ import { vercelOidc } from 'eve/channels/auth';
  * is pinned to `{ type: "app" }` by this helper and cannot be
  * overridden.
  */
-export type ConnectSlackCredentialsParams = Omit<ConnectTokenParams, 'subject'>;
+export interface ConnectSlackCredentialsContext {
+  /** Slack workspace whose app installation must supply the bot token. */
+  readonly teamId?: string;
+}
+
+export type ConnectSlackInstallationIdResolver = (
+  context: ConnectSlackCredentialsContext
+) => string | undefined | Promise<string | undefined>;
+
+export type ConnectSlackCredentialsParams = Omit<
+  ConnectTokenParams,
+  'installationId' | 'subject'
+> & {
+  /**
+   * A fixed Connect installation id, or a resolver for multi-workspace apps.
+   * The resolver maps Eve's Slack workspace context to Connect's opaque
+   * installation id.
+   */
+  readonly installationId?: string | ConnectSlackInstallationIdResolver;
+};
 
 /**
  * Build {@link SlackChannelCredentials} backed by a Vercel Connect
  * connector that stores a Slack workspace's bot token.
  *
- * The returned `botToken` is a function form, invoked once per
- * inbound webhook so the chat adapter always picks up a fresh token
- * from Vercel Connect (rotation, refresh, multi-workspace tenancy
- * are all handled server-side).
+ * The returned `botToken` is resolved when Eve makes a Slack API call,
+ * so the chat adapter always picks up a fresh token from Vercel Connect.
+ * Rotation and refresh are handled server-side; multi-workspace callers
+ * resolve the installation from webhook context.
  *
  * Slack bot tokens are app-scoped — one token per workspace install,
  * shared across every end-user — so this helper calls Vercel Connect
@@ -44,11 +63,14 @@ export type ConnectSlackCredentialsParams = Omit<ConnectTokenParams, 'subject'>;
  * });
  * ```
  *
- * Multi-workspace deployments can select a specific workspace install
- * via `installationId`:
+ * Multi-workspace deployments can resolve the Connect installation from
+ * Eve's Slack workspace context:
  *
  * ```ts
- * connectSlackCredentials("scl_...", { installationId: workspaceId });
+ * connectSlackCredentials("scl_...", {
+ *   installationId: ({ teamId }) =>
+ *     teamId ? installationIdsBySlackTeam[teamId] : undefined,
+ * });
  * ```
  */
 export function connectSlackCredentials(
@@ -57,8 +79,22 @@ export function connectSlackCredentials(
   options?: ConnectOptions
 ): SlackChannelCredentials {
   return {
-    botToken: () =>
-      getToken(connector, { ...params, subject: { type: 'app' } }, options),
+    botToken: async (context: ConnectSlackCredentialsContext = {}) => {
+      const { installationId: installationIdParam, ...tokenParams } = params;
+      const installationId =
+        typeof installationIdParam === 'function'
+          ? await installationIdParam(context)
+          : installationIdParam;
+      return getToken(
+        connector,
+        {
+          ...tokenParams,
+          ...(installationId === undefined ? {} : { installationId }),
+          subject: { type: 'app' },
+        },
+        options
+      );
+    },
     webhookVerifier: vercelOidc(),
   };
 }

--- a/packages/connect/test/eve/channel-credentials.test.ts
+++ b/packages/connect/test/eve/channel-credentials.test.ts
@@ -188,6 +188,41 @@ describe('Eve channel credential helpers', () => {
     });
   });
 
+  it('selects a Slack installation from Eve workspace context', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonTokenResponse('slack_token_a'))
+      .mockResolvedValueOnce(jsonTokenResponse('slack_token_b'));
+    const installationIdsBySlackTeam: Record<string, string> = {
+      T_A: 'inst_a',
+      T_B: 'inst_b',
+    };
+    const installationId = vi.fn(
+      async ({ teamId }: { readonly teamId?: string }) =>
+        teamId ? installationIdsBySlackTeam[teamId] : undefined
+    );
+    const credentials = connectSlackCredentials(
+      'oauth/slack-multi-workspace',
+      { installationId },
+      { vercelToken: 'vercel_token' }
+    );
+
+    await expect(
+      resolveSlackToken(credentials.botToken, { teamId: 'T_A' })
+    ).resolves.toBe('slack_token_a');
+    await expect(
+      resolveSlackToken(credentials.botToken, { teamId: 'T_B' })
+    ).resolves.toBe('slack_token_b');
+
+    expect(installationId).toHaveBeenNthCalledWith(1, { teamId: 'T_A' });
+    expect(installationId).toHaveBeenNthCalledWith(2, { teamId: 'T_B' });
+    expect(
+      fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body as string))
+    ).toEqual([
+      { installationId: 'inst_a', subject: { type: 'app' } },
+      { installationId: 'inst_b', subject: { type: 'app' } },
+    ]);
+  });
+
   function expectTokenRequest(
     connector: string,
     body: Record<string, unknown>
@@ -212,6 +247,19 @@ async function resolveToken(
     throw new Error('Expected token callback.');
   }
   return token();
+}
+
+async function resolveSlackToken(
+  token:
+    | string
+    | ((context?: { readonly teamId?: string }) => string | Promise<string>)
+    | undefined,
+  context: { readonly teamId?: string }
+): Promise<string> {
+  if (typeof token !== 'function') {
+    throw new Error('Expected token callback.');
+  }
+  return token(context);
 }
 
 function jsonTokenResponse(


### PR DESCRIPTION
## What

- Let Eve's `connectSlackCredentials` accept an installation resolver keyed by Slack's installation workspace.
- Keep fixed `installationId` values and Connect's default-install behavior.
- Cover two Slack workspaces selecting two different Connect installations.

[vercel/eve#2150](https://github.com/vercel/eve/pull/2150) now calls bot-token providers with `{ teamId }`, where `teamId` is the Slack workspace that owns the app installation. `@vercel/connect/eve` currently ignores that argument, so multi-workspace traffic still falls back to Connect's default installation.

## Token selection

Before → Eve supplied `teamId`; the Connect helper dropped it and called `getToken` without a per-request installation.

After → the helper calls a caller-provided resolver with `{ teamId }` and passes its result to `getToken` as `installationId`.

Slack team IDs and Connect installation IDs are separate namespaces (`T_*` versus opaque `inst_*`). The helper therefore requires an explicit mapping instead of forwarding a Slack ID as a Connect ID.

```ts
connectSlackCredentials('slack/my-agent', {
  installationId: ({ teamId }) =>
    teamId ? installationIdsBySlackTeam[teamId] : undefined,
});
```

A fixed `installationId` still works. If a resolver returns `undefined`, the helper omits the field and Connect keeps its default-install selection.
