### PR TITLE
[cli] Telemetry: help, docs, and config failure events

### DIFF
--- a/.changeset/o11y-telemetry-help-docs-config.md
+++ b/.changeset/o11y-telemetry-help-docs-config.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Record help usage, docs-link slugs, `vercel.json` parse/validation failures, and CLI config/auth-config read failures in telemetry. Gated behind `VERCEL_CLI_TELEMETRY_V2`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -258,6 +258,16 @@ const main = async () => {
     return code;
   };
 
+  // The opt-out state is unknowable when the CLI config cannot be read or
+  // written, so drop everything buffered and send one anonymous event.
+  const flushConfigError = async (kind: 'read' | 'write'): Promise<number> => {
+    telemetryEventStore.reset();
+    telemetry.trackConfigError(kind);
+    telemetryEventStore.updateConfig(undefined);
+    telemetryConfigLoaded = true;
+    return finishEarly(1);
+  };
+
   const parseInitialArgs = () =>
     parseArguments(
       process.argv,
@@ -318,6 +328,7 @@ const main = async () => {
 
   if (localConfig instanceof ERRORS.CantParseJSONFile) {
     output.error(`Couldn't parse JSON file ${localConfig.meta.file}.`);
+    telemetry.trackProjectConfigError('parse');
     return finishEarly(1);
   }
 
@@ -328,6 +339,7 @@ const main = async () => {
           ' or\n    '
         )}`
       );
+      telemetry.trackProjectConfigError('not_found_explicit');
       return finishEarly(1);
     } else {
       localConfig = undefined;
@@ -368,6 +380,7 @@ const main = async () => {
   const bareHelpSubcommand = targetOrSubcommand === 'help' && !subSubCommand;
   if (bareHelpOption || bareHelpSubcommand) {
     output.print(help());
+    telemetry.trackHelpRendered('root');
     return finishEarly(0);
   }
 
@@ -380,7 +393,7 @@ const main = async () => {
         VERCEL_DIR
       )}" ${errorToString(err)}`
     );
-    return finishEarly(1);
+    return flushConfigError('write');
   }
 
   let config: GlobalConfig;
@@ -397,7 +410,7 @@ const main = async () => {
             VERCEL_CONFIG_PATH
           )}" ${errorToString(err)}`
         );
-        return finishEarly(1);
+        return flushConfigError('write');
       }
     } else {
       output.error(
@@ -405,7 +418,7 @@ const main = async () => {
           VERCEL_CONFIG_PATH
         )}" ${errorToString(err)}`
       );
-      return finishEarly(1);
+      return flushConfigError('read');
     }
   }
 
@@ -449,6 +462,7 @@ const main = async () => {
             VERCEL_AUTH_CONFIG_PATH
           )}" ${errorToString(err)}`
         );
+        telemetry.trackAuthConfigError('read');
         return finishEarly(1);
       }
     }

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import { isError } from '@vercel/error-utils';
 import type { GlobalConfig } from '@vercel-internals/types';
 import didYouMean from '../did-you-mean';
-import { REDACTED, crashFrame, gatedFlag, gatedToken } from './sanitize';
+import { REDACTED, crashFrame, gatedFlag, gatedToken, slug } from './sanitize';
 import output from '../../output-manager';
 import { spawn } from 'node:child_process';
 import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
@@ -192,6 +192,10 @@ export class TelemetryClient {
       this.trackErrorCode(getProperty(err, 'code', 'string'));
       this.trackErrorSlug(getProperty(err, 'slug', 'string'));
       this.trackErrorAction(getProperty(err, 'action', 'string'));
+      const link = getProperty(err, 'link', 'string');
+      if (isV2() && link) {
+        this.trackDocsLinkShown(link);
+      }
     }
 
     if (opts.agent && !(ref && this.serverMessagesSeen.has(ref))) {
@@ -261,6 +265,51 @@ export class TelemetryClient {
       key: 'subcommand_not_found',
       value: token ? (suggestion ? gatedToken(token) : REDACTED) : 'NONE',
     });
+  }
+
+  protected trackDocsLinkShown(link: string) {
+    if (!isV2()) {
+      return;
+    }
+    this.track({ key: 'docs_link_shown', value: slug(link) });
+  }
+
+  protected trackHelpRendered(context: string) {
+    if (!isV2()) {
+      return;
+    }
+    this.track({ key: 'help_rendered', value: gatedToken(context) });
+  }
+
+  protected trackProjectConfigError(kind: 'parse' | 'not_found_explicit') {
+    if (!isV2()) {
+      return;
+    }
+    this.track({ key: 'project_config_error', value: kind });
+  }
+
+  protected trackProjectConfigValidation(code: string | undefined) {
+    if (!isV2()) {
+      return;
+    }
+    this.track({
+      key: 'project_config_validation',
+      value: code && /^[A-Z0-9_]{1,64}$/.test(code) ? code : REDACTED,
+    });
+  }
+
+  protected trackConfigError(kind: 'read' | 'write') {
+    if (!isV2()) {
+      return;
+    }
+    this.track({ key: 'config_error', value: kind });
+  }
+
+  protected trackAuthConfigError(kind: 'read') {
+    if (!isV2()) {
+      return;
+    }
+    this.track({ key: 'auth_config_error', value: kind });
   }
 
   protected trackCrash(err: unknown) {

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -495,6 +495,26 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackCrash(err);
   }
 
