### PR TITLE
fix(cli): remove stale oauth-apps references

### DIFF
--- a/.changeset/remove-oauth-apps-help.md
+++ b/.changeset/remove-oauth-apps-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove stale OAuth app command references from CLI help and agent skill documentation.

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -66,7 +66,6 @@ export const help = () => `
       metrics              <metric>    Queries observability metrics for your project or team
       mcp                              Set up MCP agents and configuration
       microfrontends                   Manages your microfrontends
-      oauth-apps           [cmd]       Register Vercel Apps (OAuth) and manage team installations
       projects                         Manages your Projects
       redirects            [cmd]       Manages redirects for your current Project
       rm | remove          [id]        Removes a deployment

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -61,7 +61,6 @@ exports[`base level help output > help 1`] = `
       metrics              <metric>    Queries observability metrics for your project or team
       mcp                              Set up MCP agents and configuration
       microfrontends                   Manages your microfrontends
-      oauth-apps           [cmd]       Register Vercel Apps (OAuth) and manage team installations
       projects                         Manages your Projects
       redirects            [cmd]       Manages redirects for your current Project
       rm | remove          [id]        Removes a deployment

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vercel-cli
-description: Deploy, manage, inspect, and troubleshoot Vercel projects from the command line. Use for Vercel deployments, Vercel Toolbar comments, build failures, projects and teams, environment variables, domains and DNS, logs, metrics, Speed Insights, Core Web Vitals, request traces, usage, activity, alerts, firewall rules, cache, cron jobs, deploy hooks, Edge Config, feature flags, integrations, connectors, Blob storage, Container Registry (VCR), microfrontends, rolling releases, custom environments, Sandbox, agent/MCP setup, OAuth apps, preview access, local development, or `vercel api` fallback.
+description: Deploy, manage, inspect, and troubleshoot Vercel projects from the command line. Use for Vercel deployments, Vercel Toolbar comments, build failures, projects and teams, environment variables, domains and DNS, logs, metrics, Speed Insights, Core Web Vitals, request traces, usage, activity, alerts, firewall rules, cache, cron jobs, deploy hooks, Edge Config, feature flags, integrations, connectors, Blob storage, Container Registry (VCR), microfrontends, rolling releases, custom environments, Sandbox, agent/MCP setup, preview access, local development, or `vercel api` fallback.
 ---
 
 # Vercel CLI Skill
@@ -71,7 +71,6 @@ Use this to route to the correct reference file:
 - **Sandbox** → `references/sandbox.md`
 - **Agent, MCP, skills discovery, or AI Gateway** → `references/agent-and-ai.md`
 - **Captured request traces (`vercel traces`, including `--open` / `--view`)** → `references/advanced.md`
-- **Vercel Apps / OAuth apps (`vercel oauth-apps`)** → `references/advanced.md`
 - **Advanced (`vercel api` fallback, webhooks)** → `references/advanced.md`
 - **Global flags** → `references/global-options.md`
 - **First-time setup** → `references/getting-started.md`

--- a/skills/vercel-cli/references/advanced.md
+++ b/skills/vercel-cli/references/advanced.md
@@ -48,22 +48,6 @@ vercel traces get req_1234567890 --open --view gantt               # specific da
 
 `--view` is only valid alongside `--open`.
 
-## `vercel oauth-apps` — Vercel Apps (OAuth)
-
-Register Vercel Apps (OAuth client IDs) and manage team installations. Useful for building integrations that authenticate against a Vercel team.
-
-```bash
-vercel oauth-apps register --name "My App" --slug my-app --redirect-uri https://app.example.com/oauth/callback
-vercel oauth-apps register --name "My App" --slug my-app --format json    # JSON output includes clientId
-vercel oauth-apps install --client-id cl_abc --permission read:project --permission read:deployment
-vercel oauth-apps install --client-id cl_abc --permission read:project --projects prj_a,prj_b   # scope to projects (or `*` for all)
-vercel oauth-apps list-requests --format json                             # pending install requests
-vercel oauth-apps dismiss cl_abc123 --yes                                 # dismiss a pending request
-vercel oauth-apps remove inst_abc123 --yes                                # uninstall (aliases: rm, uninstall)
-```
-
-`register` issues a client ID. `install` (alias `add`) installs an app to the current team using that client ID. At least one `--permission` is required (the install errors with `Provide at least one --permission` otherwise); repeat `--permission` for each scope the app needs.
-
 ## Other Commands
 
 - `vercel webhooks` — manage webhooks (create, ls, rm)

--- a/skills/vercel-cli/references/platform-ops.md
+++ b/skills/vercel-cli/references/platform-ops.md
@@ -52,7 +52,6 @@ vercel whoami --format json
 ```bash
 vercel activity --help
 vercel teams --help
-vercel oauth-apps --help
 ```
 
 If an account operation is not available through a first-class command, use `vercel api` as a fallback.


### PR DESCRIPTION
## Problem

On July 10, 2026, [commit `8642a47`](https://github.com/vercel/vercel/commit/8642a473222ba750ec6747636d28d96801ac32d4) removed `vercel oauth-apps` because its APIs were not yet available and would be reworked. The change shipped in [Vercel CLI 56.0.0](https://github.com/vercel/vercel/blob/2aee1cf86f6fd214c5b55e2fc2b2c28709f84a84/packages/cli/CHANGELOG.md#L445-L456) on July 13, 2026.

Root help and bundled CLI skill documentation still advertise the removed command. A user or agent can discover the command, then cannot use it.

## Changes

Remove the stale root-help entry, its regression snapshot, and every bundled skill reference so command discovery matches the current CLI registry.