### PR TITLE
[cli] Add remote device login

### DIFF
--- a/.changeset/remote-device-login.md
+++ b/.changeset/remote-device-login.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `vercel login --no-browser` for device login from remote machines.

--- a/packages/cli/src/commands/login/command.ts
+++ b/packages/cli/src/commands/login/command.ts
@@ -12,6 +12,12 @@ export const loginCommand = {
   ],
   options: [
     {
+      name: 'no-browser',
+      description: 'Print the device login URL without opening a browser',
+      shorthand: null,
+      type: Boolean,
+    },
+    {
       name: 'github',
       description: 'Log in with GitHub',
       shorthand: null,
@@ -39,6 +45,10 @@ export const loginCommand = {
     {
       name: 'Sign in to your Vercel account.',
       value: `${packageName} login`,
+    },
+    {
+      name: 'Sign in from a remote machine.',
+      value: `${packageName} login --no-browser`,
     },
   ],
   disabledGlobalOptions: ['token'],

--- a/packages/cli/src/commands/login/command.ts
+++ b/packages/cli/src/commands/login/command.ts
@@ -16,6 +16,7 @@ export const loginCommand = {
       description: 'Print the device login URL without opening a browser',
       shorthand: null,
       type: Boolean,
+      deprecated: false,
     },
     {
       name: 'github',

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -30,6 +30,7 @@ interface DeviceCodeFlowOptions {
   teamId?: string;
   refreshToken?: string;
   acrValues?: string;
+  openBrowser?: boolean;
   /**
    * A CLI version before 56.4.1 could persist the rotated access token after
    * step-up without persisting its matching refresh token. Recover those
@@ -105,21 +106,30 @@ export async function performDeviceCodeFlow(
     verification_uri_complete = url.toString();
   }
 
-  // Determine if we should skip opening the browser (only in CI, but not in Cursor)
+  // CI skips browser opening for every client except Cursor. --no-browser always skips it.
   const isCursorAgent =
     client.agentName === KNOWN_AGENTS.CURSOR ||
     client.agentName === KNOWN_AGENTS.CURSOR_CLI;
-  const shouldSkipBrowser = process.env.CI && !isCursorAgent;
+  const shouldSkipBrowser =
+    options?.openBrowser === false || (process.env.CI && !isCursorAgent);
 
-  o.log(
-    `\n  Visit ${chalk.bold(
-      o.link(
-        verification_uri.replace('https://', ''),
-        verification_uri_complete,
-        { color: false, fallback: () => verification_uri_complete }
-      )
-    )}${o.supportsHyperlink ? ` and enter ${chalk.bold(user_code)}` : ''}\n`
-  );
+  if (options?.openBrowser === false) {
+    o.log(
+      `\n  Open ${chalk.bold(verification_uri)} and enter ${chalk.bold(
+        user_code
+      )}\n`
+    );
+  } else {
+    o.log(
+      `\n  Visit ${chalk.bold(
+        o.link(
+          verification_uri.replace('https://', ''),
+          verification_uri_complete,
+          { color: false, fallback: () => verification_uri_complete }
+        )
+      )}${o.supportsHyperlink ? ` and enter ${chalk.bold(user_code)}` : ''}\n`
+    );
+  }
 
   // Open browser automatically unless we're in CI (excluding Cursor)
   if (!shouldSkipBrowser) {
@@ -234,9 +244,10 @@ export async function performDeviceCodeFlow(
 
 export async function login(
   client: Client,
-  telemetry: LoginTelemetryClient
+  telemetry: LoginTelemetryClient,
+  openBrowser = true
 ): Promise<number> {
-  const tokens = await performDeviceCodeFlow(client);
+  const tokens = await performDeviceCodeFlow(client, { openBrowser });
 
   if (!tokens) {
     telemetry.trackState('error');

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -78,5 +78,9 @@ export default async function login(
 
   telemetry.trackState('started');
 
-  return await future(client, telemetry);
+  return await future(
+    client,
+    telemetry,
+    parsedArgs?.flags['--no-browser'] !== true
+  );
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -5504,6 +5504,13 @@ exports[`help command > login help output snapshots > login help column width 40
 
   Sign in to your Vercel account.       
 
+  Options:
+
+   --no-browser  Print the device login  
+                 URL without opening a   
+                 browser                 
+
+
   Global Options:
 
        --cwd <DIR>            Sets the  
@@ -5556,6 +5563,10 @@ exports[`help command > login help output snapshots > login help column width 40
 
     $ vercel login
 
+  - Sign in from a remote machine.
+
+    $ vercel login --no-browser
+
 "
 `;
 
@@ -5564,6 +5575,11 @@ exports[`help command > login help output snapshots > login help column width 80
   ▲ vercel login [email or team id] [options]
 
   Sign in to your Vercel account.                                               
+
+  Options:
+
+   --no-browser  Print the device login URL without opening a browser            
+
 
   Global Options:
 
@@ -5586,6 +5602,10 @@ exports[`help command > login help output snapshots > login help column width 80
 
     $ vercel login
 
+  - Sign in from a remote machine.
+
+    $ vercel login --no-browser
+
 "
 `;
 
@@ -5594,6 +5614,11 @@ exports[`help command > login help output snapshots > login help column width 12
   ▲ vercel login [email or team id] [options]
 
   Sign in to your Vercel account.                                                                                       
+
+  Options:
+
+   --no-browser  Print the device login URL without opening a browser                                                    
+
 
   Global Options:
 
@@ -5613,6 +5638,10 @@ exports[`help command > login help output snapshots > login help column width 12
   - Sign in to your Vercel account.
 
     $ vercel login
+
+  - Sign in from a remote machine.
+
+    $ vercel login --no-browser
 
 "
 `;

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -149,6 +149,38 @@ describe('login', () => {
     expect(tokenAfter).toBe(tokenResult.access_token);
   });
 
+  it('prints device login instructions without opening a browser', async () => {
+    const authorizationResult = {
+      device_code: randomUUID(),
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://vercel.com/device',
+      verification_uri_complete:
+        'https://vercel.com/device?user_code=ABCD-EFGH',
+      expires_in: 30,
+      interval: 0.005,
+    };
+    fetch.mockResolvedValueOnce(mockResponse(authorizationResult));
+
+    await simulateTokenPolling(
+      1,
+      mockResponse({
+        access_token: randomUUID(),
+        token_type: 'Bearer',
+        expires_in: 60,
+        scope: 'openid offline_access',
+      })
+    );
+
+    await expect(
+      performDeviceCodeFlow(client, { openBrowser: false })
+    ).resolves.not.toBeNull();
+
+    expect(open.default).not.toHaveBeenCalled();
+    expect(client.getFullOutput()).toContain(
+      'Open https://vercel.com/device and enter ABCD-EFGH'
+    );
+  });
+
   it.todo('Authorization request error');
   it.todo('Token request error');
 

--- a/packages/cli/test/unit/commands/login/index.test.ts
+++ b/packages/cli/test/unit/commands/login/index.test.ts
@@ -45,4 +45,16 @@ describe('login', () => {
     futureSpy.mockRestore();
     (client as { nonInteractive: boolean }).nonInteractive = false;
   });
+
+  it('does not open a browser when --no-browser is set', async () => {
+    client.setArgv('login', '--no-browser');
+
+    const futureSpy = vi.spyOn(loginFuture, 'login').mockResolvedValue(0);
+    const exitCode = await login(client, { shouldParseArgs: true });
+
+    expect(exitCode).toBe(0);
+    expect(futureSpy).toHaveBeenCalledWith(client, expect.anything(), false);
+
+    futureSpy.mockRestore();
+  });
 });

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -25,7 +25,7 @@ Many project-aware commands also accept `--project <name-or-id>` with `--scope <
 
 Being inside an app directory is not proof that the intended project was selected. Check the resolved project explicitly, especially when a repo mapping does not cover that directory.
 
-`vercel whoami --format json` identifies the authenticated user and effective team; plain non-TTY `vercel whoami` prints only the username. Neither verifies the linked project. Read-only project commands can still require login or team SAML re-authentication and open a browser/device flow. Ask the user to complete that flow deliberately before continuing.
+`vercel whoami --format json` identifies the authenticated user and effective team; plain non-TTY `vercel whoami` prints only the username. Neither verifies the linked project. Read-only project commands can still require login or team SAML re-authentication and open a browser/device flow. Ask the user to complete that flow deliberately before continuing. For remote and automated authentication, read [`references/authentication.md`](references/authentication.md).
 
 ## Quick Start
 
@@ -49,6 +49,7 @@ Use this to route to the correct reference file:
 - **Rolling releases, deploy hooks, cron jobs, cache, git connection, Edge Config, redirects, custom environments** → `references/project-infra.md`
 - **Local development** → `references/local-development.md`
 - **Environment variables** → `references/environment-variables.md`
+- **Authentication, remote servers, or access tokens** → `references/authentication.md`
 - **CI/CD automation** → `references/ci-automation.md`
 - **Domains or DNS** → `references/domains-and-dns.md`
 - **Projects or teams** → `references/projects-and-teams.md`
@@ -86,5 +87,6 @@ Use this to route to the correct reference file:
 - **Using `vercel deploy` after `vercel build` without `--prebuilt`**: The build output is ignored.
 - **Using `vercel redeploy` for no-cache rebuilds**: `vercel redeploy` does not expose a no-cache flag; use `vercel deploy --force` without `--with-cache` when you need a fresh deployment that does not retain build cache.
 - **Hardcoding tokens in flags**: Use `VERCEL_TOKEN` env var instead of `--token`.
+- **Saving an OAuth session on an untrusted server**: Use a narrow project-scoped token when the server is trusted with the environment values. Do not authenticate an untrusted server.
 - **Disabling deployment protection**: Use `vercel curl` instead to access preview deploys.
 - **Using `vercel api` too early**: Prefer first-class CLI commands when they expose the needed data or mutation.

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -87,6 +87,6 @@ Use this to route to the correct reference file:
 - **Using `vercel deploy` after `vercel build` without `--prebuilt`**: The build output is ignored.
 - **Using `vercel redeploy` for no-cache rebuilds**: `vercel redeploy` does not expose a no-cache flag; use `vercel deploy --force` without `--with-cache` when you need a fresh deployment that does not retain build cache.
 - **Hardcoding tokens in flags**: Use `VERCEL_TOKEN` env var instead of `--token`.
-- **Saving an OAuth session on an untrusted server**: Use a narrow project-scoped token when the server is trusted with the environment values. Do not authenticate an untrusted server.
+- **Saving an OAuth session on an untrusted server**: Use a token with only the access required for the command when the server is trusted with the environment values. Do not authenticate an untrusted server.
 - **Disabling deployment protection**: Use `vercel curl` instead to access preview deploys.
 - **Using `vercel api` too early**: Prefer first-class CLI commands when they expose the needed data or mutation.

--- a/skills/vercel-cli/command/vercel.md
+++ b/skills/vercel-cli/command/vercel.md
@@ -20,7 +20,7 @@ Based on task type, read `references/<topic>.md`. Use `vercel <command> --help` 
 
 - Run `vercel project inspect --non-interactive` from the intended working directory and confirm the owner and project; stop on `link_required` or a mismatch instead of treating `.vercel/` existence as proof
 - Use `vercel pull` for project settings and environment data under `.vercel/`; use `vercel env pull` for `.env.local` or another file that is already excluded from source control
-- If login or team SAML re-authentication opens a browser/device flow, wait for deliberate user completion before continuing
+- If login or team SAML re-authentication opens a browser/device flow, wait for deliberate user completion before continuing. Use `vercel login --no-browser` on a trusted remote server and read `references/authentication.md` before handling credentials on a shared, disposable, or untrusted server
 - Use `--non-interactive` for prompt-free runs and `--yes` only when confirmation is required
 - Use `VERCEL_TOKEN` env var for auth (not `--token`)
 - Use first-class CLI commands before `vercel api`

--- a/skills/vercel-cli/references/authentication.md
+++ b/skills/vercel-cli/references/authentication.md
@@ -4,13 +4,13 @@ Vercel CLI uses either a saved OAuth session or an access token. Choose the meth
 
 ## Choose an authentication method
 
-| Environment                         | Authentication                                      | Credential lifetime                         |
-| ----------------------------------- | --------------------------------------------------- | ------------------------------------------- |
-| Trusted computer or personal server | `vercel login`                                      | Saved OAuth session refreshes automatically |
-| Trusted server over SSH             | `vercel login --no-browser`                         | Saved OAuth session refreshes automatically |
-| Unattended automation               | Project-scoped `VERCEL_TOKEN` from a secret manager | Token is supplied for each run              |
-| Shared or disposable server         | Project-scoped `VERCEL_TOKEN` from a secret manager | Do not save an OAuth session                |
-| Untrusted server                    | Do not authenticate or pull environment variables   | No credential                               |
+| Environment                         | Authentication                                    | Credential lifetime                         |
+| ----------------------------------- | ------------------------------------------------- | ------------------------------------------- |
+| Trusted computer or personal server | `vercel login`                                    | Saved OAuth session refreshes automatically |
+| Trusted server over SSH             | `vercel login --no-browser`                       | Saved OAuth session refreshes automatically |
+| Unattended automation               | `VERCEL_TOKEN` from a secret manager              | Token is supplied for each run              |
+| Shared or disposable server         | `VERCEL_TOKEN` from a secret manager              | Do not save an OAuth session                |
+| Untrusted server                    | Do not authenticate or pull environment variables | No credential                               |
 
 `vercel env pull` writes plaintext environment variables to a local file. Do not use it on a machine that must not read those values, even if its access token is narrowly scoped.
 
@@ -28,11 +28,11 @@ Use this only when the remote machine is trusted with your Vercel account. A lat
 
 ## Automate with an access token
 
-For scheduled jobs and non-interactive commands, create an access token at https://vercel.com/account/tokens and store it in the host's secret manager. Prefer a project-scoped token. It limits the token to one project instead of every team and project you can access.
+For scheduled jobs and non-interactive commands, create an access token at https://vercel.com/account/tokens and store it in the host's secret manager. Choose the narrowest scope that supports every command in the job. A project-scoped token limits access to one project, but commands such as `vercel env pull` can require access to the owning team.
 
 ```bash
-export VERCEL_TOKEN=<project-scoped-token>
-vercel env pull .env.local --yes
+export VERCEL_TOKEN=<access-token>
+vercel env pull .env.local
 ```
 
 `VERCEL_TOKEN` takes precedence over saved credentials. The CLI does not save or refresh it. Do not pass a token through `--token` unless no secret environment mechanism is available because command-line arguments can appear in process listings.
@@ -44,7 +44,7 @@ For a server without a local `.vercel/` link, set both project identifiers or pa
 ```bash
 export VERCEL_ORG_ID=<team-id>
 export VERCEL_PROJECT_ID=<project-id>
-vercel env pull .env.local --yes
+vercel env pull .env.local
 ```
 
 Confirm the resolved project before a consequential read or mutation with `vercel project inspect --non-interactive`.

--- a/skills/vercel-cli/references/authentication.md
+++ b/skills/vercel-cli/references/authentication.md
@@ -1,0 +1,50 @@
+# Authentication
+
+Vercel CLI uses either a saved OAuth session or an access token. Choose the method based on how much you trust the machine and whether a person can approve a login.
+
+## Choose an authentication method
+
+| Environment                         | Authentication                                      | Credential lifetime                         |
+| ----------------------------------- | --------------------------------------------------- | ------------------------------------------- |
+| Trusted computer or personal server | `vercel login`                                      | Saved OAuth session refreshes automatically |
+| Trusted server over SSH             | `vercel login --no-browser`                         | Saved OAuth session refreshes automatically |
+| Unattended automation               | Project-scoped `VERCEL_TOKEN` from a secret manager | Token is supplied for each run              |
+| Shared or disposable server         | Project-scoped `VERCEL_TOKEN` from a secret manager | Do not save an OAuth session                |
+| Untrusted server                    | Do not authenticate or pull environment variables   | No credential                               |
+
+`vercel env pull` writes plaintext environment variables to a local file. Do not use it on a machine that must not read those values, even if its access token is narrowly scoped.
+
+## Sign in from a remote machine
+
+Run this in an interactive SSH session:
+
+```bash
+vercel login --no-browser
+```
+
+The CLI prints `https://vercel.com/device` and a one-time code. Open that URL on your phone or client computer, enter the code, and approve the sign-in. The remote CLI waits for approval, then saves an OAuth access token and refresh token in its configured credential store. Verify the active account with `vercel whoami`.
+
+Use this only when the remote machine is trusted with your Vercel account. A later command that reads sensitive environment variables can require the same device-authorization step again.
+
+## Automate with an access token
+
+For scheduled jobs and non-interactive commands, create an access token at https://vercel.com/account/tokens and store it in the host's secret manager. Prefer a project-scoped token. It limits the token to one project instead of every team and project you can access.
+
+```bash
+export VERCEL_TOKEN=<project-scoped-token>
+vercel env pull .env.local --yes
+```
+
+`VERCEL_TOKEN` takes precedence over saved credentials. The CLI does not save or refresh it. Do not pass a token through `--token` unless no secret environment mechanism is available because command-line arguments can appear in process listings.
+
+## Scope the project explicitly
+
+For a server without a local `.vercel/` link, set both project identifiers or pass an explicit project and team:
+
+```bash
+export VERCEL_ORG_ID=<team-id>
+export VERCEL_PROJECT_ID=<project-id>
+vercel env pull .env.local --yes
+```
+
+Confirm the resolved project before a consequential read or mutation with `vercel project inspect --non-interactive`.

--- a/skills/vercel-cli/references/ci-automation.md
+++ b/skills/vercel-cli/references/ci-automation.md
@@ -2,7 +2,7 @@
 
 ## Authentication
 
-Use `VERCEL_TOKEN` env var (not `--token` — it leaks in process listings). Use `--scope` if the token has access to multiple teams.
+Use a project-scoped `VERCEL_TOKEN` from the CI secret manager, not `--token`, which can leak in process listings. Use `--scope` if the token has access to multiple teams. Read [authentication](authentication.md) for remote-server and credential-persistence guidance.
 
 ## The Standard CI Deploy Pattern
 

--- a/skills/vercel-cli/references/ci-automation.md
+++ b/skills/vercel-cli/references/ci-automation.md
@@ -2,7 +2,7 @@
 
 ## Authentication
 
-Use a project-scoped `VERCEL_TOKEN` from the CI secret manager, not `--token`, which can leak in process listings. Use `--scope` if the token has access to multiple teams. Read [authentication](authentication.md) for remote-server and credential-persistence guidance.
+Use `VERCEL_TOKEN` from the CI secret manager, not `--token`, which can leak in process listings. Choose the narrowest token scope that supports every command in the job. Use `--scope` if the token has access to multiple teams. Read [authentication](authentication.md) for remote-server and credential-persistence guidance.
 
 ## The Standard CI Deploy Pattern
 

--- a/skills/vercel-cli/references/getting-started.md
+++ b/skills/vercel-cli/references/getting-started.md
@@ -8,7 +8,7 @@ npm i -g vercel
 
 ## First-Time Setup
 
-1. **Authenticate** - `vercel login` opens a browser/device flow. For CI, use the `VERCEL_TOKEN` environment variable instead. Wait for deliberate user completion when a browser flow starts.
+1. **Authenticate** - Run `vercel login` on a trusted computer. On a trusted remote server, run `vercel login --no-browser` and approve the device flow from your phone or client computer. For automation, use a project-scoped `VERCEL_TOKEN`. Read [authentication](authentication.md) before using a shared, disposable, or untrusted server.
 2. **Link your project** - `vercel link` for a working-directory project or `vercel link --repo` for repository directory mappings. Both create files under `.vercel/`.
 3. **Verify the target** - from the intended working directory, run `vercel project inspect --non-interactive` and confirm its owner and project. Stop on `link_required` or a mismatch rather than linking automatically. `vercel whoami --format json` identifies the authenticated user and effective team, not the linked project.
 4. **Pull local data** - `vercel pull` writes project settings and environment data under `.vercel/`, including `.vercel/.env.<environment>.local`. Use `vercel env pull` to write `.env.local` or another file that is already excluded from source control.

--- a/skills/vercel-cli/references/getting-started.md
+++ b/skills/vercel-cli/references/getting-started.md
@@ -8,7 +8,7 @@ npm i -g vercel
 
 ## First-Time Setup
 
-1. **Authenticate** - Run `vercel login` on a trusted computer. On a trusted remote server, run `vercel login --no-browser` and approve the device flow from your phone or client computer. For automation, use a project-scoped `VERCEL_TOKEN`. Read [authentication](authentication.md) before using a shared, disposable, or untrusted server.
+1. **Authenticate** - Run `vercel login` on a trusted computer. On a trusted remote server, run `vercel login --no-browser` and approve the device flow from your phone or client computer. For automation, inject `VERCEL_TOKEN` from a secret manager. Read [authentication](authentication.md) before using a shared, disposable, or untrusted server.
 2. **Link your project** - `vercel link` for a working-directory project or `vercel link --repo` for repository directory mappings. Both create files under `.vercel/`.
 3. **Verify the target** - from the intended working directory, run `vercel project inspect --non-interactive` and confirm its owner and project. Stop on `link_required` or a mismatch rather than linking automatically. `vercel whoami --format json` identifies the authenticated user and effective team, not the linked project.
 4. **Pull local data** - `vercel pull` writes project settings and environment data under `.vercel/`, including `.vercel/.env.<environment>.local`. Use `vercel env pull` to write `.env.local` or another file that is already excluded from source control.


### PR DESCRIPTION
## Problem

`vercel login` starts a device authorization flow and opens a browser. On a trusted server accessed through SSH, opening a browser on the server is not useful even when the developer can approve the device flow from another computer. The CLI did not provide an explicit remote-login workflow.

For example, a developer can log in from their laptop but cannot deliberately ask an SSH host to print the device URL and continue without its browser opener.

## Changes

`vercel login --no-browser` now prints the verification URL and code, then waits for the device authorization to finish without opening a browser. The normal local browser flow and the existing CI behavior remain unchanged.

The help output and device-flow tests cover the new option. The bundled CLI skill also explains when an OAuth session, a scoped token, or no credentials are appropriate on remote hosts.
