### PR TITLE
test: adapter server action meta routes

### DIFF
--- a/.changeset/server-action-adapter-test.md
+++ b/.changeset/server-action-adapter-test.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Test the Vercel adapter build containing server action meta routes.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -29,7 +29,7 @@
     "@vercel/nft": "1.10.0"
   },
   "devDependencies": {
-    "@next-community/adapter-vercel": "0.0.1-beta.24",
+    "@next-community/adapter-vercel": "https://adapter-vercel-adapter-85xoxkqt5.vercel.app/adapter.tgz",
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
     "@types/bytes": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1760,8 +1760,8 @@ importers:
         version: 1.10.0(rollup@4.60.4)
     devDependencies:
       '@next-community/adapter-vercel':
-        specifier: 0.0.1-beta.24
-        version: 0.0.1-beta.24
+        specifier: https://adapter-vercel-adapter-85xoxkqt5.vercel.app/adapter.tgz
+        version: https://adapter-vercel-adapter-85xoxkqt5.vercel.app/adapter.tgz
       '@types/aws-lambda':
         specifier: 8.10.19
         version: 8.10.19
@@ -4583,8 +4583,9 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next-community/adapter-vercel@0.0.1-beta.24':
-    resolution: {integrity: sha512-6c3DfRgVcDocIB2CTpp+7txplXMdrK69/CwyLJMDmcB2mvdjpXjKBOOJwjwa13E8zBPzhvRKnmkBxj+U40UUvw==}
+  '@next-community/adapter-vercel@https://adapter-vercel-adapter-85xoxkqt5.vercel.app/adapter.tgz':
+    resolution: {integrity: sha512-DRQsnsiakCNtftlfnouEc6qETDo6TLgU9GsjTjHU+osxCkKXzGuw9dPcSoUKmG2kPi47qONVBmg9gzHAZTH+XQ==, tarball: https://adapter-vercel-adapter-85xoxkqt5.vercel.app/adapter.tgz}
+    version: 0.0.1-beta.29
     engines: {node: '>= 20.6.0'}
 
   '@next/env@11.1.2':
@@ -15171,7 +15172,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@next-community/adapter-vercel@0.0.1-beta.24': {}
+  '@next-community/adapter-vercel@https://adapter-vercel-adapter-85xoxkqt5.vercel.app/adapter.tgz': {}
 
   '@next/env@11.1.2': {}
 


### PR DESCRIPTION
Use the adapter deployment containing nextjs/adapter-vercel#113 to generate a Vercel CLI tarball for the Next.js deploy tests.\n\nAdapter artifact: https://adapter-vercel-adapter-85xoxkqt5.vercel.app/adapter.tgz