### PR TITLE
[cli] Telemetry foundation: flush all exit paths, sanitize primitives, exit_code event

### DIFF
--- a/.changeset/o11y-telemetry-foundation.md
+++ b/.changeset/o11y-telemetry-foundation.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Reliably flush telemetry on all CLI exit paths (including `--version`, help, and early failures), add value-sanitization primitives, and record an `exit_code` event behind `VERCEL_CLI_TELEMETRY_V2`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -84,6 +84,7 @@ import type { VercelConfig } from '@vercel/client';
 import box from './util/output/box';
 import { TelemetryEventStore } from './util/telemetry';
 import { RootTelemetryClient } from './util/telemetry/root';
+import { setTelemetryReporter } from './util/telemetry/reporter';
 import { readVercelPluginActiveSessionMarker } from './util/telemetry/vercel-plugin';
 import { help } from './args';
 import { checkTelemetryStatus } from './util/telemetry/check-status';
@@ -198,6 +199,47 @@ const main = async () => {
     process.stdin.isTTY = true;
   }
 
+  const telemetryEventStore = new TelemetryEventStore({
+    isDebug: process.env.VERCEL_TELEMETRY_DEBUG === '1',
+    cliDevice: isTelemetryFlushCommand
+      ? undefined
+      : {
+          filePath: join(VERCEL_DIR, 'telemetry-device.json'),
+        },
+    cliSession: isTelemetryFlushCommand
+      ? undefined
+      : {
+          filePath: join(VERCEL_DIR, 'telemetry-session.json'),
+        },
+  });
+
+  const telemetry = new RootTelemetryClient({
+    opts: {
+      store: telemetryEventStore,
+    },
+  });
+  setTelemetryReporter(telemetry);
+
+  // Flush-and-exit for paths that run before the global config is loaded
+  // (help, version, early failures). Loads the config best-effort so the
+  // opt-out state is known; when unreadable, the batch is silently dropped.
+  let telemetryConfigLoaded = false;
+  const finishEarly = async (code: number): Promise<number> => {
+    if (!telemetryConfigLoaded) {
+      try {
+        const earlyConfig = configFiles.readConfigFile();
+        checkTelemetryStatus({ config: earlyConfig });
+        telemetryEventStore.updateConfig(earlyConfig.telemetry);
+        telemetryConfigLoaded = true;
+      } catch {
+        // config unavailable: leave the store disabled
+      }
+    }
+    telemetry.trackExitCode(code);
+    await telemetryEventStore.save();
+    return code;
+  };
+
   const parseInitialArgs = () =>
     parseArguments(
       process.argv,
@@ -221,16 +263,44 @@ const main = async () => {
     });
   } catch (err: unknown) {
     printError(err);
-    return 1;
+    return finishEarly(1);
   }
 
+  const { isAgent, agent: detectedAgent } = await determineAgent();
+  telemetry.trackInvocationId(telemetryEventStore.currentInvocationId);
+  telemetry.trackDeviceId(telemetryEventStore.currentDeviceId);
+  const vercelPluginMarker = readVercelPluginActiveSessionMarker();
+  if (vercelPluginMarker) {
+    telemetry.trackVercelPluginActiveSession();
+    telemetry.trackVercelPluginVersion(vercelPluginMarker.pluginVersion);
+  }
+  telemetry.trackAgenticUse(detectedAgent?.name);
+  telemetry.trackCPUs();
+  telemetry.trackPlatform();
+  telemetry.trackArch();
+  telemetry.trackCIVendorName();
+  telemetry.trackStdinIsTTY(process.stdin?.isTTY === true);
+  telemetry.trackVersion(pkg.version);
+  telemetry.trackCliOptionCwd(parsedArgs.flags['--cwd']);
+  telemetry.trackCliOptionLocalConfig(parsedArgs.flags['--local-config']);
+  telemetry.trackCliOptionGlobalConfig(parsedArgs.flags['--global-config']);
+  telemetry.trackCliFlagDebug(parsedArgs.flags['--debug']);
+  telemetry.trackCliFlagNoColor(parsedArgs.flags['--no-color']);
+  telemetry.trackCliOptionScope(parsedArgs.flags['--scope']);
+  telemetry.trackCliOptionToken(parsedArgs.flags['--token']);
+  telemetry.trackCliOptionTeam(parsedArgs.flags['--team']);
+  telemetry.trackCliOptionApi(parsedArgs.flags['--api']);
+
   const localConfigPath = parsedArgs.flags['--local-config'];
