### PR TITLE
[cli] Read coding agent keys on demand

### DIFF
--- a/.changeset/keychain-fetch-on-use.md
+++ b/.changeset/keychain-fetch-on-use.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Keep macOS Keychain credentials out of the shell environment when configuring Claude Code and supported Codex versions.

--- a/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
+++ b/packages/cli/src/commands/ai-gateway/coding-agents-setup.ts
@@ -52,12 +52,19 @@ import {
   promptAgentConsent,
 } from '../../util/ai-gateway/coding-agents/consent';
 import { runMachine } from '../../util/ai-gateway/coding-agents/machine';
-import { KEY_PLACEHOLDER } from '../../util/ai-gateway/coding-agents/gateway';
+import {
+  GATEWAY_API_KEY_ENV,
+  KEY_PLACEHOLDER,
+} from '../../util/ai-gateway/coding-agents/gateway';
 import {
   isKeychainAvailable,
   storeKeyInKeychain,
   copyToClipboard,
 } from '../../util/ai-gateway/coding-agents/keychain';
+import {
+  detectCodexAuthSupport,
+  MIN_CODEX_AUTH_VERSION,
+} from '../../util/ai-gateway/coding-agents/codex-version';
 import {
   outputAgentError,
   shouldEmitNonInteractiveCommandError,
@@ -351,6 +358,25 @@ export default async function codingAgentsSetup(
     useKeychain = await promptKeychain(client);
   }
 
+  let codexSupportsAuthCommand = true;
+  if (useKeychain && agents.some(a => a.id === 'codex')) {
+    const support = detectCodexAuthSupport();
+    codexSupportsAuthCommand = support.supported;
+    if (!support.supported) {
+      const message = support.version
+        ? `Codex ${support.version} can't read the key from the macOS Keychain (needs ${MIN_CODEX_AUTH_VERSION} or newer); Codex will use the ${GATEWAY_API_KEY_ENV} environment variable instead. Update Codex and re-run to switch.`
+        : `Couldn't determine the Codex version; Codex will use the ${GATEWAY_API_KEY_ENV} environment variable instead of the macOS Keychain. Check that codex is on your PATH and re-run to switch.`;
+      machineWarnings.push({
+        agent: 'codex',
+        code: 'codex_auth_command_unsupported',
+        message,
+      });
+      if (!machine) {
+        printWarning(message);
+      }
+    }
+  }
+
   if (canPrompt && !yes) {
     const missing = agents.filter(
       a =>
@@ -394,6 +420,7 @@ export default async function codingAgentsSetup(
     apiKey: previewKey,
     home,
     useKeychain,
+    codexSupportsAuthCommand,
     overrides,
     shellRcOverride,
     baseUrlOverride: baseUrl,
@@ -425,6 +452,7 @@ export default async function codingAgentsSetup(
           expiresAt: keyExpiresAt,
         }),
       useKeychain,
+      codexSupportsAuthCommand,
       overrides,
       shellRcOverride,
       baseUrlOverride: baseUrl,
@@ -588,6 +616,7 @@ export default async function codingAgentsSetup(
     apiKey: keySource.key,
     home,
     useKeychain,
+    codexSupportsAuthCommand,
     overrides,
     shellRcOverride,
     baseUrlOverride: baseUrl,

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/claude-code.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
-import type { CodingAgent, EnvExport } from '../types';
-import { mergeJson, pathExists } from '../config-files';
+import type { CodingAgent } from '../types';
+import { mergeJson, pathExists, removeJsonPath } from '../config-files';
+import { keychainHelperCommand } from '../keychain';
 import {
   GATEWAY_CLAUDE_CODE_BASE_URL,
   resolveGatewayBaseUrl,
@@ -12,10 +13,9 @@ import {
  * `/v1` (the Anthropic SDK appends `/v1/messages`). `ANTHROPIC_API_KEY` must be
  * emptied because it takes precedence over `ANTHROPIC_AUTH_TOKEN`.
  *
- * With Keychain enabled we keep the token out of `settings.json` and export
- * `ANTHROPIC_AUTH_TOKEN` from the shell rc (resolved from the Keychain) instead,
- * so the secret never lands in the config file. Claude Code then reads the token
- * from its inherited environment.
+ * With Keychain enabled we keep the token out of `settings.json` and use
+ * `apiKeyHelper` so Claude Code reads it directly from the Keychain.
+ * `ANTHROPIC_AUTH_TOKEN` is emptied so it cannot shadow the helper.
  *
  * Docs: https://vercel.com/docs/ai-gateway/coding-agents/claude-code
  */
@@ -50,9 +50,10 @@ export const claudeCode: CodingAgent = {
       ANTHROPIC_API_KEY: '',
       CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: '1',
     };
-    const envExports: EnvExport[] = [];
+    const patch: Record<string, unknown> = { env };
     if (ctx.useKeychain) {
-      envExports.push({ name: 'ANTHROPIC_AUTH_TOKEN', value: ctx.apiKey });
+      patch.apiKeyHelper = keychainHelperCommand();
+      env.ANTHROPIC_AUTH_TOKEN = '';
     } else {
       env.ANTHROPIC_AUTH_TOKEN = ctx.apiKey;
     }
@@ -62,14 +63,18 @@ export const claudeCode: CodingAgent = {
           path,
           label: 'Claude Code settings',
           format: 'json',
-          transform: current => mergeJson(current, { env }),
+          transform: current => {
+            const next = mergeJson(current, patch);
+            return ctx.useKeychain
+              ? next
+              : removeJsonPath(next, ['apiKeyHelper'], keychainHelperCommand());
+          },
         },
       ],
-      envExports,
+      envExports: [],
       notes: ctx.useKeychain
         ? [
-            'The Anthropic auth token is read from your shell environment (Keychain-backed).',
-            'Open a new terminal so ANTHROPIC_AUTH_TOKEN is loaded, then restart Claude Code.',
+            'Claude Code reads the key from the macOS Keychain. Restart Claude Code to pick up the new settings.',
           ]
         : ['Restart Claude Code to pick up the new settings.'],
     };

--- a/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/agents/codex.ts
@@ -1,7 +1,8 @@
 import { join } from 'node:path';
-import type { AgentWarning, CodingAgent } from '../types';
-import { mergeToml, pathExists } from '../config-files';
+import type { AgentWarning, CodingAgent, EnvExport } from '../types';
+import { mergeToml, pathExists, removeTomlPath } from '../config-files';
 import { isMacAppInstalled } from '../desktop-apps';
+import { keychainAuthCommand } from '../keychain';
 import {
   GATEWAY_CODEX_BASE_URL,
   GATEWAY_API_KEY_ENV,
@@ -18,8 +19,10 @@ const CODEX_DESKTOP_APP = 'Codex.app';
  * rejected by current Codex). We deliberately do NOT pin a `model` — the user
  * keeps choosing their own. `wire_api` MUST be `responses` — Codex removed Chat
  * Completions support, and the gateway serves the Responses API at
- * `/v1/responses`. The key itself never lands in the TOML; `env_key` names an env
- * var Codex reads at runtime, so we also export it via the shell rc.
+ * `/v1/responses`.
+ *
+ * Codex 0.118.0+ can read the Keychain through provider `auth`; older versions
+ * use `env_key` and a shell export. The two settings are mutually exclusive.
  *
  * Docs: https://vercel.com/docs/ai-gateway/coding-agents/openai-codex
  */
@@ -61,33 +64,55 @@ export const codex: CodingAgent = {
 
   buildPlan(ctx) {
     const path = this.configPath(ctx);
+    const useAuthCommand =
+      Boolean(ctx.useKeychain) && ctx.codexSupportsAuthCommand !== false;
+    const provider: Record<string, unknown> = {
+      name: 'Vercel AI Gateway',
+      base_url: resolveGatewayBaseUrl(
+        ctx.baseUrlOverride,
+        GATEWAY_CODEX_BASE_URL
+      ),
+      wire_api: 'responses',
+    };
+    if (useAuthCommand) {
+      const { command, args } = keychainAuthCommand();
+      provider.auth = {
+        command,
+        args,
+        timeout_ms: 5000,
+        refresh_interval_ms: 300000,
+      };
+    } else {
+      provider.env_key = GATEWAY_API_KEY_ENV;
+    }
+    const envExports: EnvExport[] = useAuthCommand
+      ? []
+      : [{ name: GATEWAY_API_KEY_ENV, value: ctx.apiKey }];
     return {
       fileChanges: [
         {
           path,
           label: 'Codex config',
           format: 'toml',
-          transform: current =>
-            mergeToml(current, {
+          transform: current => {
+            const merged = mergeToml(current, {
               model_provider: 'vercel',
-              model_providers: {
-                vercel: {
-                  name: 'Vercel AI Gateway',
-                  base_url: resolveGatewayBaseUrl(
-                    ctx.baseUrlOverride,
-                    GATEWAY_CODEX_BASE_URL
-                  ),
-                  env_key: GATEWAY_API_KEY_ENV,
-                  wire_api: 'responses',
-                },
-              },
-            }),
+              model_providers: { vercel: provider },
+            });
+            return removeTomlPath(merged, [
+              'model_providers',
+              'vercel',
+              useAuthCommand ? 'env_key' : 'auth',
+            ]);
+          },
         },
       ],
-      envExports: [{ name: GATEWAY_API_KEY_ENV, value: ctx.apiKey }],
+      envExports,
       notes: [
         'Codex now defaults to the Vercel AI Gateway; pick a model with --model or in config.',
-        `Open a new terminal so ${GATEWAY_API_KEY_ENV} is loaded, or run: export ${GATEWAY_API_KEY_ENV}=<key>`,
+        useAuthCommand
+          ? 'Codex reads the key from the macOS Keychain; restart Codex to pick up the new config.'
+          : `Open a new terminal so ${GATEWAY_API_KEY_ENV} is loaded, or run: export ${GATEWAY_API_KEY_ENV}=<key>`,
       ],
     };
   },

--- a/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/apply.ts
@@ -6,6 +6,7 @@ import {
   writeConfigFile,
   upsertManagedBlock,
   isSymlink,
+  MANAGED_BLOCK_START,
 } from './config-files';
 import { KEY_PLACEHOLDER } from './gateway';
 import { keychainLookup } from './keychain';
@@ -178,6 +179,18 @@ export async function buildSetupPlan(
       owner: 'Environment',
       transform: current => upsertManagedBlock(current, body),
     });
+  } else if (ctx.useKeychain) {
+    const rcPath = detectShellRc(ctx.home, ctx.shellRcOverride);
+    const rc = await readFileOrNull(rcPath);
+    if (rc?.includes(MANAGED_BLOCK_START)) {
+      notes.push({
+        id: 'environment',
+        displayName: 'Environment',
+        notes: [
+          `${rcPath} still exports the key from an earlier setup; the selected agents no longer need it. Remove the "vercel ai-gateway" block if nothing else uses it.`,
+        ],
+      });
+    }
   }
 
   const byPath = new Map<

--- a/packages/cli/src/util/ai-gateway/coding-agents/codex-version.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/codex-version.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from 'node:child_process';
+
+/** First Codex release with command-backed custom-provider authentication. */
+export const MIN_CODEX_AUTH_VERSION = '0.118.0';
+
+export interface CodexAuthSupport {
+  supported: boolean;
+  version: string | null;
+}
+
+export function parseCodexVersion(output: string): string | null {
+  return output.match(/\d+\.\d+\.\d+/)?.[0] ?? null;
+}
+
+export function supportsAuthCommand(version: string): boolean {
+  const parts = version.split('.').map(Number);
+  const min = MIN_CODEX_AUTH_VERSION.split('.').map(Number);
+  for (let i = 0; i < min.length; i++) {
+    if (parts[i] !== min[i]) {
+      return parts[i] > min[i];
+    }
+  }
+  return true;
+}
+
+export function detectCodexAuthSupport(): CodexAuthSupport {
+  let out: string;
+  try {
+    out = execFileSync('codex', ['--version'], {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return { supported: false, version: null };
+  }
+  const version = parseCodexVersion(out);
+  return version
+    ? { supported: supportsAuthCommand(version), version }
+    : { supported: false, version: null };
+}

--- a/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/config-files.ts
@@ -164,6 +164,13 @@ function tomlScalar(value: unknown): string | null {
       return Number.isFinite(value) ? String(value) : null;
     case 'boolean':
       return String(value);
+    case 'object': {
+      if (Array.isArray(value)) {
+        const items = value.map(tomlScalar);
+        return items.some(i => i === null) ? null : `[${items.join(', ')}]`;
+      }
+      return null;
+    }
     default:
       return null;
   }
@@ -343,6 +350,141 @@ export function mergeToml(current: string | null, patch: JsonObject): string {
     // fall through to the legacy rewrite
   }
   return legacy();
+}
+
+/** Remove an assignment or table while preserving unrelated TOML text. */
+export function removeTomlPath(current: string, path: string[]): string {
+  if (!current.trim() || path.length === 0) {
+    return current;
+  }
+  let parsed: JsonObject;
+  try {
+    parsed = tomlParse(current) as JsonObject;
+  } catch {
+    return current;
+  }
+  let cursor: unknown = parsed;
+  for (const seg of path.slice(0, -1)) {
+    if (!isPlainObject(cursor)) {
+      return current;
+    }
+    cursor = cursor[seg];
+  }
+  const leaf = path[path.length - 1];
+  if (!isPlainObject(cursor) || !(leaf in cursor)) {
+    return current;
+  }
+  const removed = cursor[leaf];
+  delete cursor[leaf];
+
+  const lines = current.split('\n');
+  const content = (line: string) =>
+    line.endsWith('\r') ? line.slice(0, -1) : line;
+  const headerAt = (i: number): string | null => {
+    const m = content(lines[i]).match(TOML_HEADER);
+    if (!m) {
+      return null;
+    }
+    return m[1]
+      .split('.')
+      .map(s => s.trim())
+      .join('.');
+  };
+
+  const out: string[] = [];
+  if (isPlainObject(removed)) {
+    const name = path.join('.');
+    let skipping = false;
+    for (let i = 0; i < lines.length; i++) {
+      const header = headerAt(i);
+      if (header !== null) {
+        skipping = header === name || header.startsWith(`${name}.`);
+      }
+      if (!skipping) {
+        out.push(lines[i]);
+      }
+    }
+  } else {
+    const section = path.slice(0, -1).join('.');
+    const escaped = leaf.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const assignment = new RegExp(`^\\s*${escaped}\\s*=`);
+    let inSection = section === '';
+    let removedLine = false;
+    for (let i = 0; i < lines.length; i++) {
+      const header = headerAt(i);
+      if (header !== null) {
+        inSection = header === section;
+      } else if (
+        inSection &&
+        !removedLine &&
+        assignment.test(content(lines[i]))
+      ) {
+        removedLine = true;
+        continue;
+      }
+      out.push(lines[i]);
+    }
+  }
+
+  const result = out.join('\n');
+  try {
+    if (isDeepStrictEqual(tomlParse(result), parsed)) {
+      return result;
+    }
+  } catch {
+    // fall through to the full rewrite
+  }
+  return `${tomlStringify(parsed)}\n`;
+}
+
+/** Remove a JSON key, optionally only when it matches an expected value. */
+export function removeJsonPath(
+  current: string,
+  path: string[],
+  onlyIfEquals?: unknown
+): string {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(current);
+  } catch {
+    return current;
+  }
+  if (!isPlainObject(raw) || path.length === 0) {
+    return current;
+  }
+  let cursor: unknown = raw;
+  for (const seg of path.slice(0, -1)) {
+    if (!isPlainObject(cursor)) {
+      return current;
+    }
+    cursor = cursor[seg];
+  }
+  const leaf = path[path.length - 1];
+  if (!isPlainObject(cursor) || !(leaf in cursor)) {
+    return current;
+  }
+  if (
+    onlyIfEquals !== undefined &&
+    !isDeepStrictEqual(cursor[leaf], onlyIfEquals)
+  ) {
+    return current;
+  }
+  delete cursor[leaf];
+  const modifyOptions = current.trim().includes('\n')
+    ? { formattingOptions: detectJsonFormatting(current) }
+    : {};
+  try {
+    const text = applyEdits(
+      current,
+      modify(current, path, undefined, modifyOptions)
+    );
+    if (isDeepStrictEqual(JSON.parse(text), raw)) {
+      return text;
+    }
+  } catch {
+    // fall through to the full rewrite
+  }
+  return `${JSON.stringify(raw, null, 2)}\n`;
 }
 
 export const MANAGED_BLOCK_START = '# >>> vercel ai-gateway >>>';

--- a/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/keychain.ts
@@ -38,8 +38,26 @@ export function storeKeyInKeychain(key: string): boolean {
   }
 }
 
+export function keychainHelperCommand(): string {
+  return `${SECURITY_BIN} find-generic-password -s '${KEYCHAIN_SERVICE}' -a '${KEYCHAIN_ACCOUNT}' -w`;
+}
+
+export function keychainAuthCommand(): { command: string; args: string[] } {
+  return {
+    command: SECURITY_BIN,
+    args: [
+      'find-generic-password',
+      '-s',
+      KEYCHAIN_SERVICE,
+      '-a',
+      KEYCHAIN_ACCOUNT,
+      '-w',
+    ],
+  };
+}
+
 export function keychainLookup(opts: { fish?: boolean } = {}): string {
-  const cmd = `${SECURITY_BIN} find-generic-password -s '${KEYCHAIN_SERVICE}' -a '${KEYCHAIN_ACCOUNT}' -w 2>/dev/null`;
+  const cmd = `${keychainHelperCommand()} 2>/dev/null`;
   return opts.fish ? `(${cmd})` : `$(${cmd})`;
 }
 

--- a/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/machine.ts
@@ -21,6 +21,7 @@ export async function runMachine(args: {
   keySource: KeySource | null;
   createKey: () => Promise<string>;
   useKeychain: boolean;
+  codexSupportsAuthCommand?: boolean;
   overrides?: Record<string, string>;
   shellRcOverride?: string;
   baseUrlOverride?: string;
@@ -170,6 +171,7 @@ export async function runMachine(args: {
     apiKey: key,
     home,
     useKeychain,
+    codexSupportsAuthCommand: args.codexSupportsAuthCommand,
     overrides: args.overrides,
     shellRcOverride: args.shellRcOverride,
     baseUrlOverride: args.baseUrlOverride,

--- a/packages/cli/src/util/ai-gateway/coding-agents/render.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/render.ts
@@ -158,7 +158,7 @@ export function buildAgentPrompt(plan: SetupPlan, apiKey: string): string {
   const sections: string[] = [
     'Set up the Vercel AI Gateway for my coding agents by applying the file changes below.',
     'For each file, create it if missing or edit it to match the diff (lines starting with `+` are added, `-` are removed; `⋯` marks skipped unchanged lines).',
-    `Any masked value (e.g. ${maskSecret(apiKey)}) is my AI Gateway API key, stored in my macOS Keychain; the config and shell already reference it with \`${'security find-generic-password'}\`, so leave those lookups as-is and do not ask me to paste the key.`,
+    `Any masked value (e.g. ${maskSecret(apiKey)}) is my AI Gateway API key, stored in my macOS Keychain; the config files already reference it with \`${'security find-generic-password'}\`, so leave those lookups as-is and do not ask me to paste the key.`,
     '',
   ];
   for (const change of plan.changes) {

--- a/packages/cli/src/util/ai-gateway/coding-agents/types.ts
+++ b/packages/cli/src/util/ai-gateway/coding-agents/types.ts
@@ -2,6 +2,8 @@ export interface SetupContext {
   apiKey: string;
   home: string;
   useKeychain?: boolean;
+  /** `false` falls back to env-var auth when Codex lacks provider `auth`. */
+  codexSupportsAuthCommand?: boolean;
   overrides?: Record<string, string>;
   shellRcOverride?: string;
   baseUrlOverride?: string;

--- a/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
+++ b/packages/cli/test/unit/commands/ai-gateway/coding-agents-setup.test.ts
@@ -42,7 +42,13 @@ import {
   isKeychainAvailable,
   storeKeyInKeychain,
   keychainLookup,
+  keychainHelperCommand,
 } from '../../../../src/util/ai-gateway/coding-agents/keychain';
+import {
+  MIN_CODEX_AUTH_VERSION,
+  parseCodexVersion,
+  supportsAuthCommand,
+} from '../../../../src/util/ai-gateway/coding-agents/codex-version';
 
 // A pass-through mock of the keychain module: tests that set `available` get a
 // fake in-memory keychain (usable on Linux CI); everything else hits the real
@@ -79,6 +85,27 @@ vi.mock(
         keychainState.copied.push(text);
         return keychainState.copyResult;
       },
+    };
+  }
+);
+
+const codexVersionState = vi.hoisted(() => ({
+  support: { supported: true, version: '0.130.0' } as {
+    supported: boolean;
+    version: string | null;
+  },
+}));
+
+vi.mock(
+  '../../../../src/util/ai-gateway/coding-agents/codex-version',
+  async importOriginal => {
+    const actual =
+      await importOriginal<
+        typeof import('../../../../src/util/ai-gateway/coding-agents/codex-version')
+      >();
+    return {
+      ...actual,
+      detectCodexAuthSupport: () => codexVersionState.support,
     };
   }
 );
@@ -124,7 +151,7 @@ function codexConfigPath() {
   return join(home, '.codex', 'config.toml');
 }
 function bashrcPath() {
-  return join(home, '.bashrc');
+  return detectShellRc(home);
 }
 function opencodeConfigPath() {
   return join(home, '.config', 'opencode', 'opencode.json');
@@ -139,6 +166,7 @@ beforeEach(() => {
   keychainState.storeResult = true;
   keychainState.copied.length = 0;
   keychainState.copyResult = true;
+  codexVersionState.support = { supported: true, version: '0.130.0' };
   desktopState.codex = false;
   home = mkdtempSync(join(tmpdir(), 'vc-setup-agents-'));
   savedEnv = {
@@ -456,6 +484,101 @@ describe('ai-gateway coding-agents setup', () => {
         expect(shell?.next).not.toContain(secret);
       }
     );
+
+    it('writes a Codex auth command instead of a shell export under keychain', async () => {
+      useUser();
+      client.nonInteractive = true;
+      keychainState.available = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0042',
+        '--agent',
+        'codex'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const raw = readFileSync(codexConfigPath(), 'utf8');
+      const toml = tomlParse(raw) as any;
+      expect(toml.model_providers.vercel.auth.command).toBe(
+        '/usr/bin/security'
+      );
+      expect(toml.model_providers.vercel.env_key).toBeUndefined();
+      expect(raw).not.toContain('vck_DummyKey0042');
+      expect(keychainState.stored).toContain('vck_DummyKey0042');
+      expect(existsSync(detectShellRc(home))).toBe(false);
+    });
+
+    it('warns and falls back to the env var when Codex is too old', async () => {
+      useUser();
+      client.nonInteractive = true;
+      keychainState.available = true;
+      codexVersionState.support = { supported: false, version: '0.110.0' };
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0043',
+        '--agent',
+        'codex'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const toml = tomlParse(readFileSync(codexConfigPath(), 'utf8')) as any;
+      expect(toml.model_providers.vercel.env_key).toBe('AI_GATEWAY_API_KEY');
+      expect(toml.model_providers.vercel.auth).toBeUndefined();
+      // Keychain-backed shell exports only exist on macOS (no shell rc on Windows).
+      if (process.platform !== 'win32') {
+        const rc = readFileSync(detectShellRc(home), 'utf8');
+        expect(rc).toContain('export AI_GATEWAY_API_KEY=');
+        expect(rc).toContain('security find-generic-password');
+      }
+
+      const out = JSON.parse(client.stdout.getFullOutput());
+      expect(out.status).toBe('ok');
+      const warning = out.warnings.find(
+        (w: any) => w.code === 'codex_auth_command_unsupported'
+      );
+      expect(warning?.agent).toBe('codex');
+      expect(warning?.message).toContain('0.110.0');
+      expect(warning?.message).toContain(MIN_CODEX_AUTH_VERSION);
+    });
+
+    it('configures Claude Code with an apiKeyHelper under keychain', async () => {
+      useUser();
+      client.nonInteractive = true;
+      keychainState.available = true;
+      client.setArgv(
+        'ai-gateway',
+        'coding-agents',
+        'setup',
+        '--key',
+        'vck_DummyKey0044',
+        '--agent',
+        'claude-code'
+      );
+
+      const exitCode = await aiGateway(client);
+      expect(exitCode).toBe(0);
+
+      const raw = readFileSync(claudeSettingsPath(), 'utf8');
+      const settings = JSON.parse(raw);
+      expect(settings.apiKeyHelper).toContain('security find-generic-password');
+      expect(settings.env.ANTHROPIC_BASE_URL).toBe(
+        'https://ai-gateway.vercel.sh/claude-code'
+      );
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('');
+      expect(raw).not.toContain('vck_DummyKey0044');
+      expect(keychainState.stored).toContain('vck_DummyKey0044');
+      expect(existsSync(detectShellRc(home))).toBe(false);
+    });
 
     it('configures Pi via the native vercel-ai-gateway auth entry (0600)', async () => {
       useUser();
@@ -802,34 +925,81 @@ describe('ai-gateway coding-agents setup', () => {
         expect(storeKeyInKeychain('vck_whatever')).toBe(false);
       }
       expect(keychainLookup()).toContain('security find-generic-password');
+      expect(keychainHelperCommand()).toContain(
+        'security find-generic-password'
+      );
+      expect(keychainHelperCommand()).not.toContain('$(');
     });
 
-    // Keychain-backed shell exports only exist on macOS (no shell rc on Windows).
-    it.skipIf(process.platform === 'win32')(
-      'keeps the secret out of the configs and reads it from the shell',
-      async () => {
-        const secret = 'vck_KeychainSecret321';
-        const plan = await buildSetupPlan([claudeCode], {
-          apiKey: secret,
-          home,
-          useKeychain: true,
-        });
+    it('replaces a foreign apiKeyHelper and empties an embedded token', async () => {
+      const secret = 'vck_KeychainSecret321';
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        claudeSettingsPath(),
+        JSON.stringify(
+          {
+            apiKeyHelper: 'my-custom-helper',
+            env: { ANTHROPIC_AUTH_TOKEN: 'vck_OldEmbedded99' },
+          },
+          null,
+          2
+        ),
+        'utf8'
+      );
 
-        // The env-based agent resolves its var from the Keychain at runtime.
-        const shell = plan.changes.find(c => c.format === 'shell');
-        expect(shell?.next).toContain('security find-generic-password');
-        expect(shell?.next).toContain('export ANTHROPIC_AUTH_TOKEN=');
-        expect(shell?.next).not.toContain(secret);
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: secret,
+        home,
+        useKeychain: true,
+      });
 
-        // Claude's token is no longer embedded in settings.json.
-        const claude = plan.changes.find(
-          c => c.label === 'Claude Code settings'
-        );
-        expect(claude?.next).toContain('ANTHROPIC_BASE_URL');
-        expect(claude?.next).not.toContain('ANTHROPIC_AUTH_TOKEN');
-        expect(claude?.next).not.toContain(secret);
-      }
-    );
+      // The helper-based agent resolves its token from the Keychain at runtime.
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      const settings = JSON.parse(claude?.next ?? '{}');
+      expect(settings.apiKeyHelper).toBe(keychainHelperCommand());
+      // Claude's token is no longer embedded in settings.json.
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('');
+      expect(claude?.next).not.toContain('vck_OldEmbedded99');
+    });
+
+    it('removes our apiKeyHelper when reconfiguring without the Keychain', async () => {
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        claudeSettingsPath(),
+        JSON.stringify({ apiKeyHelper: keychainHelperCommand() }, null, 2),
+        'utf8'
+      );
+
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: 'vck_Plain111',
+        home,
+        useKeychain: false,
+      });
+
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      const settings = JSON.parse(claude?.next ?? '{}');
+      expect(settings.apiKeyHelper).toBeUndefined();
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('vck_Plain111');
+    });
+
+    it('leaves a custom apiKeyHelper alone when the Keychain is off', async () => {
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        claudeSettingsPath(),
+        JSON.stringify({ apiKeyHelper: 'my-custom-helper' }, null, 2),
+        'utf8'
+      );
+
+      const plan = await buildSetupPlan([claudeCode], {
+        apiKey: 'vck_Plain222',
+        home,
+        useKeychain: false,
+      });
+
+      const claude = plan.changes.find(c => c.label === 'Claude Code settings');
+      const settings = JSON.parse(claude?.next ?? '{}');
+      expect(settings.apiKeyHelper).toBe('my-custom-helper');
+    });
 
     it('embeds the key directly when keychain is off', async () => {
       const secret = 'vck_PlainSecret654';
@@ -843,21 +1013,98 @@ describe('ai-gateway coding-agents setup', () => {
       expect(claude?.next).toContain(secret);
     });
 
-    // Keychain-backed shell exports only exist on macOS (no shell rc on Windows).
+    it('removes a stale env_key and keeps comments when switching to the auth command', async () => {
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      writeFileSync(
+        codexConfigPath(),
+        [
+          '# my precious comment',
+          'model = "gpt-5"',
+          'model_provider = "vercel"',
+          '',
+          '[model_providers.vercel]',
+          'name = "Vercel AI Gateway"',
+          'base_url = "https://ai-gateway.vercel.sh/codex/v1"',
+          'env_key = "AI_GATEWAY_API_KEY"',
+          'wire_api = "responses"',
+          '',
+        ].join('\n'),
+        'utf8'
+      );
+
+      const plan = await buildSetupPlan([codex], {
+        apiKey: 'vck_x',
+        home,
+        useKeychain: true,
+      });
+
+      const cfg = plan.changes.find(c => c.label === 'Codex config');
+      expect(cfg?.status).toBe('update');
+      expect(cfg?.next).toContain('# my precious comment');
+      expect(cfg?.next).not.toContain('env_key');
+      const toml = tomlParse(cfg?.next ?? '') as any;
+      expect(toml.model).toBe('gpt-5');
+      expect(toml.model_providers.vercel.auth.command).toBe(
+        '/usr/bin/security'
+      );
+    });
+
+    it('removes the auth command when reconfiguring without the Keychain', async () => {
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      writeFileSync(
+        codexConfigPath(),
+        [
+          'model_provider = "vercel"',
+          '',
+          '[model_providers.vercel]',
+          'name = "Vercel AI Gateway"',
+          'base_url = "https://ai-gateway.vercel.sh/codex/v1"',
+          'wire_api = "responses"',
+          '',
+          '[model_providers.vercel.auth]',
+          'command = "/usr/bin/security"',
+          'args = ["find-generic-password", "-s", "Vercel AI Gateway", "-a", "vercel-ai-gateway", "-w"]',
+          'timeout_ms = 5000',
+          'refresh_interval_ms = 300000',
+          '',
+        ].join('\n'),
+        'utf8'
+      );
+
+      const plan = await buildSetupPlan([codex], {
+        apiKey: 'vck_Plain333',
+        home,
+        useKeychain: false,
+      });
+
+      const cfg = plan.changes.find(c => c.label === 'Codex config');
+      const toml = tomlParse(cfg?.next ?? '') as any;
+      expect(toml.model_providers.vercel.auth).toBeUndefined();
+      expect(toml.model_providers.vercel.env_key).toBe('AI_GATEWAY_API_KEY');
+    });
+
+    // Shell rc management is intentionally skipped on Windows.
     it.skipIf(process.platform === 'win32')(
-      'reads the Codex env key from the Keychain instead of the config',
+      'notes a stale shell export when the selected agents no longer need it',
       async () => {
-        const secret = 'vck_KeychainSecret321';
+        writeFileSync(
+          detectShellRc(home),
+          upsertManagedBlock(
+            null,
+            `export AI_GATEWAY_API_KEY="${keychainLookup()}"`
+          ),
+          'utf8'
+        );
+
         const plan = await buildSetupPlan([codex], {
-          apiKey: secret,
+          apiKey: 'vck_x',
           home,
           useKeychain: true,
         });
 
-        const shell = plan.changes.find(c => c.format === 'shell');
-        expect(shell?.next).toContain('security find-generic-password');
-        expect(shell?.next).toContain('export AI_GATEWAY_API_KEY=');
-        expect(shell?.next).not.toContain(secret);
+        expect(plan.changes.some(c => c.format === 'shell')).toBe(false);
+        const env = plan.notes.find(n => n.id === 'environment');
+        expect(env?.notes.join(' ')).toContain('no longer need');
       }
     );
   });
@@ -2694,14 +2941,14 @@ describe('ai-gateway coding-agents setup', () => {
           true
         );
 
-        // A single shared shell block. Codex and OpenCode both want
-        // AI_GATEWAY_API_KEY — it's exported once (deduped) — and Claude Code
-        // contributes ANTHROPIC_AUTH_TOKEN.
+        // A single shared shell block. OpenCode contributes
+        // AI_GATEWAY_API_KEY once; Claude Code and Codex read the Keychain
+        // directly and contribute no exports.
         const shells = plan.changes.filter(c => c.format === 'shell');
         expect(shells).toHaveLength(1);
         const gateway = shells[0].next?.match(/AI_GATEWAY_API_KEY/g) ?? [];
         expect(gateway).toHaveLength(1);
-        expect(shells[0].next).toContain('ANTHROPIC_AUTH_TOKEN');
+        expect(shells[0].next).not.toContain('ANTHROPIC_AUTH_TOKEN');
       }
     );
 
@@ -2714,5 +2961,21 @@ describe('ai-gateway coding-agents setup', () => {
       expect(codexChange?.status).toBe('error');
       expect(codexChange?.error).toContain('not valid TOML');
     });
+  });
+});
+
+vitestDescribe('codex auth-command support', () => {
+  it('parses the codex --version output', () => {
+    expect(parseCodexVersion('codex-cli 0.130.1')).toBe('0.130.1');
+    expect(parseCodexVersion('0.118.0\n')).toBe('0.118.0');
+    expect(parseCodexVersion('garbage')).toBeNull();
+  });
+
+  it('gates on the minimum version', () => {
+    expect(supportsAuthCommand(MIN_CODEX_AUTH_VERSION)).toBe(true);
+    expect(supportsAuthCommand('0.130.0')).toBe(true);
+    expect(supportsAuthCommand('1.0.0')).toBe(true);
+    expect(supportsAuthCommand('0.117.9')).toBe(false);
+    expect(supportsAuthCommand('0.9.9')).toBe(false);
   });
 });


