### PR TITLE
[cli] Telemetry v2: enable by default and document the event catalog

### DIFF
--- a/.changeset/o11y-telemetry-flip.md
+++ b/.changeset/o11y-telemetry-flip.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Enable telemetry v2 events by default (removing the `VERCEL_CLI_TELEMETRY_V2` gate); the standard opt-out via `vercel telemetry disable` or `VERCEL_TELEMETRY_DISABLED` applies.

--- a/packages/cli/src/util/telemetry/README.md
+++ b/packages/cli/src/util/telemetry/README.md
@@ -124,3 +124,33 @@ it('tracks humor level', async () => {
   ]);
 });
 ```
+
+## Failure and outcome events
+
+Beyond command/flag usage, the CLI records structured failure and outcome
+signals. All values pass through the sanitization primitives in
+`sanitize.ts` (constants, charset-gated short tokens, our own doc slugs,
+salted hashes, or counts) — free-form user input never leaves the machine.
+
+| Key | Value | Emitted from |
+| --- | --- | --- |
+| `exit_code` | numeric exit code, every invocation | `finishWithExitCode` |
+| `command_not_found` / `command_not_found_suggestion` | `gatedToken` of the unknown token; did-you-mean match or `NONE` | `index.ts` |
+| `subcommand_not_found` | `gatedToken` of the unknown subcommand | `getSubcommand` |
+| `parse_error` | `unknown_option:<gatedFlag>` or the `arg` error code | `parseArguments` |
+| `error_status` / `error_code` / `error_slug` / `error_action` | structured fields from tracked errors (all users) | `trackError` via `printError` and the root handler |
+| `error_server_message` | first 500 chars of the server message (**agent sessions only**) | `trackError` |
+| `docs_link_shown` | `slug` of our own err.sh/docs link | `trackError` |
+| `crash` | error name + top stack-frame basename and line | uncaught handlers |
+| `help_rendered` | help context (e.g. `root`) | `index.ts` |
+| `project_config_error` / `project_config_validation` | `parse`/`not_found_explicit`; `NowBuildError` code | `index.ts`, `validateConfig` |
+| `config_error` / `auth_config_error` | `read`/`write`; sent as a single **anonymous** event when the CLI config is unreadable | `index.ts` |
+| `output:deploy_state` / `output:logs_matched` | deployment `readyState`; `SOME`/`NONE` | `printDeploymentStatus`, `displayRuntimeLogs` |
+| `args_fingerprint` | HMAC of the invocation's structural shape (command token, arg count, flag names) keyed with a local-only salt that is never transmitted | `index.ts` |
+| `agent`, `agent_version`, `agent_detection_source`, `agent_detection_conflict` | detected harness name/version, `env`/`proctree`/`both`, conflicts | `@vercel/detect-agent` |
+| `agent_task_id` | UUID-shaped id from `AI_AGENT_TASK_ID` (anything else redacts) | `index.ts` |
+| `context_id` | hash scoping the session to one terminal/harness, keyed with the same local-only salt | event store |
+
+Sessions are persisted per context in `telemetry-session.json` as a map of
+context hashes to sessions (30 min inactivity / 24 h max, pruned, capped at
+50 entries).

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -30,10 +30,6 @@ import { isNativeBinaryInstall } from '../native-install';
 const LogLabel = `['telemetry']:`;
 const MAX_ERROR_SERVER_MESSAGE_LENGTH = 500;
 
-function isV2(): boolean {
-  return process.env.VERCEL_CLI_TELEMETRY_V2 === '1';
-}
-
 function getProperty<T extends 'string' | 'number'>(
   value: unknown,
   key: string,
@@ -169,9 +165,6 @@ export class TelemetryClient {
   }
 
   protected trackExitCode(code: number) {
-    if (!isV2()) {
-      return;
-    }
     this.track({
       key: 'exit_code',
       value: String(code),
@@ -182,17 +175,14 @@ export class TelemetryClient {
   private serverMessagesSeen = new WeakSet<object>();
 
   /**
-   * Structured error fields for all users under v2; the free-text server
-   * message only for agent sessions. Deduped per error object because both
+   * Structured error fields for all users; the free-text server message
+   * only for agent sessions. Deduped per error object because both
    * `printError` and the top-level handler may see the same error.
    */
   protected trackError(err: unknown, opts: { agent?: boolean } = {}) {
     const ref = typeof err === 'object' && err !== null ? err : undefined;
 
-    if (
-      (opts.agent || isV2()) &&
-      !(ref && this.structuredErrorsSeen.has(ref))
-    ) {
+    if (!(ref && this.structuredErrorsSeen.has(ref))) {
       if (ref) {
         this.structuredErrorsSeen.add(ref);
       }
@@ -201,7 +191,7 @@ export class TelemetryClient {
       this.trackErrorSlug(getProperty(err, 'slug', 'string'));
       this.trackErrorAction(getProperty(err, 'action', 'string'));
       const link = getProperty(err, 'link', 'string');
-      if (isV2() && link) {
+      if (link) {
         this.trackDocsLinkShown(link);
       }
     }
@@ -223,9 +213,6 @@ export class TelemetryClient {
    * could be arbitrary user content — is redacted.
    */
   protected trackParseError(err: unknown, knownFlags: readonly string[] = []) {
-    if (!isV2()) {
-      return;
-    }
     const code = getProperty(err, 'code', 'string');
     let value = 'unknown';
     if (code === 'ARG_UNKNOWN_OPTION' && isError(err)) {
@@ -248,9 +235,6 @@ export class TelemetryClient {
    * or project names, so only the fact is recorded.
    */
   protected trackCommandNotFound(token: string, suggestion?: string) {
-    if (!isV2()) {
-      return;
-    }
     this.track({
       key: 'command_not_found',
       value: suggestion ? gatedToken(token) : REDACTED,
@@ -266,9 +250,6 @@ export class TelemetryClient {
     token: string | undefined,
     suggestion?: string
   ) {
-    if (!isV2()) {
-      return;
-    }
     this.track({
       key: 'subcommand_not_found',
       value: token ? (suggestion ? gatedToken(token) : REDACTED) : 'NONE',
@@ -276,30 +257,18 @@ export class TelemetryClient {
   }
 
   protected trackDocsLinkShown(link: string) {
-    if (!isV2()) {
-      return;
-    }
     this.track({ key: 'docs_link_shown', value: slug(link) });
   }
 
   protected trackHelpRendered(context: string) {
-    if (!isV2()) {
-      return;
-    }
     this.track({ key: 'help_rendered', value: gatedToken(context) });
   }
 
   protected trackProjectConfigError(kind: 'parse' | 'not_found_explicit') {
-    if (!isV2()) {
-      return;
-    }
     this.track({ key: 'project_config_error', value: kind });
   }
 
   protected trackProjectConfigValidation(code: string | undefined) {
-    if (!isV2()) {
-      return;
-    }
     this.track({
       key: 'project_config_validation',
       value: code && /^[A-Z0-9_]{1,64}$/.test(code) ? code : REDACTED,
@@ -307,23 +276,14 @@ export class TelemetryClient {
   }
 
   protected trackConfigError(kind: 'read' | 'write') {
-    if (!isV2()) {
-      return;
-    }
     this.track({ key: 'config_error', value: kind });
   }
 
   protected trackAuthConfigError(kind: 'read') {
-    if (!isV2()) {
-      return;
-    }
     this.track({ key: 'auth_config_error', value: kind });
   }
 
   protected trackDeployState(readyState: string) {
-    if (!isV2()) {
-      return;
-    }
     this.trackCommandOutput({
       key: 'deploy_state',
       value: /^[A-Z_]{1,32}$/.test(readyState) ? readyState : REDACTED,
@@ -331,9 +291,6 @@ export class TelemetryClient {
   }
 
   protected trackLogsMatched(matched: boolean) {
-    if (!isV2()) {
-      return;
-    }
     this.trackCommandOutput({
       key: 'logs_matched',
       value: matched ? 'SOME' : 'NONE',
@@ -341,14 +298,11 @@ export class TelemetryClient {
   }
 
   protected trackArgsFingerprint(argv: readonly string[], salt: string) {
-    if (!isV2()) {
-      return;
-    }
     this.track({ key: 'args_fingerprint', value: fp(argv, salt) });
   }
 
   protected trackAgentTaskId(id: string | undefined) {
-    if (!isV2() || !id) {
+    if (!id) {
       return;
     }
     // UUID-shape only: structurally incapable of carrying user content.
@@ -361,7 +315,7 @@ export class TelemetryClient {
   }
 
   protected trackAgentVersion(version: string | undefined) {
-    if (!isV2() || !version) {
+    if (!version) {
       return;
     }
     this.track({
@@ -373,7 +327,7 @@ export class TelemetryClient {
   protected trackAgentDetectionSource(
     source: 'env' | 'proctree' | 'both' | undefined
   ) {
-    if (!isV2() || !source) {
+    if (!source) {
       return;
     }
     this.track({ key: 'agent_detection_source', value: source });
@@ -382,7 +336,7 @@ export class TelemetryClient {
   protected trackAgentDetectionConflict(
     conflict: { env: string; proctree: string } | undefined
   ) {
-    if (!isV2() || !conflict) {
+    if (!conflict) {
       return;
     }
     this.track({
@@ -392,16 +346,13 @@ export class TelemetryClient {
   }
 
   protected trackContextId(contextId: string | undefined) {
-    if (!isV2() || !contextId) {
+    if (!contextId) {
       return;
     }
     this.track({ key: 'context_id', value: contextId });
   }
 
   protected trackCrash(err: unknown) {
-    if (!isV2()) {
-      return;
-    }
     const name =
       isError(err) && /^[a-zA-Z]{1,64}$/.test(err.name) ? err.name : 'Error';
     const stack = isError(err) ? err.stack : undefined;

--- a/packages/cli/test/unit/telemetry/attribution.test.ts
+++ b/packages/cli/test/unit/telemetry/attribution.test.ts
@@ -14,7 +14,6 @@ let telemetry: RootTelemetryClient;
 let store: TelemetryEventStore;
 
 beforeEach(() => {
-  vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
   store = new TelemetryEventStore({ isDebug: true, config: {} });
   telemetry = new RootTelemetryClient({ opts: { store } });
 });

--- a/packages/cli/test/unit/telemetry/exit-code.test.ts
+++ b/packages/cli/test/unit/telemetry/exit-code.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { TelemetryEventStore } from '../../../src/util/telemetry';
 import { RootTelemetryClient } from '../../../src/util/telemetry/root';
 
@@ -16,20 +16,10 @@ describe('exit_code tracking', () => {
     });
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it('tracks exit_code when v2 flag is enabled', () => {
-    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
+  it('tracks exit_code', () => {
     telemetry.trackExitCode(1);
     expect(telemetryEventStore.readonlyEvents).toMatchObject([
       { key: 'exit_code', value: '1' },
     ]);
-  });
-
-  it('tracks nothing without the v2 flag', () => {
-    telemetry.trackExitCode(1);
-    expect(telemetryEventStore.readonlyEvents).toHaveLength(0);
   });
 });

--- a/packages/cli/test/unit/telemetry/failure-events.test.ts
+++ b/packages/cli/test/unit/telemetry/failure-events.test.ts
@@ -13,7 +13,6 @@ let telemetry: RootTelemetryClient;
 let store: TelemetryEventStore;
 
 beforeEach(() => {
-  vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
   store = new TelemetryEventStore({ isDebug: true, config: {} });
   telemetry = new RootTelemetryClient({ opts: { store } });
 });
@@ -35,7 +34,7 @@ describe('trackError', () => {
       serverMessage: 'Rate limited',
     });
 
-  it('tracks structured fields for non-agents under v2', () => {
+  it('tracks structured fields for non-agents', () => {
     telemetry.trackError(apiError());
     expect(store.readonlyEvents).toMatchObject([
       { key: 'error_status', value: '429' },
@@ -45,14 +44,7 @@ describe('trackError', () => {
     ]);
   });
 
-  it('tracks nothing for non-agents without v2', () => {
-    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
-    telemetry.trackError(apiError());
-    expect(store.readonlyEvents).toHaveLength(0);
-  });
-
-  it('adds server message for agents regardless of v2', () => {
-    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
+  it('adds server message for agents', () => {
     telemetry.trackError(apiError(), { agent: true });
     expect(keys()).toEqual([
       'error_status',
@@ -119,12 +111,6 @@ describe('command_not_found', () => {
       { key: 'command_not_found', value: '[REDACTED]' },
       { key: 'command_not_found_suggestion', value: 'NONE' },
     ]);
-  });
-
-  it('tracks nothing without v2', () => {
-    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
-    telemetry.trackCommandNotFound('deplyo', 'deploy');
-    expect(store.readonlyEvents).toHaveLength(0);
   });
 });
 

--- a/packages/cli/test/unit/telemetry/help-docs-config.test.ts
+++ b/packages/cli/test/unit/telemetry/help-docs-config.test.ts
@@ -8,7 +8,6 @@ let telemetry: RootTelemetryClient;
 let store: TelemetryEventStore;
 
 beforeEach(() => {
-  vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
   store = new TelemetryEventStore({ isDebug: true, config: {} });
   telemetry = new RootTelemetryClient({ opts: { store } });
 });
@@ -93,15 +92,5 @@ describe('cli config events', () => {
       { key: 'config_error', value: 'read' },
       { key: 'auth_config_error', value: 'read' },
     ]);
-  });
-
-  it('tracks nothing without v2', () => {
-    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
-    telemetry.trackHelpRendered('root');
-    telemetry.trackProjectConfigError('parse');
-    telemetry.trackConfigError('read');
-    telemetry.trackAuthConfigError('read');
-    telemetry.trackProjectConfigValidation('X');
-    expect(store.readonlyEvents).toHaveLength(0);
   });
 });

--- a/packages/cli/test/unit/telemetry/task-signals.test.ts
+++ b/packages/cli/test/unit/telemetry/task-signals.test.ts
@@ -7,7 +7,6 @@ let telemetry: RootTelemetryClient;
 let store: TelemetryEventStore;
 
 beforeEach(() => {
-  vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '1');
   store = new TelemetryEventStore({ isDebug: true, config: {} });
   telemetry = new RootTelemetryClient({ opts: { store } });
 });
@@ -72,16 +71,5 @@ describe('agent_task_id', () => {
       '[REDACTED]',
       '[REDACTED]',
     ]);
-  });
-});
-
-describe('v2 gating', () => {
-  it('tracks nothing without the flag', () => {
-    vi.stubEnv('VERCEL_CLI_TELEMETRY_V2', '');
-    telemetry.trackDeployState('READY');
-    telemetry.trackLogsMatched(true);
-    telemetry.trackArgsFingerprint(['x'], 's');
-    telemetry.trackAgentTaskId('t');
-    expect(store.readonlyEvents).toHaveLength(0);
   });
 });


### PR DESCRIPTION
> **Stack 6/6** — stacks on `o11y/5-attribution`.

- Deletes `VERCEL_CLI_TELEMETRY_V2` and all gate checks; v2 events now ship under the standard opt-out (`vercel telemetry disable` / `VERCEL_TELEMETRY_DISABLED=1`)
- Adds the full event + sanitization catalog to the telemetry README

⚠️ **Merge gates**: (1) data-team sign-off on canary volume — every invocation now emits ~4 extra events, failures more; (2) the public docs page `vercel.com/docs/cli/about-telemetry` (external repo) must list the new categories before this merges, since the first-run notice links there.

