### PR TITLE
[CLI] adding plugin install id to telemetry

### DIFF
--- a/.changeset/plugin-install-id-telemetry.md
+++ b/.changeset/plugin-install-id-telemetry.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Track the Vercel plugin installation ID from the active-session marker in CLI telemetry.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -391,6 +391,7 @@ const main = async () => {
   if (vercelPluginMarker) {
     telemetry.trackVercelPluginActiveSession();
     telemetry.trackVercelPluginVersion(vercelPluginMarker.pluginVersion);
+    telemetry.trackVercelPluginInstallId(vercelPluginMarker.installId);
   }
   telemetry.trackAgenticUse(detectedAgent?.name);
   telemetry.trackCPUs();

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -251,6 +251,15 @@ export class TelemetryClient {
     }
   }
 
+  protected trackVercelPluginInstallId(installId: string | undefined) {
+    if (installId) {
+      this.track({
+        key: 'vercel_plugin_install_id',
+        value: installId,
+      });
+    }
+  }
+
   protected trackErrorStatus(status: number | string | undefined) {
     if (typeof status !== 'undefined') {
       this.track({

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -515,6 +515,10 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackVercelPluginVersion(version);
   }
 
+  trackVercelPluginInstallId(installId: string | undefined) {
+    super.trackVercelPluginInstallId(installId);
+  }
+
   trackErrorStatus(status: number | string | undefined) {
     super.trackErrorStatus(status);
   }

--- a/packages/cli/src/util/telemetry/vercel-plugin.ts
+++ b/packages/cli/src/util/telemetry/vercel-plugin.ts
@@ -9,9 +9,12 @@ const ACTIVE_SESSION_MARKER_PATH = join(
   'active-session.json'
 );
 const SEMVERISH_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export interface VercelPluginActiveSessionMarker {
   pluginVersion: string;
+  installId?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -46,8 +49,17 @@ export function readVercelPluginActiveSessionMarker(
       return null;
     }
 
+    // `installId` is absent on plugins older than 0.49.0 and must never
+    // invalidate the marker — dropping the field keeps the active-session and
+    // version events flowing for those installs.
+    const installId =
+      typeof marker.installId === 'string' && UUID_V4_RE.test(marker.installId)
+        ? marker.installId
+        : undefined;
+
     return {
       pluginVersion: marker.pluginVersion,
+      ...(installId ? { installId } : {}),
     };
   } catch {
     return null;

--- a/packages/cli/test/unit/telemetry/vercel-plugin.test.ts
+++ b/packages/cli/test/unit/telemetry/vercel-plugin.test.ts
@@ -40,6 +40,53 @@ describe('vercel plugin active-session marker', () => {
     ).toEqual({ pluginVersion: '0.42.1' });
   });
 
+  it('reads the install id when the marker carries one', () => {
+    writeMarker({
+      schema: 1,
+      active: true,
+      pluginVersion: '0.49.0',
+      updatedAt: 1000,
+      expiresAt: 2000,
+      installId: '3f2504e0-4f89-41d3-9a0c-0305e82c3301',
+    });
+
+    expect(
+      readVercelPluginActiveSessionMarker({
+        filePath: markerFilePath,
+        now: () => 1500,
+      })
+    ).toEqual({
+      pluginVersion: '0.49.0',
+      installId: '3f2504e0-4f89-41d3-9a0c-0305e82c3301',
+    });
+  });
+
+  it('keeps the marker when the install id is absent or malformed', () => {
+    for (const installId of [
+      undefined,
+      'not-a-uuid',
+      '',
+      42,
+      '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+    ]) {
+      writeMarker({
+        schema: 1,
+        active: true,
+        pluginVersion: '0.49.0',
+        updatedAt: 1000,
+        expiresAt: 2000,
+        installId,
+      });
+
+      expect(
+        readVercelPluginActiveSessionMarker({
+          filePath: markerFilePath,
+          now: () => 1500,
+        })
+      ).toEqual({ pluginVersion: '0.49.0' });
+    }
+  });
+
   it('ignores a missing, expired, or malformed marker', () => {
     expect(
       readVercelPluginActiveSessionMarker({ filePath: markerFilePath })
@@ -79,6 +126,9 @@ describe('vercel plugin active-session marker', () => {
 
     telemetry.trackVercelPluginActiveSession();
     telemetry.trackVercelPluginVersion('0.42.1');
+    telemetry.trackVercelPluginInstallId(
+      '3f2504e0-4f89-41d3-9a0c-0305e82c3301'
+    );
 
     expect(telemetryEventStore.readonlyEvents).toMatchObject([
       {
@@ -88,6 +138,30 @@ describe('vercel plugin active-session marker', () => {
       {
         key: 'vercel_plugin_version',
         value: '0.42.1',
+      },
+      {
+        key: 'vercel_plugin_install_id',
+        value: '3f2504e0-4f89-41d3-9a0c-0305e82c3301',
+      },
+    ]);
+  });
+
+  it('omits the install id event when the marker has none', () => {
+    const telemetryEventStore = new TelemetryEventStore({
+      isDebug: true,
+      config: { enabled: true },
+    });
+    const telemetry = new RootTelemetryClient({
+      opts: { store: telemetryEventStore },
+    });
+
+    telemetry.trackVercelPluginActiveSession();
+    telemetry.trackVercelPluginInstallId(undefined);
+
+    expect(telemetryEventStore.readonlyEvents).toMatchObject([
+      {
+        key: 'vercel_plugin_active_session',
+        value: 'TRUE',
       },
     ]);
   });


### PR DESCRIPTION
## Summary

Adds the Vercel plugin's installation ID to CLI telemetry as `vercel_plugin_install_id`, read from the `active-session.json` marker the CLI already reads.

This finishes the plugin→CLI link started in #16346. Today we can see that a command ran inside a plugin session, but not which installation that session came from — so we can't measure how many plugin installs go on to use the CLI. That conversion rate is what this unlocks. Tracked in PIPE-6602.

## Changes

- `util/telemetry/vercel-plugin.ts` — reads and validates `installId` off the marker
- `util/telemetry/index.ts` — `trackVercelPluginInstallId`, guarded like `trackVercelPluginVersion`
- `util/telemetry/root.ts` — public passthrough
- `index.ts` — emitted alongside the two existing plugin events
- Unit coverage and a changeset

Mirrors #16346 throughout.

## Tests

```bash
cd packages/cli
pnpm vitest run test/unit/telemetry/vercel-plugin.test.ts
```

6 passing (3 existing, 3 new). I couldn't run the package's full suite locally — `vitest.config.mts` pulls in `@vercel/build-utils` → `@vercel/python-analysis`, which needs a Rust toolchain — so I ran the file through a standalone config and CI is the real check here.

## Depends on vercel/vercel-plugin#157

The marker doesn't carry `installId` until that lands. Until then this reads a field that isn't there and emits nothing — safe, but inert.

## One deliberate inconsistency

`installId` is optional, and a malformed value drops just that field instead of invalidating the marker. The `pluginVersion` check directly above it returns `null`.

Every marker ever written has carried `pluginVersion`, so its absence means corruption. `installId` is absent on every plugin below 0.49.0, so rejecting the marker would drop `vercel_plugin_active_session` and `vercel_plugin_version` for most installs during rollout — which would show up as a usage decline rather than a schema skew.

It also can't become required later: `getOrCreateInstallationId()` returns null if the file can't be written or read back, so a current plugin can legitimately write a marker without one.

Leaving it optional also makes the rollout gap countable — `vercel_plugin_active_session = TRUE AND vercel_plugin_install_id IS NULL` is the not-yet-upgraded population.

## Questions

@jeffsee55 — two things I'd like your read on.

**1. Almost nobody can emit this yet, for reasons outside both repos.** `plugin:install_id` shipped in plugin 0.48.0, but `anthropics/claude-plugins-official` pins the Vercel plugin to commit `19606ac` — that's 0.45.1, 10 commits behind main, with the install_id PR inside the gap. So the official-marketplace population emits nothing until that pin moves, which looks like it needs a PR to Anthropic's repo. The plugin repo has no release automation (one `ci.yml`, no tags or changesets), so I couldn't work out who owns that bump on our side. Any idea who does?

**2. Who signs off on reversing the `active-session.json` decision?** vercel/vercel-plugin#136 deliberately kept the install ID out of the marker and said so in its README — this PR and vercel/vercel-plugin#157 reverse that. Melkey's position at the time was that he didn't want a UUID minted without someone else advising. Is this yours to approve, or does it need Melkey?

On the surface area itself: the CLI already emits `device_id` on every invocation, the ID is only readable while a marker is fresh (1h TTL), and none is created under `VERCEL_PLUGIN_TELEMETRY=off`.