### PR DESCRIPTION
he current Claude Code and Codex setup exports the AI Gateway key into the shell environment, causing every child process to inherit it. This PR configures supported agents to fetch the key from the macOS Keychain only when needed.

## Added in this PR

- Configure Claude Code with `apiKeyHelper` and clear `ANTHROPIC_AUTH_TOKEN` so an existing value cannot shadow the helper.
- Configure Codex 0.118.0+ with command-backed provider authentication.
- Detect older or unavailable Codex versions, warn, and retain the `AI_GATEWAY_API_KEY` shell-export fallback.
- Migrate between helper/auth and environment-based configurations while preserving unrelated config content and custom Claude helpers when switching away from Keychain mode.
- Warn when an older managed shell block remains after the selected agents no longer require it.

## Notes

- Not sure if the detecting of older codex versions is worth it since they are updated very often
- I'm not familiar with the project so I assisted myself with AI. I will take a deeper look at the code (notably tests seems to be a bit too much?) if this feature is welcome
- Having the password in the keychain **does not** prevent it from being read by other processes, but it does prevent it from being accidentally exposed in logs or process lists, so I think this is still worth it
- This supersedes the now-stale Claude-only PR [#17189](https://github.com/vercel/vercel/pull/17189) and also adds fetch-on-use support for Codex.
