### PR TITLE
[ci] Mint VERCEL_TOKEN from GitHub OIDC on zero-conf

### DIFF
--- a/.changeset/oidc-cli-ci-tokens.md
+++ b/.changeset/oidc-cli-ci-tokens.md
@@ -1,0 +1,4 @@
+---
+---
+
+Exchange GitHub OIDC for short-lived Vercel CLI tokens in CI and point Turborepo remote cache at zero-conf-vtest314 instead of the vercel team.

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Setup Turborepo Remote Cache
         uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
         with:
-          team: ${{ vars.TURBO_TEAM }}
+          # zero-conf-vtest314
+          team: team_whnAQ3A1tbgFP0cDEVtL8tlk
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/nightly-test-no-cache.yml
+++ b/.github/workflows/nightly-test-no-cache.yml
@@ -20,6 +20,8 @@ env:
   VERCEL_TELEMETRY_DISABLED: '1'
   # Force turbo to ignore all caches (local and remote) for every task.
   TURBO_FORCE: 'true'
+  # zero-conf-vtest314 — Vercel CLI OIDC policy
+  VERCEL_TEAM_ID: team_whnAQ3A1tbgFP0cDEVtL8tlk
 
 concurrency:
   group: ${{ github.workflow }}
@@ -73,6 +75,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Authenticate Vercel CLI
+        uses: vercel/authenticate-cli-action@cec4e78ed4686ab05721608393617a31147f082b
+        with:
+          team: ${{ env.VERCEL_TEAM_ID }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -120,8 +126,6 @@ jobs:
           fi
         shell: bash
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
           FORCE_COLOR: '1'
           VITEST_TEST_FILES: ${{ matrix.useEnvPaths == true && join(matrix.testPaths, ' ') || '' }}
@@ -147,6 +151,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Authenticate Vercel CLI
+        uses: vercel/authenticate-cli-action@cec4e78ed4686ab05721608393617a31147f082b
+        with:
+          team: ${{ env.VERCEL_TEAM_ID }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -272,8 +280,6 @@ jobs:
           # Per-package pip install specs (e.g. VERCEL_RUNTIME_PYTHON,
           # VERCEL_WORKERS_PYTHON) are also available here, injected into
           # $GITHUB_ENV by the "Resolve Python wheel URLs" step above.
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           FORCE_COLOR: '1'
 
   alert-on-failure:

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -95,7 +95,8 @@ jobs:
       - name: Setup Turborepo Remote Cache
         uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
         with:
-          team: ${{ vars.TURBO_TEAM }}
+          # zero-conf-vtest314
+          team: team_whnAQ3A1tbgFP0cDEVtL8tlk
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,8 @@ jobs:
       - name: Setup Turborepo Remote Cache
         uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
         with:
-          team: ${{ vars.TURBO_TEAM }}
+          # zero-conf-vtest314
+          team: team_whnAQ3A1tbgFP0cDEVtL8tlk
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Setup Turborepo Remote Cache
         uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
         with:
-          team: ${{ vars.TURBO_TEAM }}
+          # zero-conf-vtest314
+          team: team_whnAQ3A1tbgFP0cDEVtL8tlk
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ permissions:
 env:
   VERCEL_TELEMETRY_DISABLED: '1'
   TURBO_REMOTE_ONLY: 'true'
+  # zero-conf-vtest314 — Turborepo cache + Vercel CLI OIDC policies
+  VERCEL_TEAM_ID: team_whnAQ3A1tbgFP0cDEVtL8tlk
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -78,7 +80,7 @@ jobs:
       - name: Setup Turborepo Remote Cache
         uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
         with:
-          team: ${{ vars.TURBO_TEAM }}
+          team: ${{ env.VERCEL_TEAM_ID }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -277,7 +279,11 @@ jobs:
       - name: Setup Turborepo Remote Cache
         uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
         with:
-          team: ${{ vars.TURBO_TEAM }}
+          team: ${{ env.VERCEL_TEAM_ID }}
+      - name: Authenticate Vercel CLI
+        uses: vercel/authenticate-cli-action@cec4e78ed4686ab05721608393617a31147f082b
+        with:
+          team: ${{ env.VERCEL_TEAM_ID }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -376,8 +382,6 @@ jobs:
           done
         shell: bash
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ needs.setup.outputs.baseSha }}
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
           FORCE_COLOR: '1'
@@ -419,7 +423,11 @@ jobs:
       - name: Setup Turborepo Remote Cache
         uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7
         with:
-          team: ${{ vars.TURBO_TEAM }}
+          team: ${{ env.VERCEL_TEAM_ID }}
+      - name: Authenticate Vercel CLI
+        uses: vercel/authenticate-cli-action@cec4e78ed4686ab05721608393617a31147f082b
+        with:
+          team: ${{ env.VERCEL_TEAM_ID }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.nodeVersion }}
@@ -565,8 +573,6 @@ jobs:
           # Per-package pip install specs (e.g. VERCEL_RUNTIME_PYTHON,
           # VERCEL_WORKERS_PYTHON) are also available here, injected into
           # $GITHUB_ENV by the "Resolve Python wheel URLs" step above.
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           TURBO_BASE_SHA: ${{ needs.setup.outputs.baseSha }}
           FORCE_COLOR: '1'
           # Datadog Test Optimization: emit per-test spans correlated to the


### PR DESCRIPTION
## Summary
- Exchange GitHub OIDC for a short-lived Vercel CLI token via `vercel/authenticate-cli-action` in unit/e2e (and nightly) jobs, instead of `secrets.VERCEL_TOKEN`.
- Point Turborepo remote cache at **zero-conf-vtest314** (`team_whnAQ3A1tbgFP0cDEVtL8tlk`) instead of `vars.TURBO_TEAM` (`vercel`).
- Leave `EVAL_TOKEN` / `NOW_EXAMPLES_VERCEL_TOKEN` on their own teams.

`authenticate-cli-action` is a private repo pinned to `cec4e78`. It must be accessible from `vercel/vercel` workflows (same-org private actions).

## Test plan
- [ ] Confirm zero-conf has a **Vercel CLI** OIDC policy for `vercel/vercel`, and a **Turborepo CLI** policy if cache should work there too.
- [ ] Confirm `authenticate-cli-action` is usable from this repo (private action access).
- [ ] PR Checks: Authenticate Vercel CLI step succeeds and unit/e2e no longer depend on `secrets.VERCEL_TOKEN`.
- [ ] E2E deploys still land on zero-conf-vtest314.
- [ ] Lint/canary turbo remote cache hits zero-conf (cold cache on first run is expected).


Made with [Cursor](https://cursor.com)