### PR TITLE
[vercel] Align usage output with dashboard

### DIFF
--- a/.changeset/friendly-taxis-compare.md
+++ b/.changeset/friendly-taxis-compare.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Align `vercel usage` with the dashboard usage page by using billing-cycle dates, displaying consumed units and Flat Rate CDN inclusion, and separating infrastructure from subscription licenses.

--- a/.changeset/friendly-taxis-compare.md
+++ b/.changeset/friendly-taxis-compare.md
@@ -2,4 +2,4 @@
 'vercel': minor
 ---
 
-Align `vercel usage` with the dashboard usage page by using billing-cycle dates, displaying consumed units and Flat Rate CDN inclusion, and separating infrastructure from subscription licenses.
+Align `vercel usage` with the dashboard usage page by using billing-cycle dates, showing product quantities and Flat Rate CDN inclusion, and separating infrastructure from subscription licenses. JSON output now reports the billing-costs response model instead of legacy FOCUS aliases.

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -35,6 +35,7 @@ type Billing = {
   cancelation?: number;
   period: { start: number; end: number };
   plan: string;
+  planIteration?: string;
   platform: string;
   status: 'active' | 'trialing' | 'overdue' | 'canceled' | 'expired';
   trial: { start: number; end: number };

--- a/packages/cli/src/commands/usage/command.ts
+++ b/packages/cli/src/commands/usage/command.ts
@@ -42,6 +42,13 @@ export const usageCommand = {
         'Group usage by a dimension instead of aggregated totals (project, region)',
       deprecated: false,
     },
+    {
+      name: 'all',
+      shorthand: null,
+      type: Boolean,
+      description: 'Show services with zero usage and zero cost',
+      deprecated: false,
+    },
     formatOption,
     jsonOption,
   ],

