### PR TITLE
[cli] Fix firewall overview failing without IP Bypass access

### DIFF
--- a/.changeset/firewall-overview-bypass-plan-gate.md
+++ b/.changeset/firewall-overview-bypass-plan-gate.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `firewall overview` failing on plans without IP Bypass. The command no longer errors when the bypass endpoint is unavailable, and reports system mitigation status from the project rather than the plan-gated bypass API.

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -30,6 +30,12 @@ function isPlanGatedError(error: unknown): boolean {
   return isAPIError(error) && error.status === 404;
 }
 
+/** Return a settled result's value, rethrowing if it rejected. */
+function unwrap<T>(result: PromiseSettledResult<T>): T {
+  if (result.status === 'rejected') throw result.reason;
+  return result.value;
+}
+
 export default async function overview(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, overviewSubcommand, client);
   if (typeof parsed === 'number') return parsed;
@@ -59,8 +65,8 @@ export default async function overview(client: Client, argv: string[]) {
 
     // The firewall config and project are required to render anything
     // meaningful, so their failures remain fatal.
-    if (configResult.status === 'rejected') throw configResult.reason;
-    if (projectResult.status === 'rejected') throw projectResult.reason;
+    const { active, draft } = unwrap(configResult);
+    const freshProject = unwrap(projectResult);
 
     // Bypass is plan-gated. When it is unavailable the rest of the overview is
     // still useful, so degrade to `null` rather than failing the command.
@@ -70,10 +76,6 @@ export default async function overview(client: Client, argv: string[]) {
     } else if (!isPlanGatedError(bypassResult.reason)) {
       throw bypassResult.reason;
     }
-
-    const configList = configResult.value;
-    const freshProject = projectResult.value;
-    const { active, draft } = configList;
 
     const attackMode: AttackModeStatus = {
       enabled: freshProject.security?.attackModeEnabled ?? false,

--- a/packages/cli/src/commands/firewall/overview.ts
+++ b/packages/cli/src/commands/firewall/overview.ts
@@ -11,7 +11,24 @@ import {
   type AttackModeStatus,
 } from '../../util/firewall/format';
 import { outputAgentError } from '../../util/agent-output';
-import type { ProjectSecurityResponse } from '../../util/firewall/types';
+import { isAPIError } from '../../util/errors-ts';
+import type {
+  BypassRule,
+  ProjectSecurityResponse,
+} from '../../util/firewall/types';
+
+/**
+ * Whether an error indicates the endpoint is gated behind the account's plan
+ * rather than having genuinely failed. The bypass API responds 404 with
+ * "IP Bypass is unavailable for this plan." on plans without the feature.
+ *
+ * Deliberately narrow: that endpoint checks permissions only after the plan
+ * gate, so a 403 means the user lacks access rather than the plan lacking the
+ * feature, and must still surface as an error.
+ */
+function isPlanGatedError(error: unknown): boolean {
+  return isAPIError(error) && error.status === 404;
+}
 
 export default async function overview(client: Client, argv: string[]) {
   const parsed = await parseSubcommandArgs(argv, overviewSubcommand, client);
@@ -30,15 +47,32 @@ export default async function overview(client: Client, argv: string[]) {
   output.spinner(`Fetching firewall overview for ${chalk.bold(project.name)}`);
 
   try {
-    const [configList, bypassList, freshProject] = await Promise.all([
-      listFirewallConfigs(client, project.id, { teamId }),
-      getBypass(client, project.id, { teamId }),
-      client.fetch<ProjectSecurityResponse>(
-        `/v9/projects/${encodeURIComponent(project.id)}`,
-        { accountId: teamId }
-      ),
-    ]);
+    const [configResult, bypassResult, projectResult] =
+      await Promise.allSettled([
+        listFirewallConfigs(client, project.id, { teamId }),
+        getBypass(client, project.id, { teamId }),
+        client.fetch<ProjectSecurityResponse>(
+          `/v9/projects/${encodeURIComponent(project.id)}`,
+          { accountId: teamId }
+        ),
+      ]);
 
+    // The firewall config and project are required to render anything
+    // meaningful, so their failures remain fatal.
+    if (configResult.status === 'rejected') throw configResult.reason;
+    if (projectResult.status === 'rejected') throw projectResult.reason;
+
+    // Bypass is plan-gated. When it is unavailable the rest of the overview is
+    // still useful, so degrade to `null` rather than failing the command.
+    let bypass: BypassRule[] | null = null;
+    if (bypassResult.status === 'fulfilled') {
+      bypass = bypassResult.value.result;
+    } else if (!isPlanGatedError(bypassResult.reason)) {
+      throw bypassResult.reason;
+    }
+
+    const configList = configResult.value;
+    const freshProject = projectResult.value;
     const { active, draft } = configList;
 
     const attackMode: AttackModeStatus = {
@@ -50,7 +84,7 @@ export default async function overview(client: Client, argv: string[]) {
       outputJson(client, {
         active,
         draft,
-        bypass: bypassList.result,
+        bypass,
         attackMode,
       });
       return 0;
@@ -58,7 +92,13 @@ export default async function overview(client: Client, argv: string[]) {
 
     output.print('\n');
     output.print(
-      formatStatusOutput(active, draft, bypassList.result, attackMode)
+      formatStatusOutput(
+        active,
+        draft,
+        bypass,
+        attackMode,
+        freshProject.security?.firewallBypassIps
+      )
     );
     output.print('\n\n');
 

--- a/packages/cli/src/util/firewall/format.ts
+++ b/packages/cli/src/util/firewall/format.ts
@@ -41,8 +41,32 @@ export type MitigationsStatus =
   | { paused: true; resumesAt?: number };
 
 /**
+ * Latest expiry that can plausibly be epoch seconds, guarding against a value
+ * in different units being read as a date tens of thousands of years out.
+ */
+const MAX_EXPIRY_SECONDS = 4102444800; // 2100-01-01
+
+/**
+ * Parse the expiry of a project bypass entry, in epoch seconds.
+ *
+ * Returns `null` when the bypass is open-ended: either it carries no expiry, or
+ * the expiry cannot be interpreted. An uninterpretable expiry is deliberately
+ * not discarded — the entry still proves a bypass exists, and on a plan-gated
+ * account this is the only evidence of one, so reporting mitigations as active
+ * would be the more dangerous reading.
+ */
+function parseExpirySeconds(expiry: string | undefined): number | null {
+  if (!expiry || !/^\d+$/.test(expiry)) return null;
+
+  const seconds = Number(expiry);
+  return Number.isSafeInteger(seconds) && seconds <= MAX_EXPIRY_SECONDS
+    ? seconds
+    : null;
+}
+
+/**
  * Expiry of every all-sources bypass in effect, in epoch seconds, using `null`
- * for one that never expires.
+ * for one that is open-ended.
  *
  * Both sources are read. The project's `firewallBypassIps` is not plan-gated,
  * so it is the only source on plans without IP Bypass; the bypass API is
@@ -55,18 +79,14 @@ function allSourcesBypassExpiries(
 ): (number | null)[] {
   const expiries: (number | null)[] = [];
 
-  // Project entries are encoded as `<cidr>#<expiry>`, the expiry omitted when
-  // the bypass is permanent.
+  // Entries are encoded as `<cidr>#<epoch-seconds>` by the bypass API, the
+  // expiry omitted when the bypass is permanent. They carry no domain: the API
+  // only records them on the project for a project-scoped bypass, which its
+  // request schema makes mutually exclusive with a domain-scoped one.
   for (const entry of firewallBypassIps) {
     const [ip, expiry] = entry.split('#');
     if (!isAllSourcesBypass(ip)) continue;
-
-    if (!expiry) {
-      expiries.push(null);
-      continue;
-    }
-    const parsed = Number.parseInt(expiry, 10);
-    if (!Number.isNaN(parsed)) expiries.push(parsed);
+    expiries.push(parseExpirySeconds(expiry));
   }
 
   for (const rule of bypass ?? []) {

--- a/packages/cli/src/util/firewall/format.ts
+++ b/packages/cli/src/util/firewall/format.ts
@@ -17,17 +17,97 @@ export interface AttackModeStatus {
   activeUntil?: number | null;
 }
 
+/** Shown in place of a value the account's plan has no access to. */
+const PLAN_UNAVAILABLE = 'Not available on this plan';
+
 export function isAllSourcesBypass(ip: string): boolean {
   return ip === '0.0.0.0/0' || ip === '::/0';
 }
 
-export function isMitigationsPaused(bypass: BypassRule[]): boolean {
-  const now = Math.floor(Date.now() / 1000);
-  return bypass.some(
-    b =>
-      isAllSourcesBypass(b.Ip) &&
-      b.Domain === '*' &&
-      (b.ExpiresAt === null || b.ExpiresAt === undefined || b.ExpiresAt > now)
+export type MitigationsStatus =
+  | { paused: false }
+  /** `resumesAt` is epoch seconds; absent for a bypass with no expiry. */
+  | { paused: true; resumesAt?: number };
+
+/**
+ * Combine two readings of mitigation status, preferring the one that keeps
+ * mitigations paused for longer. A paused state with no expiry is permanent and
+ * so outranks any expiring one.
+ */
+function mergeMitigationsStatus(
+  a: MitigationsStatus,
+  b: MitigationsStatus
+): MitigationsStatus {
+  if (!a.paused) return b;
+  if (!b.paused) return a;
+  if (a.resumesAt === undefined || b.resumesAt === undefined) {
+    return { paused: true };
+  }
+  return { paused: true, resumesAt: Math.max(a.resumesAt, b.resumesAt) };
+}
+
+/**
+ * Derive mitigation status from a project's `firewallBypassIps`, encoded as
+ * `<cidr>#<expiry>` with `<expiry>` in epoch seconds.
+ */
+function mitigationsFromProject(
+  firewallBypassIps: string[]
+): MitigationsStatus {
+  const nowSeconds = Date.now() / 1000;
+  let status: MitigationsStatus = { paused: false };
+
+  for (const entry of firewallBypassIps) {
+    const [ip, expiry] = entry.split('#');
+    if (!isAllSourcesBypass(ip)) continue;
+
+    if (!expiry) return { paused: true };
+
+    const resumesAt = Number.parseInt(expiry, 10);
+    if (!Number.isNaN(resumesAt) && resumesAt > nowSeconds) {
+      status = { paused: true, resumesAt };
+    }
+  }
+
+  return status;
+}
+
+/** Derive mitigation status from the bypass API's project-scoped rules. */
+function mitigationsFromBypassRules(bypass: BypassRule[]): MitigationsStatus {
+  const nowSeconds = Date.now() / 1000;
+  let status: MitigationsStatus = { paused: false };
+
+  for (const rule of bypass) {
+    if (!isAllSourcesBypass(rule.Ip) || rule.Domain !== '*') continue;
+
+    if (rule.ExpiresAt === null || rule.ExpiresAt === undefined) {
+      return { paused: true };
+    }
+    if (rule.ExpiresAt > nowSeconds) {
+      status = { paused: true, resumesAt: rule.ExpiresAt };
+    }
+  }
+
+  return status;
+}
+
+/**
+ * Whether system mitigations are paused, which is the case while an all-sources
+ * system bypass is in effect.
+ *
+ * Reads both available sources. The project field is not plan-gated, so it is
+ * the only source on plans without IP Bypass; the bypass API is consulted when
+ * available so that a bypass which was never mirrored onto the project is still
+ * reported. Either source reporting paused is treated as paused.
+ */
+export function getMitigationsStatus(
+  firewallBypassIps?: string[],
+  bypass?: BypassRule[] | null
+): MitigationsStatus {
+  return mergeMitigationsStatus(
+    firewallBypassIps
+      ? mitigationsFromProject(firewallBypassIps)
+      : { paused: false },
+    bypass ? mitigationsFromBypassRules(bypass) : { paused: false }
   );
 }
 
@@ -47,31 +127,34 @@ export function formatAttackModeStatus(status: AttackModeStatus): string {
   return chalk.red('On');
 }
 
-export function formatMitigationsStatus(bypass: BypassRule[]): string {
-  if (isMitigationsPaused(bypass)) {
-    const entry = bypass.find(
-      b => isAllSourcesBypass(b.Ip) && b.Domain === '*'
-    );
-    if (entry?.ExpiresAt) {
-      const remainingMs = entry.ExpiresAt * 1000 - Date.now();
-      if (remainingMs > 0) {
-        const hours = Math.floor(remainingMs / (60 * 60 * 1000));
-        const minutes = Math.floor(
-          (remainingMs % (60 * 60 * 1000)) / (60 * 1000)
-        );
-        return chalk.yellow(`Paused (auto-resumes in ${hours}h ${minutes}m)`);
-      }
+export function formatMitigationsStatus(status: MitigationsStatus): string {
+  if (!status.paused) return chalk.green('Active');
+
+  if (status.resumesAt !== undefined) {
+    const remainingMs = status.resumesAt * 1000 - Date.now();
+    if (remainingMs > 0) {
+      const hours = Math.floor(remainingMs / (60 * 60 * 1000));
+      const minutes = Math.floor(
+        (remainingMs % (60 * 60 * 1000)) / (60 * 1000)
+      );
+      return chalk.yellow(`Paused (auto-resumes in ${hours}h ${minutes}m)`);
     }
-    return chalk.yellow('Paused');
   }
-  return chalk.green('Active');
+  return chalk.yellow('Paused');
 }
 
+/**
+ * @param bypass Bypass rules, or `null` when the bypass API is unavailable on
+ * the account's plan.
+ * @param firewallBypassIps The project's `security.firewallBypassIps`, used to
+ * report mitigation status on plans where `bypass` is unavailable.
+ */
 export function formatStatusOutput(
   active: FirewallConfigResponse | null,
   draft: FirewallConfigResponse | null,
-  bypass: BypassRule[],
-  attackMode?: AttackModeStatus
+  bypass: BypassRule[] | null,
+  attackMode?: AttackModeStatus,
+  firewallBypassIps?: string[]
 ): string {
   const lines: string[] = [];
 
@@ -95,11 +178,17 @@ export function formatStatusOutput(
     );
   }
 
-  // Filter out the allSources bypass (system mitigations) from the count
-  const regularBypasses = bypass.filter(b => !isAllSourcesBypass(b.Ip));
-  lines.push(
-    `  ${chalk.bold('System Bypass:')}        ${regularBypasses.length} IP${regularBypasses.length !== 1 ? 's' : ''}`
-  );
+  if (bypass === null) {
+    lines.push(
+      `  ${chalk.bold('System Bypass:')}        ${chalk.dim(PLAN_UNAVAILABLE)}`
+    );
+  } else {
+    // Filter out the allSources bypass (system mitigations) from the count
+    const regularBypasses = bypass.filter(b => !isAllSourcesBypass(b.Ip));
+    lines.push(
+      `  ${chalk.bold('System Bypass:')}        ${regularBypasses.length} IP${regularBypasses.length !== 1 ? 's' : ''}`
+    );
+  }
 
   lines.push('');
   if (attackMode) {
@@ -108,7 +197,9 @@ export function formatStatusOutput(
     );
   }
   lines.push(
-    `  ${chalk.bold('System Mitigations:')}   ${formatMitigationsStatus(bypass)}`
+    `  ${chalk.bold('System Mitigations:')}   ${formatMitigationsStatus(
+      getMitigationsStatus(firewallBypassIps, bypass)
+    )}`
   );
 
   if (draft && draft.changes.length > 0) {

--- a/packages/cli/src/util/firewall/format.ts
+++ b/packages/cli/src/util/firewall/format.ts
@@ -20,6 +20,17 @@ export interface AttackModeStatus {
 /** Shown in place of a value the account's plan has no access to. */
 const PLAN_UNAVAILABLE = 'Not available on this plan';
 
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+
+/** Render a duration as `1h 30m`. */
+function formatDuration(ms: number): string {
+  const hours = Math.floor(ms / MS_PER_HOUR);
+  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE);
+  return `${hours}h ${minutes}m`;
+}
+
 export function isAllSourcesBypass(ip: string): boolean {
   return ip === '0.0.0.0/0' || ip === '::/0';
 }
@@ -30,85 +41,62 @@ export type MitigationsStatus =
   | { paused: true; resumesAt?: number };
 
 /**
- * Combine two readings of mitigation status, preferring the one that keeps
- * mitigations paused for longer. A paused state with no expiry is permanent and
- * so outranks any expiring one.
+ * Expiry of every all-sources bypass in effect, in epoch seconds, using `null`
+ * for one that never expires.
+ *
+ * Both sources are read. The project's `firewallBypassIps` is not plan-gated,
+ * so it is the only source on plans without IP Bypass; the bypass API is
+ * consulted when readable so that a bypass which was never mirrored onto the
+ * project is still accounted for.
  */
-function mergeMitigationsStatus(
-  a: MitigationsStatus,
-  b: MitigationsStatus
-): MitigationsStatus {
-  if (!a.paused) return b;
-  if (!b.paused) return a;
-  if (a.resumesAt === undefined || b.resumesAt === undefined) {
-    return { paused: true };
-  }
-  return { paused: true, resumesAt: Math.max(a.resumesAt, b.resumesAt) };
-}
+function allSourcesBypassExpiries(
+  firewallBypassIps: string[] = [],
+  bypass: BypassRule[] | null = []
+): (number | null)[] {
+  const expiries: (number | null)[] = [];
 
-/**
- * Derive mitigation status from a project's `firewallBypassIps`, encoded as
- * `<cidr>#<expiry>` with `<expiry>` in epoch seconds.
- */
-function mitigationsFromProject(
-  firewallBypassIps: string[]
-): MitigationsStatus {
-  const nowSeconds = Date.now() / 1000;
-  let status: MitigationsStatus = { paused: false };
-
+  // Project entries are encoded as `<cidr>#<expiry>`, the expiry omitted when
+  // the bypass is permanent.
   for (const entry of firewallBypassIps) {
     const [ip, expiry] = entry.split('#');
     if (!isAllSourcesBypass(ip)) continue;
 
-    if (!expiry) return { paused: true };
-
-    const resumesAt = Number.parseInt(expiry, 10);
-    if (!Number.isNaN(resumesAt) && resumesAt > nowSeconds) {
-      status = { paused: true, resumesAt };
+    if (!expiry) {
+      expiries.push(null);
+      continue;
     }
+    const parsed = Number.parseInt(expiry, 10);
+    if (!Number.isNaN(parsed)) expiries.push(parsed);
   }
 
-  return status;
-}
-
-/** Derive mitigation status from the bypass API's project-scoped rules. */
-function mitigationsFromBypassRules(bypass: BypassRule[]): MitigationsStatus {
-  const nowSeconds = Date.now() / 1000;
-  let status: MitigationsStatus = { paused: false };
-
-  for (const rule of bypass) {
+  for (const rule of bypass ?? []) {
     if (!isAllSourcesBypass(rule.Ip) || rule.Domain !== '*') continue;
-
-    if (rule.ExpiresAt === null || rule.ExpiresAt === undefined) {
-      return { paused: true };
-    }
-    if (rule.ExpiresAt > nowSeconds) {
-      status = { paused: true, resumesAt: rule.ExpiresAt };
-    }
+    expiries.push(rule.ExpiresAt ?? null);
   }
 
-  return status;
+  return expiries;
 }
 
 /**
  * Whether system mitigations are paused, which is the case while an all-sources
- * system bypass is in effect.
- *
- * Reads both available sources. The project field is not plan-gated, so it is
- * the only source on plans without IP Bypass; the bypass API is consulted when
- * available so that a bypass which was never mirrored onto the project is still
- * reported. Either source reporting paused is treated as paused.
+ * system bypass is in effect. A permanent bypass keeps them paused indefinitely;
+ * otherwise they resume when the last bypass expires.
  */
 export function getMitigationsStatus(
   firewallBypassIps?: string[],
   bypass?: BypassRule[] | null
 ): MitigationsStatus {
-  return mergeMitigationsStatus(
-    firewallBypassIps
-      ? mitigationsFromProject(firewallBypassIps)
-      : { paused: false },
-    bypass ? mitigationsFromBypassRules(bypass) : { paused: false }
+  const expiries = allSourcesBypassExpiries(firewallBypassIps, bypass);
+  if (expiries.includes(null)) return { paused: true };
+
+  const nowSeconds = Date.now() / MS_PER_SECOND;
+  const unexpired = expiries.filter(
+    (expiry): expiry is number => expiry !== null && expiry > nowSeconds
   );
+
+  return unexpired.length
+    ? { paused: true, resumesAt: Math.max(...unexpired) }
+    : { paused: false };
 }
 
 export function formatAttackModeStatus(status: AttackModeStatus): string {
@@ -120,9 +108,7 @@ export function formatAttackModeStatus(status: AttackModeStatus): string {
     if (remainingMs <= 0) {
       return chalk.dim('Off (expired)');
     }
-    const hours = Math.floor(remainingMs / (60 * 60 * 1000));
-    const minutes = Math.floor((remainingMs % (60 * 60 * 1000)) / (60 * 1000));
-    return chalk.red(`On (expires in ${hours}h ${minutes}m)`);
+    return chalk.red(`On (expires in ${formatDuration(remainingMs)})`);
   }
   return chalk.red('On');
 }
@@ -131,13 +117,11 @@ export function formatMitigationsStatus(status: MitigationsStatus): string {
   if (!status.paused) return chalk.green('Active');
 
   if (status.resumesAt !== undefined) {
-    const remainingMs = status.resumesAt * 1000 - Date.now();
+    const remainingMs = status.resumesAt * MS_PER_SECOND - Date.now();
     if (remainingMs > 0) {
-      const hours = Math.floor(remainingMs / (60 * 60 * 1000));
-      const minutes = Math.floor(
-        (remainingMs % (60 * 60 * 1000)) / (60 * 1000)
+      return chalk.yellow(
+        `Paused (auto-resumes in ${formatDuration(remainingMs)})`
       );
-      return chalk.yellow(`Paused (auto-resumes in ${hours}h ${minutes}m)`);
     }
   }
   return chalk.yellow('Paused');

--- a/packages/cli/src/util/firewall/types.ts
+++ b/packages/cli/src/util/firewall/types.ts
@@ -115,6 +115,15 @@ export interface ProjectSecurityResponse {
     /** Epoch milliseconds */
     attackModeActiveUntil?: number | null;
     attackModeUpdatedAt?: number;
+    /**
+     * System bypass entries encoded as `<cidr>#<expiry>`, where `<expiry>` is
+     * epoch seconds. An unexpired all-sources entry (`0.0.0.0/0` or `::/0`)
+     * means system mitigations are paused.
+     *
+     * Unlike the `/firewall/bypass` endpoint this is not plan-gated, so it is
+     * the only reliable source for mitigation status.
+     */
+    firewallBypassIps?: string[];
   };
 }
 

--- a/packages/cli/test/mocks/firewall.ts
+++ b/packages/cli/test/mocks/firewall.ts
@@ -206,6 +206,19 @@ export function useGetBypass(bypass: BypassRule[] = []) {
   });
 }
 
+/**
+ * Mock the bypass endpoint rejecting. Defaults to the 404 the API returns when
+ * the account's plan has no IP Bypass access.
+ */
+export function useGetBypassError(
+  statusCode = 404,
+  message = 'IP Bypass is unavailable for this plan.'
+) {
+  client.scenario.get('/v1/security/firewall/bypass', (_req: any, res: any) => {
+    res.status(statusCode).json({ error: { code: 'not_found', message } });
+  });
+}
+
 export const capturedRequests: {
   activate?: { version: string };
   deleteDraft?: boolean;

--- a/packages/cli/test/unit/commands/firewall/overview.test.ts
+++ b/packages/cli/test/unit/commands/firewall/overview.test.ts
@@ -183,8 +183,10 @@ describe('firewall overview', () => {
         ...defaultProject,
         id: 'firewall-test-project',
         name: 'firewall-test',
+        // The API returns `security`, but it is not modelled on `Project` —
+        // which is why the command fetches it as `ProjectSecurityResponse`.
         security: { firewallBypassIps: [`0.0.0.0/0#${resumesAt}`] },
-      });
+      } as Parameters<typeof useProject>[0]);
       useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
       useGetBypassError();
 

--- a/packages/cli/test/unit/commands/firewall/overview.test.ts
+++ b/packages/cli/test/unit/commands/firewall/overview.test.ts
@@ -178,11 +178,16 @@ describe('firewall overview', () => {
     it('reports mitigation status from the project', async () => {
       // Mitigations are read from the project, which is not plan-gated, so the
       // status is still accurate when the bypass endpoint is unavailable.
+      // Uses its own project so the mock gets a distinct route; re-registering
+      // the one from `beforeEach` would not override it.
+      client.cwd = setupTmpDir();
+      client.config.currentTeam = 'team_dummy';
       const resumesAt = Math.floor(Date.now() / 1000) + 2 * 60 * 60;
       useProject({
         ...defaultProject,
-        id: 'firewall-test-project',
-        name: 'firewall-test',
+        id: 'paused-mitigations',
+        name: 'paused-mitigations',
+        accountId: 'team_dummy',
         // The API returns `security`, but it is not modelled on `Project` —
         // which is why the command fetches it as `ProjectSecurityResponse`.
         security: { firewallBypassIps: [`0.0.0.0/0#${resumesAt}`] },
@@ -190,7 +195,7 @@ describe('firewall overview', () => {
       useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
       useGetBypassError();
 
-      client.setArgv('firewall', 'overview');
+      client.setArgv('firewall', 'overview', '--project', 'paused-mitigations');
       const exitCodePromise = firewall(client);
       await expect(client.stderr).toOutput('Paused');
       expect(await exitCodePromise).toEqual(0);

--- a/packages/cli/test/unit/commands/firewall/overview.test.ts
+++ b/packages/cli/test/unit/commands/firewall/overview.test.ts
@@ -5,6 +5,7 @@ import { useUser } from '../../../mocks/user';
 import {
   useListFirewallConfigs,
   useGetBypass,
+  useGetBypassError,
   createConfig,
   createRule,
   createIpRule,
@@ -153,5 +154,74 @@ describe('firewall overview', () => {
     client.setArgv('firewall', 'overview', '--json');
     const exitCode = await firewall(client);
     expect(exitCode).toEqual(0);
+  });
+
+  describe('when IP Bypass is unavailable on the plan', () => {
+    it('still renders the overview instead of failing', async () => {
+      useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
+      useGetBypassError();
+
+      client.setArgv('firewall', 'overview');
+      const exitCodePromise = firewall(client);
+      await expect(client.stderr).toOutput('Not available on this plan');
+      expect(await exitCodePromise).toEqual(0);
+
+      const fullOutput = client.stderr.getFullOutput();
+      // The rest of the overview is still reported.
+      expect(fullOutput).toContain('Enabled');
+      expect(fullOutput).toContain('IP Blocks');
+      expect(fullOutput).not.toContain('IP Bypass is unavailable');
+      // Bypass is gated; mitigations are not, so they must not be conflated.
+      expect(fullOutput).not.toContain('System Mitigations:   Not available');
+    });
+
+    it('reports mitigation status from the project', async () => {
+      // Mitigations are read from the project, which is not plan-gated, so the
+      // status is still accurate when the bypass endpoint is unavailable.
+      const resumesAt = Math.floor(Date.now() / 1000) + 2 * 60 * 60;
+      useProject({
+        ...defaultProject,
+        id: 'firewall-test-project',
+        name: 'firewall-test',
+        security: { firewallBypassIps: [`0.0.0.0/0#${resumesAt}`] },
+      });
+      useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
+      useGetBypassError();
+
+      client.setArgv('firewall', 'overview');
+      const exitCodePromise = firewall(client);
+      await expect(client.stderr).toOutput('Paused');
+      expect(await exitCodePromise).toEqual(0);
+
+      expect(client.stderr.getFullOutput()).toContain('auto-resumes in');
+    });
+
+    it('reports bypass as null in JSON output', async () => {
+      useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
+      useGetBypassError();
+
+      client.setArgv('firewall', 'overview', '--json');
+      const exitCode = await firewall(client);
+      expect(exitCode).toEqual(0);
+
+      const json = JSON.parse(client.stdout.getFullOutput());
+      // `null` distinguishes "unreadable" from `[]`, meaning "none configured".
+      expect(json.bypass).toBeNull();
+    });
+  });
+
+  it('still fails when the bypass request is denied by permissions', async () => {
+    // The API checks permissions after the plan gate, so a 403 means the user
+    // lacks access and must not be reported as a plan limitation.
+    useListFirewallConfigs(createConfig({ firewallEnabled: true }), null);
+    useGetBypassError(403, 'You do not have permission to read IP blocking.');
+
+    client.setArgv('firewall', 'overview');
+    const exitCode = await firewall(client);
+    expect(exitCode).toEqual(1);
+
+    expect(client.stderr.getFullOutput()).not.toContain(
+      'Not available on this plan'
+    );
   });
 });

--- a/packages/cli/test/unit/util/firewall/format.test.ts
+++ b/packages/cli/test/unit/util/firewall/format.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getMitigationsStatus,
+  formatMitigationsStatus,
+} from '../../../../src/util/firewall/format';
+import type { BypassRule } from '../../../../src/util/firewall/types';
+
+const NOW = 1_700_000_000_000;
+/** Epoch seconds, two hours after NOW. */
+const FUTURE = NOW / 1000 + 2 * 60 * 60;
+/** Epoch seconds, one hour before NOW. */
+const PAST = NOW / 1000 - 60 * 60;
+
+describe('getMitigationsStatus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports active when the project has no bypass IPs', () => {
+    expect(getMitigationsStatus(undefined)).toEqual({ paused: false });
+    expect(getMitigationsStatus([])).toEqual({ paused: false });
+  });
+
+  it('ignores bypasses that are not all-sources', () => {
+    expect(getMitigationsStatus([`1.2.3.0/24#${FUTURE}`, '10.0.0.1'])).toEqual({
+      paused: false,
+    });
+  });
+
+  it('reports paused for an unexpired all-sources bypass', () => {
+    expect(getMitigationsStatus([`0.0.0.0/0#${FUTURE}`])).toEqual({
+      paused: true,
+      resumesAt: FUTURE,
+    });
+  });
+
+  it('reports paused for an unexpired IPv6 all-sources bypass', () => {
+    expect(getMitigationsStatus([`::/0#${FUTURE}`])).toEqual({
+      paused: true,
+      resumesAt: FUTURE,
+    });
+  });
+
+  it('handles the IPv4 and IPv6 pair written by a pause', () => {
+    // Pausing mitigations writes both address families with one deadline.
+    expect(
+      getMitigationsStatus([`0.0.0.0/0#${FUTURE}`, `::/0#${FUTURE}`])
+    ).toEqual({ paused: true, resumesAt: FUTURE });
+  });
+
+  it('reports active once the bypass has expired', () => {
+    expect(getMitigationsStatus([`0.0.0.0/0#${PAST}`])).toEqual({
+      paused: false,
+    });
+  });
+
+  it('reports paused with no resume time for a permanent bypass', () => {
+    expect(getMitigationsStatus(['0.0.0.0/0'])).toEqual({ paused: true });
+  });
+
+  it('prefers a permanent bypass over an expiring one', () => {
+    expect(getMitigationsStatus([`0.0.0.0/0#${FUTURE}`, '::/0'])).toEqual({
+      paused: true,
+    });
+  });
+
+  it('ignores an unparseable expiry', () => {
+    expect(getMitigationsStatus(['0.0.0.0/0#not-a-number'])).toEqual({
+      paused: false,
+    });
+  });
+
+  describe('with bypass rules also available', () => {
+    const allSourcesRule = (
+      overrides: Partial<BypassRule> = {}
+    ): BypassRule => ({
+      OwnerId: 'team_dummy',
+      Id: 'bypass_all',
+      Ip: '0.0.0.0/0',
+      Domain: '*',
+      ProjectId: 'firewall-test-project',
+      ...overrides,
+    });
+
+    it('reports paused from the bypass rules when the project has no entry', () => {
+      // Guards against a bypass that was never mirrored onto the project.
+      expect(
+        getMitigationsStatus([], [allSourcesRule({ ExpiresAt: FUTURE })])
+      ).toEqual({ paused: true, resumesAt: FUTURE });
+    });
+
+    it('reports paused from the project when the bypass rules have no entry', () => {
+      expect(getMitigationsStatus([`0.0.0.0/0#${FUTURE}`], [])).toEqual({
+        paused: true,
+        resumesAt: FUTURE,
+      });
+    });
+
+    it('treats a bypass rule with no expiry as permanently paused', () => {
+      expect(getMitigationsStatus([], [allSourcesRule()])).toEqual({
+        paused: true,
+      });
+    });
+
+    it('ignores a domain-scoped all-sources rule', () => {
+      expect(
+        getMitigationsStatus(
+          [],
+          [allSourcesRule({ Domain: 'example.com', ExpiresAt: FUTURE })]
+        )
+      ).toEqual({ paused: false });
+    });
+
+    it('ignores an expired bypass rule', () => {
+      expect(
+        getMitigationsStatus([], [allSourcesRule({ ExpiresAt: PAST })])
+      ).toEqual({ paused: false });
+    });
+
+    it('keeps the later resume time when the sources disagree', () => {
+      const later = FUTURE + 60 * 60;
+      expect(
+        getMitigationsStatus(
+          [`0.0.0.0/0#${FUTURE}`],
+          [allSourcesRule({ ExpiresAt: later })]
+        )
+      ).toEqual({ paused: true, resumesAt: later });
+    });
+
+    it('prefers a permanent bypass over an expiring one', () => {
+      expect(
+        getMitigationsStatus([`0.0.0.0/0#${FUTURE}`], [allSourcesRule()])
+      ).toEqual({ paused: true });
+    });
+  });
+});
+
+describe('formatMitigationsStatus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders active', () => {
+    expect(formatMitigationsStatus({ paused: false })).toContain('Active');
+  });
+
+  it('renders the remaining time until mitigations resume', () => {
+    const output = formatMitigationsStatus({
+      paused: true,
+      resumesAt: FUTURE,
+    });
+    expect(output).toContain('Paused (auto-resumes in 2h 0m)');
+  });
+
+  it('renders a bare paused state for a permanent bypass', () => {
+    const output = formatMitigationsStatus({ paused: true });
+    expect(output).toContain('Paused');
+    expect(output).not.toContain('auto-resumes');
+  });
+
+  it('renders a bare paused state once the resume time has passed', () => {
+    const output = formatMitigationsStatus({ paused: true, resumesAt: PAST });
+    expect(output).toContain('Paused');
+    expect(output).not.toContain('auto-resumes');
+  });
+});

--- a/packages/cli/test/unit/util/firewall/format.test.ts
+++ b/packages/cli/test/unit/util/firewall/format.test.ts
@@ -69,9 +69,37 @@ describe('getMitigationsStatus', () => {
     });
   });
 
-  it('ignores an unparseable expiry', () => {
-    expect(getMitigationsStatus(['0.0.0.0/0#not-a-number'])).toEqual({
-      paused: false,
+  describe('when an expiry cannot be interpreted', () => {
+    // The entry still proves a bypass exists, so it must not be discarded:
+    // reporting mitigations as active is the more dangerous reading.
+    it('reports paused for a non-numeric suffix', () => {
+      expect(getMitigationsStatus(['0.0.0.0/0#not-a-number'])).toEqual({
+        paused: true,
+      });
+    });
+
+    it('reports paused for a partially numeric suffix', () => {
+      // `parseInt` would read this as 12 and treat the bypass as expired.
+      expect(getMitigationsStatus(['0.0.0.0/0#12abc'])).toEqual({
+        paused: true,
+      });
+    });
+
+    it('reports paused for a suffix that looks like a rule id', () => {
+      expect(getMitigationsStatus([`0.0.0.0/0#rule_abc123`])).toEqual({
+        paused: true,
+      });
+    });
+
+    it('reports paused for an empty suffix', () => {
+      expect(getMitigationsStatus(['0.0.0.0/0#'])).toEqual({ paused: true });
+    });
+
+    it('reports paused for a millisecond timestamp', () => {
+      // Read as seconds this would be a date ~50,000 years out.
+      expect(getMitigationsStatus([`0.0.0.0/0#${NOW}`])).toEqual({
+        paused: true,
+      });
     });
   });
 


### PR DESCRIPTION
## Why

`vercel firewall overview` fails outright on Hobby due to lack of IP Bypass access.

The command fetched the firewall config, the bypass list, and the project in a single `Promise.all`. The bypass endpoint is gated to Pro and Enterprise teams with the `FirewallIpBypass` flag, so on any other account its `404 IP Bypass is unavailable for this plan.` rejected the whole batch.

System mitigations are not plan-gated, but their status was derived from the bypass list, so it became unreportable whenever that list was unavailable.

## What changed

- `Promise.allSettled`, so a plan-gated bypass no longer takes down the command. The config and project remain fatal.
- Only a `404` is tolerated. The API checks permissions *after* the plan gate, so a `403` means the user lacks access and must still surface as an error rather than being reported as a plan limitation.
- Mitigation status now reads the project's `security.firewallBypassIps` — not plan-gated, and the same source the dashboard's security posture card uses — merged with the bypass rules when those are readable, so a bypass that was never mirrored onto the project is still reported as paused. Either source reporting paused wins, so behaviour on Pro and Enterprise is unchanged.
- `System Bypass` reports `Not available on this plan` when gated; `--json` emits `bypass: null`, distinguishing "unreadable" from `[]` meaning "none configured".

## Validation

- Ran the local CLI against a plan without IP Bypass: the overview renders with `System Bypass: Not available on this plan` and a real mitigation status, where it previously exited 1 with the raw API error.
- A permanent (no-expiry) all-sources bypass still reports `Paused`, matching the behaviour of the code being replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)