### PR TITLE
[cli][detect-agent] Telemetry: harness attribution and per-terminal sessions

### DIFF
--- a/.changeset/o11y-telemetry-attribution.md
+++ b/.changeset/o11y-telemetry-attribution.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+'@vercel/detect-agent': minor
+---
+
+Detect agent harnesses via the parent process tree (Linux/macOS, fail-open) with version resolution, and scope telemetry sessions per terminal/harness context. CLI events gated behind `VERCEL_CLI_TELEMETRY_V2`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -218,6 +218,11 @@ const main = async () => {
     process.stdin.isTTY = true;
   }
 
+  const agentResult = await determineAgent({
+    inspectProcessTree: !isTelemetryFlushCommand,
+  });
+  const { isAgent, agent: detectedAgent } = agentResult;
+
   const telemetryEventStore = new TelemetryEventStore({
     isDebug: process.env.VERCEL_TELEMETRY_DEBUG === '1',
     cliDevice: isTelemetryFlushCommand
@@ -229,6 +234,22 @@ const main = async () => {
       ? undefined
       : {
           filePath: join(VERCEL_DIR, 'telemetry-session.json'),
+        },
+    sessionContext: isTelemetryFlushCommand
+      ? undefined
+      : {
+          // Harness pid when found. Env-detected agents without one get no
+          // pid at all: each agent tool-call runs in a fresh shell, and a
+          // per-shell pid would fragment one agent session into many.
+          pid:
+            agentResult.procContext?.harnessPid ??
+            (isAgent
+              ? undefined
+              : (agentResult.procContext?.shellPid ?? process.ppid)),
+          bootTime: agentResult.procContext?.bootTime,
+          // cwd only scopes sessions for harnesses; humans cd too often.
+          cwd: isAgent ? process.cwd() : undefined,
+          agent: detectedAgent?.name,
         },
   });
 
@@ -295,15 +316,18 @@ const main = async () => {
     return finishEarly(1);
   }
 
-  const { isAgent, agent: detectedAgent } = await determineAgent();
   telemetry.trackInvocationId(telemetryEventStore.currentInvocationId);
   telemetry.trackDeviceId(telemetryEventStore.currentDeviceId);
+  telemetry.trackContextId(telemetryEventStore.currentContextId);
   const vercelPluginMarker = readVercelPluginActiveSessionMarker();
   if (vercelPluginMarker) {
     telemetry.trackVercelPluginActiveSession();
     telemetry.trackVercelPluginVersion(vercelPluginMarker.pluginVersion);
   }
   telemetry.trackAgenticUse(detectedAgent?.name);
+  telemetry.trackAgentVersion(detectedAgent?.version);
+  telemetry.trackAgentDetectionSource(detectedAgent?.source);
+  telemetry.trackAgentDetectionConflict(agentResult.conflict);
   telemetry.trackCPUs();
   telemetry.trackPlatform();
   telemetry.trackArch();

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -6,6 +6,7 @@ import didYouMean from '../did-you-mean';
 import {
   REDACTED,
   crashFrame,
+  ctxHash,
   fp,
   gatedFlag,
   gatedToken,
@@ -359,6 +360,44 @@ export class TelemetryClient {
     });
   }
 