+  trackHelpRendered(context: string) {
+    super.trackHelpRendered(context);
+  }
+
+  trackProjectConfigError(kind: 'parse' | 'not_found_explicit') {
+    super.trackProjectConfigError(kind);
+  }
+
+  trackProjectConfigValidation(code: string | undefined) {
+    super.trackProjectConfigValidation(code);
+  }
+
+  trackConfigError(kind: 'read' | 'write') {
+    super.trackConfigError(kind);
+  }
+
+  trackAuthConfigError(kind: 'read') {
+    super.trackAuthConfigError(kind);
+  }
+
   trackAgenticUse(agent: string | undefined) {
     super.trackAgenticUse(agent);
   }

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -17,6 +17,7 @@ import {
 import { fileNameSymbol } from '@vercel/client';
 import { validateProxyConfig } from '@vercel/fs-detectors';
 import { getConfigValidator } from './config-validator';
+import { getTelemetryReporter } from './telemetry/reporter';
 
 const imagesSchema = {
   type: 'object',
@@ -632,6 +633,14 @@ export function buildVercelConfigSchema() {
 }
 
 export function validateConfig(config: VercelConfig): NowBuildError | null {
+  const error = validateConfigImpl(config);
+  if (error) {
+    getTelemetryReporter()?.trackProjectConfigValidation(error.code);
+  }
+  return error;
+}
+
+function validateConfigImpl(config: VercelConfig) {
   const validate = getConfigValidator(buildVercelConfigSchema);
   if (!validate(config)) {
     if (validate.errors && validate.errors[0]) {

--- a/packages/cli/test/unit/telemetry/help-docs-config.test.ts
+++ b/packages/cli/test/unit/telemetry/help-docs-config.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+import { setTelemetryReporter } from '../../../src/util/telemetry/reporter';
+import { validateConfig } from '../../../src/util/validate-config';
+
+let telemetry: RootTelemetryClient;
+let store: TelemetryEventStore;
+
+beforeEach(() => {
+  vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
+  store = new TelemetryEventStore({ isDebug: true, config: {} });
+  telemetry = new RootTelemetryClient({ opts: { store } });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  setTelemetryReporter(undefined);
+});
+
+describe('help_rendered', () => {
+  it('tracks the help context', () => {
+    telemetry.trackHelpRendered('root');
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'help_rendered', value: 'root' },
+    ]);
+  });
+});
+
+describe('docs_link_shown', () => {
+  it('is emitted from trackError when the error carries a link', () => {
+    telemetry.trackError(
+      Object.assign(new Error('x'), {
+        code: 'NO_CREDENTIALS',
+        link: 'https://err.sh/vercel/no-credentials-found',
+      })
+    );
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'error_code', value: 'NO_CREDENTIALS' },
+      { key: 'docs_link_shown', value: 'vercel/no-credentials-found' },
+    ]);
+  });
+
+  it('redacts non-vercel links', () => {
+    telemetry.trackError(
+      Object.assign(new Error('x'), { link: 'https://evil.example.com/x' })
+    );
+    expect(
+      store.readonlyEvents.find(e => e.key === 'docs_link_shown')?.value
+    ).toBe('[REDACTED]');
+  });
+});
+
+describe('project config events', () => {
+  it('tracks parse and explicit-not-found errors', () => {
+    telemetry.trackProjectConfigError('parse');
+    telemetry.trackProjectConfigError('not_found_explicit');
+    expect(store.readonlyEvents.map(e => e.value)).toEqual([
+      'parse',
+      'not_found_explicit',
+    ]);
+  });
+
+  it('tracks validation error codes from validateConfig', () => {
+    setTelemetryReporter(telemetry);
+    const error = validateConfig({
+      functions: { 'api/test.js': { memory: 128 } },
+      builds: [{ src: 'x', use: 'y' }],
+    } as never);
+    expect(error?.code).toBeTruthy();
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'project_config_validation', value: error?.code },
+    ]);
+  });
+
+  it('emits nothing from validateConfig for valid configs', () => {
+    setTelemetryReporter(telemetry);
+    expect(validateConfig({} as never)).toBeNull();
+    expect(store.readonlyEvents).toHaveLength(0);
+  });
+
+  it('redacts unexpected code shapes', () => {
+    telemetry.trackProjectConfigValidation('has spaces!');
+    expect(store.readonlyEvents[0]?.value).toBe('[REDACTED]');
+  });
+});
+
+describe('cli config events', () => {
+  it('tracks config and auth-config failures', () => {
+    telemetry.trackConfigError('read');
+    telemetry.trackAuthConfigError('read');
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'config_error', value: 'read' },
+      { key: 'auth_config_error', value: 'read' },
+    ]);
+  });
+
+  it('tracks nothing without v2', () => {
+    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
+    telemetry.trackHelpRendered('root');
+    telemetry.trackProjectConfigError('parse');
+    telemetry.trackConfigError('read');
+    telemetry.trackAuthConfigError('read');
+    telemetry.trackProjectConfigValidation('X');
+    expect(store.readonlyEvents).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
> **Stack 3/6** — stacks on `o11y/2-failure-events`. Flag-gated.

- `help_rendered` (bare `vercel help`/`-h`, reachable thanks to PR 1); `docs_link_shown` = slug of our own err.sh/docs links, emitted when a tracked error carries one (other links redact)
- `vercel.json`: `project_config_error` (`parse` / `not_found_explicit`) + `project_config_validation` (constant `NowBuildError` code, via a thin `validateConfig` wrapper)
- CLI's own config: `config_error` / `auth_config_error`. When the config is unreadable the opt-out state is unknowable, so the buffered batch is **dropped** and a single anonymous event is sent (nothing at all under `VERCEL_TELEMETRY_DISABLED`) — flagging this explicitly for privacy review