-  let localConfig: VercelConfig | Error | undefined =
-    await earlyGetConfig(localConfigPath);
+  // The flush subprocess must not depend on the invoking directory's
+  // vercel.json: a parse failure here would drop the batch it carries.
+  let localConfig: VercelConfig | Error | undefined = isTelemetryFlushCommand
+    ? undefined
+    : await earlyGetConfig(localConfigPath);
 
   if (localConfig instanceof ERRORS.CantParseJSONFile) {
     output.error(`Couldn't parse JSON file ${localConfig.meta.file}.`);
-    return 1;
+    return finishEarly(1);
   }
 
   if (localConfig instanceof ERRORS.CantFindConfig) {
@@ -240,7 +310,7 @@ const main = async () => {
           ' or\n    '
         )}`
       );
-      return 1;
+      return finishEarly(1);
     } else {
       localConfig = undefined;
     }
@@ -248,7 +318,7 @@ const main = async () => {
 
   if (localConfig instanceof Error) {
     output.prettyError(localConfig);
-    return 1;
+    return finishEarly(1);
   }
 
   // The second argument to the command can be:
@@ -272,7 +342,7 @@ const main = async () => {
   if (!targetOrSubcommand && parsedArgs.flags['--version']) {
     // biome-ignore lint/suspicious/noConsole: intentional console usage
     console.log(pkg.version);
-    return 0;
+    return finishEarly(0);
   }
 
   // Handle bare `-h` directly
@@ -280,7 +350,7 @@ const main = async () => {
   const bareHelpSubcommand = targetOrSubcommand === 'help' && !subSubCommand;
   if (bareHelpOption || bareHelpSubcommand) {
     output.print(help());
-    return 0;
+    return finishEarly(0);
   }
 
   // Ensure that the Vercel global configuration directory exists
@@ -292,7 +362,7 @@ const main = async () => {
         VERCEL_DIR
       )}" ${errorToString(err)}`
     );
-    return 1;
+    return finishEarly(1);
   }
 
   let config: GlobalConfig;
@@ -309,7 +379,7 @@ const main = async () => {
             VERCEL_CONFIG_PATH
           )}" ${errorToString(err)}`
         );
-        return 1;
+        return finishEarly(1);
       }
     } else {
       output.error(
@@ -317,8 +387,21 @@ const main = async () => {
           VERCEL_CONFIG_PATH
         )}" ${errorToString(err)}`
       );
-      return 1;
+      return finishEarly(1);
     }
+  }
+
+  telemetryEventStore.updateConfig(config.telemetry);
+  telemetryConfigLoaded = true;
+
+  checkTelemetryStatus({
+    config,
+  });
+
+  if (process.env.FF_GUIDANCE_MODE) {
+    checkGuidanceStatus({
+      config,
+    });
   }
 
   // Check for explicit tokens before reading persisted credentials so CI/headless
@@ -348,66 +431,10 @@ const main = async () => {
             VERCEL_AUTH_CONFIG_PATH
           )}" ${errorToString(err)}`
         );
-        return 1;
+        return finishEarly(1);
       }
     }
   }
