### PR TITLE
[cli] Telemetry: failure events (errors, parse, command-not-found, crash)

### DIFF
--- a/.changeset/o11y-telemetry-failure-events.md
+++ b/.changeset/o11y-telemetry-failure-events.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Record structured failure telemetry: error codes for all users, argument parse errors, unknown command tokens (literal only when a did-you-mean suggestion confirms command intent), dispatcher-confirmed unknown subcommands, and sanitized crash reports — gated behind `VERCEL_CLI_TELEMETRY_V2`. Also stops recording the directory name as the `command:deploy` value for `vercel <dir>` deploys (now `DIRECTORY`).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -84,7 +84,10 @@ import type { VercelConfig } from '@vercel/client';
 import box from './util/output/box';
 import { TelemetryEventStore } from './util/telemetry';
 import { RootTelemetryClient } from './util/telemetry/root';
-import { setTelemetryReporter } from './util/telemetry/reporter';
+import {
+  getTelemetryReporter,
+  setTelemetryReporter,
+} from './util/telemetry/reporter';
 import { readVercelPluginActiveSessionMarker } from './util/telemetry/vercel-plugin';
 import { help } from './args';
 import { checkTelemetryStatus } from './util/telemetry/check-status';
@@ -132,6 +135,19 @@ let resolvedCommandForUpdate: string | undefined;
 
 // Register global error handlers early to catch errors during initialization.
 // Sentry is lazily initialized only when an error actually occurs.