+  protected trackAgentVersion(version: string | undefined) {
+    if (!isV2() || !version) {
+      return;
+    }
+    this.track({
+      key: 'agent_version',
+      value: /^[\w.+-]{1,32}$/.test(version) ? version : REDACTED,
+    });
+  }
+
+  protected trackAgentDetectionSource(
+    source: 'env' | 'proctree' | 'both' | undefined
+  ) {
+    if (!isV2() || !source) {
+      return;
+    }
+    this.track({ key: 'agent_detection_source', value: source });
+  }
+
+  protected trackAgentDetectionConflict(
+    conflict: { env: string; proctree: string } | undefined
+  ) {
+    if (!isV2() || !conflict) {
+      return;
+    }
+    this.track({
+      key: 'agent_detection_conflict',
+      value: `proctree:${conflict.proctree},env:${conflict.env}`,
+    });
+  }
+
+  protected trackContextId(contextId: string | undefined) {
+    if (!isV2() || !contextId) {
+      return;
+    }
+    this.track({ key: 'context_id', value: contextId });
+  }
+
   protected trackCrash(err: unknown) {
     if (!isV2()) {
       return;
@@ -592,6 +631,13 @@ export class TelemetryClient {
   }
 }
 
+export interface SessionContext {
+  pid?: number;
+  bootTime?: number;
+  cwd?: string;
+  agent?: string;
+}
+
 export class TelemetryEventStore {
   private events: Event[];
   private isDebug: boolean;
@@ -601,6 +647,7 @@ export class TelemetryEventStore {
   // Local-only HMAC salt; unlike deviceId it is never sent, so hashes made
   // with it cannot be dictionary-tested by anyone holding the telemetry.
   private fpSalt: string;
+  private contextId?: string;
   private teamId = 'NO_TEAM_ID';
   private userId = 'NO_USER_ID';
   private projectId = 'NO_PROJECT_ID';
@@ -616,6 +663,7 @@ export class TelemetryEventStore {
     config?: GlobalConfig['telemetry'];
     cliDevice?: PersistedCliDeviceOptions;
     cliSession?: PersistedCliSessionOptions;
+    sessionContext?: SessionContext;
   }) {
     this.isDebug = opts?.isDebug || false;
     this.events = [];
@@ -634,6 +682,17 @@ export class TelemetryEventStore {
     }
 
     if (this.cliSessionOptions) {
+      if (opts?.sessionContext) {
+        const { pid, bootTime, cwd, agent } = opts.sessionContext;
+        this.contextId = ctxHash(
+          [pid ?? 0, bootTime ?? 0, cwd ?? '', agent ?? ''],
+          this.fpSalt
+        );
+        this.cliSessionOptions = {
+          ...this.cliSessionOptions,
+          contextKey: this.contextId,
+        };
+      }
       this.cliSession = getOrCreatePersistedCliSession(this.cliSessionOptions);
       this.sessionId = this.cliSession.id;
     } else {
@@ -696,6 +755,10 @@ export class TelemetryEventStore {
 
   get currentSessionId() {
     return this.sessionId;
+  }
+
+  get currentContextId() {
+    return this.contextId;
   }
 
   get readonlyEvents() {

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -531,6 +531,24 @@ export class RootTelemetryClient extends TelemetryClient {
     super.trackAgentTaskId(id);
   }
 
+  trackAgentVersion(version: string | undefined) {
+    super.trackAgentVersion(version);
+  }
+
+  trackAgentDetectionSource(source: 'env' | 'proctree' | 'both' | undefined) {
+    super.trackAgentDetectionSource(source);
+  }
+
+  trackAgentDetectionConflict(
+    conflict: { env: string; proctree: string } | undefined
+  ) {
+    super.trackAgentDetectionConflict(conflict);
+  }
+
+  trackContextId(contextId: string | undefined) {
+    super.trackContextId(contextId);
+  }
+
   trackAgenticUse(agent: string | undefined) {
     super.trackAgenticUse(agent);
   }

--- a/packages/cli/src/util/telemetry/session.ts
+++ b/packages/cli/src/util/telemetry/session.ts
@@ -7,6 +7,9 @@ import writeJSON from 'write-json-file';
 export const DEFAULT_CLI_SESSION_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
 export const DEFAULT_CLI_SESSION_MAX_LIFETIME_MS = 24 * 60 * 60 * 1000;
 
+const DEFAULT_CONTEXT_KEY = 'default';
+const MAX_CONTEXTS = 50;
+
 export interface PersistedCliSession {
   id: string;
   createdAt: number;
@@ -21,9 +24,15 @@ export interface PersistedCliDevice {
 
 export interface PersistedCliSessionOptions {
   filePath: string;
+  /** Scopes the session to one terminal/harness; see `ctxHash`. */
+  contextKey?: string;
   inactivityTimeoutMs?: number;
   maxLifetimeMs?: number;
   now?: () => number;
+}
+
+interface PersistedCliSessionFile {
+  contexts: Record<string, PersistedCliSession>;
 }
 
 export interface PersistedCliDeviceOptions {
@@ -54,25 +63,60 @@ function isPersistedCliDevice(value: unknown): value is PersistedCliDevice {
   return typeof device.id === 'string';
 }
 
-function readPersistedCliSession(filePath: string): PersistedCliSession | null {
+function readPersistedCliSessionFile(
+  filePath: string
+): PersistedCliSessionFile {
   try {
-    const session = loadJSON.sync(filePath);
-    return isPersistedCliSession(session) ? session : null;
+    const data = loadJSON.sync(filePath);
+    // Pre-context files held a single top-level session.
+    if (isPersistedCliSession(data)) {
+      return { contexts: { [DEFAULT_CONTEXT_KEY]: data } };
+    }
+    if (data && typeof data === 'object' && 'contexts' in data) {
+      const contexts: Record<string, PersistedCliSession> = {};
+      for (const [key, session] of Object.entries(
+        (data as PersistedCliSessionFile).contexts ?? {}
+      )) {
+        if (isPersistedCliSession(session)) {
+          contexts[key] = session;
+        }
+      }
+      return { contexts };
+    }
   } catch {
-    return null;
+    // fall through to an empty file
   }
+  return { contexts: {} };
 }
 
-function writePersistedCliSession(
+function writePersistedCliSessionFile(
   filePath: string,
-  session: PersistedCliSession
+  file: PersistedCliSessionFile
 ): void {
   try {
     mkdirSync(dirname(filePath), { recursive: true });
-    writeJSON.sync(filePath, session, { indent: 2 });
+    writeJSON.sync(filePath, file, { indent: 2 });
   } catch {
     // best-effort for telemetry
   }
+}
+
+/** Drops sessions that can no longer be reused, oldest first past the cap. */
+function prune(
+  contexts: Record<string, PersistedCliSession>,
+  now: number,
+  inactivityTimeoutMs: number,
+  maxLifetimeMs: number
+): Record<string, PersistedCliSession> {
+  const alive = Object.entries(contexts)
+    .filter(
+      ([, s]) =>
+        now - s.lastSeenAt <= inactivityTimeoutMs &&
+        now - s.createdAt <= maxLifetimeMs
+    )
+    .sort(([, a], [, b]) => b.lastSeenAt - a.lastSeenAt)
+    .slice(0, MAX_CONTEXTS);
+  return Object.fromEntries(alive);
 }
 
 function readPersistedCliDevice(filePath: string): PersistedCliDevice | null {
@@ -104,7 +148,9 @@ export function getOrCreatePersistedCliSession(
     opts.inactivityTimeoutMs ?? DEFAULT_CLI_SESSION_INACTIVITY_TIMEOUT_MS;
   const maxLifetimeMs =
     opts.maxLifetimeMs ?? DEFAULT_CLI_SESSION_MAX_LIFETIME_MS;
-  const existing = readPersistedCliSession(opts.filePath);
+  const contextKey = opts.contextKey ?? DEFAULT_CONTEXT_KEY;
+  const file = readPersistedCliSessionFile(opts.filePath);
+  const existing = file.contexts[contextKey];
 
   const shouldReuseExisting =
     existing &&
@@ -122,7 +168,10 @@ export function getOrCreatePersistedCliSession(
         lastSeenAt: now,
       };
 
-  writePersistedCliSession(opts.filePath, session);
+  file.contexts[contextKey] = session;
+  writePersistedCliSessionFile(opts.filePath, {
+    contexts: prune(file.contexts, now, inactivityTimeoutMs, maxLifetimeMs),
+  });
   return session;
 }
 
@@ -134,7 +183,9 @@ export function touchPersistedCliSession(
     ...session,
     lastSeenAt: opts.now?.() ?? Date.now(),
   };
-  writePersistedCliSession(opts.filePath, nextSession);
+  const file = readPersistedCliSessionFile(opts.filePath);
+  file.contexts[opts.contextKey ?? DEFAULT_CONTEXT_KEY] = nextSession;
+  writePersistedCliSessionFile(opts.filePath, file);
   return nextSession;
 }
 

--- a/packages/cli/test/unit/telemetry/attribution.test.ts
+++ b/packages/cli/test/unit/telemetry/attribution.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelemetryEventStore } from '../../../src/util/telemetry';
+import { RootTelemetryClient } from '../../../src/util/telemetry/root';
+import {
+  getOrCreatePersistedCliSession,
+  touchPersistedCliSession,
+} from '../../../src/util/telemetry/session';
+import { ctxHash } from '../../../src/util/telemetry/sanitize';
+
+let telemetry: RootTelemetryClient;
+let store: TelemetryEventStore;
+
+beforeEach(() => {
+  vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
+  store = new TelemetryEventStore({ isDebug: true, config: {} });
+  telemetry = new RootTelemetryClient({ opts: { store } });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('agent attribution events', () => {
+  it('tracks version, source, and conflict', () => {
+    telemetry.trackAgentVersion('1.2.3');
+    telemetry.trackAgentDetectionSource('both');
+    telemetry.trackAgentDetectionConflict({
+      env: 'cursor',
+      proctree: 'claude',
+    });
+    expect(store.readonlyEvents).toMatchObject([
+      { key: 'agent_version', value: '1.2.3' },
+      { key: 'agent_detection_source', value: 'both' },
+      { key: 'agent_detection_conflict', value: 'proctree:claude,env:cursor' },
+    ]);
+  });
+
+  it('skips absent values and redacts odd versions', () => {
+    telemetry.trackAgentVersion(undefined);
+    telemetry.trackAgentDetectionSource(undefined);
+    telemetry.trackAgentDetectionConflict(undefined);
+    telemetry.trackContextId(undefined);
+    expect(store.readonlyEvents).toHaveLength(0);
+    telemetry.trackAgentVersion('weird version!');
+    expect(store.readonlyEvents[0]?.value).toBe('[REDACTED]');
+  });
+});
+
+describe('context-scoped sessions', () => {
+  const dir = () => mkdtempSync(join(tmpdir(), 'vc-telemetry-test-'));
+
+  it('derives a context id and scopes the persisted session to it', () => {
+    const base = dir();
+    const filePath = join(base, 'telemetry-session.json');
+    // A shared device file keeps the context-hash salt stable, as in the CLI.
+    const cliDevice = { filePath: join(base, 'telemetry-device.json') };
+    const a = new TelemetryEventStore({
+      config: {},
+      cliDevice,
+      cliSession: { filePath },
+      sessionContext: { pid: 100, bootTime: 1700000000, cwd: '/repo' },
+    });
+    const b = new TelemetryEventStore({
+      config: {},
+      cliDevice,
+      cliSession: { filePath },
+      sessionContext: { pid: 200, bootTime: 1700000000, cwd: '/repo' },
+    });
+    const aAgain = new TelemetryEventStore({
+      config: {},
+      cliDevice,
+      cliSession: { filePath },
+      sessionContext: { pid: 100, bootTime: 1700000000, cwd: '/repo' },
+    });
+
+    expect(a.currentContextId).toBeDefined();
+    expect(a.currentContextId).not.toBe(b.currentContextId);
+    expect(a.currentSessionId).not.toBe(b.currentSessionId);
+    expect(aAgain.currentSessionId).toBe(a.currentSessionId);
+
+    const file = JSON.parse(readFileSync(filePath, 'utf8'));
+    expect(Object.keys(file.contexts)).toHaveLength(2);
+  });
+
+  it('is deterministic per device salt', () => {
+    expect(ctxHash([100, 1700000000, '/repo'], 'device')).toBe(
+      ctxHash([100, 1700000000, '/repo'], 'device')
+    );
+    expect(ctxHash([100, 1700000000, '/repo'], 'device')).not.toBe(
+      ctxHash([100, 1700000000, '/repo'], 'other-device')
+    );
+  });
+
+  it('migrates legacy single-session files', () => {
+    const filePath = join(dir(), 'telemetry-session.json');
+    const now = Date.now();
+    writeFileSync(
+      filePath,
+      JSON.stringify({ id: 'legacy-id', createdAt: now, lastSeenAt: now })
+    );
+
+    const session = getOrCreatePersistedCliSession({
+      filePath,
+      now: () => now,
+    });
+    expect(session.id).toBe('legacy-id');
+
+    // touch keeps the migrated map shape
+    touchPersistedCliSession({ filePath }, session);
+    const file = JSON.parse(readFileSync(filePath, 'utf8'));
+    expect(file.contexts.default.id).toBe('legacy-id');
+  });
+
+  it('prunes expired contexts on write', () => {
+    const filePath = join(dir(), 'telemetry-session.json');
+    const now = Date.now();
+    getOrCreatePersistedCliSession({
+      filePath,
+      contextKey: 'stale',
+      now: () => now - 60 * 60 * 1000,
+    });
+    getOrCreatePersistedCliSession({
+      filePath,
+      contextKey: 'fresh',
+      now: () => now,
+    });
+
+    const file = JSON.parse(readFileSync(filePath, 'utf8'));
+    expect(Object.keys(file.contexts)).toEqual(['fresh']);
+  });
+});

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -1,5 +1,9 @@
 import { access } from 'node:fs/promises';
 import { constants } from 'node:fs';
+import { inspectProcessTree } from './proc-tree';
+
+export { inspectProcessTree } from './proc-tree';
+export type { ProcessTreeResult, HarnessMatch } from './proc-tree';
 
 const DEVIN_LOCAL_PATH = '/opt/.devin';
 
@@ -35,9 +39,27 @@ export type KnownAgentNames =
 
 export interface KnownAgentDetails {
   name: KnownAgentNames;
+  /** Harness version, when resolvable from the process tree. */
+  version?: string;
+  /** How the agent was detected. */
+  source?: 'env' | 'proctree' | 'both';
 }
 
-export type AgentResult =
+export interface ProcessContext {
+  /** PID of the matched harness process, when found. */
+  harnessPid?: number;
+  /** Immediate parent of this process (typically the shell). */
+  shellPid?: number;
+  /** System boot time (epoch seconds); guards PID reuse across reboots. */
+  bootTime?: number;
+}
+
+export interface AgentDetectionConflict {
+  env: KnownAgentNames;
+  proctree: KnownAgentNames;
+}
+
+export type AgentResult = (
   | {
       isAgent: true;
       agent: KnownAgentDetails;
@@ -45,7 +67,21 @@ export type AgentResult =
   | {
       isAgent: false;
       agent: undefined;
-    };
+    }
+) & {
+  /** Populated when `inspectProcessTree` was requested and succeeded. */
+  procContext?: ProcessContext;
+  /** Populated when env and process-tree detection disagree. */
+  conflict?: AgentDetectionConflict;
+};
+
+export interface DetermineAgentOptions {
+  /**
+   * Also walk the parent process tree (Linux/macOS, ~50ms budget,
+   * fail-open) to identify the harness binary and version.
+   */
+  inspectProcessTree?: boolean;
+}
 
 export const KNOWN_AGENTS = {
   CURSOR,
@@ -63,7 +99,61 @@ export const KNOWN_AGENTS = {
   V0,
 } as const;
 
-export async function determineAgent(): Promise<AgentResult> {
+export async function determineAgent(
+  options: DetermineAgentOptions = {}
+): Promise<AgentResult> {
+  const envResult = await determineAgentFromEnv();
+  if (!options.inspectProcessTree) {
+    return envResult;
+  }
+
+  const tree = await inspectProcessTree();
+  const procContext: ProcessContext = {
+    harnessPid: tree.match?.pid,
+    shellPid: tree.shellPid,
+    bootTime: tree.bootTime,
+  };
+
+  if (envResult.isAgent && tree.match) {
+    const sameAgent = envResult.agent.name === tree.match.name;
+    return {
+      isAgent: true,
+      agent: {
+        name: envResult.agent.name,
+        version: sameAgent ? tree.match.version : undefined,
+        source: sameAgent ? 'both' : 'env',
+      },
+      procContext,
+      conflict: sameAgent
+        ? undefined
+        : { env: envResult.agent.name, proctree: tree.match.name },
+    };
+  }
+
+  if (tree.match) {
+    return {
+      isAgent: true,
+      agent: {
+        name: tree.match.name,
+        version: tree.match.version,
+        source: 'proctree',
+      },
+      procContext,
+    };
+  }
+
+  if (envResult.isAgent) {
+    return {
+      isAgent: true,
+      agent: { ...envResult.agent, source: 'env' },
+      procContext,
+    };
+  }
+
+  return { isAgent: false, agent: undefined, procContext };
+}
+
+async function determineAgentFromEnv(): Promise<AgentResult> {
   if (process.env.AI_AGENT) {
     const name = process.env.AI_AGENT.trim();
     if (name) {

--- a/packages/detect-agent/src/proc-tree.ts
+++ b/packages/detect-agent/src/proc-tree.ts
@@ -1,0 +1,259 @@
+import { execFile } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { KnownAgentNames } from './index';
+
+export interface ProcessEntry {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+export interface HarnessMatch {
+  name: KnownAgentNames;
+  pid: number;
+  version?: string;
+}
+
+export interface ProcessTreeResult {
+  match?: HarnessMatch;
+  /** Immediate parent of the CLI process (typically the shell). */
+  shellPid?: number;
+  /** System boot time (epoch seconds); guards PID reuse across reboots. */
+  bootTime?: number;
+}
+
+const MAX_DEPTH = 5;
+const BUDGET_MS = 250;
+
+// Matched against the ancestor command line. The command line itself never
+// leaves this module: only the matched constant name and version do.
+const HARNESS_MATCHERS: {
+  name: KnownAgentNames;
+  re: RegExp;
+  packages: string[];
+}[] = [
+  {
+    name: 'claude',
+    re: /(^|\/)claude(\s|$)|@anthropic-ai\/claude-code\//,
+    packages: ['@anthropic-ai/claude-code'],
+  },
+  {
+    name: 'cursor-cli',
+    re: /(^|\/)cursor-agent(\s|$)/,
+    packages: [],
+  },
+  {
+    name: 'codex',
+    re: /(^|\/)codex(\s|$)|@openai\/codex\//,
+    packages: ['@openai/codex'],
+  },
+  {
+    name: 'gemini',
+    re: /(^|\/)gemini(\s|$)|@google\/gemini-cli\//,
+    packages: ['@google/gemini-cli'],
+  },
+  {
+    name: 'opencode',
+    re: /(^|\/)opencode(\s|$)|opencode-ai\//,
+    packages: ['opencode-ai'],
+  },
+  {
+    name: 'github-copilot',
+    re: /(^|\/)copilot(\s|$)|@github\/copilot\//,
+    packages: ['@github/copilot'],
+  },
+];
+
+export function matchHarness(
+  command: string
+): { name: KnownAgentNames; packages: string[] } | undefined {
+  return HARNESS_MATCHERS.find(m => m.re.test(command));
+}
+
+/** Parses `/proc/<pid>/stat`; the comm field may contain spaces/parens. */
+export function parseProcStat(
+  stat: string
+): { pid: number; ppid: number } | undefined {
+  const close = stat.lastIndexOf(')');
+  if (close === -1) return undefined;
+  const pid = Number.parseInt(stat.slice(0, stat.indexOf(' ')), 10);
+  const rest = stat.slice(close + 2).split(' ');
+  const ppid = Number.parseInt(rest[1], 10);
+  if (Number.isNaN(pid) || Number.isNaN(ppid)) return undefined;
+  return { pid, ppid };
+}
+
+/** Parses `ps -ax -o pid=,ppid=,command=` output. */
+export function parsePsOutput(out: string): Map<number, ProcessEntry> {
+  const entries = new Map<number, ProcessEntry>();
+  for (const line of out.split('\n')) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+    if (match) {
+      const pid = Number.parseInt(match[1], 10);
+      entries.set(pid, {
+        pid,
+        ppid: Number.parseInt(match[2], 10),
+        command: match[3],
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Resolves a version for a matched node-based harness by walking up from
+ * its script path to the nearest matching package.json.
+ */
+export function resolveHarnessVersion(
+  command: string,
+  packages: string[],
+  readFile: (path: string) => string = p => readFileSync(p, 'utf8')
+): string | undefined {
+  const script = command
+    .split(' ')
+    .find(token => /\.(c|m)?js$/.test(token) && token.includes('/'));
+  if (!script) return undefined;
+
+  let dir = dirname(script);
+  for (let i = 0; i < 10; i++) {
+    try {
+      const pkg = JSON.parse(readFile(join(dir, 'package.json')));
+      if (
+        packages.includes(pkg.name) &&
+        typeof pkg.version === 'string' &&
+        /^[\w.+-]{1,32}$/.test(pkg.version)
+      ) {
+        return pkg.version;
+      }
+    } catch {
+      // keep walking up
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+export function findHarness(
+  ancestors: ProcessEntry[],
+  readFile?: (path: string) => string
+): HarnessMatch | undefined {
+  for (const entry of ancestors) {
+    const matcher = matchHarness(entry.command);
+    if (matcher) {
+      return {
+        name: matcher.name,
+        pid: entry.pid,
+        version: resolveHarnessVersion(
+          entry.command,
+          matcher.packages,
+          readFile
+        ),
+      };
+    }
+  }
+  return undefined;
+}
+
+function getAncestorsLinux(pid: number): ProcessEntry[] {
+  const ancestors: ProcessEntry[] = [];
+  let current = pid;
+  for (let i = 0; i < MAX_DEPTH && current > 1; i++) {
+    try {
+      const stat = parseProcStat(readFileSync(`/proc/${current}/stat`, 'utf8'));
+      if (!stat) break;
+      const command = readFileSync(`/proc/${current}/cmdline`, 'utf8')
+        .split('\0')
+        .join(' ')
+        .trim();
+      ancestors.push({ pid: current, ppid: stat.ppid, command });
+      current = stat.ppid;
+    } catch {
+      break;
+    }
+  }
+  return ancestors;
+}
+
+function execOnce(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { timeout: BUDGET_MS * 4 }, (err, stdout) =>
+      err ? reject(err) : resolve(stdout)
+    );
+  });
+}
+
+async function getAncestorsDarwin(pid: number): Promise<ProcessEntry[]> {
+  const table = parsePsOutput(
+    await execOnce('ps', ['-ax', '-o', 'pid=,ppid=,command='])
+  );
+  const ancestors: ProcessEntry[] = [];
+  let current = pid;
+  for (let i = 0; i < MAX_DEPTH && current > 1; i++) {
+    const entry = table.get(current);
+    if (!entry) break;
+    ancestors.push(entry);
+    current = entry.ppid;
+  }
+  return ancestors;
+}
+
+async function getBootTime(
+  platform: NodeJS.Platform
+): Promise<number | undefined> {
+  try {
+    if (platform === 'linux') {
+      const btime = readFileSync('/proc/stat', 'utf8').match(/^btime (\d+)$/m);
+      return btime ? Number.parseInt(btime[1], 10) : undefined;
+    }
+    if (platform === 'darwin') {
+      const out = await execOnce('sysctl', ['-n', 'kern.boottime']);
+      const sec = out.match(/sec\s*=\s*(\d+)/);
+      return sec ? Number.parseInt(sec[1], 10) : undefined;
+    }
+  } catch {
+    // fail open
+  }
+  return undefined;
+}
+
+/**
+ * Walks up to five process ancestors looking for a known agent harness.
+ * Linux and macOS only; anything else (or exceeding the time budget)
+ * resolves to an empty result.
+ */
+export async function inspectProcessTree(
+  opts: { pid?: number; platform?: NodeJS.Platform } = {}
+): Promise<ProcessTreeResult> {
+  const platform = opts.platform ?? process.platform;
+  const pid = opts.pid ?? process.ppid;
+
+  if (platform !== 'linux' && platform !== 'darwin') {
+    return {};
+  }
+
+  const inspect = async (): Promise<ProcessTreeResult> => {
+    const ancestors =
+      platform === 'linux'
+        ? getAncestorsLinux(pid)
+        : await getAncestorsDarwin(pid);
+    return {
+      match: findHarness(ancestors),
+      shellPid: pid,
+      bootTime: await getBootTime(platform),
+    };
+  };
+
+  const budget = new Promise<ProcessTreeResult>(resolve => {
+    const timer = setTimeout(() => resolve({}), BUDGET_MS);
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([inspect(), budget]);
+  } catch {
+    return {};
+  }
+}

--- a/packages/detect-agent/test/unit/proc-tree.test.ts
+++ b/packages/detect-agent/test/unit/proc-tree.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findHarness,
+  inspectProcessTree,
+  matchHarness,
+  parseProcStat,
+  parsePsOutput,
+  resolveHarnessVersion,
+} from '../../src/proc-tree';
+
+describe('parseProcStat', () => {
+  it('parses pid and ppid around a comm with spaces and parens', () => {
+    expect(parseProcStat('123 (my (weird) comm) S 456 123 1 0')).toEqual({
+      pid: 123,
+      ppid: 456,
+    });
+  });
+
+  it('returns undefined for malformed input', () => {
+    expect(parseProcStat('garbage')).toBeUndefined();
+  });
+});
+
+describe('parsePsOutput', () => {
+  it('parses pid, ppid, and full command', () => {
+    const table = parsePsOutput(
+      [
+        '  100     1 /sbin/launchd',
+        '  200   100 /bin/zsh -il',
+        '  300   200 node /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js --continue',
+      ].join('\n')
+    );
+    expect(table.get(300)).toEqual({
+      pid: 300,
+      ppid: 200,
+      command:
+        'node /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js --continue',
+    });
+  });
+});
+
+describe('matchHarness', () => {
+  it.each([
+    ['node /x/@anthropic-ai/claude-code/cli.js', 'claude'],
+    ['/opt/homebrew/bin/claude', 'claude'],
+    ['cursor-agent --port 1', 'cursor-cli'],
+    ['/usr/local/bin/codex exec', 'codex'],
+    ['node /x/@google/gemini-cli/dist/index.js', 'gemini'],
+    ['opencode', 'opencode'],
+    ['node /x/@github/copilot/index.js', 'github-copilot'],
+  ])('matches %s as %s', (command, name) => {
+    expect(matchHarness(command)?.name).toBe(name);
+  });
+
+  it.each([
+    ['/bin/zsh -il'],
+    ['node server.js'],
+    ['vim claude-notes.md'],
+    ['/Users/x/my-claude-project/run.sh'],
+  ])('does not match %s', command => {
+    expect(matchHarness(command)).toBeUndefined();
+  });
+});
+
+describe('resolveHarnessVersion', () => {
+  const files: Record<string, string> = {
+    '/lib/node_modules/@anthropic-ai/claude-code/package.json': JSON.stringify({
+      name: '@anthropic-ai/claude-code',
+      version: '1.2.3',
+    }),
+  };
+  const readFile = (p: string) => {
+    if (p in files) return files[p];
+    throw new Error('ENOENT');
+  };
+
+  it('finds the nearest matching package.json', () => {
+    expect(
+      resolveHarnessVersion(
+        'node /lib/node_modules/@anthropic-ai/claude-code/cli.js',
+        ['@anthropic-ai/claude-code'],
+        readFile
+      )
+    ).toBe('1.2.3');
+  });
+
+  it('ignores non-matching packages and binaries without scripts', () => {
+    expect(
+      resolveHarnessVersion(
+        'node /lib/node_modules/@anthropic-ai/claude-code/cli.js',
+        ['@other/pkg'],
+        readFile
+      )
+    ).toBeUndefined();
+    expect(
+      resolveHarnessVersion('/usr/bin/claude', ['@anthropic-ai/claude-code'])
+    ).toBeUndefined();
+  });
+});
+
+describe('findHarness', () => {
+  it('returns the first matching ancestor with its pid', () => {
+    const match = findHarness([
+      { pid: 400, ppid: 300, command: '/bin/zsh' },
+      { pid: 300, ppid: 200, command: 'cursor-agent' },
+      { pid: 200, ppid: 1, command: '/sbin/launchd' },
+    ]);
+    expect(match).toMatchObject({ name: 'cursor-cli', pid: 300 });
+  });
+});
+
+describe('inspectProcessTree', () => {
+  it('returns empty on unsupported platforms', async () => {
+    expect(await inspectProcessTree({ platform: 'win32' })).toEqual({});
+  });
+
+  it('fails open on the current platform', async () => {
+    const result = await inspectProcessTree();
+    // Running under a test harness: no assertion on the match itself,
+    // only that the walk terminates and never throws.
+    expect(result).toBeTypeOf('object');
+  });
+});


### PR DESCRIPTION
> **Stack 5/6** — stacks on `o11y/4-task-signals`. CLI events flag-gated.

**detect-agent** (bulk of the diff, isolated package):
- `inspectProcessTree()`: walks ≤5 ancestors (Linux `/proc`, macOS `ps`), 250 ms fail-open budget; matches known harness binaries/packages; resolves version from the nearest matching `package.json` (never execs anything). **Invariant: the raw command line — which can contain prompt text — never crosses the module boundary**; only constant names + validated versions do. Windows: env-only fallback
- `determineAgent({inspectProcessTree})` merges env + proc-tree detection: `source` = `env`/`proctree`/`both`, explicit `conflict` when they disagree (env name wins for continuity)

**cli**:
- New events: `agent_version`, `agent_detection_source`, `agent_detection_conflict`, `context_id` (hash of harness-pid/boot-time/cwd-for-harnesses/agent, keyed with the **local-only, never-transmitted salt** from #4 — not the transmitted device id)
- Env-detected agents without a resolvable harness pid key their context on (boot time, cwd, agent) rather than the per-tool-call shell pid, so one agent session does not fragment into many streams (validated live against Claude Code and Codex)
- `telemetry-session.json` re-keyed to a per-context map — concurrent terminals/harnesses on one machine no longer share a session. Same 30 min/24 h windows, pruned on write, capped at 50; legacy single-session files migrate in place

Tests: fixture-driven parsers (`/proc` stat, `ps` output), version resolution, API-boundary shape, session scoping/migration/pruning. Live-validated: concurrent human + Pi + Claude Code + Codex sessions reconstruct as exactly one stream each.

