### PR TITLE
[cli] Exit cleanly when stderr closes

### DIFF
--- a/.changeset/silent-stderr-pipes.md
+++ b/.changeset/silent-stderr-pipes.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Exit cleanly when the CLI's stderr pipe closes before output finishes.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -118,13 +118,14 @@ function hasProxyConfig(): boolean {
 }
 
 /*
-  By default, node throws EPIPE errors if process.stdout is being written to
-  and a user runs it through a pipe that gets closed while the process is still outputting
-  (eg, the simple case of piping a node app through head).
+  By default, node throws EPIPE errors if process.stdout or process.stderr is
+  being written to and a user runs it through a pipe that gets closed while
+  the process is still outputting (eg, piping a node app through head).
 
-  This suppresses those errors.
+  This suppresses those errors for both output streams.
 */
 epipebomb();
+epipebomb(process.stderr);
 
 let client: Client;
 let resolvedCommandForUpdate: string | undefined;

--- a/packages/cli/test/unit/broken-pipe.test.ts
+++ b/packages/cli/test/unit/broken-pipe.test.ts
@@ -1,0 +1,44 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from 'vitest';
+
+const cliPath = fileURLToPath(new URL('../../dist/vc.js', import.meta.url));
+
+it('exits cleanly when the stderr pipe closes', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'vercel-stderr-epipe-'));
+  const child = spawn(process.execPath, [cliPath, 'help'], {
+    cwd,
+    env: {
+      ...process.env,
+      NO_UPDATE_NOTIFIER: '1',
+      VERCEL_CLI_USE_NATIVE_BINARY: '0',
+    },
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  const exitPromise = once(child, 'exit');
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill('SIGKILL');
+  }, 5_000);
+
+  child.stderr.destroy();
+
+  try {
+    const [code, signal] = await exitPromise;
+
+    expect({ code, signal, timedOut }).toEqual({
+      code: 0,
+      signal: null,
+      timedOut: false,
+    });
+  } finally {
+    clearTimeout(timeout);
+    child.kill('SIGKILL');
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/types/epipebomb/index.d.ts
+++ b/packages/cli/types/epipebomb/index.d.ts
@@ -1,3 +1,6 @@
 declare module 'epipebomb' {
-  export default function (): void;
+  export default function (
+    stream?: NodeJS.WritableStream,
+    callback?: () => void
+  ): void;
 }


### PR DESCRIPTION
## Summary

- Exit cleanly when the CLI's stderr pipe closes before output finishes.
- Extend the existing EPIPE protection to stderr with regression coverage.

Fixes #17528

## Validation

- `cd packages/cli && pnpm build && pnpm test test/unit/broken-pipe.test.ts test/unit/index.test.ts`
- `cd packages/cli && pnpm type-check`
- `pnpm biome lint packages/cli/src/index.ts packages/cli/types/epipebomb/index.d.ts packages/cli/test/unit/broken-pipe.test.ts`
- Packed npm artifact smoke test with a closed stderr pipe
