### PR TITLE
Fix “wether” typo in Lambda preload documentation

### DIFF
--- a/.changeset/neat-lambdas-spell.md
+++ b/.changeset/neat-lambdas-spell.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Correct a typo in the Lambda preload documentation.

--- a/packages/build-utils/src/process-serverless/get-lambda-preload-scripts.ts
+++ b/packages/build-utils/src/process-serverless/get-lambda-preload-scripts.ts
@@ -13,7 +13,7 @@ interface LambdaLike {
 
 /**
  * Returns an array of scripts that should be preloaded in Node.js Lambdas.
- * The `buffer` parameter is needed to decide wether or not to enable Bytecode
+ * The `buffer` parameter is needed to decide whether or not to enable Bytecode
  * Caching so it doesn't **need** to be exact (we can leave out the env layer)
  */
 export function getLambdaPreloadScripts(


### PR DESCRIPTION
Fixes #17553

## Summary
- correct the Lambda preload JSDoc spelling
- add the required patch changeset for @vercel/build-utils

## Tests
- pnpm exec biome check packages/build-utils/src/process-serverless/get-lambda-preload-scripts.ts
- pnpm exec prettier --check .changeset/neat-lambdas-spell.md
- focused Vitest suites: 27 passed