### PR TITLE
fix(next): include Turbopack *.external.js runtime modules in traced output

### DIFF
--- a/.changeset/turbo-external-modules.md
+++ b/.changeset/turbo-external-modules.md
@@ -1,0 +1,17 @@
+---
+'@vercel/next': patch
+---
+
+Fix serverless functions crashing at runtime on Next.js 16.2+ when built with
+Turbopack, with errors like:
+
+```
+Error: Cannot find module 'next/dist/server/lib/incremental-cache/tags-manifest.external.js'
+```
+
+Next.js's Turbopack-compiled runtimes (`app-route-turbo.runtime.prod.js`,
+`app-page-turbo.runtime.prod.js`) load `*.external.js` modules through
+Turbopack's `externalRequire`, which neither `@vercel/nft` nor Next.js's own
+build-time trace can see statically. `@vercel/next` now explicitly includes
+`next/dist/server/**/*.external.js` in the traced output for every Node.js
+lambda, regardless of bundler, so these modules are always present at runtime.

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -109,6 +109,16 @@ const BUNDLED_SERVER_NEXT_VERSION = 'v13.5.4';
 const BUNDLED_SERVER_NEXT_PATH =
   'next/dist/compiled/next-server/server.runtime.prod.js';
 
+// Next.js's Turbopack-compiled runtimes (e.g. app-route-turbo.runtime.prod.js,
+// app-page-turbo.runtime.prod.js) load these `*.external.js` modules through
+// Turbopack's `externalRequire`, which the file tracer cannot see statically.
+// Since Next.js 16.2 this causes traced/build-trace-based output to omit
+// required modules (e.g. `incremental-cache/tags-manifest.external.js`),
+// crashing the deployed function at runtime. Always glob these in explicitly,
+// regardless of bundler or whether a build trace file was produced.
+// related issue: https://github.com/vercel/vercel/issues/17554
+const EXTERNAL_MODULES_GLOB = 'dist/server/**/*.external.js';
+
 export async function serverBuild({
   dynamicPages,
   pagesDir,
@@ -673,6 +683,24 @@ export async function serverBuild({
         )
       ).filter((entry): entry is [string, FileFsRef] => !!entry)
     );
+
+    // The file tracer (whether run here or by Next.js's own build trace)
+    // cannot statically discover `*.external.js` modules required through
+    // Turbopack's `externalRequire`, so always include them explicitly.
+    // See the comment on `EXTERNAL_MODULES_GLOB` above for details.
+    try {
+      const nextPackageDir = path.dirname(
+        resolveFrom(projectDir, 'next/package.json')
+      );
+      const externalModuleFiles = await glob(
+        EXTERNAL_MODULES_GLOB,
+        nextPackageDir,
+        path.relative(baseDir, nextPackageDir)
+      );
+      Object.assign(initialTracedFiles, externalModuleFiles);
+    } catch (err) {
+      debug(`Failed to include Next.js *.external.js modules: ${err}`);
+    }
 
     debug('creating initial pseudo layer');
     const initialPseudoLayer = await createPseudoLayer(initialTracedFiles);


### PR DESCRIPTION
### Related issue

Fixes #17554

### What

Next.js's Turbopack-compiled runtimes (`app-route-turbo.runtime.prod.js`, `app-page-turbo.runtime.prod.js`) load `*.external.js` modules — for example `next/dist/server/lib/incremental-cache/tags-manifest.external.js` — through Turbopack's `externalRequire`. Neither `@vercel/nft`'s static trace nor Next.js's own build-time `.nft.json` trace can see these requires, so since Next.js 16.2 (Turbopack builds, the default since Next 16) they are pruned from the deployed function's `node_modules/next/dist`, and every request crashes with:

```
Error: Cannot find module 'next/dist/server/lib/incremental-cache/tags-manifest.external.js'
```

There's no user-side workaround: `outputFileTracingIncludes` is only honored by Next's own `collect-build-traces` step, which `build/index.js` skips entirely when the bundler is Turbopack.

### Fix

In `packages/next/src/server-build.ts`, after collecting the initial traced files for the shared Node.js server layer (used by every lambda regardless of whether a per-lambda `.nft.json` build trace was available), explicitly glob in `next/dist/server/**/*.external.js` from the resolved `next` package and merge the results into `initialTracedFiles`. This runs unconditionally — independent of bundler, and independent of whether Next.js produced its own trace file — so any current or future `*.external.js` runtime dependency under `next/dist/server` is always included in the Lambda output.

Verified the glob resolves all of the `*.external.js` files (including `tags-manifest.external.js`, `shared-cache-controls.external.js`, `memory-cache.external.js`, and the various `*-async-storage.external.js` modules) against a real `next@16.2.6` install, with paths correctly relative to the lambda's `baseDir`.

### Checks

- `pnpm run lint` ✅
- `pnpm run format:check` ✅
- `packages/next` builds cleanly (`node build.mjs`) ✅
- Added a changeset