-
-  const telemetryEventStore = new TelemetryEventStore({
-    isDebug: process.env.VERCEL_TELEMETRY_DEBUG === '1',
-    config: config.telemetry,
-    cliDevice: isTelemetryFlushCommand
-      ? undefined
-      : {
-          filePath: join(VERCEL_DIR, 'telemetry-device.json'),
-        },
-    cliSession: isTelemetryFlushCommand
-      ? undefined
-      : {
-          filePath: join(VERCEL_DIR, 'telemetry-session.json'),
-        },
-  });
-
-  checkTelemetryStatus({
-    config,
-  });
-
-  if (process.env.FF_GUIDANCE_MODE) {
-    checkGuidanceStatus({
-      config,
-    });
-  }
-
-  const telemetry = new RootTelemetryClient({
-    opts: {
-      store: telemetryEventStore,
-    },
-  });
-
-  const { isAgent, agent: detectedAgent } = await determineAgent();
-  telemetry.trackInvocationId(telemetryEventStore.currentInvocationId);
-  telemetry.trackDeviceId(telemetryEventStore.currentDeviceId);
-  const vercelPluginMarker = readVercelPluginActiveSessionMarker();
-  if (vercelPluginMarker) {
-    telemetry.trackVercelPluginActiveSession();
-    telemetry.trackVercelPluginVersion(vercelPluginMarker.pluginVersion);
-  }
-  telemetry.trackAgenticUse(detectedAgent?.name);
-  telemetry.trackCPUs();
-  telemetry.trackPlatform();
-  telemetry.trackArch();
-  telemetry.trackCIVendorName();
-  telemetry.trackStdinIsTTY(process.stdin?.isTTY === true);
-  telemetry.trackVersion(pkg.version);
-  telemetry.trackCliOptionCwd(parsedArgs.flags['--cwd']);
-  telemetry.trackCliOptionLocalConfig(parsedArgs.flags['--local-config']);
-  telemetry.trackCliOptionGlobalConfig(parsedArgs.flags['--global-config']);
-  telemetry.trackCliFlagDebug(parsedArgs.flags['--debug']);
-  telemetry.trackCliFlagNoColor(parsedArgs.flags['--no-color']);
-  telemetry.trackCliOptionScope(parsedArgs.flags['--scope']);
-  telemetry.trackCliOptionToken(parsedArgs.flags['--token']);
-  telemetry.trackCliOptionTeam(parsedArgs.flags['--team']);
-  telemetry.trackCliOptionApi(parsedArgs.flags['--api']);
 
   let earlyGetUserPromise: Promise<User | undefined> | undefined;
   let telemetrySaved = false;
@@ -509,6 +536,7 @@ const main = async () => {
   };
 
   const finishWithExitCode = async (code: number) => {
+    telemetry.trackExitCode(code);
     await saveTelemetry();
     return code;
   };
@@ -917,7 +945,7 @@ const main = async () => {
               availableCommands: commandNames,
             })
           ) {
-            return 1;
+            return finishWithExitCode(1);
           }
           // Fall back to `vc deploy <dir>`
           targetCommand = subcommand = 'deploy';
@@ -1221,7 +1249,7 @@ const main = async () => {
         ) {
           output.error(`The ${param(subcommand)} subcommand does not exist`);
         }
-        return 1;
+        return finishWithExitCode(1);
       }
 
       if (func.default) {
@@ -1307,7 +1335,9 @@ const main = async () => {
     return finishWithExitCode(1);
   }
 
-  await saveTelemetry();
+  // Flush before stopping the root span so the vc.postCommand span from
+  // saveTelemetry is captured in the trace file below.
+  const finalExitCode = await finishWithExitCode(exitCode ?? 0);
 
   rootSpan.stop();
 
@@ -1326,7 +1356,7 @@ const main = async () => {
     }
   }
 
-  return exitCode;
+  return finalExitCode;
 };
 
 // Start the CLI update check early so the fresh registry lookup runs in