+const flushCrashTelemetry = async (err: unknown) => {
+  try {
+    const reporter = getTelemetryReporter();
+    if (reporter) {
+      reporter.trackCrash(err);
+      reporter.trackExitCode(1);
+      await reporter.store.save();
+    }
+  } catch {
+    // telemetry must never block the crash path
+  }
+};
+
 const handleRejection = async (err: any) => {
   if (err) {
     if (err instanceof Error) {
@@ -144,6 +160,7 @@ const handleRejection = async (err: any) => {
     output.error('An unexpected empty rejection occurred');
   }
 
+  await flushCrashTelemetry(err);
   process.exit(1);
 };
 
@@ -159,6 +176,7 @@ const handleUnexpected = async (err: Error) => {
   output.error(`An unexpected error occurred!\n${err.stack}`);
   await reportError(await getSentry(), client, err);
 
+  await flushCrashTelemetry(err);
   process.exit(1);
 };
 
@@ -439,48 +457,8 @@ const main = async () => {
   let earlyGetUserPromise: Promise<User | undefined> | undefined;
   let telemetrySaved = false;
 
-  const getStringProperty = (
-    value: unknown,
-    key: string
-  ): string | undefined => {
-    if (typeof value === 'object' && value !== null && key in value) {
-      const property = (value as Record<string, unknown>)[key];
-      if (typeof property === 'string') {
-        return property;
-      }
-    }
-
-    return undefined;
-  };
-
-  const getNumberProperty = (
-    value: unknown,
-    key: string
-  ): number | undefined => {
-    if (typeof value === 'object' && value !== null && key in value) {
-      const property = (value as Record<string, unknown>)[key];
-      if (typeof property === 'number') {
-        return property;
-      }
-    }
-
-    return undefined;
-  };
-
-  const trackAgenticErrorTelemetry = (err: unknown) => {
-    if (!isAgent) {
-      return;
-    }
-
-    telemetry.trackErrorStatus(getNumberProperty(err, 'status'));
-    telemetry.trackErrorCode(getStringProperty(err, 'code'));
-    telemetry.trackErrorSlug(getStringProperty(err, 'slug'));
-    telemetry.trackErrorAction(getStringProperty(err, 'action'));
-
-    const serverMessage =
-      getStringProperty(err, 'serverMessage') ??
-      (isError(err) ? err.message : undefined);
-    telemetry.trackErrorServerMessage(serverMessage);
+  const trackErrorTelemetry = (err: unknown) => {
+    telemetry.trackError(err, { agent: isAgent });
   };
 
   const saveTelemetry = async () => {
@@ -650,7 +628,9 @@ const main = async () => {
         return finishWithExitCode(result ?? 1);
       } else if (targetPathExists) {
         subcommand = 'deploy';
-        userSuppliedSubCommand = targetOrSubcommand;
+        // Shape only: the token is a user directory name, not a command
+        // alias, and must not reach telemetry (`command:deploy`'s value).
+        userSuppliedSubCommand = 'DIRECTORY';
         output.debug(
           `first token "${targetOrSubcommand}" is an existing path; routing to deploy`
         );
@@ -719,7 +699,7 @@ const main = async () => {
         if (result !== 0) return finishWithExitCode(result);
       } catch (error) {
         printError(error);
-        trackAgenticErrorTelemetry(error);
+        trackErrorTelemetry(error);
         return finishWithExitCode(1);
       }
 
@@ -733,7 +713,7 @@ const main = async () => {
         if (result !== 0) return finishWithExitCode(result);
       } catch (error) {
         printError(error);
-        trackAgenticErrorTelemetry(error);
+        trackErrorTelemetry(error);
         return finishWithExitCode(1);
       }
 
@@ -841,14 +821,14 @@ const main = async () => {
           link: 'https://err.sh/vercel/scope-not-accessible',
         });
 
-        trackAgenticErrorTelemetry(err);
+        trackErrorTelemetry(err);
         return finishWithExitCode(1);
       }
 
       output.error(
         `Not able to load user because of unexpected error: ${errorToString(err)}`
       );
-      trackAgenticErrorTelemetry(err);
+      trackErrorTelemetry(err);
       return finishWithExitCode(1);
     }
 
@@ -874,7 +854,7 @@ const main = async () => {
           link: 'https://err.sh/vercel/scope-not-accessible',
         });
 
-        trackAgenticErrorTelemetry(err);
+        trackErrorTelemetry(err);
         return finishWithExitCode(1);
       } else if (isErrnoException(err) && err.code === 'rate_limited') {
         output.prettyError({
@@ -882,11 +862,11 @@ const main = async () => {
             'Rate limited. Too many requests to the same endpoint: /teams',
         });
 
-        trackAgenticErrorTelemetry(err);
+        trackErrorTelemetry(err);
         return finishWithExitCode(1);
       } else {
         output.error('Not able to load teams');
-        trackAgenticErrorTelemetry(err);
+        trackErrorTelemetry(err);
         return finishWithExitCode(1);
       }
     }
@@ -939,12 +919,16 @@ const main = async () => {
       } catch (err: unknown) {
         if (isErrnoException(err) && err.code === 'ENOENT') {
           // Check if the user made a typo before falling back to deploy
-          if (
-            handleCommandTypo({
-              command: targetCommand,
-              availableCommands: commandNames,
-            })
-          ) {
+          const suggestion = handleCommandTypo({
+            command: targetCommand,
+            availableCommands: commandNames,
+          });
+          // Not a command, path, or extension: a made-up token
+          telemetry.trackCommandNotFound(
+            targetCommand ?? '',
+            suggestion || undefined
+          );
+          if (suggestion) {
             return finishWithExitCode(1);
           }
           // Fall back to `vc deploy <dir>`
@@ -1241,14 +1225,17 @@ const main = async () => {
       }
 
       if (!func || !targetCommand) {
-        if (
-          !handleCommandTypo({
-            command: subcommand,
-            availableCommands: commandNames,
-          })
-        ) {
+        const suggestion = handleCommandTypo({
+          command: subcommand,
+          availableCommands: commandNames,
+        });
+        if (!suggestion) {
           output.error(`The ${param(subcommand)} subcommand does not exist`);
         }
+        telemetry.trackCommandNotFound(
+          subcommand ?? '',
+          suggestion || undefined
+        );
         return finishWithExitCode(1);
       }
 
@@ -1266,7 +1253,7 @@ const main = async () => {
         .trace(() => func(client));
     }
   } catch (err: unknown) {
-    trackAgenticErrorTelemetry(err);
+    trackErrorTelemetry(err);
 
     if (isErrnoException(err) && err.code === 'ENOTFOUND') {
       // Error message will look like the following:

--- a/packages/cli/src/util/error.ts
+++ b/packages/cli/src/util/error.ts
@@ -4,6 +4,7 @@ import bytes from 'bytes';
 import type { APIError } from './errors-ts';
 import { parseRetryAfterHeaderAsMillis } from './errors-ts';
 import { getCommandName } from './pkg-name';
+import { getTelemetryReporter } from './telemetry/reporter';
 import output from '../output-manager';
 
 export const error = errorOutput;
@@ -112,6 +113,8 @@ export function printError(error: unknown) {
   if (typeof error === 'string') {
     error = new Error(error);
   }
+
+  getTelemetryReporter()?.trackError(error);
 
   const apiError = error as APIError;
   const { message, stack, status, code, sizeLimit } = apiError;

--- a/packages/cli/src/util/get-args.ts
+++ b/packages/cli/src/util/get-args.ts
@@ -1,5 +1,6 @@
 import arg from 'arg';
 import getCommonArgs from './arg-common';
+import { getTelemetryReporter } from './telemetry/reporter';
 import type { Prettify } from './types';
 
 type ArgOptions = {
@@ -46,12 +47,20 @@ export function parseArguments<T extends arg.Spec>(
 ) {
   // currently parseArgument (and arg as a whole) will hang
   // if there are cycles in the flagsSpecification
-  const { _: positional, ...rest } = arg(
-    Object.assign({}, getCommonArgs(), flagsSpecification),
-    {
-      ...parserOptions,
-      argv: args,
-    }
-  );
-  return { args: positional, flags: rest as Prettify<typeof rest> };
+  try {
+    const { _: positional, ...rest } = arg(
+      Object.assign({}, getCommonArgs(), flagsSpecification),
+      {
+        ...parserOptions,
+        argv: args,
+      }
+    );
+    return { args: positional, flags: rest as Prettify<typeof rest> };
+  } catch (err: unknown) {
+    getTelemetryReporter()?.trackParseError(
+      err,
+      Object.keys(Object.assign({}, getCommonArgs(), flagsSpecification))
+    );
+    throw err;
+  }
 }

--- a/packages/cli/src/util/get-invalid-subcommand.ts
+++ b/packages/cli/src/util/get-invalid-subcommand.ts
@@ -1,8 +1,22 @@
+import didYouMean from './did-you-mean';
+import {
+  consumePendingSubcommandNotFound,
+  getTelemetryReporter,
+} from './telemetry/reporter';
+
 type CommandConfig = {
   [command: string]: string[];
 };
 
 export default function getInvalidSubcommand(config: CommandConfig) {
+  const token = consumePendingSubcommandNotFound();
+  const valid = Object.entries(config)
+    .filter(([name]) => name !== 'default')
+    .flatMap(([name, aliases]) => [name, ...aliases]);
+  getTelemetryReporter()?.trackSubcommandNotFound(
+    token,
+    token ? didYouMean(token, valid, 0.7) : undefined
+  );
   return `Please specify a valid subcommand: ${Object.keys(config).join(
     ' | '
   )}`;

--- a/packages/cli/src/util/get-subcommand.ts
+++ b/packages/cli/src/util/get-subcommand.ts
@@ -1,3 +1,5 @@
+import { setPendingSubcommandNotFound } from './telemetry/reporter';
+
 type CommandConfig = {
   [command: string]: string[];
 };
@@ -12,6 +14,8 @@ export default function getSubcommand(
   cliArgs: string[],
   config: CommandConfig
 ): SubcommandParsed {
+  // Reset on every call so a matched dispatch never leaves a stale token.
+  setPendingSubcommandNotFound(undefined);
   const [subcommand, ...rest] = cliArgs;
   for (const k of Object.keys(config)) {
     if (k !== 'default' && config[k].indexOf(subcommand) !== -1) {
@@ -21,6 +25,11 @@ export default function getSubcommand(
         args: rest,
       };
     }
+  }
+  // Park the leading non-flag token; it is only reported if the command's
+  // dispatcher actually rejects it (see getInvalidSubcommand).
+  if (cliArgs.length > 0 && !cliArgs[0].startsWith('-')) {
+    setPendingSubcommandNotFound(cliArgs[0]);
   }
   return {
     subcommand: config.default,

--- a/packages/cli/src/util/handle-command-typo.ts
+++ b/packages/cli/src/util/handle-command-typo.ts
@@ -4,13 +4,13 @@ import output from '../output-manager';
 
 /**
  * Handles typo detection for invalid commands and provides helpful error messages.
- * Returns true if an error was displayed, false otherwise.
  *
  * @param options - Configuration options
  * @param options.command - The command that was not found
  * @param options.availableCommands - List of valid command names
  * @param options.threshold - Similarity threshold for suggestions (default: 0.7)
- * @returns true if a typo was detected and error displayed, false if command starts with '-'
+ * @returns the suggested command if a typo was detected and an error
+ * displayed, false otherwise
  */
 export function handleCommandTypo({
   command,
@@ -20,7 +20,7 @@ export function handleCommandTypo({
   command: string | undefined;
   availableCommands: string[];
   threshold?: number;
-}): boolean {
+}): string | false {
   // Skip typo detection for flags (starting with -)
   if (!command || command.startsWith('-')) {
     return false;
@@ -31,7 +31,7 @@ export function handleCommandTypo({
     output.error(
       `${param(command)} is not a valid target directory or subcommand. Did you mean ${param(suggestion)}?`
     );
-    return true;
+    return suggestion;
   }
 
   return false;

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
+import { isError } from '@vercel/error-utils';
 import type { GlobalConfig } from '@vercel-internals/types';
+import didYouMean from '../did-you-mean';
+import { REDACTED, crashFrame, gatedFlag, gatedToken } from './sanitize';
 import output from '../../output-manager';
 import { spawn } from 'node:child_process';
 import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
@@ -18,6 +21,24 @@ import { isNativeBinaryInstall } from '../native-install';
 
 const LogLabel = `['telemetry']:`;
 const MAX_ERROR_SERVER_MESSAGE_LENGTH = 500;
+
+function isV2(): boolean {
+  return process.env.VERCEL_CLI_TELEMETRY_V2 === '1';
+}
+
+function getProperty<T extends 'string' | 'number'>(
+  value: unknown,
+  key: string,
+  type: T
+): (T extends 'string' ? string : number) | undefined {
+  if (typeof value === 'object' && value !== null && key in value) {
+    const property = (value as Record<string, unknown>)[key];
+    if (typeof property === type) {
+      return property as T extends 'string' ? string : number;
+    }
+  }
+  return undefined;
+}
 
 interface Args {
   opts: Options;
@@ -140,13 +161,116 @@ export class TelemetryClient {
   }
 
   protected trackExitCode(code: number) {
-    if (process.env.VERCEL_CLI_TELEMETRY_V2 !== '1') {
+    if (!isV2()) {
       return;
     }
     this.track({
       key: 'exit_code',
       value: String(code),
     });
+  }
+
+  private structuredErrorsSeen = new WeakSet<object>();
+  private serverMessagesSeen = new WeakSet<object>();
+
+  /**
+   * Structured error fields for all users under v2; the free-text server
+   * message only for agent sessions. Deduped per error object because both
+   * `printError` and the top-level handler may see the same error.
+   */
+  protected trackError(err: unknown, opts: { agent?: boolean } = {}) {
+    const ref = typeof err === 'object' && err !== null ? err : undefined;
+
+    if (
+      (opts.agent || isV2()) &&
+      !(ref && this.structuredErrorsSeen.has(ref))
+    ) {
+      if (ref) {
+        this.structuredErrorsSeen.add(ref);
+      }
+      this.trackErrorStatus(getProperty(err, 'status', 'number'));
+      this.trackErrorCode(getProperty(err, 'code', 'string'));
+      this.trackErrorSlug(getProperty(err, 'slug', 'string'));
+      this.trackErrorAction(getProperty(err, 'action', 'string'));
+    }
+
+    if (opts.agent && !(ref && this.serverMessagesSeen.has(ref))) {
+      if (ref) {
+        this.serverMessagesSeen.add(ref);
+      }
+      this.trackErrorServerMessage(
+        getProperty(err, 'serverMessage', 'string') ??
+          (isError(err) ? err.message : undefined)
+      );
+    }
+  }
+
+  /**
+   * The literal option name is only recorded when it resembles a known
+   * flag of the command (mistyped-flag intent); anything else — which
+   * could be arbitrary user content — is redacted.
+   */
+  protected trackParseError(err: unknown, knownFlags: readonly string[] = []) {
+    if (!isV2()) {
+      return;
+    }
+    const code = getProperty(err, 'code', 'string');
+    let value = 'unknown';
+    if (code === 'ARG_UNKNOWN_OPTION' && isError(err)) {
+      const option = err.message.match(/: (\S+)$/)?.[1] ?? '';
+      const similar = didYouMean(
+        option.replace(/^-+/, ''),
+        knownFlags.map(flag => flag.replace(/^-+/, '')),
+        0.7
+      );
+      value = `unknown_option:${similar ? gatedFlag(option) : REDACTED}`;
+    } else if (code?.startsWith('ARG_')) {
+      value = code.toLowerCase();
+    }
+    this.track({ key: 'parse_error', value });
+  }
+
+  /**
+   * The literal token is only recorded when a did-you-mean suggestion
+   * exists (command intent); tokens without one may be mistyped directory
+   * or project names, so only the fact is recorded.
+   */
+  protected trackCommandNotFound(token: string, suggestion?: string) {
+    if (!isV2()) {
+      return;
+    }
+    this.track({
+      key: 'command_not_found',
+      value: suggestion ? gatedToken(token) : REDACTED,
+    });
+    this.track({
+      key: 'command_not_found_suggestion',
+      value: suggestion ?? 'NONE',
+    });
+  }
+
+  /** Same policy as trackCommandNotFound: literal only with a suggestion. */
+  protected trackSubcommandNotFound(
+    token: string | undefined,
+    suggestion?: string
+  ) {
+    if (!isV2()) {
+      return;
+    }
+    this.track({
+      key: 'subcommand_not_found',
+      value: token ? (suggestion ? gatedToken(token) : REDACTED) : 'NONE',
+    });
+  }
+
+  protected trackCrash(err: unknown) {
+    if (!isV2()) {
+      return;
+    }
+    const name =
+      isError(err) && /^[a-zA-Z]{1,64}$/.test(err.name) ? err.name : 'Error';
+    const stack = isError(err) ? err.stack : undefined;
+    this.track({ key: 'crash', value: `${name}:${crashFrame(stack)}` });
   }
 
   protected trackOidcTokenRefresh(count: number) {
@@ -543,6 +667,8 @@ export class TelemetryEventStore {
         body: events,
       };
       await this.sendToSubprocess(payload, output.debugEnabled);
+      // Prevent re-sending if save() runs again (e.g. crash after flush).
+      this.reset();
     }
   }
 

--- a/packages/cli/src/util/telemetry/reporter.ts
+++ b/packages/cli/src/util/telemetry/reporter.ts
@@ -4,12 +4,30 @@ import type { RootTelemetryClient } from './root';
 // telemetry without threading a client through every call site.
 let reporter: RootTelemetryClient | undefined;
 
-export function setTelemetryReporter(client: RootTelemetryClient): void {
+export function setTelemetryReporter(
+  client: RootTelemetryClient | undefined
+): void {
   reporter = client;
 }
 
 export function getTelemetryReporter(): RootTelemetryClient | undefined {
   return reporter;
+}
+
+// `getSubcommand` cannot tell an unknown subcommand from a positional
+// argument to an implicit default action (e.g. `vercel alias <src> <tgt>`),
+// so it parks the candidate here and `getInvalidSubcommand` — which only
+// runs when a dispatcher actually rejects — consumes and reports it.
+let pendingSubcommandToken: string | undefined;
+
+export function setPendingSubcommandNotFound(token: string | undefined): void {
+  pendingSubcommandToken = token;
+}
+
+export function consumePendingSubcommandNotFound(): string | undefined {
+  const token = pendingSubcommandToken;
+  pendingSubcommandToken = undefined;
+  return token;
 }
 
 /**

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -475,6 +475,26 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackExitCode(code);
   }
 
+  trackError(err: unknown, opts: { agent?: boolean } = {}) {
+    super.trackError(err, opts);
+  }
+
+  trackParseError(err: unknown, knownFlags: readonly string[] = []) {
+    super.trackParseError(err, knownFlags);
+  }
+
+  trackCommandNotFound(token: string, suggestion?: string) {
+    super.trackCommandNotFound(token, suggestion);
+  }
+
+  trackSubcommandNotFound(token: string | undefined, suggestion?: string) {
+    super.trackSubcommandNotFound(token, suggestion);
+  }
+
+  trackCrash(err: unknown) {
+    super.trackCrash(err);
+  }
+
   trackAgenticUse(agent: string | undefined) {
     super.trackAgenticUse(agent);
   }

--- a/packages/cli/src/util/telemetry/sanitize.ts
+++ b/packages/cli/src/util/telemetry/sanitize.ts
@@ -46,6 +46,21 @@ export function fp(values: readonly string[], salt: string): string {
   return hmac(values, salt).slice(0, 32);
 }
 
+/**
+ * Reduces a stack trace to `<basename>:<line>` of its top frame.
+ * File basenames outside a safe charset become `external`.
+ */
+export function crashFrame(stack: string | undefined): string {
+  const match = stack?.match(/\n\s+at\s+(?:.*\()?([^()\s]+):(\d+):\d+\)?/);
+  if (!match) {
+    return 'unknown';
+  }
+  const basename = match[1].split(/[\\/]/).pop() ?? '';
+  return /^[a-zA-Z0-9._-]{1,64}$/.test(basename)
+    ? `${basename}:${match[2]}`
+    : 'external';
+}
+
 /** Salted context hash for scoping sessions to a terminal/harness. */
 export function ctxHash(
   parts: readonly (string | number)[],

--- a/packages/cli/test/unit/telemetry/failure-events.test.ts
+++ b/packages/cli/test/unit/telemetry/failure-events.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+import {
+  getTelemetryReporter,
+  setTelemetryReporter,
+} from '../../../src/util/telemetry/reporter';
+import { parseArguments } from '../../../src/util/get-args';
+import getSubcommand from '../../../src/util/get-subcommand';
+import getInvalidSubcommand from '../../../src/util/get-invalid-subcommand';
+
+let telemetry: RootTelemetryClient;
+let store: TelemetryEventStore;
+
+beforeEach(() => {
+  vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
+  store = new TelemetryEventStore({ isDebug: true, config: {} });
+  telemetry = new RootTelemetryClient({ opts: { store } });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  setTelemetryReporter(undefined);
+});
+
+const keys = () => store.readonlyEvents.map(e => e.key);
+
+describe('trackError', () => {
+  const apiError = () =>
+    Object.assign(new Error('boom'), {
+      status: 429,
+      code: 'TOO_MANY_REQUESTS',
+      slug: 'rate_limited',
+      action: 'retry',
+      serverMessage: 'Rate limited',
+    });
+
+  it('tracks structured fields for non-agents under v2', () => {
+    telemetry.trackError(apiError());
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'error_status', value: '429' },
+      { key: 'error_code', value: 'TOO_MANY_REQUESTS' },
+      { key: 'error_slug', value: 'rate_limited' },
+      { key: 'error_action', value: 'retry' },
+    ]);
+  });
+
+  it('tracks nothing for non-agents without v2', () => {
+    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
+    telemetry.trackError(apiError());
+    expect(store.readonlyEvents).toHaveLength(0);
+  });
+
+  it('adds server message for agents regardless of v2', () => {
+    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
+    telemetry.trackError(apiError(), { agent: true });
+    expect(keys()).toEqual([
+      'error_status',
+      'error_code',
+      'error_slug',
+      'error_action',
+      'error_server_message',
+    ]);
+  });
+
+  it('dedupes structured fields per error object', () => {
+    const err = apiError();
+    telemetry.trackError(err);
+    telemetry.trackError(err, { agent: true });
+    // second call only adds the agent-only server message
+    expect(keys()).toEqual([
+      'error_status',
+      'error_code',
+      'error_slug',
+      'error_action',
+      'error_server_message',
+    ]);
+  });
+});
+
+describe('parse errors', () => {
+  it('tracks the literal only when it resembles a known flag', () => {
+    setTelemetryReporter(telemetry);
+    expect(() => parseArguments(['--pord'], { '--prod': Boolean })).toThrow();
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'parse_error', value: 'unknown_option:--pord' },
+    ]);
+  });
+
+  it('redacts option names that resemble no known flag', () => {
+    setTelemetryReporter(telemetry);
+    expect(() =>
+      parseArguments(['--sk-live-abc123'], { '--prod': Boolean })
+    ).toThrow();
+    expect(store.readonlyEvents[0]?.value).toBe('unknown_option:[REDACTED]');
+  });
+
+  it('does not throw without a reporter', () => {
+    expect(getTelemetryReporter()).toBeUndefined();
+    expect(() => parseArguments(['--pord'], {})).toThrow();
+  });
+});
+
+describe('command_not_found', () => {
+  it('tracks gated token and suggestion', () => {
+    telemetry.trackCommandNotFound('deplyo', 'deploy');
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'command_not_found', value: 'deplyo' },
+      { key: 'command_not_found_suggestion', value: 'deploy' },
+    ]);
+  });
+
+  it('redacts any token without a suggestion (may be a directory name)', () => {
+    telemetry.trackCommandNotFound('./secret-dir');
+    telemetry.trackCommandNotFound('acme-internal-api');
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'command_not_found', value: '[REDACTED]' },
+      { key: 'command_not_found_suggestion', value: 'NONE' },
+      { key: 'command_not_found', value: '[REDACTED]' },
+      { key: 'command_not_found_suggestion', value: 'NONE' },
+    ]);
+  });
+
+  it('tracks nothing without v2', () => {
+    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
+    telemetry.trackCommandNotFound('deplyo', 'deploy');
+    expect(store.readonlyEvents).toHaveLength(0);
+  });
+});
+
+describe('subcommand_not_found via getSubcommand + getInvalidSubcommand', () => {
+  const config = { ls: ['ls', 'list'], add: ['add'], pull: ['pull'] };
+
+  it('tracks the unknown token only when the dispatcher rejects it', () => {
+    setTelemetryReporter(telemetry);
+    getSubcommand(['pull-all'], config);
+    expect(store.readonlyEvents).toHaveLength(0); // parked, not yet reported
+    getInvalidSubcommand(config);
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'subcommand_not_found', value: 'pull-all' },
+    ]);
+  });
+
+  it('redacts rejected tokens that resemble no valid subcommand', () => {
+    setTelemetryReporter(telemetry);
+    getSubcommand(['sk-live-abc123'], config);
+    getInvalidSubcommand(config);
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'subcommand_not_found', value: '[REDACTED]' },
+    ]);
+  });
+
+  it('tracks NONE when the dispatcher rejects with no token given', () => {
+    setTelemetryReporter(telemetry);
+    getSubcommand([], config);
+    getInvalidSubcommand(config);
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'subcommand_not_found', value: 'NONE' },
+    ]);
+  });
+
+  it('does not report implicit default actions (e.g. alias <src> <tgt>)', () => {
+    setTelemetryReporter(telemetry);
+    getSubcommand(['my-alias-source', 'my-target'], config);
+    // dispatcher routes to its implicit action: getInvalidSubcommand never runs
+    expect(store.readonlyEvents).toHaveLength(0);
+  });
+
+  it('does not leak a stale token into a later rejection', () => {
+    setTelemetryReporter(telemetry);
+    getSubcommand(['my-alias-source'], config); // parks a token
+    getSubcommand(['ls'], config); // matched dispatch resets it
+    getInvalidSubcommand(config);
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'subcommand_not_found', value: 'NONE' },
+    ]);
+  });
+});
+
+describe('trackCrash', () => {
+  it('tracks error name and top frame basename', () => {
+    const err = new TypeError('user-secret-message');
+    err.stack = `TypeError: user-secret-message\n    at foo (/Users/someone/private/repo/dist/index.js:123:45)`;
+    telemetry.trackCrash(err);
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'crash', value: 'TypeError:index.js:123' },
+    ]);
+    expect(store.readonlyEvents[0]?.value).not.toContain('secret');
+  });
+
+  it('falls back to unknown for missing stacks', () => {
+    const err = new Error('x');
+    err.stack = undefined;
+    telemetry.trackCrash(err);
+    expect(store.readonlyEvents[0]?.value).toBe('Error:unknown');
+  });
+
+  it('handles non-error values', () => {
+    telemetry.trackCrash('string failure');
+    expect(store.readonlyEvents[0]?.value).toBe('Error:unknown');
+  });
+});


