### PR TITLE
[cli] Telemetry: task-outcome signals

### DIFF
--- a/.changeset/o11y-telemetry-task-signals.md
+++ b/.changeset/o11y-telemetry-task-signals.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Record task-outcome telemetry: final deployment state, runtime-log match presence, a fingerprint of the invocation's structural shape (command token, argument count, flag names — hashed with a local-only salt that is never transmitted), and an opaque UUID from `AI_AGENT_TASK_ID`. Gated behind `VERCEL_CLI_TELEMETRY_V2`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -88,6 +88,7 @@ import {
   getTelemetryReporter,
   setTelemetryReporter,
 } from './util/telemetry/reporter';
+import { gatedToken } from './util/telemetry/sanitize';
 import { readVercelPluginActiveSessionMarker } from './util/telemetry/vercel-plugin';
 import { help } from './args';
 import { checkTelemetryStatus } from './util/telemetry/check-status';
@@ -318,6 +319,17 @@ const main = async () => {
   telemetry.trackCliOptionToken(parsedArgs.flags['--token']);
   telemetry.trackCliOptionTeam(parsedArgs.flags['--team']);
   telemetry.trackCliOptionApi(parsedArgs.flags['--api']);
+  // Structural shape only (never raw argv), salted with the local-only
+  // fingerprint salt: correlates retries without exposing argument content.
+  telemetry.trackArgsFingerprint(
+    [
+      gatedToken(parsedArgs.args[2] ?? ''),
+      String(parsedArgs.args.length - 2),
+      ...Object.keys(parsedArgs.flags).sort(),
+    ],
+    telemetryEventStore.currentFpSalt
+  );
+  telemetry.trackAgentTaskId(process.env.AI_AGENT_TASK_ID);
 
   const localConfigPath = parsedArgs.flags['--local-config'];
   // The flush subprocess must not depend on the invoking directory's

--- a/packages/cli/src/util/deploy/print-deployment-status.ts
+++ b/packages/cli/src/util/deploy/print-deployment-status.ts
@@ -10,6 +10,7 @@ import output from '../../output-manager';
 import { getCommandName } from '../pkg-name';
 import { suggestNextCommands } from '../suggest-next-commands';
 import { showPluginTipIfNeeded } from '../agent/auto-install-agentic';
+import { getTelemetryReporter } from '../telemetry/reporter';
 
 /**
  * `deployStamp()` returns a string formatted like `[47s]` (gray-wrapped).
@@ -51,6 +52,8 @@ export async function printDeploymentStatus(
   guidanceMode: boolean,
   isInit?: boolean
 ): Promise<number> {
+  getTelemetryReporter()?.trackDeployState(readyState);
+
   indications = indications || [];
 
   let isStillBuilding = false;

--- a/packages/cli/src/util/logs.ts
+++ b/packages/cli/src/util/logs.ts
@@ -12,6 +12,7 @@ import { CommandTimeout } from '../commands/logs/command';
 import output from '../output-manager';
 import stripAnsi from 'strip-ansi';
 import { toNodeReadable } from './fetch';
+import { getTelemetryReporter } from './telemetry/reporter';
 
 type Printer = (l: string) => void;
 
@@ -193,6 +194,7 @@ export async function displayRuntimeLogs(
     const stream = readable.pipe(parse ? jsonlines.parse() : split());
     let finished = false;
     let errored = false;
+    let matchedLogs = false;
 
     function finish(err?: unknown) {
       if (finished) return;
@@ -202,6 +204,7 @@ export async function displayRuntimeLogs(
       if (err) {
         reject(err);
       } else {
+        getTelemetryReporter()?.trackLogsMatched(matchedLogs);
         resolve(abortController.signal.aborted ? 1 : 0);
       }
     }
@@ -214,6 +217,7 @@ export async function displayRuntimeLogs(
         warn(`${chalk.bold(log.message)}\n`);
         return;
       }
+      matchedLogs = true;
       parse
         ? prettyPrintLogline(log, print)
         : printRawLogLine(data as string, client);

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -3,7 +3,14 @@ import os from 'node:os';
 import { isError } from '@vercel/error-utils';
 import type { GlobalConfig } from '@vercel-internals/types';
 import didYouMean from '../did-you-mean';
-import { REDACTED, crashFrame, gatedFlag, gatedToken, slug } from './sanitize';
+import {
+  REDACTED,
+  crashFrame,
+  fp,
+  gatedFlag,
+  gatedToken,
+  slug,
+} from './sanitize';
 import output from '../../output-manager';
 import { spawn } from 'node:child_process';
 import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
@@ -312,6 +319,46 @@ export class TelemetryClient {
     this.track({ key: 'auth_config_error', value: kind });
   }
 
+  protected trackDeployState(readyState: string) {
+    if (!isV2()) {
+      return;
+    }
+    this.trackCommandOutput({
+      key: 'deploy_state',
+      value: /^[A-Z_]{1,32}$/.test(readyState) ? readyState : REDACTED,
+    });
+  }
+
+  protected trackLogsMatched(matched: boolean) {
+    if (!isV2()) {
+      return;
+    }
+    this.trackCommandOutput({
+      key: 'logs_matched',
+      value: matched ? 'SOME' : 'NONE',
+    });
+  }
+
+  protected trackArgsFingerprint(argv: readonly string[], salt: string) {
+    if (!isV2()) {
+      return;
+    }
+    this.track({ key: 'args_fingerprint', value: fp(argv, salt) });
+  }
+
+  protected trackAgentTaskId(id: string | undefined) {
+    if (!isV2() || !id) {
+      return;
+    }
+    // UUID-shape only: structurally incapable of carrying user content.
+    this.track({
+      key: 'agent_task_id',
+      value: /^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$/.test(id)
+        ? id.toLowerCase()
+        : REDACTED,
+    });
+  }
+
   protected trackCrash(err: unknown) {
     if (!isV2()) {
       return;
@@ -551,6 +598,9 @@ export class TelemetryEventStore {
   private sessionId: string;
   private invocationId: string;
   private deviceId: string;
+  // Local-only HMAC salt; unlike deviceId it is never sent, so hashes made
+  // with it cannot be dictionary-tested by anyone holding the telemetry.
+  private fpSalt: string;
   private teamId = 'NO_TEAM_ID';
   private userId = 'NO_USER_ID';
   private projectId = 'NO_PROJECT_ID';
@@ -575,10 +625,12 @@ export class TelemetryEventStore {
     this.cliSessionOptions = opts?.cliSession;
     this.invocationId = randomUUID();
     this.deviceId = randomUUID();
+    this.fpSalt = randomUUID();
 
     if (this.cliDeviceOptions) {
       this.cliDevice = getOrCreatePersistedCliDevice(this.cliDeviceOptions);
       this.deviceId = this.cliDevice.id;
+      this.fpSalt = this.cliDevice.fpSalt ?? this.fpSalt;
     }
 
     if (this.cliSessionOptions) {
@@ -636,6 +688,10 @@ export class TelemetryEventStore {
 
   get currentDeviceId() {
     return this.deviceId;
+  }
+
+  get currentFpSalt() {
+    return this.fpSalt;
   }
 
   get currentSessionId() {

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -515,6 +515,22 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackAuthConfigError(kind);
   }
 
+  trackDeployState(readyState: string) {
+    super.trackDeployState(readyState);
+  }
+
+  trackLogsMatched(matched: boolean) {
+    super.trackLogsMatched(matched);
+  }
+
+  trackArgsFingerprint(argv: readonly string[], salt: string) {
+    super.trackArgsFingerprint(argv, salt);
+  }
+
+  trackAgentTaskId(id: string | undefined) {
+    super.trackAgentTaskId(id);
+  }
+
   trackAgenticUse(agent: string | undefined) {
     super.trackAgenticUse(agent);
   }

--- a/packages/cli/src/util/telemetry/session.ts
+++ b/packages/cli/src/util/telemetry/session.ts
@@ -15,6 +15,8 @@ export interface PersistedCliSession {
 
 export interface PersistedCliDevice {
   id: string;
+  /** HMAC salt for fingerprint/context hashes. Never transmitted. */
+  fpSalt?: string;
 }
 
 export interface PersistedCliSessionOptions {
@@ -141,12 +143,13 @@ export function getOrCreatePersistedCliDevice(
 ): PersistedCliDevice {
   const existing = readPersistedCliDevice(opts.filePath);
 
-  if (existing) {
+  if (existing?.fpSalt) {
     return existing;
   }
 
   const device = {
-    id: randomUUID(),
+    id: existing?.id ?? randomUUID(),
+    fpSalt: randomUUID(),
   };
 
   writePersistedCliDevice(opts.filePath, device);

--- a/packages/cli/test/unit/telemetry/task-signals.test.ts
+++ b/packages/cli/test/unit/telemetry/task-signals.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+import { fp } from '../../../src/util/telemetry/sanitize';
+
+let telemetry: RootTelemetryClient;
+let store: TelemetryEventStore;
+
+beforeEach(() => {
+  vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
+  store = new TelemetryEventStore({ isDebug: true, config: {} });
+  telemetry = new RootTelemetryClient({ opts: { store } });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('output:deploy_state', () => {
+  it('tracks ready-state constants', () => {
+    telemetry.trackDeployState('ERROR');
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'output:deploy_state', value: 'ERROR' },
+    ]);
+  });
+
+  it('redacts unexpected values', () => {
+    telemetry.trackDeployState('weird value');
+    expect(store.readonlyEvents[0]?.value).toBe('[REDACTED]');
+  });
+});
+
+describe('output:logs_matched', () => {
+  it('tracks SOME and NONE', () => {
+    telemetry.trackLogsMatched(true);
+    telemetry.trackLogsMatched(false);
+    expect(store.readonlyEvents.map(e => e.value)).toEqual(['SOME', 'NONE']);
+  });
+});
+
+describe('args_fingerprint', () => {
+  it('tracks the salted fingerprint of the argv structure', () => {
+    telemetry.trackArgsFingerprint(['deploy', '1', '--prod'], 'salt-1');
+    expect(store.readonlyEvents).toMatchObject([
+      {
+        key: 'args_fingerprint',
+        value: fp(['deploy', '1', '--prod'], 'salt-1'),
+      },
+    ]);
+    expect(store.readonlyEvents[0]?.value).not.toContain('deploy');
+  });
+
+  it('uses a local-only salt that is not the transmitted device id', () => {
+    const s = new TelemetryEventStore({ config: {} });
+    expect(s.currentFpSalt).not.toBe(s.currentDeviceId);
+  });
+});
+
+describe('agent_task_id', () => {
+  it('tracks UUID-shaped ids and skips absent ones', () => {
+    telemetry.trackAgentTaskId('A81BC81B-DEAD-4E5D-ABFF-90865D1E13B1');
+    telemetry.trackAgentTaskId(undefined);
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'agent_task_id', value: 'a81bc81b-dead-4e5d-abff-90865d1e13b1' },
+    ]);
+  });
+
+  it('redacts anything that could carry user content', () => {
+    telemetry.trackAgentTaskId('fix-payments-bug-for-acme');
+    telemetry.trackAgentTaskId('x'.repeat(65));
+    expect(store.readonlyEvents.map(e => e.value)).toEqual([
+      '[REDACTED]',
+      '[REDACTED]',
+    ]);
+  });
+});
+
+describe('v2 gating', () => {
+  it('tracks nothing without the flag', () => {
+    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
+    telemetry.trackDeployState('READY');
+    telemetry.trackLogsMatched(true);
+    telemetry.trackArgsFingerprint(['x'], 's');
+    telemetry.trackAgentTaskId('t');
+    expect(store.readonlyEvents).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
> **Stack 4/6** — stacks on `o11y/3-help-docs-config`. Flag-gated.

Enables distinguishing "API call succeeded" from "user/agent task succeeded":

- `output:deploy_state` (`READY`/`ERROR`/`CANCELED`) from `printDeploymentStatus` — one choke point covers deploy + redeploy
- `output:logs_matched` (`SOME`/`NONE`) from `displayRuntimeLogs`
- `args_fingerprint`: HMAC of the invocation's **structural shape only** (gated command token, arg count, sorted flag names — never raw argv), keyed with a **local-only salt** persisted in the device file and never transmitted. Anyone holding the telemetry cannot dictionary-test the hash; identical retries still correlate on-device
- `agent_task_id`: **UUID-shape only** from `AI_AGENT_TASK_ID` (anything else redacts) — structurally incapable of carrying user content, while still letting harnesses correlate their task with our session

Dropped `output:rollback_requested` from the plan: redundant with the existing `command:rollback` event.

Review response: the original design salted with the transmitted `device_id` and hashed raw argv — both fixed as above (the salt-transmission flaw was real; verified live that the salt never appears in batches and retries still correlate).