@@ -1422,6 +1452,9 @@ main()
 
       if (
         !userUpToDate &&
+        // client is undefined when the command exited before creating it
+        // (e.g. `--version`, bare help)
+        client !== undefined &&
         (await canAutoUpdate(
           client,
           originalExitCode,
@@ -1461,6 +1494,11 @@ main()
             `Changelog: ${output.link(changelog, changelog, { fallback: false })}\n`
           );
 
+          // client is undefined when the command exited before creating it
+          // (e.g. `--version`, bare help): show the notice, skip the prompt.
+          if (client === undefined) {
+            return;
+          }
           const upgradeExitCode = await promptAndUpgrade(client, latest);
           if (upgradeExitCode !== undefined) {
             process.exitCode = upgradeExitCode;

--- a/packages/cli/src/util/agent-output.ts
+++ b/packages/cli/src/util/agent-output.ts
@@ -1,4 +1,5 @@
 import { isError } from '@vercel/error-utils';
+import { exitWithTelemetry } from './telemetry/reporter';
 import type Client from './client';
 import { isAPIError, LinkRequiredError, ProjectNotFound } from './errors-ts';
 import { packageName } from './pkg-name';
@@ -554,7 +555,7 @@ export function outputActionRequired(
       'Run one of the commands in next[] to complete without prompting.';
   }
   client.stdout.write(`${JSON.stringify(enriched, null, 2)}\n`);
-  process.exit(exitCode);
+  exitWithTelemetry(exitCode);
 }
 
 /** True when argv explicitly requests non-interactive mode (matches main `index.ts`). */
@@ -592,7 +593,7 @@ export function outputAgentError(
     return;
   }
   client.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-  process.exit(exitCode);
+  exitWithTelemetry(exitCode);
 }
 
 /**
@@ -612,7 +613,7 @@ export function outputAgentSuccess(
     payload.hint = 'Follow up with one of the commands in next[].';
   }
   client.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-  process.exit(exitCode);
+  exitWithTelemetry(exitCode);
 }
 
 /** Suggested follow-ups for `global-config` failures (only callers of exitWithNonInteractiveError). */
@@ -801,7 +802,7 @@ function writeAgentErrorPayloadAndExit(
     hint: payload.hint ?? defaults.hint,
   };
   client.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
-  process.exit(exitCode);
+  exitWithTelemetry(exitCode);
 }
 
 function isProjectNotFoundLike(err: unknown): boolean {

--- a/packages/cli/src/util/input/select-org.ts
+++ b/packages/cli/src/util/input/select-org.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { exitWithTelemetry } from '../telemetry/reporter';
 import type Client from '../client';
 import getUser from '../get-user';
 import getTeams from '../teams/get-teams';
@@ -180,7 +181,7 @@ export default async function selectOrg(
           )}, or run ${getCommandName('teams ls')} to list your teams.`
         : 'No teams available.'
     );
-    process.exit(1);
+    exitWithTelemetry(1);
   }
 
   // An explicit signal answers the team question without prompting. The team

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -139,6 +139,16 @@ export class TelemetryClient {
     });
   }
 
+  protected trackExitCode(code: number) {
+    if (process.env.VERCEL_CLI_TELEMETRY_V2 !== '1') {
+      return;
+    }
+    this.track({
+      key: 'exit_code',
+      value: String(code),
+    });
+  }
+
   protected trackOidcTokenRefresh(count: number) {
     this.track({
       key: 'oidc-token-refresh',
@@ -372,6 +382,7 @@ export class TelemetryEventStore {
   private userId = 'NO_USER_ID';
   private projectId = 'NO_PROJECT_ID';
   private config: GlobalConfig['telemetry'];
+  private configLoaded: boolean;
   private cliDevice?: PersistedCliDevice;
   private cliSession?: PersistedCliSession;
   private cliDeviceOptions?: PersistedCliDeviceOptions;
@@ -379,13 +390,14 @@ export class TelemetryEventStore {
 
   constructor(opts?: {
     isDebug?: boolean;
-    config: GlobalConfig['telemetry'];
+    config?: GlobalConfig['telemetry'];
     cliDevice?: PersistedCliDeviceOptions;
     cliSession?: PersistedCliSessionOptions;
   }) {
     this.isDebug = opts?.isDebug || false;
     this.events = [];
     this.config = opts?.config;
+    this.configLoaded = opts?.config !== undefined;
     this.cliDeviceOptions = opts?.cliDevice;
     this.cliSessionOptions = opts?.cliSession;
     this.invocationId = randomUUID();
@@ -410,6 +422,13 @@ export class TelemetryEventStore {
     event.userId = this.userId;
     event.projectId = this.projectId;
     this.events.push(event);
+  }
+
+  // The store may be constructed before the global config is readable;
+  // events are only sent once the config (and thus opt-out state) is known.
+  updateConfig(config: GlobalConfig['telemetry']) {
+    this.config = config;
+    this.configLoaded = true;
   }
 
   updateTeamId(teamId?: string) {
@@ -462,11 +481,18 @@ export class TelemetryEventStore {
     if (process.env.VERCEL_TELEMETRY_DISABLED) {
       return false;
     }
+    if (!this.configLoaded) {
+      return false;
+    }
 
     return this.config?.enabled ?? true;
   }
 
   async save() {
+    if (this.events.length === 0) {
+      return;
+    }
+
     if (this.cliSession && this.cliSessionOptions) {
       this.cliSession = touchPersistedCliSession(
         this.cliSessionOptions,

--- a/packages/cli/src/util/telemetry/reporter.ts
+++ b/packages/cli/src/util/telemetry/reporter.ts
@@ -1,0 +1,26 @@
+import type { RootTelemetryClient } from './root';
+
+// Set once in `main()` so shared error paths (e.g. `printError`) can emit
+// telemetry without threading a client through every call site.
+let reporter: RootTelemetryClient | undefined;
+
+export function setTelemetryReporter(client: RootTelemetryClient): void {
+  reporter = client;
+}
+
+export function getTelemetryReporter(): RootTelemetryClient | undefined {
+  return reporter;
+}
+
+/**
+ * Flush-then-exit for paths that must hard-exit outside `main()`'s normal
+ * return flow. The detached flush spawn happens synchronously inside
+ * `save()`, so it survives the immediate `process.exit`.
+ */
+export function exitWithTelemetry(code: number): never {
+  if (reporter) {
+    reporter.trackExitCode(code);
+    void reporter.store.save();
+  }
+  process.exit(code);
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -471,6 +471,10 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackCPUs();
   }
 
+  trackExitCode(code: number) {
+    super.trackExitCode(code);
+  }
+
   trackAgenticUse(agent: string | undefined) {
     super.trackAgenticUse(agent);
   }

--- a/packages/cli/src/util/telemetry/sanitize.ts
+++ b/packages/cli/src/util/telemetry/sanitize.ts
@@ -1,0 +1,55 @@
+import { createHmac } from 'node:crypto';
+
+export const REDACTED = '[REDACTED]';
+
+const TOKEN_RE = /^[a-z0-9][a-z0-9:-]{0,31}$/;
+const FLAG_RE = /^--[a-z0-9-]{1,24}$/;
+const SLUG_RE = /^[a-z0-9/._-]{1,64}$/;
+
+const SLUG_PREFIXES = ['https://err.sh/', 'https://vercel.com/docs/'];
+
+/**
+ * Command-like tokens only (kebab-case, no paths or secrets).
+ * Everything else is redacted.
+ */
+export function gatedToken(value: string): string {
+  const token = value.toLowerCase();
+  return TOKEN_RE.test(token) ? token : REDACTED;
+}
+
+/** Option names only (`--foo-bar`). Everything else is redacted. */
+export function gatedFlag(value: string): string {
+  return FLAG_RE.test(value) ? value : REDACTED;
+}
+
+/** Slugs from our own error/docs links. Everything else is redacted. */
+export function slug(value: string): string {
+  let s = value;
+  for (const prefix of SLUG_PREFIXES) {
+    if (s.startsWith(prefix)) {
+      s = s.slice(prefix.length);
+      break;
+    }
+  }
+  return SLUG_RE.test(s) ? s : REDACTED;
+}
+
+function hmac(parts: readonly (string | number)[], salt: string): string {
+  return createHmac('sha256', salt).update(parts.join('\u0000')).digest('hex');
+}
+
+/**
+ * Salted fingerprint: stable per salt (device), irreversible off-device.
+ * Used to correlate repeated invocations without revealing their contents.
+ */
+export function fp(values: readonly string[], salt: string): string {
+  return hmac(values, salt).slice(0, 32);
+}
+
+/** Salted context hash for scoping sessions to a terminal/harness. */
+export function ctxHash(
+  parts: readonly (string | number)[],
+  salt: string
+): string {
+  return hmac(parts, salt).slice(0, 16);
+}

--- a/packages/cli/test/unit/telemetry/exit-code.test.ts
+++ b/packages/cli/test/unit/telemetry/exit-code.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+
+describe('exit_code tracking', () => {
+  let telemetry: RootTelemetryClient;
+  let telemetryEventStore: TelemetryEventStore;
+
+  beforeEach(() => {
+    telemetryEventStore = new TelemetryEventStore({
+      isDebug: true,
+      config: { enabled: true },
+    });
+    telemetry = new RootTelemetryClient({
+      opts: { store: telemetryEventStore },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('tracks exit_code when v2 flag is enabled', () => {
+    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
+    telemetry.trackExitCode(1);
+    expect(telemetryEventStore.readonlyEvents).toMatchObject([
+      { key: 'exit_code', value: '1' },
+    ]);
+  });
+
+  it('tracks nothing without the v2 flag', () => {
+    telemetry.trackExitCode(1);
+    expect(telemetryEventStore.readonlyEvents).toHaveLength(0);
+  });
+});

--- a/packages/cli/test/unit/telemetry/sanitize.test.ts
+++ b/packages/cli/test/unit/telemetry/sanitize.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REDACTED,
+  ctxHash,
+  fp,
+  gatedFlag,
+  gatedToken,
+  slug,
+} from '../../../src/util/telemetry/sanitize';
+
+describe('gatedToken', () => {
+  it.each([
+    ['deploy', 'deploy'],
+    ['DEPLOY', 'deploy'],
+    ['agent-runs', 'agent-runs'],
+    ['env:pull', 'env:pull'],
+    ['a'.repeat(32), 'a'.repeat(32)],
+  ])('passes command-like token %s', (input, expected) => {
+    expect(gatedToken(input)).toBe(expected);
+  });
+
+  it.each([
+    [''],
+    ['a'.repeat(33)],
+    ['./my-app'],
+    ['path/to/dir'],
+    ['file.txt'],
+    ['--flag'],
+    ['sk_live_abc123XYZ'],
+    ['has space'],
+    ['dpl_FpMqyL7Rah6o1BDG'],
+  ])('redacts %s', input => {
+    expect(gatedToken(input)).toBe(REDACTED);
+  });
+});
+
+describe('gatedFlag', () => {
+  it.each([['--prod'], ['--no-wait'], ['--f']])('passes %s', input => {
+    expect(gatedFlag(input)).toBe(input);
+  });
+
+  it.each([
+    ['-p'],
+    ['--Prod'],
+    ['--' + 'a'.repeat(25)],
+    ['--flag=value'],
+    ['prod'],
+    [''],
+  ])('redacts %s', input => {
+    expect(gatedFlag(input)).toBe(REDACTED);
+  });
+});
+
+describe('slug', () => {
+  it('strips err.sh prefix', () => {
+    expect(slug('https://err.sh/vercel/no-credentials-found')).toBe(
+      'vercel/no-credentials-found'
+    );
+  });
+
+  it('strips vercel.com docs prefix', () => {
+    expect(slug('https://vercel.com/docs/cli/deploy')).toBe('cli/deploy');
+  });
+
+  it('passes bare slugs', () => {
+    expect(slug('rate_limited')).toBe('rate_limited');
+    expect(slug('rate-limited')).toBe('rate-limited');
+  });
+
+  it('redacts arbitrary urls', () => {
+    expect(slug('https://example.com/anything')).toBe(REDACTED);
+    expect(slug('https://err.sh/../../etc/passwd?q=1')).toBe(REDACTED);
+  });
+});
+
+describe('fp', () => {
+  it('is stable for the same salt and irreversible-looking', () => {
+    const a = fp(['deploy', '--prod'], 'device-1');
+    expect(a).toBe(fp(['deploy', '--prod'], 'device-1'));
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+    expect(a).not.toContain('deploy');
+  });
+
+  it('differs across salts and inputs', () => {
+    expect(fp(['deploy'], 'device-1')).not.toBe(fp(['deploy'], 'device-2'));
+    expect(fp(['deploy'], 'device-1')).not.toBe(fp(['dev'], 'device-1'));
+  });
+
+  it('does not collapse argument boundaries', () => {
+    expect(fp(['ab', 'c'], 's')).not.toBe(fp(['a', 'bc'], 's'));
+  });
+});
+
+describe('ctxHash', () => {
+  it('is stable and short', () => {
+    const h = ctxHash([1234, 1700000000, '/repo'], 'device-1');
+    expect(h).toBe(ctxHash([1234, 1700000000, '/repo'], 'device-1'));
+    expect(h).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/packages/cli/test/unit/telemetry/store-config.test.ts
+++ b/packages/cli/test/unit/telemetry/store-config.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+
+describe('TelemetryEventStore config gating', () => {
+  beforeEach(() => {
+    // CI exports this globally; these tests assert the config gate itself.
+    vi.stubEnv('VERCEL_TELEMETRY_DISABLED', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('is disabled until the global config is loaded', () => {
+    const store = new TelemetryEventStore();
+    expect(store.enabled).toBe(false);
+  });
+
+  it('is enabled after updateConfig, including undefined telemetry config', () => {
+    const store = new TelemetryEventStore();
+    store.updateConfig(undefined);
+    expect(store.enabled).toBe(true);
+  });
+
+  it('respects an explicit opt-out from updateConfig', () => {
+    const store = new TelemetryEventStore();
+    store.updateConfig({ enabled: false });
+    expect(store.enabled).toBe(false);
+  });
+
+  it('is enabled when constructed with a config', () => {
+    const store = new TelemetryEventStore({ config: {} });
+    expect(store.enabled).toBe(true);
+  });
+
+  it('save() is a no-op with no buffered events', async () => {
+    const store = new TelemetryEventStore({ config: { enabled: true } });
+    await expect(store.save()).resolves.toBeUndefined();
+  });
+
+  it('save() flushes buffered events once enabled', async () => {
+    const store = new TelemetryEventStore({ isDebug: true });
+    const client = new RootTelemetryClient({ opts: { store } });
+    client.trackPlatform();
+    store.updateConfig(undefined);
+    await expect(store.save()).resolves.toBeUndefined();
+    expect(store.readonlyEvents).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
> **Stack 1/6** — telemetry v2. All follow-ups stack on this PR.

Several `main()` paths returned raw exit codes and silently dropped the buffered telemetry batch (unknown command, `--version`, bare help, config errors). This PR makes flushing reliable and lays plumbing for the stack; **the only new event is `exit_code`, gated behind `VERCEL_CLI_TELEMETRY_V2`** (off by default until PR 6).

- Construct `TelemetryEventStore` before the global config is read; events are buffered but only *sent* once the opt-out state is known (`updateConfig()`); `save()` no-ops on empty batches
- Route every early `return N` through `finishEarly`/`finishWithExitCode`
- `--version`, bare help, and `vercel.json` checks run **before** the global config is loaded (unchanged from `main`); `finishEarly` loads the config best-effort purely for telemetry — when it is unreadable, the batch is silently dropped and the command still succeeds
- New `sanitize.ts`: `gatedToken`, `gatedFlag`, `slug`, `fp`, `ctxHash` — all later PRs emit only through these; **please focus security review here**
- `telemetryReporter` singleton (consumers land in PR 2)
- Drive-by fix for a latent crash family found while smoke-testing (and independently flagged by the review bot): the update-notification block in `main().then()` runs with `client === undefined` when the command exits before creating it (`--version`/bare help). Both branches are now guarded: `canAutoUpdate(client, …)` (auto-update) and `promptAndUpgrade(client, …)` (interactive TTY prompt — notice still prints, prompt is skipped). Reproduced on `main`.

Compatibility: `vercel --version` and bare help work with a corrupt/unreadable global config and an unwritable global dir (verified 0/18 failures under corrupt config + dead registry).

Tests: sanitizer edge cases (paths/secrets/unicode), store gating, flag-gated `exit_code`. Changeset included. No new type errors vs `main`.