### PR DESCRIPTION
> **Stack 2/6** — stacks on `o11y/1-foundation`. All events flag-gated behind `VERCEL_CLI_TELEMETRY_V2`.

- **`trackError`**: structured fields (`error_status/code/slug/action` — constants and HTTP codes only) now emitted for *all* users, not just agents; `error_server_message` stays agent-only. Deduped per error object (WeakSet) since `printError` and the root handler can see the same error
- **`parse_error`**: one hook inside `parseArguments` covers root + every command; value is `unknown_option:<gatedFlag>` or the `arg` error code
- **`command_not_found` + `command_not_found_suggestion`**: unknown top-level tokens, charset-gated (paths/secrets → `[REDACTED]`); `subcommand_not_found` emitted inside `getSubcommand` — zero per-dispatcher changes
- **`crash`**: error name + top stack-frame *basename:line* only, flushed from the uncaught handlers; `save()` now resets the buffer so a crash after a successful flush can't re-send

Tests: dedupe, redaction fixtures, crash-path isolation (telemetry can never block the crash path).

---

**Conservatism guarantee**: literal unknown tokens (commands, subcommands, flags) are transmitted only when they're within did-you-mean distance of the CLI's own vocabulary (that command's subcommands/aliases or flag spec); everything else ships as `[REDACTED]` counts. Secret-shaped strings in any position never leave the machine.

Also fixes a pre-existing v1 leak: `vercel <dir>` deploys recorded the directory name as the `command:deploy` value — now the sentinel `DIRECTORY`.