--- a/packages/cli/src/commands/usage/command.ts
+++ b/packages/cli/src/commands/usage/command.ts
@@ -5,7 +5,7 @@ export const usageCommand = {
   name: 'usage',
   aliases: [],
   description:
-    'Show billing usage (MIUs and costs) for the current billing period or a custom date range',
+    'Show billing usage and costs for the current billing cycle or a custom date range',
   arguments: [],
   options: [
     {

--- a/packages/cli/src/commands/usage/command.ts
+++ b/packages/cli/src/commands/usage/command.ts
@@ -42,13 +42,6 @@ export const usageCommand = {
         'Group usage by a dimension instead of aggregated totals (project, region)',
       deprecated: false,
     },
-    {
-      name: 'all',
-      shorthand: null,
-      type: Boolean,
-      description: 'Show services with zero usage and zero cost',
-      deprecated: false,
-    },
     formatOption,
     jsonOption,
   ],

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -29,6 +29,7 @@ import { outputGroupBy } from './output-group-by';
 import { outputJson } from './output-json';
 import type {
   BreakdownPeriod,
+  CommitmentUsageResponse,
   CostMetric,
   CostMetricGroup,
   CostMetricsResponse,
@@ -39,7 +40,8 @@ import type {
   UsageData,
 } from './types';
 
-const COST_METRIC = 'gross_cost';
+const GROSS_COST_METRIC = 'gross_cost';
+// TODO: Add `net_cost` once the billing costs API contract supports it.
 
 export default async function usage(client: Client): Promise<number> {
   const { print, error, debug, spinner } = output;
@@ -107,16 +109,19 @@ export default async function usage(client: Client): Promise<number> {
   telemetry.trackCliOptionFrom(fromFlag);
   telemetry.trackCliOptionTo(toFlag);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
+  telemetry.trackCliFlagAll(parsedArgs.flags['--all']);
   telemetry.trackCliOptionBreakdown(breakdownFlag);
   telemetry.trackCliOptionGroupBy(groupByFlag);
 
   let contextName: string;
+  let contextType: 'team' | 'personal account';
   let teamId: string | undefined;
   let billingPeriod: { start: number; end: number } | undefined;
 
   try {
     const scope = await getScope(client);
     contextName = scope.contextName;
+    contextType = scope.team ? 'team' : 'personal account';
     teamId = scope.team?.id;
     billingPeriod = (scope.team ?? scope.user).billing?.period;
   } catch (err: unknown) {
@@ -162,13 +167,15 @@ export default async function usage(client: Client): Promise<number> {
     const query = new URLSearchParams({ from: fromDate, to: toDate });
     if (teamId) query.set('teamId', teamId);
 
-    const response = await client.fetch<CostMetricsResponse>(
+    const costsRequest = client.fetch<CostMetricsResponse>(
       `/v2/billing/costs?${query}`,
       {
         method: 'POST',
         body: {
           from: fromDate,
           to: toDate,
+          // TODO: Request `net_cost` here once the billing costs API PR lands.
+          metrics: [GROSS_COST_METRIC, 'quantity'],
           format: 'timeseries',
           views: {
             byProduct: { groupBy: ['product'] },
@@ -181,16 +188,53 @@ export default async function usage(client: Client): Promise<number> {
         useCurrentTeam: false,
       }
     );
+    const commitmentRequest =
+      usingDefaults && teamId
+        ? client
+            .fetch<CommitmentUsageResponse>(
+              `/v1/invoices/pre-commitment-usage?teamId=${encodeURIComponent(teamId)}`,
+              { useCurrentTeam: false }
+            )
+            .catch(err => {
+              debug(`Unable to fetch infrastructure credit: ${String(err)}`);
+              return null;
+            })
+        : Promise.resolve(null);
+
+    const [response, commitmentUsage] = await Promise.all([
+      costsRequest,
+      commitmentRequest,
+    ]);
 
     const usageData = processCosts(
       response,
       contextName,
+      contextType,
+      parsedArgs.flags['--scope'],
       fromDisplay,
       toDisplay,
       usingDefaults,
+      Boolean(parsedArgs.flags['--all']),
       breakdownPeriod,
       groupByDimension
     );
+    const creditLedger = commitmentUsage?.creditLedgers[0];
+    if (creditLedger) {
+      const used = roundToHundredths(
+        creditLedger.total - creditLedger.remaining
+      );
+      usageData.credit = {
+        cadence: commitmentUsage.cadence,
+        currency: creditLedger.currency,
+        allocated: creditLedger.total,
+        used,
+        remaining: creditLedger.remaining,
+        progress:
+          creditLedger.total > 0
+            ? roundToHundredths((used / creditLedger.total) * 100)
+            : 0,
+      };
+    }
 
     if (asJson) {
       outputJson(client, {
@@ -217,6 +261,15 @@ export default async function usage(client: Client): Promise<number> {
   }
 }
 
+function roundToHundredths(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function getUsageThrough(queriedAt: string, toDisplay: string): string {
+  const queriedDate = extractDatePortion(queriedAt);
+  return queriedDate < toDisplay ? queriedDate : toDisplay;
+}
+
 function parseDashboardDate(value: string, end: boolean): string {
   const date = value.includes('T')
     ? DateTime.fromISO(value)
@@ -234,9 +287,12 @@ function parseDashboardDate(value: string, end: boolean): string {
 function processCosts(
   response: CostMetricsResponse,
   contextName: string,
+  contextType: 'team' | 'personal account',
+  scope: string | undefined,
   fromDisplay: string,
   toDisplay: string,
   usingDefaults: boolean,
+  showAll: boolean,
   breakdownPeriod?: BreakdownPeriod,
   groupByDimension?: GroupByDimension
 ): UsageData {
@@ -252,6 +308,7 @@ function processCosts(
   const periodUsage = new Map<string, PeriodAggregation>();
   const groupByUsage = new Map<string, GroupAggregation>();
   let totalCost = 0;
+  let totalEffectiveCost = 0;
 
   for (const result of summaryView?.results ?? []) {
     const product = result.dimensionValues.product;
@@ -269,6 +326,7 @@ function processCosts(
       : serviceName;
     addService(services, aggregationName, aggregation);
     totalCost += aggregation.cost;
+    totalEffectiveCost += aggregation.effectiveCost;
 
     if (breakdownPeriod) {
       for (let index = 0; index < response.results.times.length; index++) {
@@ -286,8 +344,8 @@ function processCosts(
         addService(period.services, aggregationName, sample);
         period.totalCost += sample.cost;
         period.totalPricingQuantity += sample.cost;
-        period.totalEffectiveCost += sample.cost;
-        period.totalBilledCost += sample.cost;
+        period.totalEffectiveCost += sample.effectiveCost;
+        period.totalBilledCost += sample.billedCost;
         periodUsage.set(periodKey, period);
       }
     }
@@ -317,17 +375,21 @@ function processCosts(
       addService(group.services, aggregationName, aggregation);
       group.totalCost += aggregation.cost;
       group.totalPricingQuantity += aggregation.cost;
-      group.totalEffectiveCost += aggregation.cost;
-      group.totalBilledCost += aggregation.cost;
+      group.totalEffectiveCost += aggregation.effectiveCost;
+      group.totalBilledCost += aggregation.billedCost;
       groupByUsage.set(groupName, group);
     }
   }
 
   return {
     contextName,
+    contextType,
+    scope,
     fromDisplay,
     toDisplay,
+    usageThrough: getUsageThrough(response.queriedAt, toDisplay),
     usingDefaults,
+    showAll,
     chargeCount: summaryView?.results.length ?? 0,
     services,
     periodUsage,
@@ -335,8 +397,8 @@ function processCosts(
     totalCost,
     grandTotals: {
       pricingQuantity: totalCost,
-      effectiveCost: totalCost,
-      billedCost: totalCost,
+      effectiveCost: totalEffectiveCost,
+      billedCost: totalEffectiveCost,
     },
   };
 }
@@ -347,15 +409,18 @@ function aggregateResult(
   sampleIndex?: number,
   isSubscription = false
 ): ServiceAggregation {
-  const costIndex = result.metrics.indexOf(COST_METRIC);
+  const grossCostIndex = result.metrics.indexOf(GROSS_COST_METRIC);
   const quantityIndex = result.metrics.findIndex(
-    metric => metric !== COST_METRIC
+    metric => metric !== GROSS_COST_METRIC
   );
   const values =
     sampleIndex === undefined
       ? result.totalValue
       : (result.values[sampleIndex] ?? []);
-  const cost = costIndex === -1 ? 0 : (values[costIndex] ?? 0);
+  const cost = grossCostIndex === -1 ? 0 : (values[grossCostIndex] ?? 0);
+  const included = result.flatRate === true;
+  // TODO: Read `net_cost` directly once the billing costs API PR lands.
+  const effectiveCost = included ? 0 : cost;
   const quantity = quantityIndex === -1 ? 0 : (values[quantityIndex] ?? 0);
   const metric =
     quantityIndex === -1
@@ -367,12 +432,12 @@ function aggregateResult(
     quantity,
     unit,
     cost,
-    included: result.flatRate === true,
+    included,
     category: isSubscription ? 'subscription' : 'usage',
     pricingQuantity: cost,
     pricingUnit: 'USD',
-    effectiveCost: cost,
-    billedCost: cost,
+    effectiveCost,
+    billedCost: effectiveCost,
   };
 }
 
@@ -380,7 +445,7 @@ function getUnitLabel(
   metric: CostMetric | undefined,
   quantity: number
 ): string {
-  if (!metric) return 'licenses';
+  if (!metric?.unit) return quantity === 1 ? 'license' : 'licenses';
   if (metric.unit.kind === 'custom') {
     return quantity === 1
       ? (metric.unit.singular ?? metric.unit.plural ?? metric.title)

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
-import jsonlines from 'jsonlines';
-import { toNodeReadable, type Response } from '../../util/fetch';
+import { DateTime } from 'luxon';
 import { parseArguments } from '../../util/get-args';
 import { printError } from '../../util/error';
 import type Client from '../../util/client';
@@ -12,21 +11,9 @@ import { UsageTelemetryClient } from '../../util/telemetry/commands/usage';
 import { validateJsonOutput } from '../../util/output-format';
 import output from '../../output-manager';
 import { isErrnoException } from '@vercel/error-utils';
-import type { FocusCharge } from '../../util/billing/focus-charge';
-import type {
-  BreakdownPeriod,
-  GroupByDimension,
-  ServiceAggregation,
-  PeriodAggregation,
-  GroupAggregation,
-  UsageData,
-} from './types';
 import {
-  parseBillingDate,
   getDefaultFromDate,
   getDefaultToDate,
-  getDefaultFromDateDisplay,
-  getDefaultToDateDisplay,
   getPeriodKey,
   isValidBreakdownPeriod,
   VALID_BREAKDOWN_PERIODS,
@@ -35,16 +22,29 @@ import {
   isValidGroupByDimension,
   VALID_GROUP_BY_DIMENSIONS,
 } from '../../util/billing/group-by-utils';
+import { extractDatePortion } from '../../util/billing/format';
 import { outputAggregated } from './output-aggregated';
 import { outputBreakdown } from './output-breakdown';
 import { outputGroupBy } from './output-group-by';
 import { outputJson } from './output-json';
+import type {
+  BreakdownPeriod,
+  CostMetric,
+  CostMetricGroup,
+  CostMetricsResponse,
+  GroupAggregation,
+  GroupByDimension,
+  PeriodAggregation,
+  ServiceAggregation,
+  UsageData,
+} from './types';
+
+const COST_METRIC = 'gross_cost';
 
 export default async function usage(client: Client): Promise<number> {
   const { print, error, debug, spinner } = output;
-
-  let parsedArgs = null;
   const flagsSpecification = getFlagsSpecification(usageCommand.options);
+  let parsedArgs;
 
   try {
     parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
@@ -54,9 +54,7 @@ export default async function usage(client: Client): Promise<number> {
   }
 
   const telemetry = new UsageTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
+    opts: { store: client.telemetryEventStore },
   });
 
   if (parsedArgs.flags['--help']) {
@@ -71,58 +69,33 @@ export default async function usage(client: Client): Promise<number> {
     return 1;
   }
   const asJson = formatResult.jsonOutput;
-
   const fromFlag = parsedArgs.flags['--from'];
   const toFlag = parsedArgs.flags['--to'];
 
   if (Boolean(fromFlag) !== Boolean(toFlag)) {
     error(
-      'Both --from and --to must be specified or neither for the current month'
+      'Both --from and --to must be specified or neither for the current billing cycle'
     );
     return 1;
   }
-  const usingDefaults = !fromFlag && !toFlag;
-
-  let fromDate: string;
-  let toDate: string;
-  try {
-    fromDate = fromFlag
-      ? parseBillingDate(fromFlag, false)
-      : getDefaultFromDate();
-    toDate = toFlag ? parseBillingDate(toFlag, true) : getDefaultToDate();
-  } catch (err) {
-    error((err as Error).message);
-    return 1;
-  }
-
-  const fromDisplay = fromFlag ?? getDefaultFromDateDisplay();
-  const toDisplay = toFlag ?? getDefaultToDateDisplay();
 
   const breakdownFlag = parsedArgs.flags['--breakdown'];
-  let breakdownPeriod: BreakdownPeriod | undefined;
-
-  if (breakdownFlag) {
-    if (!isValidBreakdownPeriod(breakdownFlag)) {
-      error(
-        `Invalid breakdown period: "${breakdownFlag}". Valid options are: ${VALID_BREAKDOWN_PERIODS.join(', ')}`
-      );
-      return 1;
-    }
-    breakdownPeriod = breakdownFlag;
+  if (breakdownFlag && !isValidBreakdownPeriod(breakdownFlag)) {
+    error(
+      `Invalid breakdown period: "${breakdownFlag}". Valid options are: ${VALID_BREAKDOWN_PERIODS.join(', ')}`
+    );
+    return 1;
   }
+  const breakdownPeriod = breakdownFlag as BreakdownPeriod | undefined;
 
   const groupByFlag = parsedArgs.flags['--group-by'];
-  let groupByDimension: GroupByDimension | undefined;
-
-  if (groupByFlag) {
-    if (!isValidGroupByDimension(groupByFlag)) {
-      error(
-        `Invalid group-by dimension: "${groupByFlag}". Valid options are: ${VALID_GROUP_BY_DIMENSIONS.join(', ')}`
-      );
-      return 1;
-    }
-    groupByDimension = groupByFlag;
+  if (groupByFlag && !isValidGroupByDimension(groupByFlag)) {
+    error(
+      `Invalid group-by dimension: "${groupByFlag}". Valid options are: ${VALID_GROUP_BY_DIMENSIONS.join(', ')}`
+    );
+    return 1;
   }
+  const groupByDimension = groupByFlag as GroupByDimension | undefined;
 
   if (breakdownPeriod && groupByDimension) {
     error(
@@ -137,20 +110,15 @@ export default async function usage(client: Client): Promise<number> {
   telemetry.trackCliOptionBreakdown(breakdownFlag);
   telemetry.trackCliOptionGroupBy(groupByFlag);
 
-  if (fromFlag) {
-    debug(`Date conversion: ${fromFlag} -> ${fromDate}`);
-  }
-  if (toFlag) {
-    debug(`Date conversion: ${toFlag} (end of day) -> ${toDate}`);
-  }
-
   let contextName: string;
   let teamId: string | undefined;
+  let billingPeriod: { start: number; end: number } | undefined;
 
   try {
     const scope = await getScope(client);
     contextName = scope.contextName;
     teamId = scope.team?.id;
+    billingPeriod = (scope.team ?? scope.user).billing?.period;
   } catch (err: unknown) {
     if (
       isErrnoException(err) &&
@@ -162,41 +130,66 @@ export default async function usage(client: Client): Promise<number> {
     throw err;
   }
 
+  const usingDefaults = !fromFlag && !toFlag;
+  let fromDate: string;
+  let toDate: string;
+  try {
+    fromDate = fromFlag
+      ? parseDashboardDate(fromFlag, false)
+      : billingPeriod
+        ? new Date(billingPeriod.start).toISOString()
+        : getDefaultFromDate();
+    toDate = toFlag
+      ? parseDashboardDate(toFlag, true)
+      : billingPeriod
+        ? new Date(billingPeriod.end).toISOString()
+        : getDefaultToDate();
+  } catch (err) {
+    error((err as Error).message);
+    return 1;
+  }
+
+  const fromDisplay = fromFlag ?? extractDatePortion(fromDate);
+  const toDisplay = toFlag ?? extractDatePortion(toDate);
+  debug(`Fetching dashboard usage from ${fromDate} to ${toDate}`);
+
   const start = Date.now();
   if (!asJson) {
     spinner(`Fetching usage data for ${chalk.bold(contextName)}`);
   }
 
-  debug(`Fetching charges from ${fromDate} to ${toDate}`);
-
-  const query = new URLSearchParams({
-    from: fromDate,
-    to: toDate,
-  });
-  if (teamId) {
-    query.set('teamId', teamId);
-  }
-
   try {
-    const response = await client.fetch(`/v1/billing/charges?${query}`, {
-      json: false,
-      useCurrentTeam: false,
-    });
+    const query = new URLSearchParams({ from: fromDate, to: toDate });
+    if (teamId) query.set('teamId', teamId);
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      error(`Failed to fetch usage data: ${response.status} ${errorText}`);
-      return 1;
-    }
+    const response = await client.fetch<CostMetricsResponse>(
+      `/v2/billing/costs?${query}`,
+      {
+        method: 'POST',
+        body: {
+          from: fromDate,
+          to: toDate,
+          format: 'timeseries',
+          views: {
+            byProduct: { groupBy: ['product'] },
+            byProductRegionProject: {
+              groupBy: ['product', 'region', 'project'],
+            },
+          },
+          userAgent: 'vercel-cli.usage',
+        },
+        useCurrentTeam: false,
+      }
+    );
 
-    const usageData = await processCharges(
+    const usageData = processCosts(
       response,
-      breakdownPeriod,
-      groupByDimension,
       contextName,
       fromDisplay,
       toDisplay,
-      usingDefaults
+      usingDefaults,
+      breakdownPeriod,
+      groupByDimension
     );
 
     if (asJson) {
@@ -211,24 +204,12 @@ export default async function usage(client: Client): Promise<number> {
     }
 
     if (groupByDimension) {
-      outputGroupBy({
-        data: usageData,
-        groupByDimension,
-        startTime: start,
-      });
+      outputGroupBy({ data: usageData, groupByDimension, startTime: start });
     } else if (breakdownPeriod) {
-      outputBreakdown({
-        data: usageData,
-        breakdownPeriod,
-        startTime: start,
-      });
+      outputBreakdown({ data: usageData, breakdownPeriod, startTime: start });
     } else {
-      outputAggregated({
-        data: usageData,
-        startTime: start,
-      });
+      outputAggregated({ data: usageData, startTime: start });
     }
-
     return 0;
   } catch (err) {
     output.prettyError(err);
@@ -236,155 +217,212 @@ export default async function usage(client: Client): Promise<number> {
   }
 }
 
-function getGroupKey(charge: FocusCharge, dimension: GroupByDimension): string {
-  if (dimension === 'project') {
-    return (
-      charge.Tags?.ProjectName || charge.Tags?.ProjectId || '(unattributed)'
+function parseDashboardDate(value: string, end: boolean): string {
+  const date = value.includes('T')
+    ? DateTime.fromISO(value)
+    : DateTime.fromISO(value, { zone: 'America/Los_Angeles' }).startOf('day');
+  if (!date.isValid) {
+    throw new Error(
+      `Invalid date: "${value}". Expected ISO 8601 format (YYYY-MM-DD)`
     );
   }
-  return charge.RegionName || charge.RegionId || '(global)';
+  return (end && !value.includes('T') ? date.plus({ days: 1 }) : date)
+    .toUTC()
+    .toISO()!;
 }
 
-async function processCharges(
-  response: Response,
-  breakdownPeriod: BreakdownPeriod | undefined,
-  groupByDimension: GroupByDimension | undefined,
+function processCosts(
+  response: CostMetricsResponse,
   contextName: string,
   fromDisplay: string,
   toDisplay: string,
-  usingDefaults: boolean
-): Promise<UsageData> {
+  usingDefaults: boolean,
+  breakdownPeriod?: BreakdownPeriod,
+  groupByDimension?: GroupByDimension
+): UsageData {
+  const metrics = new Map(
+    response.metrics.map(metric => [metric.slug, metric])
+  );
+  const products = response.results.dimensionsMeta.product?.values ?? {};
+  const projects = response.results.dimensionsMeta.project?.values ?? {};
+  const regions = response.results.dimensionsMeta.region?.values ?? {};
+  const summaryView = response.results.views.byProduct;
+  const detailView = response.results.views.byProductRegionProject;
   const services = new Map<string, ServiceAggregation>();
   const periodUsage = new Map<string, PeriodAggregation>();
   const groupByUsage = new Map<string, GroupAggregation>();
-  let grandPricingQuantity = 0;
-  let grandEffective = 0;
-  let grandBilled = 0;
-  let chargeCount = 0;
-  let pricingUnit = 'MIUs';
+  let totalCost = 0;
 
-  await new Promise<void>((resolve, reject) => {
-    // gzip compression is assumed
-    const readable = toNodeReadable(response.body);
-    const stream = readable.pipe(jsonlines.parse());
+  for (const result of summaryView?.results ?? []) {
+    const product = result.dimensionValues.product;
+    if (!product) continue;
+    const productMetadata = products[product];
+    const serviceName = productMetadata?.title ?? product;
+    const aggregation = aggregateResult(
+      result,
+      metrics,
+      undefined,
+      productMetadata?.category === 'Subscription Licenses'
+    );
+    const aggregationName = aggregation.included
+      ? `${serviceName} (Flat Rate CDN)`
+      : serviceName;
+    addService(services, aggregationName, aggregation);
+    totalCost += aggregation.cost;
 
-    stream.on('data', (charge: FocusCharge) => {
-      chargeCount++;
-
-      // Capture pricing unit from the first charge
-      if (chargeCount === 1 && charge.PricingUnit) {
-        pricingUnit = charge.PricingUnit;
-      }
-
-      const serviceName = charge.ServiceName || 'Unknown';
-      const quantity = charge.PricingQuantity || 0;
-      const effective = charge.EffectiveCost || 0;
-      const billed = charge.BilledCost || 0;
-
-      // Accumulate grand totals
-      grandPricingQuantity += quantity;
-      grandEffective += effective;
-      grandBilled += billed;
-
-      // Accumulate per service
-      const existing = services.get(serviceName) || {
-        pricingQuantity: 0,
-        effectiveCost: 0,
-        billedCost: 0,
-        pricingUnit: charge.PricingUnit || pricingUnit,
-      };
-      services.set(serviceName, {
-        pricingQuantity: existing.pricingQuantity + quantity,
-        effectiveCost: existing.effectiveCost + effective,
-        billedCost: existing.billedCost + billed,
-        pricingUnit: existing.pricingUnit,
-      });
-
-      // Accumulate per period per service (for breakdown view)
-      if (breakdownPeriod) {
+    if (breakdownPeriod) {
+      for (let index = 0; index < response.results.times.length; index++) {
         const periodKey = getPeriodKey(
-          charge.ChargePeriodStart,
+          response.results.times[index],
           breakdownPeriod
         );
-
-        if (!periodUsage.has(periodKey)) {
-          periodUsage.set(periodKey, {
-            services: new Map(),
-            totalPricingQuantity: 0,
-            totalEffectiveCost: 0,
-            totalBilledCost: 0,
-          });
-        }
-        const periodData = periodUsage.get(periodKey)!;
-        periodData.totalPricingQuantity += quantity;
-        periodData.totalEffectiveCost += effective;
-        periodData.totalBilledCost += billed;
-
-        const periodService = periodData.services.get(serviceName) || {
-          pricingQuantity: 0,
-          effectiveCost: 0,
-          billedCost: 0,
-          pricingUnit: charge.PricingUnit || pricingUnit,
-        };
-        periodData.services.set(serviceName, {
-          pricingQuantity: periodService.pricingQuantity + quantity,
-          effectiveCost: periodService.effectiveCost + effective,
-          billedCost: periodService.billedCost + billed,
-          pricingUnit: periodService.pricingUnit,
-        });
+        const period = periodUsage.get(periodKey) ?? emptyPeriod();
+        const sample = aggregateResult(
+          result,
+          metrics,
+          index,
+          productMetadata?.category === 'Subscription Licenses'
+        );
+        addService(period.services, aggregationName, sample);
+        period.totalCost += sample.cost;
+        period.totalPricingQuantity += sample.cost;
+        period.totalEffectiveCost += sample.cost;
+        period.totalBilledCost += sample.cost;
+        periodUsage.set(periodKey, period);
       }
+    }
+  }
 
-      // Accumulate per group-by dimension
-      if (groupByDimension) {
-        const groupKey = getGroupKey(charge, groupByDimension);
-
-        if (!groupByUsage.has(groupKey)) {
-          groupByUsage.set(groupKey, {
-            services: new Map(),
-            totalPricingQuantity: 0,
-            totalEffectiveCost: 0,
-            totalBilledCost: 0,
-          });
-        }
-        const groupData = groupByUsage.get(groupKey)!;
-        groupData.totalPricingQuantity += quantity;
-        groupData.totalEffectiveCost += effective;
-        groupData.totalBilledCost += billed;
-
-        const groupService = groupData.services.get(serviceName) || {
-          pricingQuantity: 0,
-          effectiveCost: 0,
-          billedCost: 0,
-          pricingUnit: charge.PricingUnit || pricingUnit,
-        };
-        groupData.services.set(serviceName, {
-          pricingQuantity: groupService.pricingQuantity + quantity,
-          effectiveCost: groupService.effectiveCost + effective,
-          billedCost: groupService.billedCost + billed,
-          pricingUnit: groupService.pricingUnit,
-        });
-      }
-    });
-
-    stream.on('end', resolve);
-    stream.on('error', reject);
-    readable.on('error', reject);
-  });
+  if (groupByDimension) {
+    for (const result of detailView?.results ?? []) {
+      const product = result.dimensionValues.product;
+      if (!product) continue;
+      const productMetadata = products[product];
+      const serviceName = productMetadata?.title ?? product;
+      const aggregation = aggregateResult(
+        result,
+        metrics,
+        undefined,
+        productMetadata?.category === 'Subscription Licenses'
+      );
+      const aggregationName = aggregation.included
+        ? `${serviceName} (Flat Rate CDN)`
+        : serviceName;
+      const id = result.dimensionValues[groupByDimension];
+      const fallback =
+        groupByDimension === 'project' ? '(unattributed)' : '(global)';
+      const metadata = groupByDimension === 'project' ? projects : regions;
+      const groupName = id ? (metadata[id]?.title ?? id) : fallback;
+      const group = groupByUsage.get(groupName) ?? emptyGroup();
+      addService(group.services, aggregationName, aggregation);
+      group.totalCost += aggregation.cost;
+      group.totalPricingQuantity += aggregation.cost;
+      group.totalEffectiveCost += aggregation.cost;
+      group.totalBilledCost += aggregation.cost;
+      groupByUsage.set(groupName, group);
+    }
+  }
 
   return {
     contextName,
     fromDisplay,
     toDisplay,
     usingDefaults,
-    pricingUnit,
-    chargeCount,
+    chargeCount: summaryView?.results.length ?? 0,
     services,
     periodUsage,
     groupByUsage,
+    totalCost,
     grandTotals: {
-      pricingQuantity: grandPricingQuantity,
-      effectiveCost: grandEffective,
-      billedCost: grandBilled,
+      pricingQuantity: totalCost,
+      effectiveCost: totalCost,
+      billedCost: totalCost,
     },
+  };
+}
+
+function aggregateResult(
+  result: CostMetricGroup,
+  metrics: Map<string, CostMetric>,
+  sampleIndex?: number,
+  isSubscription = false
+): ServiceAggregation {
+  const costIndex = result.metrics.indexOf(COST_METRIC);
+  const quantityIndex = result.metrics.findIndex(
+    metric => metric !== COST_METRIC
+  );
+  const values =
+    sampleIndex === undefined
+      ? result.totalValue
+      : (result.values[sampleIndex] ?? []);
+  const cost = costIndex === -1 ? 0 : (values[costIndex] ?? 0);
+  const quantity = quantityIndex === -1 ? 0 : (values[quantityIndex] ?? 0);
+  const metric =
+    quantityIndex === -1
+      ? undefined
+      : metrics.get(result.metrics[quantityIndex]);
+  const unit = getUnitLabel(metric, quantity);
+
+  return {
+    quantity,
+    unit,
+    cost,
+    included: result.flatRate === true,
+    category: isSubscription ? 'subscription' : 'usage',
+    pricingQuantity: cost,
+    pricingUnit: 'USD',
+    effectiveCost: cost,
+    billedCost: cost,
+  };
+}
+
+function getUnitLabel(
+  metric: CostMetric | undefined,
+  quantity: number
+): string {
+  if (!metric) return 'licenses';
+  if (metric.unit.kind === 'custom') {
+    return quantity === 1
+      ? (metric.unit.singular ?? metric.unit.plural ?? metric.title)
+      : (metric.unit.plural ?? metric.unit.singular ?? metric.title);
+  }
+  return metric.unit.name ?? metric.title;
+}
+
+function addService(
+  services: Map<string, ServiceAggregation>,
+  name: string,
+  value: ServiceAggregation
+): void {
+  const existing = services.get(name);
+  if (!existing) {
+    services.set(name, { ...value });
+    return;
+  }
+  existing.quantity += value.quantity;
+  existing.cost += value.cost;
+  existing.included ||= value.included;
+  existing.pricingQuantity += value.pricingQuantity;
+  existing.effectiveCost += value.effectiveCost;
+  existing.billedCost += value.billedCost;
+}
+
+function emptyPeriod(): PeriodAggregation {
+  return {
+    services: new Map(),
+    totalCost: 0,
+    totalPricingQuantity: 0,
+    totalEffectiveCost: 0,
+    totalBilledCost: 0,
+  };
+}
+
+function emptyGroup(): GroupAggregation {
+  return {
+    services: new Map(),
+    totalCost: 0,
+    totalPricingQuantity: 0,
+    totalEffectiveCost: 0,
+    totalBilledCost: 0,
   };
 }

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -30,6 +30,7 @@ import { outputJson } from './output-json';
 import type {
   BreakdownPeriod,
   CommitmentUsageResponse,
+  CostMetric,
   CostMetricGroup,
   CostMetricsResponse,
   GroupAggregation,
@@ -329,6 +330,7 @@ function processCosts(
     const aggregation = aggregateResult(
       result,
       product,
+      response.metrics,
       undefined,
       productMetadata?.category === 'Subscription Licenses'
     );
@@ -346,6 +348,7 @@ function processCosts(
         const sample = aggregateResult(
           result,
           product,
+          response.metrics,
           index,
           productMetadata?.category === 'Subscription Licenses'
         );
@@ -366,6 +369,7 @@ function processCosts(
       const aggregation = aggregateResult(
         result,
         product,
+        response.metrics,
         undefined,
         productMetadata?.category === 'Subscription Licenses'
       );
@@ -413,12 +417,16 @@ function getCostUnit(response: CostMetricsResponse): UsageData['costUnit'] {
 function aggregateResult(
   result: CostMetricGroup,
   product: string,
+  metrics: CostMetric[],
   sampleIndex?: number,
   isSubscription = false
 ): ServiceAggregation {
   const grossCostIndex = result.metrics.indexOf(GROSS_COST_METRIC);
   const quantityIndex = result.metrics.findIndex(
     metric => metric !== GROSS_COST_METRIC
+  );
+  const quantityMetric = metrics.find(
+    metric => metric.slug === result.metrics[quantityIndex]
   );
   const values =
     sampleIndex === undefined
@@ -430,21 +438,44 @@ function aggregateResult(
   const effectiveCost = included ? 0 : cost;
   const rawQuantity = quantityIndex === -1 ? 0 : (values[quantityIndex] ?? 0);
   const quantity = isSubscription ? rawQuantity || 1 : rawQuantity;
-  const unit = isSubscription
-    ? quantity === 1
-      ? 'license'
-      : 'licenses'
-    : undefined;
+  const units = getQuantityUnits(quantityMetric, product, isSubscription);
 
   return {
     product,
     quantity,
-    unit,
+    ...units,
     cost,
     included,
     category: isSubscription ? 'subscription' : 'usage',
     effectiveCost,
   };
+}
+
+function getQuantityUnits(
+  metric: CostMetric | undefined,
+  product: string,
+  isSubscription: boolean
+): Pick<ServiceAggregation, 'unit' | 'singularUnit' | 'unitKind'> {
+  if (isSubscription) {
+    return { unit: 'licenses', singularUnit: 'license' };
+  }
+
+  if (!metric?.unit) return {};
+  if (metric.unit.kind === 'custom') {
+    const singularUnit = metric.unit.singular;
+    const unit = metric.unit.plural ?? singularUnit;
+    if (!unit || singularUnit === metric.title || unit === metric.title)
+      return {};
+    return { unit, singularUnit };
+  }
+
+  if (metric.unit.kind === 'digitalStorage' && metric.unit.name) {
+    return { unit: metric.unit.name, unitKind: metric.unit.kind };
+  }
+
+  const unit = metric.unit.name;
+  if (!unit || unit === metric.title || unit === product) return {};
+  return { unit, unitKind: metric.unit.kind };
 }
 
 function addService(
@@ -457,14 +488,16 @@ function addService(
     services.set(name, { ...value });
     return;
   }
+  const previousQuantity = existing.quantity;
   existing.quantity =
     existing.category === 'subscription'
-      ? Math.max(existing.quantity, value.quantity)
-      : existing.quantity + value.quantity;
+      ? Math.max(previousQuantity, value.quantity)
+      : previousQuantity + value.quantity;
   existing.cost += value.cost;
   if (value.quantity !== 0) {
+    // Zero-quantity contributors do not decide whether a product is included.
     existing.included =
-      existing.quantity === value.quantity
+      previousQuantity === 0
         ? value.included
         : existing.included && value.included;
   }

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { DateTime } from 'luxon';
 import { parseArguments } from '../../util/get-args';
 import { printError } from '../../util/error';
 import type Client from '../../util/client';
@@ -15,6 +14,7 @@ import {
   getDefaultFromDate,
   getDefaultToDate,
   getPeriodKey,
+  parseBillingDate,
   isValidBreakdownPeriod,
   VALID_BREAKDOWN_PERIODS,
 } from '../../util/billing/period-utils';
@@ -30,7 +30,6 @@ import { outputJson } from './output-json';
 import type {
   BreakdownPeriod,
   CommitmentUsageResponse,
-  CostMetric,
   CostMetricGroup,
   CostMetricsResponse,
   GroupAggregation,
@@ -109,7 +108,6 @@ export default async function usage(client: Client): Promise<number> {
   telemetry.trackCliOptionFrom(fromFlag);
   telemetry.trackCliOptionTo(toFlag);
   telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
-  telemetry.trackCliFlagAll(parsedArgs.flags['--all']);
   telemetry.trackCliOptionBreakdown(breakdownFlag);
   telemetry.trackCliOptionGroupBy(groupByFlag);
 
@@ -117,13 +115,22 @@ export default async function usage(client: Client): Promise<number> {
   let contextType: 'team' | 'personal account';
   let teamId: string | undefined;
   let billingPeriod: { start: number; end: number } | undefined;
+  let hasPrecommitment = false;
 
   try {
     const scope = await getScope(client);
+    const owner = scope.team ?? scope.user;
     contextName = scope.contextName;
     contextType = scope.team ? 'team' : 'personal account';
     teamId = scope.team?.id;
-    billingPeriod = (scope.team ?? scope.user).billing?.period;
+    billingPeriod = owner.billing?.period;
+    const billing = owner.billing as
+      | { plan?: string; planIteration?: string }
+      | undefined;
+    hasPrecommitment =
+      billing?.plan === 'enterprise' ||
+      billing?.planIteration === 'plus' ||
+      (billing?.plan === 'pro' && billing?.planIteration === 'flex');
   } catch (err: unknown) {
     if (
       isErrnoException(err) &&
@@ -140,12 +147,12 @@ export default async function usage(client: Client): Promise<number> {
   let toDate: string;
   try {
     fromDate = fromFlag
-      ? parseDashboardDate(fromFlag, false)
+      ? parseBillingDate(fromFlag, false)
       : billingPeriod
         ? new Date(billingPeriod.start).toISOString()
         : getDefaultFromDate();
     toDate = toFlag
-      ? parseDashboardDate(toFlag, true)
+      ? parseBillingDate(toFlag, true)
       : billingPeriod
         ? new Date(billingPeriod.end).toISOString()
         : getDefaultToDate();
@@ -164,32 +171,36 @@ export default async function usage(client: Client): Promise<number> {
   }
 
   try {
-    const query = new URLSearchParams({ from: fromDate, to: toDate });
+    const query = new URLSearchParams();
     if (teamId) query.set('teamId', teamId);
+    const views: Record<string, { groupBy: string[] }> = {
+      byProduct: { groupBy: ['product'] },
+    };
+    if (groupByDimension) {
+      views.byProductRegionProject = {
+        groupBy: ['product', 'region', 'project'],
+      };
+    }
 
     const costsRequest = client.fetch<CostMetricsResponse>(
-      `/v2/billing/costs?${query}`,
+      `/v2/billing/costs${query.size > 0 ? `?${query}` : ''}`,
       {
         method: 'POST',
         body: {
           from: fromDate,
           to: toDate,
+          currency: 'USD',
           // TODO: Request `net_cost` here once the billing costs API PR lands.
           metrics: [GROSS_COST_METRIC, 'quantity'],
           format: 'timeseries',
-          views: {
-            byProduct: { groupBy: ['product'] },
-            byProductRegionProject: {
-              groupBy: ['product', 'region', 'project'],
-            },
-          },
+          views,
           userAgent: 'vercel-cli.usage',
         },
         useCurrentTeam: false,
       }
     );
     const commitmentRequest =
-      usingDefaults && teamId
+      usingDefaults && teamId && hasPrecommitment
         ? client
             .fetch<CommitmentUsageResponse>(
               `/v1/invoices/pre-commitment-usage?teamId=${encodeURIComponent(teamId)}`,
@@ -206,18 +217,16 @@ export default async function usage(client: Client): Promise<number> {
       commitmentRequest,
     ]);
 
-    const usageData = processCosts(
-      response,
+    const usageData = processCosts(response, {
       contextName,
       contextType,
-      parsedArgs.flags['--scope'],
+      scope: parsedArgs.flags['--scope'],
       fromDisplay,
       toDisplay,
       usingDefaults,
-      Boolean(parsedArgs.flags['--all']),
       breakdownPeriod,
-      groupByDimension
-    );
+      groupByDimension,
+    });
     const creditLedger = commitmentUsage?.creditLedgers[0];
     if (creditLedger) {
       const used = roundToHundredths(
@@ -270,40 +279,42 @@ function getUsageThrough(queriedAt: string, toDisplay: string): string {
   return queriedDate < toDisplay ? queriedDate : toDisplay;
 }
 
-function parseDashboardDate(value: string, end: boolean): string {
-  const date = value.includes('T')
-    ? DateTime.fromISO(value)
-    : DateTime.fromISO(value, { zone: 'America/Los_Angeles' }).startOf('day');
-  if (!date.isValid) {
-    throw new Error(
-      `Invalid date: "${value}". Expected ISO 8601 format (YYYY-MM-DD)`
-    );
-  }
-  return (end && !value.includes('T') ? date.plus({ days: 1 }) : date)
-    .toUTC()
-    .toISO()!;
-}
-
 function processCosts(
   response: CostMetricsResponse,
-  contextName: string,
-  contextType: 'team' | 'personal account',
-  scope: string | undefined,
-  fromDisplay: string,
-  toDisplay: string,
-  usingDefaults: boolean,
-  showAll: boolean,
-  breakdownPeriod?: BreakdownPeriod,
-  groupByDimension?: GroupByDimension
+  options: {
+    contextName: string;
+    contextType: 'team' | 'personal account';
+    scope?: string;
+    fromDisplay: string;
+    toDisplay: string;
+    usingDefaults: boolean;
+    breakdownPeriod?: BreakdownPeriod;
+    groupByDimension?: GroupByDimension;
+  }
 ): UsageData {
-  const metrics = new Map(
-    response.metrics.map(metric => [metric.slug, metric])
-  );
+  const {
+    contextName,
+    contextType,
+    scope,
+    fromDisplay,
+    toDisplay,
+    usingDefaults,
+    breakdownPeriod,
+    groupByDimension,
+  } = options;
   const products = response.results.dimensionsMeta.product?.values ?? {};
   const projects = response.results.dimensionsMeta.project?.values ?? {};
   const regions = response.results.dimensionsMeta.region?.values ?? {};
   const summaryView = response.results.views.byProduct;
   const detailView = response.results.views.byProductRegionProject;
+  if (
+    groupByDimension &&
+    (!detailView || !detailView.groupBy.includes(groupByDimension))
+  ) {
+    throw new Error(
+      `Usage cannot be grouped by ${groupByDimension} for this team.`
+    );
+  }
   const services = new Map<string, ServiceAggregation>();
   const periodUsage = new Map<string, PeriodAggregation>();
   const groupByUsage = new Map<string, GroupAggregation>();
@@ -317,14 +328,10 @@ function processCosts(
     const serviceName = productMetadata?.title ?? product;
     const aggregation = aggregateResult(
       result,
-      metrics,
       undefined,
       productMetadata?.category === 'Subscription Licenses'
     );
-    const aggregationName = aggregation.included
-      ? `${serviceName} (Flat Rate CDN)`
-      : serviceName;
-    addService(services, aggregationName, aggregation);
+    addService(services, serviceName, aggregation);
     totalCost += aggregation.cost;
     totalEffectiveCost += aggregation.effectiveCost;
 
@@ -334,18 +341,15 @@ function processCosts(
           response.results.times[index],
           breakdownPeriod
         );
-        const period = periodUsage.get(periodKey) ?? emptyPeriod();
+        const period = periodUsage.get(periodKey) ?? emptyAggregation();
         const sample = aggregateResult(
           result,
-          metrics,
           index,
           productMetadata?.category === 'Subscription Licenses'
         );
-        addService(period.services, aggregationName, sample);
+        addService(period.services, serviceName, sample);
         period.totalCost += sample.cost;
-        period.totalPricingQuantity += sample.cost;
         period.totalEffectiveCost += sample.effectiveCost;
-        period.totalBilledCost += sample.billedCost;
         periodUsage.set(periodKey, period);
       }
     }
@@ -359,24 +363,18 @@ function processCosts(
       const serviceName = productMetadata?.title ?? product;
       const aggregation = aggregateResult(
         result,
-        metrics,
         undefined,
         productMetadata?.category === 'Subscription Licenses'
       );
-      const aggregationName = aggregation.included
-        ? `${serviceName} (Flat Rate CDN)`
-        : serviceName;
       const id = result.dimensionValues[groupByDimension];
       const fallback =
         groupByDimension === 'project' ? '(unattributed)' : '(global)';
       const metadata = groupByDimension === 'project' ? projects : regions;
       const groupName = id ? (metadata[id]?.title ?? id) : fallback;
-      const group = groupByUsage.get(groupName) ?? emptyGroup();
-      addService(group.services, aggregationName, aggregation);
+      const group = groupByUsage.get(groupName) ?? emptyAggregation();
+      addService(group.services, serviceName, aggregation);
       group.totalCost += aggregation.cost;
-      group.totalPricingQuantity += aggregation.cost;
       group.totalEffectiveCost += aggregation.effectiveCost;
-      group.totalBilledCost += aggregation.billedCost;
       groupByUsage.set(groupName, group);
     }
   }
@@ -389,30 +387,24 @@ function processCosts(
     toDisplay,
     usageThrough: getUsageThrough(response.queriedAt, toDisplay),
     usingDefaults,
-    showAll,
-    chargeCount: summaryView?.results.length ?? 0,
+    costUnit: 'USD',
     services,
     periodUsage,
     groupByUsage,
     totalCost,
     grandTotals: {
-      pricingQuantity: totalCost,
       effectiveCost: totalEffectiveCost,
-      billedCost: totalEffectiveCost,
     },
   };
 }
 
 function aggregateResult(
   result: CostMetricGroup,
-  metrics: Map<string, CostMetric>,
   sampleIndex?: number,
   isSubscription = false
 ): ServiceAggregation {
   const grossCostIndex = result.metrics.indexOf(GROSS_COST_METRIC);
-  const quantityIndex = result.metrics.findIndex(
-    metric => metric !== GROSS_COST_METRIC
-  );
+  const quantityIndex = result.metrics.indexOf('quantity');
   const values =
     sampleIndex === undefined
       ? result.totalValue
@@ -421,12 +413,13 @@ function aggregateResult(
   const included = result.flatRate === true;
   // TODO: Read `net_cost` directly once the billing costs API PR lands.
   const effectiveCost = included ? 0 : cost;
-  const quantity = quantityIndex === -1 ? 0 : (values[quantityIndex] ?? 0);
-  const metric =
-    quantityIndex === -1
-      ? undefined
-      : metrics.get(result.metrics[quantityIndex]);
-  const unit = getUnitLabel(metric, quantity);
+  const rawQuantity = quantityIndex === -1 ? 0 : (values[quantityIndex] ?? 0);
+  const quantity = isSubscription ? rawQuantity || 1 : rawQuantity;
+  const unit = isSubscription
+    ? quantity === 1
+      ? 'license'
+      : 'licenses'
+    : undefined;
 
   return {
     quantity,
@@ -434,24 +427,8 @@ function aggregateResult(
     cost,
     included,
     category: isSubscription ? 'subscription' : 'usage',
-    pricingQuantity: cost,
-    pricingUnit: 'USD',
     effectiveCost,
-    billedCost: effectiveCost,
   };
-}
-
-function getUnitLabel(
-  metric: CostMetric | undefined,
-  quantity: number
-): string {
-  if (!metric?.unit) return quantity === 1 ? 'license' : 'licenses';
-  if (metric.unit.kind === 'custom') {
-    return quantity === 1
-      ? (metric.unit.singular ?? metric.unit.plural ?? metric.title)
-      : (metric.unit.plural ?? metric.unit.singular ?? metric.title);
-  }
-  return metric.unit.name ?? metric.title;
 }
 
 function addService(
@@ -466,28 +443,14 @@ function addService(
   }
   existing.quantity += value.quantity;
   existing.cost += value.cost;
-  existing.included ||= value.included;
-  existing.pricingQuantity += value.pricingQuantity;
+  existing.included &&= value.included;
   existing.effectiveCost += value.effectiveCost;
-  existing.billedCost += value.billedCost;
 }
 
-function emptyPeriod(): PeriodAggregation {
+function emptyAggregation(): PeriodAggregation {
   return {
     services: new Map(),
     totalCost: 0,
-    totalPricingQuantity: 0,
     totalEffectiveCost: 0,
-    totalBilledCost: 0,
-  };
-}
-
-function emptyGroup(): GroupAggregation {
-  return {
-    services: new Map(),
-    totalCost: 0,
-    totalPricingQuantity: 0,
-    totalEffectiveCost: 0,
-    totalBilledCost: 0,
   };
 }

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -404,7 +404,9 @@ function aggregateResult(
   isSubscription = false
 ): ServiceAggregation {
   const grossCostIndex = result.metrics.indexOf(GROSS_COST_METRIC);
-  const quantityIndex = result.metrics.indexOf('quantity');
+  const quantityIndex = result.metrics.findIndex(
+    metric => metric !== GROSS_COST_METRIC
+  );
   const values =
     sampleIndex === undefined
       ? result.totalValue

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -33,6 +33,7 @@ import type {
   CostMetric,
   CostMetricGroup,
   CostMetricsResponse,
+  CostMetricView,
   GroupAggregation,
   GroupByDimension,
   PeriodAggregation,
@@ -41,7 +42,35 @@ import type {
 } from './types';
 
 const GROSS_COST_METRIC = 'gross_cost';
+const SUMMARY_VIEW = 'byProduct';
+const DETAIL_VIEW = 'byProductRegionProject';
 // TODO: Add `net_cost` once the billing costs API contract supports it.
+
+type CostViewRequest = Record<string, { groupBy: string[] }>;
+
+function getCostViews(groupByDimension?: GroupByDimension): {
+  views: CostViewRequest;
+  summaryViewName: string;
+  detailViewName?: string;
+  includeCredit: boolean;
+} {
+  const views: CostViewRequest = {
+    [SUMMARY_VIEW]: { groupBy: ['product'] },
+  };
+
+  if (groupByDimension) {
+    views[DETAIL_VIEW] = {
+      groupBy: ['product', 'region', 'project'],
+    };
+  }
+
+  return {
+    views,
+    summaryViewName: SUMMARY_VIEW,
+    detailViewName: groupByDimension ? DETAIL_VIEW : undefined,
+    includeCredit: true,
+  };
+}
 
 export default async function usage(client: Client): Promise<number> {
   const { print, error, debug, spinner } = output;
@@ -174,14 +203,7 @@ export default async function usage(client: Client): Promise<number> {
   try {
     const query = new URLSearchParams();
     if (teamId) query.set('teamId', teamId);
-    const views: Record<string, { groupBy: string[] }> = {
-      byProduct: { groupBy: ['product'] },
-    };
-    if (groupByDimension) {
-      views.byProductRegionProject = {
-        groupBy: ['product', 'region', 'project'],
-      };
-    }
+    const viewPlan = getCostViews(groupByDimension);
 
     const queryString = query.toString();
     const costsRequest = client.fetch<CostMetricsResponse>(
@@ -194,7 +216,7 @@ export default async function usage(client: Client): Promise<number> {
           // TODO: Request `net_cost` here once the billing costs API PR lands.
           metrics: [GROSS_COST_METRIC, 'quantity'],
           format: 'timeseries',
-          views,
+          views: viewPlan.views,
           userAgent: 'vercel-cli.usage',
         },
         useCurrentTeam: false,
@@ -219,6 +241,10 @@ export default async function usage(client: Client): Promise<number> {
     ]);
 
     const usageData = processCosts(response, {
+      summaryView: response.results.views[viewPlan.summaryViewName],
+      detailView: viewPlan.detailViewName
+        ? response.results.views[viewPlan.detailViewName]
+        : undefined,
       contextName,
       contextType,
       scope: parsedArgs.flags['--scope'],
@@ -228,23 +254,7 @@ export default async function usage(client: Client): Promise<number> {
       breakdownPeriod,
       groupByDimension,
     });
-    const creditLedger = commitmentUsage?.creditLedgers[0];
-    if (creditLedger) {
-      const used = roundToHundredths(
-        creditLedger.total - creditLedger.remaining
-      );
-      usageData.credit = {
-        cadence: commitmentUsage.cadence,
-        currency: creditLedger.currency,
-        allocated: creditLedger.total,
-        used,
-        remaining: creditLedger.remaining,
-        progress:
-          creditLedger.total > 0
-            ? roundToHundredths((used / creditLedger.total) * 100)
-            : 0,
-      };
-    }
+    attachCredit(usageData, commitmentUsage, viewPlan.includeCredit);
 
     if (asJson) {
       outputJson(client, {
@@ -280,9 +290,35 @@ function getUsageThrough(queriedAt: string, toDisplay: string): string {
   return queriedDate < toDisplay ? queriedDate : toDisplay;
 }
 
+function attachCredit(
+  usageData: UsageData,
+  commitmentUsage: CommitmentUsageResponse | null,
+  includeCredit: boolean
+): void {
+  if (!includeCredit) return;
+
+  const creditLedger = commitmentUsage?.creditLedgers[0];
+  if (!creditLedger) return;
+
+  const used = roundToHundredths(creditLedger.total - creditLedger.remaining);
+  usageData.credit = {
+    cadence: commitmentUsage.cadence,
+    currency: creditLedger.currency,
+    allocated: creditLedger.total,
+    used,
+    remaining: creditLedger.remaining,
+    progress:
+      creditLedger.total > 0
+        ? roundToHundredths((used / creditLedger.total) * 100)
+        : 0,
+  };
+}
+
 function processCosts(
   response: CostMetricsResponse,
   options: {
+    summaryView?: CostMetricView;
+    detailView?: CostMetricView;
     contextName: string;
     contextType: 'team' | 'personal account';
     scope?: string;
@@ -294,6 +330,8 @@ function processCosts(
   }
 ): UsageData {
   const {
+    summaryView,
+    detailView,
     contextName,
     contextType,
     scope,
@@ -306,8 +344,6 @@ function processCosts(
   const products = response.results.dimensionsMeta.product?.values ?? {};
   const projects = response.results.dimensionsMeta.project?.values ?? {};
   const regions = response.results.dimensionsMeta.region?.values ?? {};
-  const summaryView = response.results.views.byProduct;
-  const detailView = response.results.views.byProductRegionProject;
   if (
     groupByDimension &&
     (!detailView || !detailView.groupBy.includes(groupByDimension))

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -124,9 +124,9 @@ export default async function usage(client: Client): Promise<number> {
     contextType = scope.team ? 'team' : 'personal account';
     teamId = scope.team?.id;
     billingPeriod = owner.billing?.period;
-    const billing = owner.billing as
-      | { plan?: string; planIteration?: string }
-      | undefined;
+    const billing = owner.billing;
+    // Keep this predicate aligned with `hasPrecommitment` in
+    // api/packages/billing/orb-client/utils/get-precommitment-usage.ts.
     hasPrecommitment =
       billing?.plan === 'enterprise' ||
       billing?.planIteration === 'plus' ||
@@ -182,14 +182,14 @@ export default async function usage(client: Client): Promise<number> {
       };
     }
 
+    const queryString = query.toString();
     const costsRequest = client.fetch<CostMetricsResponse>(
-      `/v2/billing/costs${query.size > 0 ? `?${query}` : ''}`,
+      `/v2/billing/costs${queryString ? `?${queryString}` : ''}`,
       {
         method: 'POST',
         body: {
           from: fromDate,
           to: toDate,
-          currency: 'USD',
           // TODO: Request `net_cost` here once the billing costs API PR lands.
           metrics: [GROSS_COST_METRIC, 'quantity'],
           format: 'timeseries',
@@ -328,6 +328,7 @@ function processCosts(
     const serviceName = productMetadata?.title ?? product;
     const aggregation = aggregateResult(
       result,
+      product,
       undefined,
       productMetadata?.category === 'Subscription Licenses'
     );
@@ -344,6 +345,7 @@ function processCosts(
         const period = periodUsage.get(periodKey) ?? emptyAggregation();
         const sample = aggregateResult(
           result,
+          product,
           index,
           productMetadata?.category === 'Subscription Licenses'
         );
@@ -363,6 +365,7 @@ function processCosts(
       const serviceName = productMetadata?.title ?? product;
       const aggregation = aggregateResult(
         result,
+        product,
         undefined,
         productMetadata?.category === 'Subscription Licenses'
       );
@@ -387,7 +390,7 @@ function processCosts(
     toDisplay,
     usageThrough: getUsageThrough(response.queriedAt, toDisplay),
     usingDefaults,
-    costUnit: 'USD',
+    costUnit: getCostUnit(response),
     services,
     periodUsage,
     groupByUsage,
@@ -398,8 +401,18 @@ function processCosts(
   };
 }
 
+function getCostUnit(response: CostMetricsResponse): UsageData['costUnit'] {
+  const unit = response.metrics.find(
+    metric => metric.slug === GROSS_COST_METRIC
+  )?.unit;
+  return unit?.singular === 'MIU' || unit?.plural === 'MIUs'
+    ? 'managed_infrastructure_units'
+    : 'USD';
+}
+
 function aggregateResult(
   result: CostMetricGroup,
+  product: string,
   sampleIndex?: number,
   isSubscription = false
 ): ServiceAggregation {
@@ -424,6 +437,7 @@ function aggregateResult(
     : undefined;
 
   return {
+    product,
     quantity,
     unit,
     cost,
@@ -443,9 +457,17 @@ function addService(
     services.set(name, { ...value });
     return;
   }
-  existing.quantity += value.quantity;
+  existing.quantity =
+    existing.category === 'subscription'
+      ? Math.max(existing.quantity, value.quantity)
+      : existing.quantity + value.quantity;
   existing.cost += value.cost;
-  existing.included &&= value.included;
+  if (value.quantity !== 0) {
+    existing.included =
+      existing.quantity === value.quantity
+        ? value.included
+        : existing.included && value.included;
+  }
   existing.effectiveCost += value.effectiveCost;
 }
 

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -3,7 +3,7 @@ import table from '../../util/output/table';
 import output from '../../output-manager';
 import elapsed from '../../util/output/elapsed';
 import { formatCurrency, formatQuantity } from '../../util/billing/format';
-import type { OutputOptions } from './types';
+import type { OutputOptions, ServiceAggregation } from './types';
 
 export function outputAggregated({ data, startTime }: OutputOptions): void {
   const { print, log } = output;
@@ -12,16 +12,14 @@ export function outputAggregated({ data, startTime }: OutputOptions): void {
     `Usage for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
   );
   log('');
-  const periodSuffix = data.usingDefaults ? ' (current month)' : '';
+  const periodSuffix = data.usingDefaults ? ' (current billing cycle)' : '';
   log(
     `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
   );
-  log(`${chalk.gray('Charges processed:')} ${data.chargeCount}`);
-  log(`${chalk.gray('Pricing unit:')} ${data.pricingUnit}`);
   log('');
 
   const sortedServices = [...data.services.entries()].sort(
-    (a, b) => b[1].billedCost - a[1].billedCost
+    (a, b) => b[1].cost - a[1].cost
   );
 
   if (sortedServices.length === 0) {
@@ -29,33 +27,47 @@ export function outputAggregated({ data, startTime }: OutputOptions): void {
     return;
   }
 
-  const quantityHeader =
-    data.pricingUnit === 'USD' ? 'Usage (USD)' : data.pricingUnit;
-  const headers = ['Service', quantityHeader, 'Effective Cost', 'Billed Cost'];
-  const rows = sortedServices.map(([name, svc]) => [
-    name,
-    formatQuantity(svc.pricingQuantity, svc.pricingUnit),
-    formatCurrency(svc.effectiveCost),
-    formatCurrency(svc.billedCost),
-  ]);
+  const usage = sortedServices.filter(
+    ([, service]) => service.category === 'usage'
+  );
+  const subscriptions = sortedServices.filter(
+    ([, service]) => service.category === 'subscription'
+  );
 
-  rows.push([
-    chalk.bold('Total'),
-    chalk.bold(
-      formatQuantity(data.grandTotals.pricingQuantity, data.pricingUnit)
-    ),
-    chalk.bold(formatCurrency(data.grandTotals.effectiveCost)),
-    chalk.bold(formatCurrency(data.grandTotals.billedCost)),
+  if (usage.length > 0) {
+    log(chalk.bold('Infrastructure'));
+    printTable(print, usage);
+    log('');
+  }
+
+  if (subscriptions.length > 0) {
+    log(chalk.bold('Subscription licenses'));
+    printTable(print, subscriptions);
+    log('');
+  }
+
+  log(
+    `${chalk.gray('Estimated total:')} ${chalk.bold(formatCurrency(data.totalCost))}`
+  );
+}
+
+function printTable(
+  print: (message: string) => void,
+  services: [string, ServiceAggregation][]
+): void {
+  const headers = ['Service', 'Usage', 'Cost'];
+  const rows = services.map(([name, service]) => [
+    service.included ? chalk.blue(name) : name,
+    service.category === 'subscription'
+      ? formatQuantity(service.quantity || 1, 'licenses')
+      : formatQuantity(service.quantity, service.unit),
+    service.included ? 'Included' : formatCurrency(service.cost),
   ]);
 
   const tablePrint = table(
-    [headers.map(h => chalk.bold(chalk.cyan(h))), ...rows],
-    { hsep: 4, align: ['l', 'r', 'r', 'r'] }
+    [headers.map(header => chalk.bold(chalk.cyan(header))), ...rows],
+    { hsep: 4, align: ['l', 'r', 'r'] }
   ).replace(/^/gm, '  ');
 
-  print(`\n${tablePrint}\n\n`);
-
-  log(
-    `${chalk.gray('Amount due:')} ${chalk.bold(formatCurrency(data.grandTotals.billedCost))}`
-  );
+  print(`\n${tablePrint}\n`);
 }

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -3,27 +3,43 @@ import table from '../../util/output/table';
 import output from '../../output-manager';
 import elapsed from '../../util/output/elapsed';
 import { formatCurrency, formatQuantity } from '../../util/billing/format';
-import type { OutputOptions, ServiceAggregation } from './types';
+import type { OutputOptions, ServiceAggregation, UsageData } from './types';
+import {
+  outputHiddenServicesHint,
+  outputUsageHeader,
+  visibleServices,
+} from './output-utils';
 
 export function outputAggregated({ data, startTime }: OutputOptions): void {
   const { print, log } = output;
 
-  log(
-    `Usage for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
-  );
-  log('');
-  const periodSuffix = data.usingDefaults ? ' (current billing cycle)' : '';
-  log(
-    `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
-  );
-  log('');
+  outputUsageHeader(data, 'Usage', elapsed(Date.now() - startTime));
 
-  const sortedServices = [...data.services.entries()].sort(
-    (a, b) => b[1].cost - a[1].cost
+  if (data.credit) {
+    log(chalk.bold('Credit'));
+    if (data.credit.cadence) {
+      log(
+        `  ${chalk.gray('Cadence')}    ${formatCadence(data.credit.cadence)}`
+      );
+    }
+    log(
+      `  ${chalk.gray('Used')}       ${formatCurrency(data.credit.used)} of ${formatCurrency(data.credit.allocated)}`
+    );
+    log(
+      `  ${chalk.gray('Remaining')}  ${formatCurrency(data.credit.remaining)}`
+    );
+    log(`  ${chalk.gray('Progress')}   ${Math.round(data.credit.progress)}%`);
+    log('');
+  }
+
+  const allServices = [...data.services.entries()];
+  const sortedServices = visibleServices(data.services, data.showAll).sort(
+    (a, b) => b[1].effectiveCost - a[1].effectiveCost
   );
 
   if (sortedServices.length === 0) {
     log('No usage data found for this period.');
+    outputHiddenServicesHint(allServices.length, data.scope);
     return;
   }
 
@@ -36,32 +52,96 @@ export function outputAggregated({ data, startTime }: OutputOptions): void {
 
   if (usage.length > 0) {
     log(chalk.bold('Infrastructure'));
-    printTable(print, usage);
+    printTable(print, usage, 'Infrastructure subtotal');
     log('');
   }
 
   if (subscriptions.length > 0) {
     log(chalk.bold('Subscription licenses'));
-    printTable(print, subscriptions);
+    printTable(print, subscriptions, 'Subscriptions subtotal');
     log('');
   }
 
-  log(
-    `${chalk.gray('Estimated total:')} ${chalk.bold(formatCurrency(data.totalCost))}`
+  printBillSummary(print, usage, subscriptions, data.credit?.used);
+  outputHiddenServicesHint(
+    allServices.length - sortedServices.length,
+    data.scope
+  );
+}
+
+function formatCadence(
+  cadence: NonNullable<NonNullable<UsageData['credit']>['cadence']>
+): string {
+  return cadence
+    .split('_')
+    .map(word => word[0].toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function printBillSummary(
+  print: (message: string) => void,
+  usage: [string, ServiceAggregation][],
+  subscriptions: [string, ServiceAggregation][],
+  creditsApplied = 0
+): void {
+  const subscriptionCost = sumEffectiveCost(subscriptions);
+  const infrastructureCost = sumEffectiveCost(usage);
+  const appliedCredit = Math.min(creditsApplied, infrastructureCost);
+  const estimatedBill = subscriptionCost + infrastructureCost - appliedCredit;
+  const rows = [
+    ['Subscriptions', formatCurrency(subscriptionCost)],
+    ['Infrastructure usage', formatCurrency(infrastructureCost)],
+  ];
+
+  if (appliedCredit > 0) {
+    rows.push(['Credits applied', `-${formatCurrency(appliedCredit)}`]);
+  }
+  rows.push([
+    chalk.bold('Estimated bill'),
+    chalk.bold(formatCurrency(estimatedBill)),
+  ]);
+
+  const tablePrint = table(rows, { hsep: 4, align: ['l', 'r'] }).replace(
+    /^/gm,
+    '  '
+  );
+  print(`${tablePrint}\n`);
+}
+
+function sumEffectiveCost(services: [string, ServiceAggregation][]): number {
+  return services.reduce(
+    (total, [, service]) => total + service.effectiveCost,
+    0
   );
 }
 
 function printTable(
   print: (message: string) => void,
-  services: [string, ServiceAggregation][]
+  services: [string, ServiceAggregation][],
+  subtotalLabel: string
 ): void {
-  const headers = ['Service', 'Usage', 'Cost'];
-  const rows = services.map(([name, service]) => [
-    service.included ? chalk.blue(name) : name,
-    service.category === 'subscription'
-      ? formatQuantity(service.quantity || 1, 'licenses')
-      : formatQuantity(service.quantity, service.unit),
-    service.included ? 'Included' : formatCurrency(service.cost),
+  const headers = ['Service', 'Usage', 'Effective Cost'];
+  const rows = services.map(([name, service]) => {
+    const quantity =
+      service.category === 'subscription'
+        ? service.quantity || 1
+        : service.quantity;
+    return [
+      service.included ? chalk.blue(name) : name,
+      service.category === 'subscription'
+        ? formatQuantity(quantity, quantity === 1 ? 'license' : 'licenses')
+        : formatQuantity(quantity, service.unit),
+      formatCurrency(service.effectiveCost),
+    ];
+  });
+  const subtotal = services.reduce(
+    (total, [, service]) => total + service.effectiveCost,
+    0
+  );
+  rows.push([
+    chalk.bold(subtotalLabel),
+    '',
+    chalk.bold(formatCurrency(subtotal)),
   ]);
 
   const tablePrint = table(

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -129,8 +129,10 @@ function printTable(
     return [
       service.included ? chalk.blue(name) : name,
       service.category === 'subscription'
-        ? formatQuantity(quantity, quantity === 1 ? 'license' : 'licenses')
-        : formatQuantity(quantity, service.unit),
+        ? formatQuantity(quantity, quantity === 1 ? 'license' : 'licenses', {
+            compact: true,
+          })
+        : formatQuantity(quantity, service.unit, { compact: true }),
       formatCurrency(service.effectiveCost),
     ];
   });

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -82,9 +82,7 @@ function formatCadence(
 }
 
 function formatCredit(amount: number, currency: string): string {
-  return currency === 'managed_infrastructure_units'
-    ? formatQuantity(amount, 'MIUs')
-    : formatBillingAmount(amount, 'USD');
+  return formatBillingAmount(amount, currency);
 }
 
 function printBillSummary(
@@ -138,14 +136,12 @@ function printTable(
   const rows = services.map(([name, service]) => {
     return [
       service.included ? chalk.blue(name) : name,
-      service.category === 'subscription'
-        ? formatQuantity(service.quantity, service.unit ?? 'licenses', {
-            compact: true,
-          })
-        : formatQuantity(service.quantity, undefined, {
-            compact: true,
-            showSmallValues: true,
-          }),
+      formatQuantity(service.quantity, service.unit, {
+        compact: true,
+        showSmallValues: service.category === 'usage',
+        singularUnit: service.singularUnit,
+        unitKind: service.unitKind,
+      }),
       formatBillingAmount(service.effectiveCost, costUnit),
     ];
   });

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -138,6 +138,7 @@ function printTable(
           })
         : formatQuantity(service.quantity, service.unit ?? '', {
             compact: true,
+            showSmallValues: true,
           }).trim(),
       formatCurrency(service.effectiveCost),
     ];

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -23,23 +23,23 @@ export function outputAggregated({ data, startTime }: OutputOptions): void {
       );
     }
     log(
-      `  ${chalk.gray('Used')}       ${formatCurrency(data.credit.used)} of ${formatCurrency(data.credit.allocated)}`
+      `  ${chalk.gray('Used')}       ${formatCredit(data.credit.used, data.credit.currency)} of ${formatCredit(data.credit.allocated, data.credit.currency)}`
     );
     log(
-      `  ${chalk.gray('Remaining')}  ${formatCurrency(data.credit.remaining)}`
+      `  ${chalk.gray('Remaining')}  ${formatCredit(data.credit.remaining, data.credit.currency)}`
     );
     log(`  ${chalk.gray('Progress')}   ${Math.round(data.credit.progress)}%`);
     log('');
   }
 
   const allServices = [...data.services.entries()];
-  const sortedServices = visibleServices(data.services, data.showAll).sort(
+  const sortedServices = visibleServices(data.services).sort(
     (a, b) => b[1].effectiveCost - a[1].effectiveCost
   );
 
   if (sortedServices.length === 0) {
     log('No usage data found for this period.');
-    outputHiddenServicesHint(allServices.length, data.scope);
+    outputHiddenServicesHint(allServices.length);
     return;
   }
 
@@ -62,11 +62,13 @@ export function outputAggregated({ data, startTime }: OutputOptions): void {
     log('');
   }
 
-  printBillSummary(print, usage, subscriptions, data.credit?.used);
-  outputHiddenServicesHint(
-    allServices.length - sortedServices.length,
-    data.scope
+  printBillSummary(
+    print,
+    usage,
+    subscriptions,
+    data.credit?.currency === data.costUnit ? data.credit.used : 0
   );
+  outputHiddenServicesHint(allServices.length - sortedServices.length);
 }
 
 function formatCadence(
@@ -76,6 +78,12 @@ function formatCadence(
     .split('_')
     .map(word => word[0].toUpperCase() + word.slice(1))
     .join(' ');
+}
+
+function formatCredit(amount: number, currency: string): string {
+  return currency === 'USD'
+    ? formatCurrency(amount)
+    : formatQuantity(amount, 'MIUs');
 }
 
 function printBillSummary(
@@ -122,17 +130,15 @@ function printTable(
 ): void {
   const headers = ['Service', 'Usage', 'Effective Cost'];
   const rows = services.map(([name, service]) => {
-    const quantity =
-      service.category === 'subscription'
-        ? service.quantity || 1
-        : service.quantity;
     return [
       service.included ? chalk.blue(name) : name,
       service.category === 'subscription'
-        ? formatQuantity(quantity, quantity === 1 ? 'license' : 'licenses', {
+        ? formatQuantity(service.quantity, service.unit ?? 'licenses', {
             compact: true,
           })
-        : formatQuantity(quantity, service.unit, { compact: true }),
+        : formatQuantity(service.quantity, service.unit ?? '', {
+            compact: true,
+          }).trim(),
       formatCurrency(service.effectiveCost),
     ];
   });

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -157,7 +157,7 @@ function printTable(
 
   const tablePrint = table(
     [headers.map(header => chalk.bold(chalk.cyan(header))), ...rows],
-    { hsep: 4, align: ['l', 'r', 'r'] }
+    { hsep: 4, align: ['l', 'l', 'r'] }
   ).replace(/^/gm, '  ');
 
   print(`\n${tablePrint}\n`);

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import table from '../../util/output/table';
 import output from '../../output-manager';
 import elapsed from '../../util/output/elapsed';
-import { formatCurrency, formatQuantity } from '../../util/billing/format';
+import { formatBillingAmount, formatQuantity } from '../../util/billing/format';
 import type { OutputOptions, ServiceAggregation, UsageData } from './types';
 import {
   outputHiddenServicesHint,
@@ -52,13 +52,13 @@ export function outputAggregated({ data, startTime }: OutputOptions): void {
 
   if (usage.length > 0) {
     log(chalk.bold('Infrastructure'));
-    printTable(print, usage, 'Infrastructure subtotal');
+    printTable(print, usage, 'Infrastructure subtotal', data.costUnit);
     log('');
   }
 
   if (subscriptions.length > 0) {
     log(chalk.bold('Subscription licenses'));
-    printTable(print, subscriptions, 'Subscriptions subtotal');
+    printTable(print, subscriptions, 'Subscriptions subtotal', data.costUnit);
     log('');
   }
 
@@ -66,6 +66,7 @@ export function outputAggregated({ data, startTime }: OutputOptions): void {
     print,
     usage,
     subscriptions,
+    data.costUnit,
     data.credit?.currency === data.costUnit ? data.credit.used : 0
   );
   outputHiddenServicesHint(allServices.length - sortedServices.length);
@@ -81,15 +82,16 @@ function formatCadence(
 }
 
 function formatCredit(amount: number, currency: string): string {
-  return currency === 'USD'
-    ? formatCurrency(amount)
-    : formatQuantity(amount, 'MIUs');
+  return currency === 'managed_infrastructure_units'
+    ? formatQuantity(amount, 'MIUs')
+    : formatBillingAmount(amount, 'USD');
 }
 
 function printBillSummary(
   print: (message: string) => void,
   usage: [string, ServiceAggregation][],
   subscriptions: [string, ServiceAggregation][],
+  costUnit: UsageData['costUnit'],
   creditsApplied = 0
 ): void {
   const subscriptionCost = sumEffectiveCost(subscriptions);
@@ -97,16 +99,19 @@ function printBillSummary(
   const appliedCredit = Math.min(creditsApplied, infrastructureCost);
   const estimatedBill = subscriptionCost + infrastructureCost - appliedCredit;
   const rows = [
-    ['Subscriptions', formatCurrency(subscriptionCost)],
-    ['Infrastructure usage', formatCurrency(infrastructureCost)],
+    ['Subscriptions', formatBillingAmount(subscriptionCost, costUnit)],
+    ['Infrastructure usage', formatBillingAmount(infrastructureCost, costUnit)],
   ];
 
   if (appliedCredit > 0) {
-    rows.push(['Credits applied', `-${formatCurrency(appliedCredit)}`]);
+    rows.push([
+      'Credits applied',
+      `-${formatBillingAmount(appliedCredit, costUnit)}`,
+    ]);
   }
   rows.push([
     chalk.bold('Estimated bill'),
-    chalk.bold(formatCurrency(estimatedBill)),
+    chalk.bold(formatBillingAmount(estimatedBill, costUnit)),
   ]);
 
   const tablePrint = table(rows, { hsep: 4, align: ['l', 'r'] }).replace(
@@ -126,7 +131,8 @@ function sumEffectiveCost(services: [string, ServiceAggregation][]): number {
 function printTable(
   print: (message: string) => void,
   services: [string, ServiceAggregation][],
-  subtotalLabel: string
+  subtotalLabel: string,
+  costUnit: UsageData['costUnit']
 ): void {
   const headers = ['Service', 'Usage', 'Effective Cost'];
   const rows = services.map(([name, service]) => {
@@ -136,11 +142,11 @@ function printTable(
         ? formatQuantity(service.quantity, service.unit ?? 'licenses', {
             compact: true,
           })
-        : formatQuantity(service.quantity, service.unit ?? '', {
+        : formatQuantity(service.quantity, undefined, {
             compact: true,
             showSmallValues: true,
-          }).trim(),
-      formatCurrency(service.effectiveCost),
+          }),
+      formatBillingAmount(service.effectiveCost, costUnit),
     ];
   });
   const subtotal = services.reduce(
@@ -150,7 +156,7 @@ function printTable(
   rows.push([
     chalk.bold(subtotalLabel),
     '',
-    chalk.bold(formatCurrency(subtotal)),
+    chalk.bold(formatBillingAmount(subtotal, costUnit)),
   ]);
 
   const tablePrint = table(

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -4,6 +4,11 @@ import output from '../../output-manager';
 import elapsed from '../../util/output/elapsed';
 import { formatCurrency, formatQuantity } from '../../util/billing/format';
 import type { OutputOptions, BreakdownPeriod } from './types';
+import {
+  outputHiddenServicesHint,
+  outputUsageHeader,
+  visibleServices,
+} from './output-utils';
 
 function getPeriodLabel(period: BreakdownPeriod): string {
   switch (period) {
@@ -24,15 +29,11 @@ export function outputBreakdown({
   const { print, log } = output;
   const periodLabel = getPeriodLabel(breakdownPeriod!);
 
-  log(
-    `${periodLabel} Usage for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
+  outputUsageHeader(
+    data,
+    `${periodLabel} usage`,
+    elapsed(Date.now() - startTime)
   );
-  log('');
-  const periodSuffix = data.usingDefaults ? ' (current billing cycle)' : '';
-  log(
-    `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
-  );
-  log('');
 
   const sortedPeriods = [...data.periodUsage.keys()].sort();
   if (sortedPeriods.length === 0) {
@@ -40,23 +41,31 @@ export function outputBreakdown({
     return;
   }
 
+  let hiddenCount = 0;
   for (const periodKey of sortedPeriods) {
     const periodData = data.periodUsage.get(periodKey)!;
-    const sortedServices = [...periodData.services.entries()].sort(
-      (a, b) => b[1].cost - a[1].cost
-    );
+    const allServices = [...periodData.services.entries()];
+    const sortedServices = visibleServices(
+      periodData.services,
+      data.showAll
+    ).sort((a, b) => b[1].effectiveCost - a[1].effectiveCost);
+    hiddenCount += allServices.length - sortedServices.length;
+    if (sortedServices.length === 0) continue;
+
     log(
-      `${chalk.bold(chalk.cyan(periodKey))} (${formatCurrency(periodData.totalCost)})`
+      `${chalk.bold(chalk.cyan(periodKey))} (${formatCurrency(
+        periodData.totalEffectiveCost
+      )})`
     );
 
     const rows = sortedServices.map(([name, service]) => [
       service.included ? chalk.blue(name) : name,
       formatQuantity(service.quantity, service.unit),
-      service.included ? 'Included' : formatCurrency(service.cost),
+      formatCurrency(service.effectiveCost),
     ]);
     const tablePrint = table(
       [
-        ['Service', 'Usage', 'Cost'].map(header =>
+        ['Service', 'Usage', 'Effective Cost'].map(header =>
           chalk.bold(chalk.gray(header))
         ),
         ...rows,
@@ -65,4 +74,5 @@ export function outputBreakdown({
     ).replace(/^/gm, '  ');
     print(`${tablePrint}\n`);
   }
+  outputHiddenServicesHint(hiddenCount, data.scope);
 }

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -60,7 +60,7 @@ export function outputBreakdown({
 
     const rows = sortedServices.map(([name, service]) => [
       service.included ? chalk.blue(name) : name,
-      formatQuantity(service.quantity, service.unit),
+      formatQuantity(service.quantity, service.unit, { compact: true }),
       formatCurrency(service.effectiveCost),
     ]);
     const tablePrint = table(

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -13,8 +13,6 @@ function getPeriodLabel(period: BreakdownPeriod): string {
       return 'Weekly';
     case 'monthly':
       return 'Monthly';
-    default:
-      return 'Period';
   }
 }
 
@@ -24,58 +22,47 @@ export function outputBreakdown({
   startTime,
 }: OutputOptions): void {
   const { print, log } = output;
-
   const periodLabel = getPeriodLabel(breakdownPeriod!);
 
   log(
     `${periodLabel} Usage for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
   );
   log('');
-  const periodSuffix = data.usingDefaults ? ' (current month)' : '';
+  const periodSuffix = data.usingDefaults ? ' (current billing cycle)' : '';
   log(
     `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
   );
-  log(`${chalk.gray('Charges processed:')} ${data.chargeCount}`);
-  log(`${chalk.gray('Pricing unit:')} ${data.pricingUnit}`);
   log('');
 
-  const sortedServices = [...data.services.entries()].sort(
-    (a, b) => b[1].billedCost - a[1].billedCost
-  );
-
-  if (sortedServices.length === 0) {
+  const sortedPeriods = [...data.periodUsage.keys()].sort();
+  if (sortedPeriods.length === 0) {
     log('No usage data found for this period.');
     return;
   }
 
-  const quantityHeader =
-    data.pricingUnit === 'USD' ? 'Usage (USD)' : data.pricingUnit;
-
-  // Sort periods chronologically
-  const sortedPeriods = [...data.periodUsage.keys()].sort();
-
   for (const periodKey of sortedPeriods) {
     const periodData = data.periodUsage.get(periodKey)!;
-    const sortedPeriodServices = [...periodData.services.entries()].sort(
-      (a, b) => b[1].billedCost - a[1].billedCost
+    const sortedServices = [...periodData.services.entries()].sort(
+      (a, b) => b[1].cost - a[1].cost
     );
-
     log(
-      `${chalk.bold(chalk.cyan(periodKey))} (Total: ${formatQuantity(periodData.totalPricingQuantity, data.pricingUnit)}, ${formatCurrency(periodData.totalBilledCost)})`
+      `${chalk.bold(chalk.cyan(periodKey))} (${formatCurrency(periodData.totalCost)})`
     );
 
-    const headers = ['Service', quantityHeader, 'Billed Cost'];
-    const rows = sortedPeriodServices.map(([name, svc]) => [
-      name,
-      formatQuantity(svc.pricingQuantity, svc.pricingUnit),
-      formatCurrency(svc.billedCost),
+    const rows = sortedServices.map(([name, service]) => [
+      service.included ? chalk.blue(name) : name,
+      formatQuantity(service.quantity, service.unit),
+      service.included ? 'Included' : formatCurrency(service.cost),
     ]);
-
     const tablePrint = table(
-      [headers.map(h => chalk.bold(chalk.gray(h))), ...rows],
+      [
+        ['Service', 'Usage', 'Cost'].map(header =>
+          chalk.bold(chalk.gray(header))
+        ),
+        ...rows,
+      ],
       { hsep: 4, align: ['l', 'r', 'r'] }
     ).replace(/^/gm, '  ');
-
     print(`${tablePrint}\n`);
   }
 }

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -63,6 +63,8 @@ export function outputBreakdown({
       formatQuantity(service.quantity, service.unit, {
         compact: true,
         showSmallValues: true,
+        singularUnit: service.singularUnit,
+        unitKind: service.unitKind,
       }),
       formatBillingAmount(service.effectiveCost, data.costUnit),
     ]);

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -61,6 +61,7 @@ export function outputBreakdown({
       service.included ? chalk.blue(name) : name,
       formatQuantity(service.quantity, service.unit ?? '', {
         compact: true,
+        showSmallValues: true,
       }).trim(),
       formatCurrency(service.effectiveCost),
     ]);

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -45,10 +45,9 @@ export function outputBreakdown({
   for (const periodKey of sortedPeriods) {
     const periodData = data.periodUsage.get(periodKey)!;
     const allServices = [...periodData.services.entries()];
-    const sortedServices = visibleServices(
-      periodData.services,
-      data.showAll
-    ).sort((a, b) => b[1].effectiveCost - a[1].effectiveCost);
+    const sortedServices = visibleServices(periodData.services).sort(
+      (a, b) => b[1].effectiveCost - a[1].effectiveCost
+    );
     hiddenCount += allServices.length - sortedServices.length;
     if (sortedServices.length === 0) continue;
 
@@ -60,7 +59,9 @@ export function outputBreakdown({
 
     const rows = sortedServices.map(([name, service]) => [
       service.included ? chalk.blue(name) : name,
-      formatQuantity(service.quantity, service.unit, { compact: true }),
+      formatQuantity(service.quantity, service.unit ?? '', {
+        compact: true,
+      }).trim(),
       formatCurrency(service.effectiveCost),
     ]);
     const tablePrint = table(
@@ -74,5 +75,5 @@ export function outputBreakdown({
     ).replace(/^/gm, '  ');
     print(`${tablePrint}\n`);
   }
-  outputHiddenServicesHint(hiddenCount, data.scope);
+  outputHiddenServicesHint(hiddenCount);
 }

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import table from '../../util/output/table';
 import output from '../../output-manager';
 import elapsed from '../../util/output/elapsed';
-import { formatCurrency, formatQuantity } from '../../util/billing/format';
+import { formatBillingAmount, formatQuantity } from '../../util/billing/format';
 import type { OutputOptions, BreakdownPeriod } from './types';
 import {
   outputHiddenServicesHint,
@@ -52,18 +52,19 @@ export function outputBreakdown({
     if (sortedServices.length === 0) continue;
 
     log(
-      `${chalk.bold(chalk.cyan(periodKey))} (${formatCurrency(
-        periodData.totalEffectiveCost
+      `${chalk.bold(chalk.cyan(periodKey))} (${formatBillingAmount(
+        periodData.totalEffectiveCost,
+        data.costUnit
       )})`
     );
 
     const rows = sortedServices.map(([name, service]) => [
       service.included ? chalk.blue(name) : name,
-      formatQuantity(service.quantity, service.unit ?? '', {
+      formatQuantity(service.quantity, service.unit, {
         compact: true,
         showSmallValues: true,
-      }).trim(),
-      formatCurrency(service.effectiveCost),
+      }),
+      formatBillingAmount(service.effectiveCost, data.costUnit),
     ]);
     const tablePrint = table(
       [

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -75,7 +75,7 @@ export function outputBreakdown({
         ),
         ...rows,
       ],
-      { hsep: 4, align: ['l', 'r', 'r'] }
+      { hsep: 4, align: ['l', 'l', 'r'] }
     ).replace(/^/gm, '  ');
     print(`${tablePrint}\n`);
   }

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -6,14 +6,7 @@ import { formatCurrency, formatQuantity } from '../../util/billing/format';
 import type { OutputOptions, GroupByDimension } from './types';
 
 function getDimensionLabel(dimension: GroupByDimension): string {
-  switch (dimension) {
-    case 'project':
-      return 'Project';
-    case 'region':
-      return 'Region';
-    default:
-      return 'Group';
-  }
+  return dimension === 'project' ? 'Project' : 'Region';
 }
 
 export function outputGroupBy({
@@ -28,52 +21,45 @@ export function outputGroupBy({
     `Usage by ${dimensionLabel} for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
   );
   log('');
-  const periodSuffix = data.usingDefaults ? ' (current month)' : '';
+  const periodSuffix = data.usingDefaults ? ' (current billing cycle)' : '';
   log(
     `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
   );
-  log(`${chalk.gray('Charges processed:')} ${data.chargeCount}`);
-  log(`${chalk.gray('Pricing unit:')} ${data.pricingUnit}`);
   log('');
 
   const sortedGroups = [...data.groupByUsage.entries()].sort(
-    (a, b) => b[1].totalBilledCost - a[1].totalBilledCost
+    (a, b) => b[1].totalCost - a[1].totalCost
   );
-
   if (sortedGroups.length === 0) {
     log('No usage data found for this period.');
     return;
   }
 
-  const quantityHeader =
-    data.pricingUnit === 'USD' ? 'Usage (USD)' : data.pricingUnit;
-
   for (const [groupName, groupData] of sortedGroups) {
     log(
-      `${chalk.bold(chalk.cyan(groupName))} (Total: ${formatQuantity(groupData.totalPricingQuantity, data.pricingUnit)}, ${formatCurrency(groupData.totalBilledCost)})`
+      `${chalk.bold(chalk.cyan(groupName))} (${formatCurrency(groupData.totalCost)})`
     );
-
-    const sortedServices = [...groupData.services.entries()].sort(
-      (a, b) => b[1].billedCost - a[1].billedCost
-    );
-
-    const headers = ['Service', quantityHeader, 'Billed Cost'];
-    const rows = sortedServices.map(([name, svc]) => [
-      name,
-      formatQuantity(svc.pricingQuantity, svc.pricingUnit),
-      formatCurrency(svc.billedCost),
-    ]);
-
+    const rows = [...groupData.services.entries()]
+      .sort((a, b) => b[1].cost - a[1].cost)
+      .map(([name, service]) => [
+        service.included ? chalk.blue(name) : name,
+        formatQuantity(service.quantity, service.unit),
+        service.included ? 'Included' : formatCurrency(service.cost),
+      ]);
     const tablePrint = table(
-      [headers.map(h => chalk.bold(chalk.gray(h))), ...rows],
+      [
+        ['Service', 'Usage', 'Cost'].map(header =>
+          chalk.bold(chalk.gray(header))
+        ),
+        ...rows,
+      ],
       { hsep: 4, align: ['l', 'r', 'r'] }
     ).replace(/^/gm, '  ');
-
     print(`${tablePrint}\n`);
   }
 
   log('');
   log(
-    `${chalk.gray('Amount due:')} ${chalk.bold(formatCurrency(data.grandTotals.billedCost))}`
+    `${chalk.gray('Estimated total:')} ${chalk.bold(formatCurrency(data.totalCost))}`
   );
 }

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -4,6 +4,11 @@ import output from '../../output-manager';
 import elapsed from '../../util/output/elapsed';
 import { formatCurrency, formatQuantity } from '../../util/billing/format';
 import type { OutputOptions, GroupByDimension } from './types';
+import {
+  outputHiddenServicesHint,
+  outputUsageHeader,
+  visibleServices,
+} from './output-utils';
 
 function getDimensionLabel(dimension: GroupByDimension): string {
   return dimension === 'project' ? 'Project' : 'Region';
@@ -17,38 +22,42 @@ export function outputGroupBy({
   const { print, log } = output;
   const dimensionLabel = getDimensionLabel(groupByDimension!);
 
-  log(
-    `Usage by ${dimensionLabel} for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
+  outputUsageHeader(
+    data,
+    `Usage by ${dimensionLabel}`,
+    elapsed(Date.now() - startTime)
   );
-  log('');
-  const periodSuffix = data.usingDefaults ? ' (current billing cycle)' : '';
-  log(
-    `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
-  );
-  log('');
 
   const sortedGroups = [...data.groupByUsage.entries()].sort(
-    (a, b) => b[1].totalCost - a[1].totalCost
+    (a, b) => b[1].totalEffectiveCost - a[1].totalEffectiveCost
   );
   if (sortedGroups.length === 0) {
     log('No usage data found for this period.');
     return;
   }
 
+  let hiddenCount = 0;
   for (const [groupName, groupData] of sortedGroups) {
-    log(
-      `${chalk.bold(chalk.cyan(groupName))} (${formatCurrency(groupData.totalCost)})`
+    const allServices = [...groupData.services.entries()];
+    const services = visibleServices(groupData.services, data.showAll).sort(
+      (a, b) => b[1].effectiveCost - a[1].effectiveCost
     );
-    const rows = [...groupData.services.entries()]
-      .sort((a, b) => b[1].cost - a[1].cost)
-      .map(([name, service]) => [
-        service.included ? chalk.blue(name) : name,
-        formatQuantity(service.quantity, service.unit),
-        service.included ? 'Included' : formatCurrency(service.cost),
-      ]);
+    hiddenCount += allServices.length - services.length;
+    if (services.length === 0) continue;
+
+    log(
+      `${chalk.bold(chalk.cyan(groupName))} (${formatCurrency(
+        groupData.totalEffectiveCost
+      )})`
+    );
+    const rows = services.map(([name, service]) => [
+      service.included ? chalk.blue(name) : name,
+      formatQuantity(service.quantity, service.unit),
+      formatCurrency(service.effectiveCost),
+    ]);
     const tablePrint = table(
       [
-        ['Service', 'Usage', 'Cost'].map(header =>
+        ['Service', 'Usage', 'Effective Cost'].map(header =>
           chalk.bold(chalk.gray(header))
         ),
         ...rows,
@@ -60,6 +69,9 @@ export function outputGroupBy({
 
   log('');
   log(
-    `${chalk.gray('Estimated total:')} ${chalk.bold(formatCurrency(data.totalCost))}`
+    `${chalk.gray('Estimated total:')} ${chalk.bold(
+      formatCurrency(data.grandTotals.effectiveCost)
+    )}`
   );
+  outputHiddenServicesHint(hiddenCount, data.scope);
 }

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -52,7 +52,7 @@ export function outputGroupBy({
     );
     const rows = services.map(([name, service]) => [
       service.included ? chalk.blue(name) : name,
-      formatQuantity(service.quantity, service.unit),
+      formatQuantity(service.quantity, service.unit, { compact: true }),
       formatCurrency(service.effectiveCost),
     ]);
     const tablePrint = table(

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -54,6 +54,7 @@ export function outputGroupBy({
       service.included ? chalk.blue(name) : name,
       formatQuantity(service.quantity, service.unit ?? '', {
         compact: true,
+        showSmallValues: true,
       }).trim(),
       formatCurrency(service.effectiveCost),
     ]);

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -68,7 +68,7 @@ export function outputGroupBy({
         ),
         ...rows,
       ],
-      { hsep: 4, align: ['l', 'r', 'r'] }
+      { hsep: 4, align: ['l', 'l', 'r'] }
     ).replace(/^/gm, '  ');
     print(`${tablePrint}\n`);
   }

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -39,7 +39,7 @@ export function outputGroupBy({
   let hiddenCount = 0;
   for (const [groupName, groupData] of sortedGroups) {
     const allServices = [...groupData.services.entries()];
-    const services = visibleServices(groupData.services, data.showAll).sort(
+    const services = visibleServices(groupData.services).sort(
       (a, b) => b[1].effectiveCost - a[1].effectiveCost
     );
     hiddenCount += allServices.length - services.length;
@@ -52,7 +52,9 @@ export function outputGroupBy({
     );
     const rows = services.map(([name, service]) => [
       service.included ? chalk.blue(name) : name,
-      formatQuantity(service.quantity, service.unit, { compact: true }),
+      formatQuantity(service.quantity, service.unit ?? '', {
+        compact: true,
+      }).trim(),
       formatCurrency(service.effectiveCost),
     ]);
     const tablePrint = table(
@@ -73,5 +75,5 @@ export function outputGroupBy({
       formatCurrency(data.grandTotals.effectiveCost)
     )}`
   );
-  outputHiddenServicesHint(hiddenCount, data.scope);
+  outputHiddenServicesHint(hiddenCount);
 }

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -56,6 +56,8 @@ export function outputGroupBy({
       formatQuantity(service.quantity, service.unit, {
         compact: true,
         showSmallValues: true,
+        singularUnit: service.singularUnit,
+        unitKind: service.unitKind,
       }),
       formatBillingAmount(service.effectiveCost, data.costUnit),
     ]);

--- a/packages/cli/src/commands/usage/output-group-by.ts
+++ b/packages/cli/src/commands/usage/output-group-by.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import table from '../../util/output/table';
 import output from '../../output-manager';
 import elapsed from '../../util/output/elapsed';
-import { formatCurrency, formatQuantity } from '../../util/billing/format';
+import { formatBillingAmount, formatQuantity } from '../../util/billing/format';
 import type { OutputOptions, GroupByDimension } from './types';
 import {
   outputHiddenServicesHint,
@@ -46,17 +46,18 @@ export function outputGroupBy({
     if (services.length === 0) continue;
 
     log(
-      `${chalk.bold(chalk.cyan(groupName))} (${formatCurrency(
-        groupData.totalEffectiveCost
+      `${chalk.bold(chalk.cyan(groupName))} (${formatBillingAmount(
+        groupData.totalEffectiveCost,
+        data.costUnit
       )})`
     );
     const rows = services.map(([name, service]) => [
       service.included ? chalk.blue(name) : name,
-      formatQuantity(service.quantity, service.unit ?? '', {
+      formatQuantity(service.quantity, service.unit, {
         compact: true,
         showSmallValues: true,
-      }).trim(),
-      formatCurrency(service.effectiveCost),
+      }),
+      formatBillingAmount(service.effectiveCost, data.costUnit),
     ]);
     const tablePrint = table(
       [
@@ -73,7 +74,7 @@ export function outputGroupBy({
   log('');
   log(
     `${chalk.gray('Estimated total:')} ${chalk.bold(
-      formatCurrency(data.grandTotals.effectiveCost)
+      formatBillingAmount(data.grandTotals.effectiveCost, data.costUnit)
     )}`
   );
   outputHiddenServicesHint(hiddenCount);

--- a/packages/cli/src/commands/usage/output-json.ts
+++ b/packages/cli/src/commands/usage/output-json.ts
@@ -37,6 +37,10 @@ export function outputJson(
     pricingUnit: 'USD',
   };
 
+  if (data.credit) {
+    jsonOutput.credit = data.credit;
+  }
+
   if (breakdownPeriod) {
     jsonOutput.breakdown = {
       period: breakdownPeriod,

--- a/packages/cli/src/commands/usage/output-json.ts
+++ b/packages/cli/src/commands/usage/output-json.ts
@@ -1,5 +1,21 @@
 import type Client from '../../util/client';
-import type { JsonOutputOptions } from './types';
+import type { JsonOutputOptions, ServiceAggregation } from './types';
+
+function serializeService(name: string, service: ServiceAggregation) {
+  return {
+    name,
+    quantity: service.quantity,
+    unit: service.unit,
+    cost: service.cost,
+    included: service.included,
+    category: service.category,
+    // Existing fields are retained for scripts consuming the current contract.
+    pricingQuantity: service.pricingQuantity,
+    pricingUnit: service.pricingUnit,
+    effectiveCost: service.effectiveCost,
+    billedCost: service.billedCost,
+  };
+}
 
 export function outputJson(
   client: Client,
@@ -12,93 +28,67 @@ export function outputJson(
   }: JsonOutputOptions
 ): void {
   const sortedServices = [...data.services.entries()].sort(
-    (a, b) => b[1].billedCost - a[1].billedCost
+    (a, b) => b[1].cost - a[1].cost
   );
 
-  const sortedPeriods = [...data.periodUsage.keys()].sort();
-
   const jsonOutput: Record<string, unknown> = {
-    period: {
-      from: fromDate,
-      to: toDate,
-    },
+    period: { from: fromDate, to: toDate },
     context: data.contextName,
-    pricingUnit: data.pricingUnit,
+    pricingUnit: 'USD',
   };
 
-  // Include breakdown data if a breakdown period is specified
   if (breakdownPeriod) {
     jsonOutput.breakdown = {
       period: breakdownPeriod,
-      data: sortedPeriods.map(periodKey => {
-        const periodData = data.periodUsage.get(periodKey)!;
-        const sortedPeriodServices = [...periodData.services.entries()].sort(
-          (a, b) => b[1].billedCost - a[1].billedCost
-        );
+      data: [...data.periodUsage.keys()].sort().map(periodKey => {
+        const period = data.periodUsage.get(periodKey)!;
         return {
           periodKey,
-          services: sortedPeriodServices.map(([name, svc]) => ({
-            name,
-            pricingQuantity: svc.pricingQuantity,
-            pricingUnit: svc.pricingUnit,
-            effectiveCost: svc.effectiveCost,
-            billedCost: svc.billedCost,
-          })),
+          services: [...period.services.entries()]
+            .sort((a, b) => b[1].cost - a[1].cost)
+            .map(([name, service]) => serializeService(name, service)),
           totals: {
-            pricingQuantity: periodData.totalPricingQuantity,
-            effectiveCost: periodData.totalEffectiveCost,
-            billedCost: periodData.totalBilledCost,
+            cost: period.totalCost,
+            pricingQuantity: period.totalPricingQuantity,
+            effectiveCost: period.totalEffectiveCost,
+            billedCost: period.totalBilledCost,
           },
         };
       }),
     };
   }
 
-  // Include group-by data if a dimension is specified
   if (groupByDimension) {
-    const sortedGroups = [...data.groupByUsage.entries()].sort(
-      (a, b) => b[1].totalBilledCost - a[1].totalBilledCost
-    );
-
     jsonOutput.groupBy = {
       dimension: groupByDimension,
-      data: sortedGroups.map(([groupName, groupData]) => {
-        const sortedGroupServices = [...groupData.services.entries()].sort(
-          (a, b) => b[1].billedCost - a[1].billedCost
-        );
-        return {
-          name: groupName,
-          services: sortedGroupServices.map(([name, svc]) => ({
-            name,
-            pricingQuantity: svc.pricingQuantity,
-            pricingUnit: svc.pricingUnit,
-            effectiveCost: svc.effectiveCost,
-            billedCost: svc.billedCost,
-          })),
+      data: [...data.groupByUsage.entries()]
+        .sort((a, b) => b[1].totalCost - a[1].totalCost)
+        .map(([name, group]) => ({
+          name,
+          services: [...group.services.entries()]
+            .sort((a, b) => b[1].cost - a[1].cost)
+            .map(([serviceName, service]) =>
+              serializeService(serviceName, service)
+            ),
           totals: {
-            pricingQuantity: groupData.totalPricingQuantity,
-            effectiveCost: groupData.totalEffectiveCost,
-            billedCost: groupData.totalBilledCost,
+            cost: group.totalCost,
+            pricingQuantity: group.totalPricingQuantity,
+            effectiveCost: group.totalEffectiveCost,
+            billedCost: group.totalBilledCost,
           },
-        };
-      }),
+        })),
     };
   }
 
-  jsonOutput.services = sortedServices.map(([name, svc]) => ({
-    name,
-    pricingQuantity: svc.pricingQuantity,
-    pricingUnit: svc.pricingUnit,
-    effectiveCost: svc.effectiveCost,
-    billedCost: svc.billedCost,
-  }));
-
+  jsonOutput.services = sortedServices.map(([name, service]) =>
+    serializeService(name, service)
+  );
   jsonOutput.totals = {
+    cost: data.totalCost,
     pricingQuantity: data.grandTotals.pricingQuantity,
     effectiveCost: data.grandTotals.effectiveCost,
     billedCost: data.grandTotals.billedCost,
   };
-
   jsonOutput.chargeCount = data.chargeCount;
 
   client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);

--- a/packages/cli/src/commands/usage/output-json.ts
+++ b/packages/cli/src/commands/usage/output-json.ts
@@ -9,11 +9,7 @@ function serializeService(name: string, service: ServiceAggregation) {
     cost: service.cost,
     included: service.included,
     category: service.category,
-    // Existing fields are retained for scripts consuming the current contract.
-    pricingQuantity: service.pricingQuantity,
-    pricingUnit: service.pricingUnit,
     effectiveCost: service.effectiveCost,
-    billedCost: service.billedCost,
   };
 }
 
@@ -34,7 +30,7 @@ export function outputJson(
   const jsonOutput: Record<string, unknown> = {
     period: { from: fromDate, to: toDate },
     context: data.contextName,
-    pricingUnit: 'USD',
+    costUnit: data.costUnit,
   };
 
   if (data.credit) {
@@ -53,9 +49,7 @@ export function outputJson(
             .map(([name, service]) => serializeService(name, service)),
           totals: {
             cost: period.totalCost,
-            pricingQuantity: period.totalPricingQuantity,
             effectiveCost: period.totalEffectiveCost,
-            billedCost: period.totalBilledCost,
           },
         };
       }),
@@ -76,9 +70,7 @@ export function outputJson(
             ),
           totals: {
             cost: group.totalCost,
-            pricingQuantity: group.totalPricingQuantity,
             effectiveCost: group.totalEffectiveCost,
-            billedCost: group.totalBilledCost,
           },
         })),
     };
@@ -89,11 +81,8 @@ export function outputJson(
   );
   jsonOutput.totals = {
     cost: data.totalCost,
-    pricingQuantity: data.grandTotals.pricingQuantity,
     effectiveCost: data.grandTotals.effectiveCost,
-    billedCost: data.grandTotals.billedCost,
   };
-  jsonOutput.chargeCount = data.chargeCount;
 
   client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
 }

--- a/packages/cli/src/commands/usage/output-json.ts
+++ b/packages/cli/src/commands/usage/output-json.ts
@@ -4,6 +4,7 @@ import type { JsonOutputOptions, ServiceAggregation } from './types';
 function serializeService(name: string, service: ServiceAggregation) {
   return {
     name,
+    product: service.product,
     quantity: service.quantity,
     unit: service.unit,
     cost: service.cost,

--- a/packages/cli/src/commands/usage/output-utils.ts
+++ b/packages/cli/src/commands/usage/output-utils.ts
@@ -1,0 +1,75 @@
+import chalk from 'chalk';
+import { DateTime } from 'luxon';
+import output from '../../output-manager';
+import type { ServiceAggregation, UsageData } from './types';
+
+export function isEmptyService(service: ServiceAggregation): boolean {
+  return (
+    service.quantity === 0 && service.cost === 0 && service.effectiveCost === 0
+  );
+}
+
+export function visibleServices(
+  services: Map<string, ServiceAggregation>,
+  showAll: boolean
+): [string, ServiceAggregation][] {
+  return [...services.entries()].filter(
+    ([, service]) => showAll || !isEmptyService(service)
+  );
+}
+
+export function outputUsageHeader(
+  data: UsageData,
+  title: string,
+  elapsedSuffix: string
+): void {
+  const { log } = output;
+  log(
+    `${title} for ${data.contextType} ${chalk.bold(data.contextName)} ${elapsedSuffix}`
+  );
+  log('');
+  if (data.usingDefaults) {
+    log(
+      `${chalk.gray('Billing cycle:')} ${formatRange(data.fromDisplay, data.toDisplay)}`
+    );
+  } else {
+    log(
+      `${chalk.gray('Period:')} ${formatRange(data.fromDisplay, data.toDisplay)}`
+    );
+  }
+  log(`${chalk.gray('Usage through:')} ${formatDate(data.usageThrough)}`);
+  log(chalk.gray('Costs are accrued through this date, not forecast.'));
+  log('');
+}
+
+export function outputHiddenServicesHint(
+  hiddenCount: number,
+  scope?: string
+): void {
+  if (hiddenCount <= 0) return;
+  const scopeFlag = scope ? ` --scope ${scope}` : '';
+  output.log(
+    chalk.gray(
+      `${hiddenCount} ${hiddenCount === 1 ? 'service' : 'services'} with no usage hidden. Show all with: vc usage${scopeFlag} --all`
+    )
+  );
+}
+
+function formatRange(from: string, to: string): string {
+  const start = parseDate(from);
+  const end = parseDate(to);
+  if (!start || !end) return `${from} to ${to}`;
+
+  const sameYear = start.year === end.year;
+  const startText = start.toFormat(sameYear ? 'LLL d' : 'LLL d, yyyy');
+  return `${startText}–${end.toFormat('LLL d, yyyy')}`;
+}
+
+function formatDate(value: string): string {
+  return parseDate(value)?.toFormat('LLL d, yyyy') ?? value;
+}
+
+function parseDate(value: string): DateTime | null {
+  const date = DateTime.fromISO(value, { zone: 'utc' });
+  return date.isValid ? date : null;
+}

--- a/packages/cli/src/commands/usage/output-utils.ts
+++ b/packages/cli/src/commands/usage/output-utils.ts
@@ -4,17 +4,19 @@ import output from '../../output-manager';
 import type { ServiceAggregation, UsageData } from './types';
 
 export function isEmptyService(service: ServiceAggregation): boolean {
+  if (service.category === 'subscription') {
+    return service.cost === 0 && service.effectiveCost === 0;
+  }
   return (
     service.quantity === 0 && service.cost === 0 && service.effectiveCost === 0
   );
 }
 
 export function visibleServices(
-  services: Map<string, ServiceAggregation>,
-  showAll: boolean
+  services: Map<string, ServiceAggregation>
 ): [string, ServiceAggregation][] {
   return [...services.entries()].filter(
-    ([, service]) => showAll || !isEmptyService(service)
+    ([, service]) => !isEmptyService(service)
   );
 }
 
@@ -42,15 +44,11 @@ export function outputUsageHeader(
   log('');
 }
 
-export function outputHiddenServicesHint(
-  hiddenCount: number,
-  scope?: string
-): void {
+export function outputHiddenServicesHint(hiddenCount: number): void {
   if (hiddenCount <= 0) return;
-  const scopeFlag = scope ? ` --scope ${scope}` : '';
   output.log(
     chalk.gray(
-      `${hiddenCount} ${hiddenCount === 1 ? 'service' : 'services'} with no usage hidden. Show all with: vc usage${scopeFlag} --all`
+      `${hiddenCount} ${hiddenCount === 1 ? 'service' : 'services'} with no usage hidden.`
     )
   );
 }

--- a/packages/cli/src/commands/usage/types.ts
+++ b/packages/cli/src/commands/usage/types.ts
@@ -2,15 +2,71 @@ export type BreakdownPeriod = 'daily' | 'weekly' | 'monthly';
 
 export type GroupByDimension = 'project' | 'region';
 
+export interface MetricUnit {
+  kind: string;
+  name?: string;
+  singular?: string;
+  plural?: string;
+}
+
+export interface CostMetric {
+  slug: string;
+  title: string;
+  unit: MetricUnit;
+}
+
+export interface CostMetricGroup {
+  dimensionValues: Record<string, string | null>;
+  metrics: string[];
+  values: number[][];
+  totalValue: number[];
+  flatRate?: boolean;
+}
+
+export interface CostMetricsResponse {
+  metrics: CostMetric[];
+  from: string;
+  to: string;
+  results: {
+    granularity: {
+      unit: 'hour' | 'day' | 'week' | 'month';
+      step: number;
+    };
+    times: string[];
+    dimensionsMeta: Record<
+      string,
+      | {
+          values?: Record<string, { title?: string; category?: string }>;
+        }
+      | undefined
+    >;
+    views: Record<
+      string,
+      {
+        groupBy: string[];
+        results: CostMetricGroup[];
+      }
+    >;
+  };
+}
+
 export interface ServiceAggregation {
+  quantity: number;
+  unit: string;
+  cost: number;
+  included: boolean;
+  category: 'usage' | 'subscription';
+  // Kept for backwards-compatible JSON output.
   pricingQuantity: number;
+  pricingUnit: string;
   effectiveCost: number;
   billedCost: number;
-  pricingUnit: string;
 }
 
 export interface PeriodAggregation {
   services: Map<string, ServiceAggregation>;
+  totalCost: number;
+  // Kept for backwards-compatible JSON output.
   totalPricingQuantity: number;
   totalEffectiveCost: number;
   totalBilledCost: number;
@@ -18,6 +74,8 @@ export interface PeriodAggregation {
 
 export interface GroupAggregation {
   services: Map<string, ServiceAggregation>;
+  totalCost: number;
+  // Kept for backwards-compatible JSON output.
   totalPricingQuantity: number;
   totalEffectiveCost: number;
   totalBilledCost: number;
@@ -28,12 +86,13 @@ export interface UsageData {
   fromDisplay: string;
   toDisplay: string;
   usingDefaults: boolean;
-  pricingUnit: string;
   chargeCount: number;
   services: Map<string, ServiceAggregation>;
   periodUsage: Map<string, PeriodAggregation>;
   groupByUsage: Map<string, GroupAggregation>;
+  totalCost: number;
   grandTotals: {
+    // Kept for backwards-compatible JSON output.
     pricingQuantity: number;
     effectiveCost: number;
     billedCost: number;

--- a/packages/cli/src/commands/usage/types.ts
+++ b/packages/cli/src/commands/usage/types.ts
@@ -12,7 +12,7 @@ export interface MetricUnit {
 export interface CostMetric {
   slug: string;
   title: string;
-  unit: MetricUnit;
+  unit: MetricUnit | null;
 }
 
 export interface CostMetricGroup {
@@ -27,6 +27,7 @@ export interface CostMetricsResponse {
   metrics: CostMetric[];
   from: string;
   to: string;
+  queriedAt: string;
   results: {
     granularity: {
       unit: 'hour' | 'day' | 'week' | 'month';
@@ -81,12 +82,38 @@ export interface GroupAggregation {
   totalBilledCost: number;
 }
 
+export interface CreditSummary {
+  cadence?: 'one_time' | 'annual' | 'monthly' | 'quarterly' | 'semi_annual';
+  currency: string;
+  allocated: number;
+  used: number;
+  remaining: number;
+  progress: number;
+}
+
+export interface CommitmentUsageResponse {
+  creditLedgers: Array<{
+    currency: string;
+    title: string;
+    periodStart: string;
+    periodEnd: string;
+    total: number;
+    remaining: number;
+  }>;
+  cadence?: CreditSummary['cadence'];
+}
+
 export interface UsageData {
   contextName: string;
+  contextType: 'team' | 'personal account';
+  scope?: string;
   fromDisplay: string;
   toDisplay: string;
+  usageThrough: string;
   usingDefaults: boolean;
+  showAll: boolean;
   chargeCount: number;
+  credit?: CreditSummary;
   services: Map<string, ServiceAggregation>;
   periodUsage: Map<string, PeriodAggregation>;
   groupByUsage: Map<string, GroupAggregation>;

--- a/packages/cli/src/commands/usage/types.ts
+++ b/packages/cli/src/commands/usage/types.ts
@@ -53,34 +53,22 @@ export interface CostMetricsResponse {
 
 export interface ServiceAggregation {
   quantity: number;
-  unit: string;
+  unit?: string;
   cost: number;
   included: boolean;
   category: 'usage' | 'subscription';
-  // Kept for backwards-compatible JSON output.
-  pricingQuantity: number;
-  pricingUnit: string;
   effectiveCost: number;
-  billedCost: number;
 }
 
-export interface PeriodAggregation {
+export interface Aggregation {
   services: Map<string, ServiceAggregation>;
   totalCost: number;
-  // Kept for backwards-compatible JSON output.
-  totalPricingQuantity: number;
   totalEffectiveCost: number;
-  totalBilledCost: number;
 }
 
-export interface GroupAggregation {
-  services: Map<string, ServiceAggregation>;
-  totalCost: number;
-  // Kept for backwards-compatible JSON output.
-  totalPricingQuantity: number;
-  totalEffectiveCost: number;
-  totalBilledCost: number;
-}
+export type PeriodAggregation = Aggregation;
+
+export type GroupAggregation = Aggregation;
 
 export interface CreditSummary {
   cadence?: 'one_time' | 'annual' | 'monthly' | 'quarterly' | 'semi_annual';
@@ -111,18 +99,14 @@ export interface UsageData {
   toDisplay: string;
   usageThrough: string;
   usingDefaults: boolean;
-  showAll: boolean;
-  chargeCount: number;
+  costUnit: 'USD';
   credit?: CreditSummary;
   services: Map<string, ServiceAggregation>;
   periodUsage: Map<string, PeriodAggregation>;
   groupByUsage: Map<string, GroupAggregation>;
   totalCost: number;
   grandTotals: {
-    // Kept for backwards-compatible JSON output.
-    pricingQuantity: number;
     effectiveCost: number;
-    billedCost: number;
   };
 }
 

--- a/packages/cli/src/commands/usage/types.ts
+++ b/packages/cli/src/commands/usage/types.ts
@@ -52,6 +52,7 @@ export interface CostMetricsResponse {
 }
 
 export interface ServiceAggregation {
+  product: string;
   quantity: number;
   unit?: string;
   cost: number;
@@ -99,7 +100,7 @@ export interface UsageData {
   toDisplay: string;
   usageThrough: string;
   usingDefaults: boolean;
-  costUnit: 'USD';
+  costUnit: 'USD' | 'managed_infrastructure_units';
   credit?: CreditSummary;
   services: Map<string, ServiceAggregation>;
   periodUsage: Map<string, PeriodAggregation>;

--- a/packages/cli/src/commands/usage/types.ts
+++ b/packages/cli/src/commands/usage/types.ts
@@ -23,6 +23,11 @@ export interface CostMetricGroup {
   flatRate?: boolean;
 }
 
+export interface CostMetricView {
+  groupBy: string[];
+  results: CostMetricGroup[];
+}
+
 export interface CostMetricsResponse {
   metrics: CostMetric[];
   from: string;
@@ -41,13 +46,7 @@ export interface CostMetricsResponse {
         }
       | undefined
     >;
-    views: Record<
-      string,
-      {
-        groupBy: string[];
-        results: CostMetricGroup[];
-      }
-    >;
+    views: Record<string, CostMetricView>;
   };
 }
 

--- a/packages/cli/src/commands/usage/types.ts
+++ b/packages/cli/src/commands/usage/types.ts
@@ -55,6 +55,8 @@ export interface ServiceAggregation {
   product: string;
   quantity: number;
   unit?: string;
+  singularUnit?: string;
+  unitKind?: string;
   cost: number;
   included: boolean;
   category: 'usage' | 'subscription';

--- a/packages/cli/src/util/billing/format.ts
+++ b/packages/cli/src/util/billing/format.ts
@@ -1,12 +1,16 @@
 export function formatCurrency(amount: number): string {
-  return `$${amount.toFixed(4)}`;
+  return `$${amount.toFixed(2)}`;
 }
 
 export function formatQuantity(quantity: number, unit: string): string {
   if (unit === 'USD') {
-    return `$${quantity.toFixed(4)}`;
+    return formatCurrency(quantity);
   }
-  return quantity.toFixed(4);
+
+  return `${new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+    notation: Math.abs(quantity) >= 1000 ? 'compact' : 'standard',
+  }).format(quantity)} ${unit}`;
 }
 
 export function extractDatePortion(isoString: string): string {

--- a/packages/cli/src/util/billing/format.ts
+++ b/packages/cli/src/util/billing/format.ts
@@ -7,10 +7,11 @@ export function formatQuantity(quantity: number, unit: string): string {
     return formatCurrency(quantity);
   }
 
+  const displayUnit = quantity === 1 && unit === 'licenses' ? 'license' : unit;
   return `${new Intl.NumberFormat('en-US', {
     maximumFractionDigits: 2,
     notation: Math.abs(quantity) >= 1000 ? 'compact' : 'standard',
-  }).format(quantity)} ${unit}`;
+  }).format(quantity)} ${displayUnit}`;
 }
 
 export function extractDatePortion(isoString: string): string {

--- a/packages/cli/src/util/billing/format.ts
+++ b/packages/cli/src/util/billing/format.ts
@@ -2,7 +2,11 @@ export function formatCurrency(amount: number): string {
   return `$${amount.toFixed(2)}`;
 }
 
-export function formatQuantity(quantity: number, unit: string): string {
+export function formatQuantity(
+  quantity: number,
+  unit: string,
+  options: { compact?: boolean } = {}
+): string {
   if (unit === 'USD') {
     return formatCurrency(quantity);
   }
@@ -10,7 +14,8 @@ export function formatQuantity(quantity: number, unit: string): string {
   const displayUnit = quantity === 1 && unit === 'licenses' ? 'license' : unit;
   return `${new Intl.NumberFormat('en-US', {
     maximumFractionDigits: 2,
-    notation: Math.abs(quantity) >= 1000 ? 'compact' : 'standard',
+    notation:
+      options.compact && Math.abs(quantity) >= 1000 ? 'compact' : 'standard',
   }).format(quantity)} ${displayUnit}`;
 }
 

--- a/packages/cli/src/util/billing/format.ts
+++ b/packages/cli/src/util/billing/format.ts
@@ -2,9 +2,15 @@ export function formatCurrency(amount: number): string {
   return `$${amount.toFixed(2)}`;
 }
 
+export function formatBillingAmount(amount: number, unit: string): string {
+  return unit === 'USD'
+    ? formatCurrency(amount)
+    : formatQuantity(amount, 'MIUs');
+}
+
 export function formatQuantity(
   quantity: number,
-  unit: string,
+  unit = '',
   options: { compact?: boolean; showSmallValues?: boolean } = {}
 ): string {
   if (unit === 'USD') {
@@ -27,7 +33,7 @@ export function formatQuantity(
         : `>${formatter.format(-0.01)}`
       : formattedQuantity;
 
-  return `${displayQuantity} ${displayUnit}`;
+  return displayUnit ? `${displayQuantity} ${displayUnit}` : displayQuantity;
 }
 
 export function extractDatePortion(isoString: string): string {

--- a/packages/cli/src/util/billing/format.ts
+++ b/packages/cli/src/util/billing/format.ts
@@ -3,21 +3,31 @@ export function formatCurrency(amount: number): string {
 }
 
 export function formatBillingAmount(amount: number, unit: string): string {
-  return unit === 'USD'
-    ? formatCurrency(amount)
-    : formatQuantity(amount, 'MIUs');
+  return unit === 'managed_infrastructure_units'
+    ? formatQuantity(amount, 'MIUs')
+    : formatCurrency(amount);
 }
 
 export function formatQuantity(
   quantity: number,
   unit = '',
-  options: { compact?: boolean; showSmallValues?: boolean } = {}
+  options: {
+    compact?: boolean;
+    showSmallValues?: boolean;
+    singularUnit?: string;
+    unitKind?: string;
+  } = {}
 ): string {
   if (unit === 'USD') {
     return formatCurrency(quantity);
   }
 
-  const displayUnit = quantity === 1 && unit === 'licenses' ? 'license' : unit;
+  if (options.unitKind === 'digitalStorage') {
+    return formatStorageQuantity(quantity, unit);
+  }
+
+  const displayUnit =
+    quantity === 1 && options.singularUnit ? options.singularUnit : unit;
   const formatter = new Intl.NumberFormat('en-US', {
     maximumFractionDigits: 2,
     notation:
@@ -34,6 +44,24 @@ export function formatQuantity(
       : formattedQuantity;
 
   return displayUnit ? `${displayQuantity} ${displayUnit}` : displayQuantity;
+}
+
+function formatStorageQuantity(quantity: number, unit: string): string {
+  const units = ['byte', 'kilobyte', 'megabyte', 'gigabyte', 'terabyte'];
+  const symbols = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const startIndex = units.indexOf(unit.toLowerCase());
+  if (startIndex === -1) return formatQuantity(quantity, unit);
+
+  let value = quantity;
+  let unitIndex = startIndex;
+  while (Math.abs(value) >= 1000 && unitIndex < symbols.length - 1) {
+    value /= 1000;
+    unitIndex++;
+  }
+
+  return `${new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+  }).format(value)} ${symbols[unitIndex]}`;
 }
 
 export function extractDatePortion(isoString: string): string {

--- a/packages/cli/src/util/billing/format.ts
+++ b/packages/cli/src/util/billing/format.ts
@@ -5,18 +5,29 @@ export function formatCurrency(amount: number): string {
 export function formatQuantity(
   quantity: number,
   unit: string,
-  options: { compact?: boolean } = {}
+  options: { compact?: boolean; showSmallValues?: boolean } = {}
 ): string {
   if (unit === 'USD') {
     return formatCurrency(quantity);
   }
 
   const displayUnit = quantity === 1 && unit === 'licenses' ? 'license' : unit;
-  return `${new Intl.NumberFormat('en-US', {
+  const formatter = new Intl.NumberFormat('en-US', {
     maximumFractionDigits: 2,
     notation:
       options.compact && Math.abs(quantity) >= 1000 ? 'compact' : 'standard',
-  }).format(quantity)} ${displayUnit}`;
+  });
+  const formattedQuantity = formatter.format(quantity);
+  const roundsToZero =
+    formatter.format(Math.abs(quantity)) === formatter.format(0);
+  const displayQuantity =
+    options.showSmallValues && quantity !== 0 && roundsToZero
+      ? quantity > 0
+        ? `<${formatter.format(0.01)}`
+        : `>${formatter.format(-0.01)}`
+      : formattedQuantity;
+
+  return `${displayQuantity} ${displayUnit}`;
 }
 
 export function extractDatePortion(isoString: string): string {

--- a/packages/cli/src/util/telemetry/commands/usage/index.ts
+++ b/packages/cli/src/util/telemetry/commands/usage/index.ts
@@ -30,6 +30,12 @@ export class UsageTelemetryClient
     }
   }
 
+  trackCliFlagAll(all: boolean | undefined) {
+    if (all) {
+      this.trackCliFlag('all');
+    }
+  }
+
   trackCliOptionBreakdown(breakdown: string | undefined) {
     if (breakdown) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/usage/index.ts
+++ b/packages/cli/src/util/telemetry/commands/usage/index.ts
@@ -30,12 +30,6 @@ export class UsageTelemetryClient
     }
   }
 
-  trackCliFlagAll(all: boolean | undefined) {
-    if (all) {
-      this.trackCliFlag('all');
-    }
-  }
-
   trackCliOptionBreakdown(breakdown: string | undefined) {
     if (breakdown) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/contract/index.test.ts
+++ b/packages/cli/test/unit/commands/contract/index.test.ts
@@ -109,6 +109,7 @@ describe('contract', () => {
       const output = client.getFullOutput();
       expect(output).toContain('Enterprise');
       expect(output).toContain('Usage');
+      expect(output).toContain('1,000,000 MIUs');
     });
 
     it('should output JSON with --format json', async () => {

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -30,13 +30,94 @@ function createMockCharge(overrides: Partial<FocusCharge> = {}): FocusCharge {
 }
 
 function useBillingCharges(charges: FocusCharge[] = []) {
-  client.scenario.get('/v1/billing/charges', (_req, res) => {
-    res.setHeader('Content-Type', 'application/jsonl');
-    // Stream JSONL response
-    for (const charge of charges) {
-      res.write(JSON.stringify(charge) + '\n');
-    }
-    res.end();
+  client.scenario.post('/v2/billing/costs', (_req, res) => {
+    const products = Object.fromEntries(
+      charges.map(charge => [
+        charge.ServiceName,
+        {
+          title: charge.ServiceName,
+          category:
+            charge.Tags.Category === 'Subscription Licenses'
+              ? 'Subscription Licenses'
+              : 'Vercel Functions',
+        },
+      ])
+    );
+    const projects = Object.fromEntries(
+      charges.flatMap(charge =>
+        charge.Tags.ProjectId
+          ? [[charge.Tags.ProjectId, { title: charge.Tags.ProjectName }]]
+          : []
+      )
+    );
+    const regions = Object.fromEntries(
+      charges.flatMap(charge =>
+        charge.RegionId ? [[charge.RegionId, { title: charge.RegionName }]] : []
+      )
+    );
+    const times = [
+      ...new Set(charges.map(charge => charge.ChargePeriodStart)),
+    ].sort();
+
+    res.json({
+      metrics: [
+        {
+          slug: 'gross_cost',
+          title: 'Cost',
+          unit: { kind: 'standard', name: 'USD' },
+        },
+        {
+          slug: 'quantity',
+          title: 'Usage',
+          unit: { kind: 'custom', singular: 'unit', plural: 'units' },
+        },
+      ],
+      from: times.at(0) ?? '2025-12-01T08:00:00.000Z',
+      to: '2026-01-01T08:00:00.000Z',
+      results: {
+        granularity: { unit: 'day', step: 1 },
+        times,
+        dimensionsMeta: {
+          product: { values: products },
+          project: { values: projects },
+          region: { values: regions },
+        },
+        views: {
+          byProduct: {
+            groupBy: ['product'],
+            results: charges.map(charge => ({
+              dimensionValues: { product: charge.ServiceName },
+              metrics: ['gross_cost', 'quantity'],
+              values: times.map(time =>
+                time === charge.ChargePeriodStart
+                  ? [charge.BilledCost, charge.ConsumedQuantity]
+                  : [0, 0]
+              ),
+              totalValue: [charge.BilledCost, charge.ConsumedQuantity],
+              flatRate: charge.Tags.FlatRate === 'true',
+            })),
+          },
+          byProductRegionProject: {
+            groupBy: ['product', 'region', 'project'],
+            results: charges.map(charge => ({
+              dimensionValues: {
+                product: charge.ServiceName,
+                project: charge.Tags.ProjectId ?? null,
+                region: charge.RegionId ?? null,
+              },
+              metrics: ['gross_cost', 'quantity'],
+              values: times.map(time =>
+                time === charge.ChargePeriodStart
+                  ? [charge.BilledCost, charge.ConsumedQuantity]
+                  : [0, 0]
+              ),
+              totalValue: [charge.BilledCost, charge.ConsumedQuantity],
+              flatRate: charge.Tags.FlatRate === 'true',
+            })),
+          },
+        },
+      },
+    });
   });
 }
 
@@ -100,6 +181,55 @@ describe('usage', () => {
       expect(output).toContain('Edge Middleware Invocations');
     });
 
+    it('should display included Flat Rate CDN usage in consumed units', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Edge Requests',
+          ConsumedQuantity: 12040,
+          ConsumedUnit: 'requests',
+          PricingQuantity: 0,
+          EffectiveCost: 0,
+          BilledCost: 0,
+          Tags: { FlatRate: 'true' },
+        }),
+      ]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('12K units');
+      expect(output).toContain('Edge Requests (Flat Rate CDN)');
+      expect(output).toContain('Included');
+      expect(output).not.toContain('Amount due');
+    });
+
+    it('should separate subscription licenses from infrastructure usage', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Pro',
+          ConsumedQuantity: 1,
+          BilledCost: 20,
+          Tags: { Category: 'Subscription Licenses' },
+        }),
+        createMockCharge({
+          ServiceName: 'Function Invocations',
+          ConsumedQuantity: 8340,
+          BilledCost: 0.01,
+        }),
+      ]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('Infrastructure');
+      expect(output).toContain('Subscription licenses');
+      expect(output).toContain('Estimated total:');
+    });
+
     it('should output JSON with --format json', async () => {
       const mockCharges = [
         createMockCharge({
@@ -126,7 +256,11 @@ describe('usage', () => {
       const output = client.stdout.getFullOutput();
       const json = JSON.parse(output);
       expect(json.services).toHaveLength(1);
+      expect(json.pricingUnit).toEqual('USD');
       expect(json.services[0].name).toEqual('Serverless Function Execution');
+      expect(json.services[0].quantity).toEqual(1000000);
+      expect(json.services[0].unit).toEqual('units');
+      expect(json.totals.cost).toEqual(10);
       expect(json.totals.billedCost).toEqual(10);
     });
 

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -29,7 +29,36 @@ function createMockCharge(overrides: Partial<FocusCharge> = {}): FocusCharge {
   };
 }
 
-function useBillingCharges(charges: FocusCharge[] = []) {
+function useCommitmentUsage({
+  total = 20,
+  remaining = 17.96,
+  cadence = 'monthly',
+}: {
+  total?: number;
+  remaining?: number;
+  cadence?: 'one_time' | 'annual' | 'monthly' | 'quarterly' | 'semi_annual';
+} = {}) {
+  client.scenario.get('/v1/invoices/pre-commitment-usage', (_req, res) => {
+    res.json({
+      creditLedgers: [
+        {
+          currency: 'USD',
+          title: 'Infrastructure credit',
+          periodStart: '2025-12-01T08:00:00.000Z',
+          periodEnd: '2026-01-01T08:00:00.000Z',
+          total,
+          remaining,
+        },
+      ],
+      cadence,
+    });
+  });
+}
+
+function useBillingCharges(
+  charges: FocusCharge[] = [],
+  quantityUnit: 'inferred' | 'none' = 'inferred'
+) {
   client.scenario.post('/v2/billing/costs', (_req, res) => {
     const products = Object.fromEntries(
       charges.map(charge => [
@@ -69,11 +98,19 @@ function useBillingCharges(charges: FocusCharge[] = []) {
         {
           slug: 'quantity',
           title: 'Usage',
-          unit: { kind: 'custom', singular: 'unit', plural: 'units' },
+          unit:
+            quantityUnit === 'none'
+              ? null
+              : charges.some(
+                    charge => charge.Tags.Category !== 'Subscription Licenses'
+                  )
+                ? { kind: 'custom', singular: 'unit', plural: 'units' }
+                : null,
         },
       ],
       from: times.at(0) ?? '2025-12-01T08:00:00.000Z',
       to: '2026-01-01T08:00:00.000Z',
+      queriedAt: '2025-12-15T12:00:00.000Z',
       results: {
         granularity: { unit: 'day', step: 1 },
         times,
@@ -145,6 +182,7 @@ describe('usage', () => {
       expect(output).toContain('--from');
       expect(output).toContain('--to');
       expect(output).toContain('--breakdown');
+      expect(output).toContain('--all');
       expect(output).toContain('--format');
     });
   });
@@ -179,6 +217,195 @@ describe('usage', () => {
       const output = client.getFullOutput();
       expect(output).toContain('Serverless Function Execution');
       expect(output).toContain('Edge Middleware Invocations');
+      expect(output).toContain('Usage for personal account');
+      expect(output).toContain('Usage through: Dec 15, 2025');
+      expect(output).toContain('Infrastructure subtotal');
+      expect(output).toContain('Infrastructure usage    $15.00');
+      expect(output).toContain('Estimated bill          $15.00');
+    });
+
+    it('should identify a selected team as the billing target', async () => {
+      client.config.currentTeam = 'team_dummy';
+      useBillingCharges([]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+
+      expect(client.getFullOutput()).toContain('Usage for team');
+    });
+
+    it('should display the current monthly infrastructure credit for a team', async () => {
+      client.config.currentTeam = 'team_dummy';
+      useBillingCharges([]);
+      useCommitmentUsage();
+
+      client.setArgv('usage');
+      expect(await usage(client)).toEqual(0);
+
+      const output = client.getFullOutput();
+      expect(output).toContain('Credit');
+      expect(output).toContain('Cadence    Monthly');
+      expect(output).toContain('Used       $2.04 of $20.00');
+      expect(output).toContain('Remaining  $17.96');
+      expect(output).toContain('Progress   10%');
+    });
+
+    it('should explain how credits affect the estimated bill', async () => {
+      client.config.currentTeam = 'team_dummy';
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Infrastructure usage',
+          BilledCost: 2.04,
+        }),
+        createMockCharge({
+          ServiceName: 'Subscriptions',
+          ConsumedQuantity: 1,
+          BilledCost: 115,
+          Tags: { Category: 'Subscription Licenses' },
+        }),
+      ]);
+      useCommitmentUsage();
+
+      client.setArgv('usage');
+      expect(await usage(client)).toEqual(0);
+
+      const output = client.getFullOutput();
+      expect(output).toMatch(/Subscriptions\s+\$115\.00/);
+      expect(output).toMatch(/Infrastructure usage\s+\$2\.04/);
+      expect(output).toMatch(/Credits applied\s+-\$2\.04/);
+      expect(output).toMatch(/Estimated bill\s+\$115\.00/);
+    });
+
+    it('should include the current infrastructure credit in JSON output', async () => {
+      client.config.currentTeam = 'team_dummy';
+      useBillingCharges([]);
+      useCommitmentUsage();
+
+      client.setArgv('usage', '--format', 'json');
+      expect(await usage(client)).toEqual(0);
+
+      const json = JSON.parse(client.stdout.getFullOutput());
+      expect(json.credit).toEqual({
+        cadence: 'monthly',
+        currency: 'USD',
+        allocated: 20,
+        used: 2.04,
+        remaining: 17.96,
+        progress: 10.2,
+      });
+    });
+
+    it('should continue when current infrastructure credit is unavailable', async () => {
+      client.config.currentTeam = 'team_dummy';
+      useBillingCharges([]);
+      client.scenario.get('/v1/invoices/pre-commitment-usage', (_req, res) => {
+        res.status(500).json({ error: { message: 'Unavailable' } });
+      });
+
+      client.setArgv('usage');
+      expect(await usage(client)).toEqual(0);
+      expect(client.getFullOutput()).toContain('No usage data found');
+      expect(client.getFullOutput()).not.toContain('Cadence    Monthly');
+    });
+
+    it('should omit current infrastructure credit for a custom date range', async () => {
+      client.config.currentTeam = 'team_dummy';
+      useBillingCharges([]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+      expect(client.getFullOutput()).not.toContain('Cadence    Monthly');
+    });
+
+    it('should hide empty services by default and show them with --all', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Used Service',
+          ConsumedQuantity: 10,
+          BilledCost: 2,
+          EffectiveCost: 1,
+        }),
+        createMockCharge({
+          ServiceName: 'Flat Rate CDN Advanced',
+          ConsumedQuantity: 0,
+          BilledCost: 0,
+          EffectiveCost: 0,
+          Tags: { Category: 'Subscription Licenses' },
+        }),
+      ]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+      let output = client.getFullOutput();
+      expect(output).toContain('Used Service');
+      expect(output).not.toContain('Flat Rate CDN Advanced');
+      expect(output).toContain('1 service with no usage hidden');
+
+      const previousOutputLength = output.length;
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--all'
+      );
+      expect(await usage(client)).toEqual(0);
+      output = client.getFullOutput().slice(previousOutputLength);
+      expect(output).toContain('Flat Rate CDN Advanced');
+      expect(output).toContain('1 license');
+      expect(output).not.toContain('1 licenses');
+      expect(output).not.toContain('with no usage hidden');
+    });
+
+    it('should singularize license units regardless of service category', async () => {
+      useBillingCharges(
+        [
+          createMockCharge({
+            ServiceName: 'v0 Enterprise',
+            ConsumedQuantity: 1,
+            BilledCost: 100,
+          }),
+          createMockCharge({
+            ServiceName: 'Standard Enterprise Support',
+            ConsumedQuantity: 1,
+            BilledCost: 50,
+          }),
+        ],
+        'none'
+      );
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+
+      const output = client.getFullOutput();
+      expect(output).toMatch(/v0 Enterprise\s+1 license/);
+      expect(output).toMatch(/Standard Enterprise Support\s+1 license/);
+      expect(output).not.toContain('1 licenses');
+    });
+
+    it('should preserve an explicit scope in the show-all command', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Unused Service',
+          ConsumedQuantity: 0,
+          BilledCost: 0,
+        }),
+      ]);
+
+      client.setArgv(
+        'usage',
+        '--scope',
+        'team_dummy',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31'
+      );
+      expect(await usage(client)).toEqual(0);
+      expect(client.getFullOutput()).toContain(
+        'Show all with: vc usage --scope team_dummy --all'
+      );
     });
 
     it('should display included Flat Rate CDN usage in consumed units', async () => {
@@ -187,9 +414,9 @@ describe('usage', () => {
           ServiceName: 'Edge Requests',
           ConsumedQuantity: 12040,
           ConsumedUnit: 'requests',
-          PricingQuantity: 0,
+          PricingQuantity: 2,
           EffectiveCost: 0,
-          BilledCost: 0,
+          BilledCost: 2,
           Tags: { FlatRate: 'true' },
         }),
       ]);
@@ -199,10 +426,33 @@ describe('usage', () => {
 
       expect(exitCode).toEqual(0);
       const output = client.getFullOutput();
-      expect(output).toContain('12K units');
+      expect(output).toContain('12.04K units');
       expect(output).toContain('Edge Requests (Flat Rate CDN)');
-      expect(output).toContain('Included');
+      expect(output).toContain('Effective Cost');
+      expect(output).toContain('$0.00');
+      expect(output).not.toContain('Net Cost');
       expect(output).not.toContain('Amount due');
+    });
+
+    it('should handle subscription metrics with a null unit', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Flat Rate CDN Standard',
+          ConsumedQuantity: 1,
+          BilledCost: 25,
+          EffectiveCost: 25,
+          Tags: { Category: 'Subscription Licenses' },
+        }),
+      ]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('Flat Rate CDN Standard');
+      expect(output).toContain('1 license');
+      expect(output).toContain('$25.00');
     });
 
     it('should separate subscription licenses from infrastructure usage', async () => {
@@ -227,7 +477,7 @@ describe('usage', () => {
       const output = client.getFullOutput();
       expect(output).toContain('Infrastructure');
       expect(output).toContain('Subscription licenses');
-      expect(output).toContain('Estimated total:');
+      expect(output).toContain('Estimated bill');
     });
 
     it('should output JSON with --format json', async () => {

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -92,6 +92,8 @@ function useBillingCharges(
     const times = [
       ...new Set(charges.map(charge => charge.ChargePeriodStart)),
     ].sort();
+    const quantityMetricSlug = (charge: FocusCharge) =>
+      `usage_${charge.ServiceName.replaceAll(' ', '_').toLowerCase()}`;
 
     res.json({
       metrics: [
@@ -100,18 +102,19 @@ function useBillingCharges(
           title: 'Cost',
           unit: { kind: 'standard', name: 'USD' },
         },
-        {
-          slug: 'quantity',
-          title: 'Usage',
+        ...charges.map(charge => ({
+          slug: quantityMetricSlug(charge),
+          title: charge.ServiceName,
           unit:
-            quantityUnit === 'none'
+            quantityUnit === 'none' ||
+            charge.Tags.Category === 'Subscription Licenses'
               ? null
-              : charges.some(
-                    charge => charge.Tags.Category !== 'Subscription Licenses'
-                  )
-                ? { kind: 'custom', singular: 'unit', plural: 'units' }
-                : null,
-        },
+              : {
+                  kind: 'custom',
+                  singular: charge.ConsumedUnit.replace(/s$/, ''),
+                  plural: charge.ConsumedUnit,
+                },
+        })),
       ],
       from: times.at(0) ?? '2025-12-01T08:00:00.000Z',
       to: '2026-01-01T08:00:00.000Z',
@@ -129,7 +132,7 @@ function useBillingCharges(
             groupBy: ['product'],
             results: charges.map(charge => ({
               dimensionValues: { product: charge.ServiceName },
-              metrics: ['gross_cost', 'quantity'],
+              metrics: ['gross_cost', quantityMetricSlug(charge)],
               values: times.map(time =>
                 time === charge.ChargePeriodStart
                   ? [charge.BilledCost, charge.ConsumedQuantity]
@@ -147,7 +150,7 @@ function useBillingCharges(
                 project: charge.Tags.ProjectId ?? null,
                 region: charge.RegionId ?? null,
               },
-              metrics: ['gross_cost', 'quantity'],
+              metrics: ['gross_cost', quantityMetricSlug(charge)],
               values: times.map(time =>
                 time === charge.ChargePeriodStart
                   ? [charge.BilledCost, charge.ConsumedQuantity]
@@ -415,6 +418,58 @@ describe('usage', () => {
       expect(client.getFullOutput()).not.toContain('Cadence    Monthly');
     });
 
+    it('should distinguish small nonzero usage from exact zero', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Small Positive Usage',
+          ConsumedQuantity: 0.004,
+          BilledCost: 1,
+        }),
+        createMockCharge({
+          ServiceName: 'Small Negative Usage',
+          ConsumedQuantity: -0.004,
+          BilledCost: 1,
+        }),
+        createMockCharge({
+          ServiceName: 'Fixed Fee',
+          ConsumedQuantity: 0,
+          BilledCost: 1,
+        }),
+      ]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+
+      const output = client.getFullOutput();
+      expect(output).toMatch(/Small Positive Usage\s+<0\.01\s+\$1\.00/);
+      expect(output).toMatch(/Small Negative Usage\s+>-0\.01\s+\$1\.00/);
+      expect(output).toMatch(/Fixed Fee\s+0\s+\$1\.00/);
+    });
+
+    it('should preserve small nonzero usage in JSON output', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Small Usage',
+          ConsumedQuantity: 0.004,
+          BilledCost: 1,
+        }),
+      ]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--format',
+        'json'
+      );
+      expect(await usage(client)).toEqual(0);
+
+      const json = JSON.parse(client.stdout.getFullOutput());
+      expect(json.services[0].quantity).toEqual(0.004);
+    });
+
     it('should hide empty services', async () => {
       useBillingCharges([
         createMockCharge({
@@ -442,18 +497,21 @@ describe('usage', () => {
     });
 
     it('should omit unknown product units', async () => {
-      useBillingCharges([
-        createMockCharge({
-          ServiceName: 'v0 Enterprise',
-          ConsumedQuantity: 1,
-          BilledCost: 100,
-        }),
-        createMockCharge({
-          ServiceName: 'Standard Enterprise Support',
-          ConsumedQuantity: 1,
-          BilledCost: 50,
-        }),
-      ]);
+      useBillingCharges(
+        [
+          createMockCharge({
+            ServiceName: 'v0 Enterprise',
+            ConsumedQuantity: 1,
+            BilledCost: 100,
+          }),
+          createMockCharge({
+            ServiceName: 'Standard Enterprise Support',
+            ConsumedQuantity: 1,
+            BilledCost: 50,
+          }),
+        ],
+        'none'
+      );
 
       client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
       expect(await usage(client)).toEqual(0);
@@ -484,7 +542,7 @@ describe('usage', () => {
       expect(exitCode).toEqual(0);
       const output = client.getFullOutput();
       expect(output).toContain('12.04K');
-      expect(output).not.toContain('12.04K units');
+      expect(output).not.toContain('12.04K requests');
       expect(output).toContain('Edge Requests');
       expect(output).not.toContain('Edge Requests (Flat Rate CDN)');
       expect(output).toContain('Effective Cost');

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -61,7 +61,8 @@ function useBillingCharges(
   charges: FocusCharge[] = [],
   quantityUnit: 'inferred' | 'none' = 'inferred',
   onRequest?: (request: { body: unknown; query: unknown }) => void,
-  detailGroupBy = ['product', 'region', 'project']
+  detailGroupBy = ['product', 'region', 'project'],
+  costUnit: 'USD' | 'managed_infrastructure_units' = 'USD'
 ) {
   client.scenario.post('/v2/billing/costs', (req, res) => {
     onRequest?.({ body: req.body, query: req.query });
@@ -100,7 +101,10 @@ function useBillingCharges(
         {
           slug: 'gross_cost',
           title: 'Cost',
-          unit: { kind: 'standard', name: 'USD' },
+          unit:
+            costUnit === 'USD'
+              ? { kind: 'custom', singular: 'dollar', plural: 'dollars' }
+              : { kind: 'custom', singular: 'MIU', plural: 'MIUs' },
         },
         ...charges.map(charge => ({
           slug: quantityMetricSlug(charge),
@@ -238,13 +242,13 @@ describe('usage', () => {
       expect(output).toContain('Estimated bill          $15.00');
     });
 
-    it('should request USD costs and only request the detail view for group-by', async () => {
+    it('should use the account cost currency and only request the detail view for group-by', async () => {
       const requests: Array<{ body: any; query: any }> = [];
       useBillingCharges([], 'inferred', request => requests.push(request));
 
       client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
       expect(await usage(client)).toEqual(0);
-      expect(requests[0].body.currency).toEqual('USD');
+      expect(requests[0].body).not.toHaveProperty('currency');
       expect(requests[0].body.views).toEqual({
         byProduct: { groupBy: ['product'] },
       });
@@ -327,14 +331,20 @@ describe('usage', () => {
       expect(output).toContain('Progress   10%');
     });
 
-    it('should format MIU credits without subtracting them from a USD bill', async () => {
+    it('should display and apply MIU credits to MIU costs', async () => {
       client.config.currentTeam = 'team_dummy';
-      useBillingCharges([
-        createMockCharge({
-          ServiceName: 'Infrastructure usage',
-          BilledCost: 10,
-        }),
-      ]);
+      useBillingCharges(
+        [
+          createMockCharge({
+            ServiceName: 'Infrastructure usage',
+            BilledCost: 10,
+          }),
+        ],
+        'inferred',
+        undefined,
+        ['product', 'region', 'project'],
+        'managed_infrastructure_units'
+      );
       useCommitmentUsage({
         total: 1000,
         remaining: 750,
@@ -347,8 +357,9 @@ describe('usage', () => {
       const output = client.getFullOutput();
       expect(output).toContain('Used       250 MIUs of 1,000 MIUs');
       expect(output).toContain('Remaining  750 MIUs');
-      expect(output).not.toContain('Credits applied');
-      expect(output).toMatch(/Estimated bill\s+\$10\.00/);
+      expect(output).toMatch(/Infrastructure usage\s+10 MIUs/);
+      expect(output).toMatch(/Credits applied\s+-10 MIUs/);
+      expect(output).toMatch(/Estimated bill\s+0 MIUs/);
     });
 
     it('should explain how credits affect the estimated bill', async () => {
@@ -581,10 +592,47 @@ describe('usage', () => {
       expect(json.services).toEqual([
         expect.objectContaining({
           name: 'Edge Requests',
+          product: 'Edge Requests',
           quantity: 12040,
           cost: 2,
           effectiveCost: 2,
           included: false,
+        }),
+      ]);
+    });
+
+    it('should preserve included status when the metered quantity is zero', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Edge Requests',
+          ConsumedQuantity: 12000,
+          BilledCost: 0,
+          Tags: { FlatRate: 'true' },
+        }),
+        createMockCharge({
+          ServiceName: 'Edge Requests',
+          ConsumedQuantity: 0,
+          BilledCost: 0,
+        }),
+      ]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--format',
+        'json'
+      );
+      expect(await usage(client)).toEqual(0);
+
+      const json = JSON.parse(client.stdout.getFullOutput());
+      expect(json.services).toEqual([
+        expect.objectContaining({
+          product: 'Edge Requests',
+          quantity: 12000,
+          included: true,
         }),
       ]);
     });
@@ -739,6 +787,39 @@ describe('usage', () => {
       // Should show services
       expect(output).toContain('Serverless Function Execution');
       expect(output).toContain('Edge Middleware Invocations');
+    });
+
+    it('should treat subscription quantities as gauges in breakdowns', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Pro',
+          ConsumedQuantity: 1,
+          BilledCost: 20,
+          ChargePeriodStart: '2025-12-01T08:00:00.000Z',
+          Tags: { Category: 'Subscription Licenses' },
+        }),
+        createMockCharge({
+          ServiceName: 'Pro',
+          ConsumedQuantity: 1,
+          BilledCost: 0,
+          ChargePeriodStart: '2025-12-02T08:00:00.000Z',
+          Tags: { Category: 'Subscription Licenses' },
+        }),
+      ]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--breakdown',
+        'weekly'
+      );
+      expect(await usage(client)).toEqual(0);
+
+      expect(client.getFullOutput()).toMatch(/Pro\s+1 license\s+\$20\.00/);
+      expect(client.getFullOutput()).not.toContain('2 licenses');
     });
 
     it('should display weekly breakdown with --breakdown weekly', async () => {

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -113,11 +113,13 @@ function useBillingCharges(
             quantityUnit === 'none' ||
             charge.Tags.Category === 'Subscription Licenses'
               ? null
-              : {
-                  kind: 'custom',
-                  singular: charge.ConsumedUnit.replace(/s$/, ''),
-                  plural: charge.ConsumedUnit,
-                },
+              : charge.ConsumedUnit === 'byte'
+                ? { kind: 'digitalStorage', name: 'byte' }
+                : {
+                    kind: 'custom',
+                    singular: charge.ConsumedUnit.replace(/s$/, ''),
+                    plural: charge.ConsumedUnit,
+                  },
         })),
       ],
       from: times.at(0) ?? '2025-12-01T08:00:00.000Z',
@@ -315,6 +317,24 @@ describe('usage', () => {
       expect(requested).toEqual(false);
     });
 
+    it.each([
+      ['plus', { plan: 'pro', planIteration: 'plus' }],
+      ['Pro Flex', { plan: 'pro', planIteration: 'flex' }],
+    ])('should request precommitment usage for %s teams', async (_name, billing) => {
+      client.config.currentTeam = 'team_dummy';
+      Object.assign(team, { billing });
+      useBillingCharges([]);
+      let requested = false;
+      client.scenario.get('/v1/invoices/pre-commitment-usage', (_req, res) => {
+        requested = true;
+        res.json({ creditLedgers: [] });
+      });
+
+      client.setArgv('usage');
+      expect(await usage(client)).toEqual(0);
+      expect(requested).toEqual(true);
+    });
+
     it('should display the current monthly infrastructure credit for a team', async () => {
       client.config.currentTeam = 'team_dummy';
       useBillingCharges([]);
@@ -407,6 +427,30 @@ describe('usage', () => {
       });
     });
 
+    it('should include the account MIU cost unit in JSON output', async () => {
+      useBillingCharges(
+        [createMockCharge({ BilledCost: 10 })],
+        'inferred',
+        undefined,
+        ['product', 'region', 'project'],
+        'managed_infrastructure_units'
+      );
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--format',
+        'json'
+      );
+      expect(await usage(client)).toEqual(0);
+      expect(JSON.parse(client.stdout.getFullOutput()).costUnit).toEqual(
+        'managed_infrastructure_units'
+      );
+    });
+
     it('should continue when current infrastructure credit is unavailable', async () => {
       client.config.currentTeam = 'team_dummy';
       useBillingCharges([]);
@@ -452,9 +496,13 @@ describe('usage', () => {
       expect(await usage(client)).toEqual(0);
 
       const output = client.getFullOutput();
-      expect(output).toMatch(/Small Positive Usage\s+<0\.01\s+\$1\.00/);
-      expect(output).toMatch(/Small Negative Usage\s+>-0\.01\s+\$1\.00/);
-      expect(output).toMatch(/Fixed Fee\s+0\s+\$1\.00/);
+      expect(output).toMatch(
+        /Small Positive Usage\s+<0\.01 GB-Seconds\s+\$1\.00/
+      );
+      expect(output).toMatch(
+        /Small Negative Usage\s+>-0\.01 GB-Seconds\s+\$1\.00/
+      );
+      expect(output).toMatch(/Fixed Fee\s+0 GB-Seconds\s+\$1\.00/);
     });
 
     it('should preserve small nonzero usage in JSON output', async () => {
@@ -507,6 +555,26 @@ describe('usage', () => {
       expect(output).not.toContain('Show all with:');
     });
 
+    it('should pluralize the hidden services hint', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Empty Usage',
+          ConsumedQuantity: 0,
+        }),
+        createMockCharge({
+          ServiceName: 'Empty Subscription',
+          ConsumedQuantity: 0,
+          Tags: { Category: 'Subscription Licenses' },
+        }),
+      ]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+      expect(client.getFullOutput()).toContain(
+        '2 services with no usage hidden'
+      );
+    });
+
     it('should omit unknown product units', async () => {
       useBillingCharges(
         [
@@ -552,14 +620,61 @@ describe('usage', () => {
 
       expect(exitCode).toEqual(0);
       const output = client.getFullOutput();
-      expect(output).toContain('12.04K');
-      expect(output).not.toContain('12.04K requests');
+      expect(output).toContain('12.04K requests');
       expect(output).toContain('Edge Requests');
       expect(output).not.toContain('Edge Requests (Flat Rate CDN)');
       expect(output).toContain('Effective Cost');
       expect(output).toContain('$0.00');
       expect(output).not.toContain('Net Cost');
       expect(output).not.toContain('Amount due');
+    });
+
+    it('should use singular custom units', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Edge Requests',
+          ConsumedQuantity: 1,
+          ConsumedUnit: 'requests',
+          BilledCost: 1,
+        }),
+      ]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+      expect(client.getFullOutput()).toMatch(
+        /Edge Requests\s+1 request\s+\$1\.00/
+      );
+    });
+
+    it('should format digital storage while preserving raw JSON quantities', async () => {
+      const charge = createMockCharge({
+        ServiceName: 'Data Transfer',
+        ConsumedQuantity: 1_500_000_000,
+        ConsumedUnit: 'byte',
+        BilledCost: 1,
+      });
+      useBillingCharges([charge]);
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+      expect(client.getFullOutput()).toMatch(
+        /Data Transfer\s+1\.5 GB\s+\$1\.00/
+      );
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--format',
+        'json'
+      );
+      expect(await usage(client)).toEqual(0);
+      const json = JSON.parse(client.stdout.getFullOutput());
+      expect(json.services[0]).toEqual(
+        expect.objectContaining({ quantity: 1_500_000_000, unit: 'byte' })
+      );
     });
 
     it('should merge flat-rate and metered usage into one product row', async () => {
@@ -712,7 +827,7 @@ describe('usage', () => {
       expect(json.costUnit).toEqual('USD');
       expect(json.services[0].name).toEqual('Serverless Function Execution');
       expect(json.services[0].quantity).toEqual(1000000);
-      expect(json.services[0]).not.toHaveProperty('unit');
+      expect(json.services[0].unit).toEqual('GB-Seconds');
       expect(json.services[0]).not.toHaveProperty('pricingQuantity');
       expect(json.services[0]).not.toHaveProperty('billedCost');
       expect(json.totals).toEqual({ cost: 10, effectiveCost: 10 });

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -33,16 +33,18 @@ function useCommitmentUsage({
   total = 20,
   remaining = 17.96,
   cadence = 'monthly',
+  currency = 'USD',
 }: {
   total?: number;
   remaining?: number;
   cadence?: 'one_time' | 'annual' | 'monthly' | 'quarterly' | 'semi_annual';
+  currency?: string;
 } = {}) {
   client.scenario.get('/v1/invoices/pre-commitment-usage', (_req, res) => {
     res.json({
       creditLedgers: [
         {
-          currency: 'USD',
+          currency,
           title: 'Infrastructure credit',
           periodStart: '2025-12-01T08:00:00.000Z',
           periodEnd: '2026-01-01T08:00:00.000Z',
@@ -57,9 +59,12 @@ function useCommitmentUsage({
 
 function useBillingCharges(
   charges: FocusCharge[] = [],
-  quantityUnit: 'inferred' | 'none' = 'inferred'
+  quantityUnit: 'inferred' | 'none' = 'inferred',
+  onRequest?: (request: { body: unknown; query: unknown }) => void,
+  detailGroupBy = ['product', 'region', 'project']
 ) {
-  client.scenario.post('/v2/billing/costs', (_req, res) => {
+  client.scenario.post('/v2/billing/costs', (req, res) => {
+    onRequest?.({ body: req.body, query: req.query });
     const products = Object.fromEntries(
       charges.map(charge => [
         charge.ServiceName,
@@ -135,7 +140,7 @@ function useBillingCharges(
             })),
           },
           byProductRegionProject: {
-            groupBy: ['product', 'region', 'project'],
+            groupBy: detailGroupBy,
             results: charges.map(charge => ({
               dimensionValues: {
                 product: charge.ServiceName,
@@ -182,15 +187,21 @@ describe('usage', () => {
       expect(output).toContain('--from');
       expect(output).toContain('--to');
       expect(output).toContain('--breakdown');
-      expect(output).toContain('--all');
+      expect(output).not.toContain('--all');
       expect(output).toContain('--format');
     });
   });
 
   describe('with team context', () => {
+    let team: Record<string, unknown>;
+
     beforeEach(() => {
       useUser();
-      useTeams('team_dummy');
+      const teams = useTeams('team_dummy');
+      team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+      Object.assign(team, {
+        billing: { plan: 'enterprise', planIteration: 'unbundled' },
+      });
     });
 
     it('should fetch and display usage data', async () => {
@@ -224,6 +235,52 @@ describe('usage', () => {
       expect(output).toContain('Estimated bill          $15.00');
     });
 
+    it('should request USD costs and only request the detail view for group-by', async () => {
+      const requests: Array<{ body: any; query: any }> = [];
+      useBillingCharges([], 'inferred', request => requests.push(request));
+
+      client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
+      expect(await usage(client)).toEqual(0);
+      expect(requests[0].body.currency).toEqual('USD');
+      expect(requests[0].body.views).toEqual({
+        byProduct: { groupBy: ['product'] },
+      });
+      expect(requests[0].query).not.toHaveProperty('from');
+      expect(requests[0].query).not.toHaveProperty('to');
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'project'
+      );
+      expect(await usage(client)).toEqual(0);
+      expect(requests[1].body.views.byProductRegionProject).toEqual({
+        groupBy: ['product', 'region', 'project'],
+      });
+    });
+
+    it('should reject group-by when the API strips the requested dimension', async () => {
+      useBillingCharges([], 'inferred', undefined, ['product']);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--group-by',
+        'project'
+      );
+      expect(await usage(client)).toEqual(1);
+      expect(client.getFullOutput()).toContain(
+        'Usage cannot be grouped by project for this team.'
+      );
+    });
+
     it('should identify a selected team as the billing target', async () => {
       client.config.currentTeam = 'team_dummy';
       useBillingCharges([]);
@@ -232,6 +289,23 @@ describe('usage', () => {
       expect(await usage(client)).toEqual(0);
 
       expect(client.getFullOutput()).toContain('Usage for team');
+    });
+
+    it('should skip the precommitment request for teams without precommitment', async () => {
+      client.config.currentTeam = 'team_dummy';
+      Object.assign(team, {
+        billing: { plan: 'pro', planIteration: 'unbundled' },
+      });
+      useBillingCharges([]);
+      let requested = false;
+      client.scenario.get('/v1/invoices/pre-commitment-usage', (_req, res) => {
+        requested = true;
+        res.json({ creditLedgers: [] });
+      });
+
+      client.setArgv('usage');
+      expect(await usage(client)).toEqual(0);
+      expect(requested).toEqual(false);
     });
 
     it('should display the current monthly infrastructure credit for a team', async () => {
@@ -248,6 +322,30 @@ describe('usage', () => {
       expect(output).toContain('Used       $2.04 of $20.00');
       expect(output).toContain('Remaining  $17.96');
       expect(output).toContain('Progress   10%');
+    });
+
+    it('should format MIU credits without subtracting them from a USD bill', async () => {
+      client.config.currentTeam = 'team_dummy';
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Infrastructure usage',
+          BilledCost: 10,
+        }),
+      ]);
+      useCommitmentUsage({
+        total: 1000,
+        remaining: 750,
+        currency: 'managed_infrastructure_units',
+      });
+
+      client.setArgv('usage');
+      expect(await usage(client)).toEqual(0);
+
+      const output = client.getFullOutput();
+      expect(output).toContain('Used       250 MIUs of 1,000 MIUs');
+      expect(output).toContain('Remaining  750 MIUs');
+      expect(output).not.toContain('Credits applied');
+      expect(output).toMatch(/Estimated bill\s+\$10\.00/);
     });
 
     it('should explain how credits affect the estimated bill', async () => {
@@ -317,7 +415,7 @@ describe('usage', () => {
       expect(client.getFullOutput()).not.toContain('Cadence    Monthly');
     });
 
-    it('should hide empty services by default and show them with --all', async () => {
+    it('should hide empty services', async () => {
       useBillingCharges([
         createMockCharge({
           ServiceName: 'Used Service',
@@ -336,76 +434,35 @@ describe('usage', () => {
 
       client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
       expect(await usage(client)).toEqual(0);
-      let output = client.getFullOutput();
+      const output = client.getFullOutput();
       expect(output).toContain('Used Service');
       expect(output).not.toContain('Flat Rate CDN Advanced');
       expect(output).toContain('1 service with no usage hidden');
-
-      const previousOutputLength = output.length;
-      client.setArgv(
-        'usage',
-        '--from',
-        '2025-12-01',
-        '--to',
-        '2025-12-31',
-        '--all'
-      );
-      expect(await usage(client)).toEqual(0);
-      output = client.getFullOutput().slice(previousOutputLength);
-      expect(output).toContain('Flat Rate CDN Advanced');
-      expect(output).toContain('1 license');
-      expect(output).not.toContain('1 licenses');
-      expect(output).not.toContain('with no usage hidden');
+      expect(output).not.toContain('Show all with:');
     });
 
-    it('should singularize license units regardless of service category', async () => {
-      useBillingCharges(
-        [
-          createMockCharge({
-            ServiceName: 'v0 Enterprise',
-            ConsumedQuantity: 1,
-            BilledCost: 100,
-          }),
-          createMockCharge({
-            ServiceName: 'Standard Enterprise Support',
-            ConsumedQuantity: 1,
-            BilledCost: 50,
-          }),
-        ],
-        'none'
-      );
+    it('should omit unknown product units', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'v0 Enterprise',
+          ConsumedQuantity: 1,
+          BilledCost: 100,
+        }),
+        createMockCharge({
+          ServiceName: 'Standard Enterprise Support',
+          ConsumedQuantity: 1,
+          BilledCost: 50,
+        }),
+      ]);
 
       client.setArgv('usage', '--from', '2025-12-01', '--to', '2025-12-31');
       expect(await usage(client)).toEqual(0);
 
       const output = client.getFullOutput();
-      expect(output).toMatch(/v0 Enterprise\s+1 license/);
-      expect(output).toMatch(/Standard Enterprise Support\s+1 license/);
-      expect(output).not.toContain('1 licenses');
-    });
-
-    it('should preserve an explicit scope in the show-all command', async () => {
-      useBillingCharges([
-        createMockCharge({
-          ServiceName: 'Unused Service',
-          ConsumedQuantity: 0,
-          BilledCost: 0,
-        }),
-      ]);
-
-      client.setArgv(
-        'usage',
-        '--scope',
-        'team_dummy',
-        '--from',
-        '2025-12-01',
-        '--to',
-        '2025-12-31'
-      );
-      expect(await usage(client)).toEqual(0);
-      expect(client.getFullOutput()).toContain(
-        'Show all with: vc usage --scope team_dummy --all'
-      );
+      expect(output).toMatch(/v0 Enterprise\s+1\s+\$100\.00/);
+      expect(output).toMatch(/Standard Enterprise Support\s+1\s+\$50\.00/);
+      expect(output).not.toContain('unit');
+      expect(output).not.toContain('license');
     });
 
     it('should display included Flat Rate CDN usage in consumed units', async () => {
@@ -426,12 +483,52 @@ describe('usage', () => {
 
       expect(exitCode).toEqual(0);
       const output = client.getFullOutput();
-      expect(output).toContain('12.04K units');
-      expect(output).toContain('Edge Requests (Flat Rate CDN)');
+      expect(output).toContain('12.04K');
+      expect(output).not.toContain('12.04K units');
+      expect(output).toContain('Edge Requests');
+      expect(output).not.toContain('Edge Requests (Flat Rate CDN)');
       expect(output).toContain('Effective Cost');
       expect(output).toContain('$0.00');
       expect(output).not.toContain('Net Cost');
       expect(output).not.toContain('Amount due');
+    });
+
+    it('should merge flat-rate and metered usage into one product row', async () => {
+      useBillingCharges([
+        createMockCharge({
+          ServiceName: 'Edge Requests',
+          ConsumedQuantity: 12000,
+          BilledCost: 0,
+          Tags: { FlatRate: 'true' },
+        }),
+        createMockCharge({
+          ServiceName: 'Edge Requests',
+          ConsumedQuantity: 40,
+          BilledCost: 2,
+        }),
+      ]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--format',
+        'json'
+      );
+      expect(await usage(client)).toEqual(0);
+
+      const json = JSON.parse(client.stdout.getFullOutput());
+      expect(json.services).toEqual([
+        expect.objectContaining({
+          name: 'Edge Requests',
+          quantity: 12040,
+          cost: 2,
+          effectiveCost: 2,
+          included: false,
+        }),
+      ]);
     });
 
     it('should handle subscription metrics with a null unit', async () => {
@@ -506,12 +603,14 @@ describe('usage', () => {
       const output = client.stdout.getFullOutput();
       const json = JSON.parse(output);
       expect(json.services).toHaveLength(1);
-      expect(json.pricingUnit).toEqual('USD');
+      expect(json.costUnit).toEqual('USD');
       expect(json.services[0].name).toEqual('Serverless Function Execution');
       expect(json.services[0].quantity).toEqual(1000000);
-      expect(json.services[0].unit).toEqual('units');
-      expect(json.totals.cost).toEqual(10);
-      expect(json.totals.billedCost).toEqual(10);
+      expect(json.services[0]).not.toHaveProperty('unit');
+      expect(json.services[0]).not.toHaveProperty('pricingQuantity');
+      expect(json.services[0]).not.toHaveProperty('billedCost');
+      expect(json.totals).toEqual({ cost: 10, effectiveCost: 10 });
+      expect(json).not.toHaveProperty('chargeCount');
     });
 
     it('should track telemetry for date options', async () => {
@@ -698,10 +797,15 @@ describe('usage', () => {
       expect(json.breakdown.data).toHaveLength(2);
       expect(json.breakdown.data[0].periodKey).toEqual('2025-12-01');
       expect(json.breakdown.data[1].periodKey).toEqual('2025-12-02');
-      expect(json.breakdown.data[0].totals.billedCost).toEqual(10);
-      expect(json.breakdown.data[1].totals.billedCost).toEqual(20);
-      // Grand totals should still be present
-      expect(json.totals.billedCost).toEqual(30);
+      expect(json.breakdown.data[0].totals).toEqual({
+        cost: 10,
+        effectiveCost: 10,
+      });
+      expect(json.breakdown.data[1].totals).toEqual({
+        cost: 20,
+        effectiveCost: 20,
+      });
+      expect(json.totals).toEqual({ cost: 30, effectiveCost: 30 });
     });
 
     it('should track telemetry for --breakdown option', async () => {
@@ -940,13 +1044,18 @@ describe('usage', () => {
       expect(json.groupBy).toBeDefined();
       expect(json.groupBy.dimension).toEqual('project');
       expect(json.groupBy.data).toHaveLength(2);
-      // Sorted by billedCost descending
+      // Sorted by cost descending
       expect(json.groupBy.data[0].name).toEqual('my-api');
-      expect(json.groupBy.data[0].totals.billedCost).toEqual(20);
+      expect(json.groupBy.data[0].totals).toEqual({
+        cost: 20,
+        effectiveCost: 20,
+      });
       expect(json.groupBy.data[1].name).toEqual('my-web-app');
-      expect(json.groupBy.data[1].totals.billedCost).toEqual(10);
-      // Grand totals should still be present
-      expect(json.totals.billedCost).toEqual(30);
+      expect(json.groupBy.data[1].totals).toEqual({
+        cost: 10,
+        effectiveCost: 10,
+      });
+      expect(json.totals).toEqual({ cost: 30, effectiveCost: 30 });
     });
 
     it('should error when --breakdown and --group-by are used together', async () => {


### PR DESCRIPTION
## Summary

Align `vercel usage` with the dashboard billing model, billing-cycle defaults, and output hierarchy.

- Show product usage quantities and estimated costs from `/v2/billing/costs`
- Preserve Flat Rate CDN usage as `included` when all nonzero contributors are flat-rate
- Separate infrastructure usage from subscription licenses and include applicable infrastructure credits
- Report JSON using the billing-costs model, including stable product slugs and explicit quantity, unit, cost, inclusion, category, and effective-cost fields

## Problem

The CLI read FOCUS charge rows from `/v1/billing/charges`, aggregated `PricingQuantity`, and labeled the result as usage. For Flat Rate CDN customers, included requests and transfer therefore appeared as `$0.0000`; subscription licenses were mixed into infrastructure; and `BilledCost` was presented as the amount due without subscription charges or credits.

The default range also used calendar month-to-date instead of the current billing cycle, and the output omitted infrastructure-credit context.

## Solution

`vercel usage` now queries `/v2/billing/costs` using the dashboard's product and product/project/region views. It defaults to the resolved account's billing period with a calendar fallback, formats product-specific quantities, separates subscription licenses, and displays an estimated bill with matching infrastructure credits.

The human-readable aggregated, breakdown, and grouped views share consistent filtering and formatting. JSON output now reflects the billing-costs response model rather than the legacy FOCUS aliases.

### Product decisions

- Costs, credits, and estimated bills use the account's native cost unit: USD or managed infrastructure units (MIUs).
- Subscription quantities are gauges, so aggregation uses the maximum license count in the period rather than summing samples.
- A service remains `included` when every nonzero contributing row is flat-rate; zero-quantity rows do not change that status.
- Human-readable quantities retain small nonzero values while limiting displayed precision to two decimal places.

## Validation

Validated in Vercel Sandbox `usage-pr-17565`:

- `pnpm --filter vercel... build` — passed
- `pnpm test test/unit/commands/usage/index.test.ts` — passed, 40/40 tests
- `pnpm exec biome check packages/cli/src/commands/usage packages/cli/src/util/billing/format.ts packages/cli/src/util/telemetry/commands/usage/index.ts packages/cli/test/unit/commands/usage/index.test.ts` — passed
- Local commit hooks — Biome format and lint passed

| Before | After |
| --- | --- |
| <img width="884" height="629" alt="Screenshot 2026-09-09 at 10 22 42 AM" src="https://github.com/user-attachments/assets/18c69e98-23ce-40f2-ad50-c4268c883728" /> | <img width="612" height="601" alt="Screenshot 2026-09-09 at 10 23 07 AM" src="https://github.com/user-attachments/assets/c30c7bf4-2814-4ba7-9806-9d88783e7167" /> |
