### PR TITLE
[connect] Provision Eve connectors on demand

### DIFF
--- a/.changeset/tidy-connectors-retry.md
+++ b/.changeset/tidy-connectors-retry.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': patch
+---
+
+Try Eve token and authorization requests before provisioning, then provision and retry once only when the connector is missing or not linked to the project.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -118,9 +118,10 @@ export default defineMcpClientConnection({
 });
 ```
 
-By default, `connect()` provisions or links the connector for the deploying
-Vercel project on first use. Pass `autoProvision: false` when the connector is
-managed elsewhere.
+By default, `connect()` uses an existing project link when available. If the
+connector is missing or not linked, it provisions or links it and retries the
+request once. Pass `autoProvision: false` when the connector is managed
+elsewhere.
 
 ### Better Auth
 

--- a/packages/connect/src/authorization.ts
+++ b/packages/connect/src/authorization.ts
@@ -4,7 +4,10 @@ import {
   validateCallbackUrl,
   validateWebhookUrl,
 } from './internal/url-validation.js';
-import type { ConnectTokenParams } from './token.js';
+import {
+  createConnectErrorFromResponse,
+  type ConnectTokenParams,
+} from './token.js';
 
 export interface ConnectAuthorizationOptions {
   vercelToken?: string;
@@ -93,12 +96,9 @@ export async function startAuthorization(
   });
 
   if (!response.ok) {
-    let errorText: string | undefined;
-    try {
-      errorText = await response.text();
-    } catch {}
-    throw new Error(
-      `Failed to start authorization: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ''}`
+    throw await createConnectErrorFromResponse(
+      response,
+      'Failed to start authorization'
     );
   }
 

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -45,6 +45,7 @@ import type {
   ConnectTokenSubject,
 } from '../token.js';
 import {
+  ConnectError,
   ConnectorInstallationRequiredError,
   deleteTokenCacheEntry,
   getTokenResponse,
@@ -187,8 +188,8 @@ export interface EveAuthorizationOptions {
 
   /**
    * Create or link the declared connector against the deploying Vercel
-   * project before the first token / authorization call. Defaults to
-   * `true`.
+   * project when a token / authorization call reports that the connector
+   * is missing or not linked. Defaults to `true`.
    *
    * The provision request is authenticated with the deployment OIDC token
    * and carries the eve connection's `url` plus this connector UID. Connect
@@ -196,9 +197,10 @@ export interface EveAuthorizationOptions {
    * OAuth connector when the UID already exists, and scopes the new project
    * link to the OIDC token's environment and higher promotion targets.
    *
-   * Set this to `false` for callers that intentionally manage the connector
-   * linkage elsewhere. Opaque connector ids (`scl_...`) and connections
-   * without a URL are skipped automatically.
+   * Existing linked connectors are used directly without a provisioning
+   * request. Set this to `false` for callers that intentionally manage the
+   * connector linkage elsewhere. Opaque connector ids (`scl_...`) and
+   * connections without a URL are skipped automatically.
    */
   readonly autoProvision?: boolean;
 
@@ -439,11 +441,16 @@ function buildInteractiveDefinition(
       connection,
     }: GetTokenOptions): Promise<TokenResult> {
       try {
-        await autoProvisionConnectorIfEnabled(options, connection);
-        const response = await getTokenResponse(
-          options.connector,
-          await buildTokenParams(options, principal, connection),
-          getTokenConnectOptions(options)
+        const params = await buildTokenParams(options, principal, connection);
+        const response = await withConnectorProvisioningFallback(
+          options,
+          connection,
+          () =>
+            getTokenResponse(
+              options.connector,
+              params,
+              getTokenConnectOptions(options)
+            )
         );
         return { token: response.token, expiresAt: response.expiresAt };
       } catch (error) {
@@ -460,7 +467,6 @@ function buildInteractiveDefinition(
       challenge: ConnectionAuthorizationChallengeWithDisplayName;
     }> {
       try {
-        await autoProvisionConnectorIfEnabled(options, connection);
         // eve's `webhook` parameter is also the browser-redirect
         // target when `callbackUrl` is absent — the orchestrator mints
         // it via `createWebhook({ respondWith:
@@ -480,15 +486,17 @@ function buildInteractiveDefinition(
         // OIDC, which is what lets per-workflow dynamic webhook URLs
         // work without an OAuth-style redirect-URI allowlist.
         const completionWebhook = connectCompletionWebhook(webhook);
-        const response = await startAuthorization(
-          options.connector,
-          await buildTokenParams(options, principal, connection),
-          {
-            ...options.connectOptions,
-            callbackUrl: callbackUrl ?? webhook,
-            ...(completionWebhook ? { webhook: completionWebhook } : null),
-            deviceCode: true,
-          }
+        const params = await buildTokenParams(options, principal, connection);
+        const response = await withConnectorProvisioningFallback(
+          options,
+          connection,
+          () =>
+            startAuthorization(options.connector, params, {
+              ...options.connectOptions,
+              callbackUrl: callbackUrl ?? webhook,
+              ...(completionWebhook ? { webhook: completionWebhook } : null),
+              deviceCode: true,
+            })
         );
         // Sign-in buttons name the destination service ("Sign in with
         // Salesforce"), matching the OAuth idiom — the consent screen
@@ -522,11 +530,12 @@ function buildInteractiveDefinition(
       connection,
     }: CompleteAuthorizationOptions): Promise<TokenResult> {
       try {
-        await autoProvisionConnectorIfEnabled(options, connection);
-        const response = await getTokenResponse(
-          options.connector,
-          await buildTokenParams(options, principal, connection),
-          options.connectOptions
+        const params = await buildTokenParams(options, principal, connection);
+        const response = await withConnectorProvisioningFallback(
+          options,
+          connection,
+          () =>
+            getTokenResponse(options.connector, params, options.connectOptions)
         );
         return { token: response.token, expiresAt: response.expiresAt };
       } catch (error) {
@@ -557,11 +566,16 @@ function buildNonInteractiveDefinition(
       connection,
     }: GetTokenOptions): Promise<TokenResult> {
       try {
-        await autoProvisionConnectorIfEnabled(options, connection);
-        const response = await getTokenResponse(
-          options.connector,
-          await buildTokenParams(options, principal, connection),
-          getTokenConnectOptions(options)
+        const params = await buildTokenParams(options, principal, connection);
+        const response = await withConnectorProvisioningFallback(
+          options,
+          connection,
+          () =>
+            getTokenResponse(
+              options.connector,
+              params,
+              getTokenConnectOptions(options)
+            )
         );
         return { token: response.token, expiresAt: response.expiresAt };
       } catch (error) {
@@ -571,18 +585,44 @@ function buildNonInteractiveDefinition(
   };
 }
 
-async function autoProvisionConnectorIfEnabled(
+async function withConnectorProvisioningFallback<T>(
   options: EveAuthorizationOptions,
-  connection: EveConnectionAuthorizationContext
-): Promise<void> {
-  if (options.autoProvision === false) {
-    return;
+  connection: EveConnectionAuthorizationContext,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (
+      options.autoProvision === false ||
+      !isMissingConnectorOrProjectLink(error)
+    ) {
+      throw error;
+    }
   }
+
   await provisionEveOAuthConnector({
     connector: options.connector,
     connection,
     connectOptions: options.connectOptions,
   });
+  return operation();
+}
+
+function isMissingConnectorOrProjectLink(error: unknown): boolean {
+  if (!(error instanceof ConnectError)) {
+    return false;
+  }
+
+  if (error.status === 404 && error.code === 'not_found') {
+    return true;
+  }
+
+  return (
+    error.status === 403 &&
+    error.code === 'forbidden' &&
+    /connector is not linked to this project/i.test(error.message)
+  );
 }
 
 /**

--- a/packages/connect/test/eve/connection-authorization.test.ts
+++ b/packages/connect/test/eve/connection-authorization.test.ts
@@ -37,11 +37,11 @@ describe('connect() adapter provisioning', () => {
     vi.restoreAllMocks();
   });
 
-  it('provisions and links a UID connector before fetching a token', async () => {
-    const connector = 'mcp.example.com/provisioned';
-    fetchMock
-      .mockResolvedValueOnce(jsonProvisionResponse(connector))
-      .mockResolvedValueOnce(jsonTokenResponse('tok_provisioned', connector));
+  it('uses an existing project link without provisioning', async () => {
+    const connector = 'mcp.example.com/already-linked';
+    fetchMock.mockResolvedValueOnce(
+      jsonTokenResponse('tok_existing', connector)
+    );
 
     const definition = connect(connector) as InteractiveAuthorizationDefinition;
 
@@ -50,35 +50,19 @@ describe('connect() adapter provisioning', () => {
       connection: CONNECTION,
     });
 
-    expect(result.token).toBe('tok_provisioned');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.token).toBe('tok_existing');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    const [provisionUrl, provisionInit] = fetchMock.mock.calls[0];
-    expect(provisionUrl).toBe(
-      'https://api.vercel.com/v1/connect/connectors/managed/oauth'
-    );
-    expect(provisionInit).toMatchObject({
-      method: 'POST',
-      headers: expect.objectContaining({
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer oidc_token',
-      }),
-    });
-    expect(JSON.parse(provisionInit.body as string)).toEqual({
-      serverUrl: CONNECTION.url,
-      uid: connector,
-    });
-
-    const [tokenUrl] = fetchMock.mock.calls[1];
+    const [tokenUrl] = fetchMock.mock.calls[0];
     expect(tokenUrl).toBe(
-      'https://api.vercel.com/v1/connect/token/mcp.example.com%2Fprovisioned'
+      'https://api.vercel.com/v1/connect/token/mcp.example.com%2Falready-linked'
     );
   });
 
-  it('reuses successful provisioning for the same connector and server URL', async () => {
-    const connector = 'mcp.example.com/provision-cache';
+  it('links an unlinked connector and retries the token request once', async () => {
+    const connector = 'mcp.example.com/unlinked';
     fetchMock
+      .mockResolvedValueOnce(jsonUnlinkedResponse())
       .mockResolvedValueOnce(jsonProvisionResponse(connector))
       .mockResolvedValueOnce(jsonTokenResponse('tok_first', connector))
       .mockResolvedValueOnce(jsonTokenResponse('tok_second', connector));
@@ -99,7 +83,13 @@ describe('connect() adapter provisioning', () => {
 
     expect(first.token).toBe('tok_first');
     expect(second.token).toBe('tok_second');
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      'https://api.vercel.com/v1/connect/token/mcp.example.com%2Funlinked',
+      'https://api.vercel.com/v1/connect/connectors/managed/oauth',
+      'https://api.vercel.com/v1/connect/token/mcp.example.com%2Funlinked',
+      'https://api.vercel.com/v1/connect/token/mcp.example.com%2Funlinked',
+    ]);
     expect(
       fetchMock.mock.calls.filter(
         ([url]) =>
@@ -111,8 +101,10 @@ describe('connect() adapter provisioning', () => {
   it('keeps provision cache entries scoped to the Vercel token', async () => {
     const connector = 'mcp.example.com/token-scoped-cache';
     fetchMock
+      .mockResolvedValueOnce(jsonMissingConnectorResponse())
       .mockResolvedValueOnce(jsonProvisionResponse(connector))
       .mockResolvedValueOnce(jsonTokenResponse('tok_project_a', connector))
+      .mockResolvedValueOnce(jsonMissingConnectorResponse())
       .mockResolvedValueOnce(jsonProvisionResponse(connector))
       .mockResolvedValueOnce(jsonTokenResponse('tok_project_b', connector));
 
@@ -138,29 +130,18 @@ describe('connect() adapter provisioning', () => {
 
     expect(first.token).toBe('tok_project_a');
     expect(second.token).toBe('tok_project_b');
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(fetchMock.mock.calls[0][1]?.headers).toMatchObject({
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({
       Authorization: 'Bearer oidc_project_a',
     });
-    expect(fetchMock.mock.calls[2][1]?.headers).toMatchObject({
+    expect(fetchMock.mock.calls[4][1]?.headers).toMatchObject({
       Authorization: 'Bearer oidc_project_b',
     });
   });
 
-  it('provisions before starting an interactive authorization flow', async () => {
+  it('uses an existing project link when starting authorization', async () => {
     const connector = 'mcp.example.com/start-authorization';
-    fetchMock
-      .mockResolvedValueOnce(jsonProvisionResponse(connector))
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            request: 'req_1',
-            verifier: 'ver_1',
-            url: 'https://connect.vercel.com/authorize/req_1',
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      );
+    fetchMock.mockResolvedValueOnce(jsonAuthorizationResponse('req_1'));
 
     const definition = connect(connector) as InteractiveAuthorizationDefinition;
 
@@ -171,13 +152,33 @@ describe('connect() adapter provisioning', () => {
     });
 
     expect(challenge.url).toBe('https://connect.vercel.com/authorize/req_1');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://api.vercel.com/v1/connect/connectors/managed/oauth'
-    );
-    expect(fetchMock.mock.calls[1][0]).toBe(
       'https://api.vercel.com/v1/connect/authorize/mcp.example.com%2Fstart-authorization'
     );
+  });
+
+  it('provisions and retries when starting authorization without a project link', async () => {
+    const connector = 'mcp.example.com/start-authorization-unlinked';
+    fetchMock
+      .mockResolvedValueOnce(jsonUnlinkedResponse())
+      .mockResolvedValueOnce(jsonProvisionResponse(connector))
+      .mockResolvedValueOnce(jsonAuthorizationResponse('req_2'));
+
+    const definition = connect(connector) as InteractiveAuthorizationDefinition;
+
+    const { challenge } = await definition.startAuthorization({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+      callbackUrl: 'https://example.com/callback',
+    });
+
+    expect(challenge.url).toBe('https://connect.vercel.com/authorize/req_2');
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      'https://api.vercel.com/v1/connect/authorize/mcp.example.com%2Fstart-authorization-unlinked',
+      'https://api.vercel.com/v1/connect/connectors/managed/oauth',
+      'https://api.vercel.com/v1/connect/authorize/mcp.example.com%2Fstart-authorization-unlinked',
+    ]);
   });
 
   it('skips provisioning for opaque connector ids', async () => {
@@ -199,54 +200,50 @@ describe('connect() adapter provisioning', () => {
     );
   });
 
-  it('falls back to token fetching when an existing connector is not managed OAuth', async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            error: {
-              code: 'conflict',
-              message:
-                'A connector with uid "linear" already exists and is not an OAuth connector.',
-            },
-          }),
-          { status: 409, headers: { 'Content-Type': 'application/json' } }
-        )
+  it('does not provision for unrelated token errors', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'forbidden',
+            message: 'Connector is not enabled for this environment',
+          },
+        }),
+        { status: 403, headers: { 'Content-Type': 'application/json' } }
       )
-      .mockResolvedValueOnce(jsonTokenResponse('tok_linear', 'linear'));
+    );
 
     const definition = connect('linear') as InteractiveAuthorizationDefinition;
 
-    const result = await definition.getToken({
-      principal: PRINCIPAL,
-      connection: CONNECTION,
-    });
+    await expect(
+      definition.getToken({
+        principal: PRINCIPAL,
+        connection: CONNECTION,
+      })
+    ).rejects.toThrow('Connector is not enabled for this environment');
 
-    expect(result.token).toBe('tok_linear');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://api.vercel.com/v1/connect/connectors/managed/oauth'
-    );
-    expect(fetchMock.mock.calls[1][0]).toBe(
       'https://api.vercel.com/v1/connect/token/linear'
     );
   });
 
   it('allows callers to disable provisioning', async () => {
     const connector = 'mcp.example.com/manual-link';
-    fetchMock.mockResolvedValueOnce(jsonTokenResponse('tok_manual', connector));
+    fetchMock.mockResolvedValueOnce(jsonUnlinkedResponse());
 
     const definition = connect({
       connector,
       autoProvision: false,
     }) as InteractiveAuthorizationDefinition;
 
-    const result = await definition.getToken({
-      principal: PRINCIPAL,
-      connection: CONNECTION,
-    });
+    await expect(
+      definition.getToken({
+        principal: PRINCIPAL,
+        connection: CONNECTION,
+      })
+    ).rejects.toThrow('Connector is not linked to this project');
 
-    expect(result.token).toBe('tok_manual');
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe(
       'https://api.vercel.com/v1/connect/token/mcp.example.com%2Fmanual-link'
@@ -780,5 +777,26 @@ function jsonProvisionResponse(uid: string): Response {
       type: 'oauth',
     }),
     { status: 201, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function jsonMissingConnectorResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: { code: 'not_found', message: 'Connector not found' },
+    }),
+    { status: 404, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function jsonUnlinkedResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: 'forbidden',
+        message: 'Connector is not linked to this project',
+      },
+    }),
+    { status: 403, headers: { 'Content-Type': 'application/json' } }
   );
 }


### PR DESCRIPTION
## Summary

- try Eve token and authorization requests before provisioning connectors
- provision and retry once only for `404/not_found` or the exact unlinked-project `403`
- preserve failures for disabled environments and all unrelated authorization errors
- use the shared typed Connect error parser for authorization-start failures

This lets existing dashboard-created, already-linked connectors continue working without requiring the project OIDC provisioning flag, while retaining automatic creation/linking for missing connectors.

## Tests

- `pnpm test` in `packages/connect` (93 tests)
- `pnpm typecheck` in `packages/connect`
- pre-commit Biome formatting and lint