### PR TITLE
[cli] dev: don't inject full project env into forked dev servers

### DIFF
--- a/.changeset/dev-projectsettings-env-bloat.md
+++ b/.changeset/dev-projectsettings-env-bloat.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vercel dev` injecting the entire project env into every builder dev server. When a project was linked, `vercel dev` passed the full `Project` object (including `env`, an array of every environment variable across all branches) as `projectSettings`. That object is serialized into `VERCEL_DEV_CONFIG` and forked into each dev server's environment, so on projects with many branches it could exceed the OS environment-block limit and fail the fork with `E2BIG`. `vercel dev` now passes only the project settings, dropping the unused `env` and `latestDeployments` fields.

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -145,7 +145,23 @@ export default async function dev(
 
     client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
-    projectSettings = project;
+    // The linked `project` response carries bulky runtime-only fields that are
+    // not part of `ProjectSettings` — notably `env`, an array of every
+    // environment record across all branches, and `latestDeployments`.
+    // `projectSettings` is serialized into `VERCEL_DEV_CONFIG` and injected into
+    // the forked dev server's environment; on projects with many branches that
+    // `env` array can push the environment block past the OS `ARG_MAX` limit and
+    // fail the fork with `E2BIG`. Keep only the settings — the real env values
+    // reach the dev server separately via `envValues`.
+    const {
+      env: _env,
+      latestDeployments: _latestDeployments,
+      ...settings
+    } = project as typeof project & {
+      env?: unknown;
+      latestDeployments?: unknown;
+    };
+    projectSettings = settings;
     projectId = project.id;
     orgId = org.id;
 

--- a/packages/cli/test/unit/commands/dev/index.test.ts
+++ b/packages/cli/test/unit/commands/dev/index.test.ts
@@ -22,6 +22,7 @@ const { mockStart, devServerInstances, mockedRepoRoots } = vi.hoisted(() => ({
     cwd: string;
     projectId?: string;
     orgId?: string;
+    projectSettings?: unknown;
   }[],
   mockedRepoRoots: new Map<string, string>(),
 }));
@@ -32,11 +33,15 @@ vi.mock('../../../../src/util/dev/server', async () => {
   >('../../../../src/util/dev/server');
   class DevServer {
     devCommand = 'framework dev';
-    constructor(cwd: string, options: { projectId?: string; orgId?: string }) {
+    constructor(
+      cwd: string,
+      options: { projectId?: string; orgId?: string; projectSettings?: unknown }
+    ) {
       devServerInstances.push({
         cwd,
         projectId: options.projectId,
         orgId: options.orgId,
+        projectSettings: options.projectSettings,
       });
     }
     feed() {}
@@ -440,6 +445,47 @@ describe('dev', () => {
         projectId: undefined,
         orgId: undefined,
       });
+    });
+  });
+
+  describe('projectSettings', () => {
+    it('strips the bulky `env` and `latestDeployments` fields from the projectSettings passed to DevServer', async () => {
+      // `getLinkedProject` returns a full `Project` whose `env` array holds
+      // every environment record across all branches (>1MB on large projects).
+      // That object is serialized into VERCEL_DEV_CONFIG and forked into the
+      // dev server's environment, so `dev` must drop it (and `latestDeployments`)
+      // while preserving the actual project settings.
+      const spy = vi.spyOn(linkModule, 'getLinkedProject').mockResolvedValue({
+        status: 'linked',
+        org: { type: 'team', id: orgId, slug: 'team' },
+        project: {
+          id: projectId,
+          name: projectName,
+          framework: 'vite',
+          env: [
+            { id: 'e1', key: 'SECRET_ONE', value: 'a' },
+            { id: 'e2', key: 'SECRET_TWO', value: 'b' },
+          ],
+          latestDeployments: [{ id: 'dpl_1' }],
+        },
+      } as unknown as Awaited<ReturnType<typeof linkModule.getLinkedProject>>);
+
+      client.setArgv('dev', projectPath);
+      await expect(dev(client)).resolves.toEqual(undefined);
+
+      expect(devServerInstances).toHaveLength(1);
+      const projectSettings = devServerInstances[0].projectSettings as Record<
+        string,
+        unknown
+      >;
+      expect(projectSettings).toBeDefined();
+      // The bulky fields must be gone…
+      expect(projectSettings.env).toBeUndefined();
+      expect(projectSettings.latestDeployments).toBeUndefined();
+      // …but the real settings must be preserved.
+      expect(projectSettings.framework).toBe('vite');
+
+      spy.mockRestore();
     });
   });
 


### PR DESCRIPTION
### Summary

`vercel dev` fails to start (or spawns a bloated environment) on projects that
have accumulated many environment records across branches. On such a project the
forked builder dev-server can die with `spawn E2BIG`, because the entire linked
project — including its `env` array of every environment record across every
branch — is serialized into the `VERCEL_DEV_CONFIG` environment variable and
injected into each fork.

On a real project we saw `VERCEL_DEV_CONFIG` reach **~1.45 MB**, of which
**~1.45 MB was `projectSettings.env`** (939 records). That pushes the child
process's environment block past the OS `ARG_MAX` limit and fails the fork.

### Root cause

In `packages/cli/src/commands/dev/dev.ts`, the whole `project` object returned by
`getLinkedProject` was assigned to `projectSettings`:

```ts
projectSettings = project;
```

`projectSettings` is serialized into `VERCEL_DEV_CONFIG` and passed to the forked
dev server. But `project` carries bulky runtime-only fields that are **not** part
of `ProjectSettings` — most importantly `env` (every env record across all
branches) and `latestDeployments`. The forked dev server never reads that `env`
array; the real environment values reach it separately via `envValues`
(`pullEnvRecords`).

### Fix

Strip the runtime-only fields before assigning:

```ts
const {
  env: _env,
  latestDeployments: _latestDeployments,
  ...settings
} = project as typeof project & { env?: unknown; latestDeployments?: unknown };
projectSettings = settings;
```

(The cast is needed only because these fields aren't declared on the `Project`
type.) The dev server still receives all real settings and all real env values —
just not the multi-megabyte per-branch env dump it never used.

### Testing

Added a unit test in `test/unit/commands/dev/index.test.ts` that stubs
`getLinkedProject` to return a project carrying `env` and `latestDeployments`
arrays and asserts they are stripped from the `projectSettings` handed to
`DevServer`, while real settings (e.g. `framework`) are preserved.

```
✓ test/unit/commands/dev/index.test.ts (17 tests)
  ✓ dev > projectSettings > strips the bulky `env` and `latestDeployments`
          fields from the projectSettings passed to DevServer
Test Files  1 passed (1)
     Tests  17 passed (17)
```

`pnpm type-check` and Biome are clean on the changed files. Includes a `patch`
changeset for `vercel`.
