### PR TITLE
fix(cli): enforce strict cron secret validation

### DIFF
--- a/.changeset/five-coins-jam.md
+++ b/.changeset/five-coins-jam.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Validate `CRON_SECRET` in more deploy/build cron paths, including prebuilt output and synthesized service crons.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -808,12 +808,9 @@ async function doBuild(
     throw validateError;
   }
 
-  // Validate CRON_SECRET if crons are defined
-  if (localConfig.crons && localConfig.crons.length > 0) {
-    const cronSecretError = validateCronSecret(process.env.CRON_SECRET);
-    if (cronSecretError) {
-      throw cronSecretError;
-    }
+  const cronSecretError = validateCronSecret(process.env.CRON_SECRET);
+  if (cronSecretError) {
+    throw cronSecretError;
   }
 
   const projectSettings = {

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -95,6 +95,7 @@ import { UploadErrorMissingArchive } from '../../util/deploy/process-deployment'
 import { displayBuildLogsUntilFinalError } from '../../util/logs';
 import { determineAgent } from '@vercel/detect-agent';
 import { validateJsonOutput } from '../../util/output-format';
+import { validateCronSecret } from '../../util/validate-cron-secret';
 
 const COMMAND_CONFIG = {
   init: getCommandAliases(initSubcommand),
@@ -337,7 +338,6 @@ async function handleInitDeployment(
   }
 
   localConfig = localConfig || {};
-
   if (localConfig.name) {
     output.print(
       `${prependEmoji(
@@ -410,6 +410,12 @@ async function handleInitDeployment(
     await addProcessEnv(log, deploymentBuildEnv);
   } catch (err: unknown) {
     error(errorToString(err));
+    return 1;
+  }
+
+  const cronSecretError = validateCronSecret(process.env.CRON_SECRET);
+  if (cronSecretError) {
+    output.prettyError(cronSecretError);
     return 1;
   }
 
@@ -1208,6 +1214,7 @@ async function handleDefaultDeploy(
       });
       return 1;
     }
+
   }
   // #endregion
 
@@ -1359,6 +1366,12 @@ async function handleDefaultDeploy(
     await addProcessEnv(log, deploymentBuildEnv);
   } catch (err: unknown) {
     error(errorToString(err));
+    return 1;
+  }
+
+  const cronSecretError = validateCronSecret(process.env.CRON_SECRET);
+  if (cronSecretError) {
+    output.prettyError(cronSecretError);
     return 1;
   }
   // #endregion

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1505,6 +1505,45 @@ createServer((_req, res) => {
     }
   });
 
+  it('should fail build when synthesized service crons exist and CRON_SECRET is invalid', async () => {
+    const cwd = fixture('with-services-cron');
+    const output = join(cwd, '.vercel', 'output');
+    client.cwd = cwd;
+    process.env.CRON_SECRET = 'my\nsecret';
+
+    try {
+      const exitCode = await build(client);
+      expect(exitCode).toBe(1);
+
+      const builds = await fs.readJSON(join(output, 'builds.json'));
+      expect(builds.error).toMatchObject({
+        code: 'INVALID_CRON_SECRET',
+      });
+      expect(builds.error.message).toContain('control character');
+    } finally {
+      delete process.env.CRON_SECRET;
+    }
+  });
+
+  it('should fail build when CRON_SECRET is invalid, even without crons configured', async () => {
+    const cwd = fixture('static');
+    const output = join(cwd, '.vercel', 'output');
+    client.cwd = cwd;
+    process.env.CRON_SECRET = 'my\nsecret';
+
+    try {
+      const exitCode = await build(client);
+      expect(exitCode).toBe(1);
+
+      const builds = await fs.readJSON(join(output, 'builds.json'));
+      expect(builds.error).toMatchObject({
+        code: 'INVALID_CRON_SECRET',
+      });
+    } finally {
+      delete process.env.CRON_SECRET;
+    }
+  });
+
   it('should fail build when CRON_SECRET contains invalid HTTP header characters', async () => {
     const cwd = fixture('with-cron');
     const output = join(cwd, '.vercel', 'output');

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -455,6 +455,92 @@ describe('deploy', () => {
     expect(exitCode, 'exit code for "deploy"').toEqual(1);
   });
 
+  it('should reject `--prebuilt` deploys when prebuilt output has crons and CRON_SECRET is invalid', async () => {
+    const cwd = setupTmpDir('deploy-prebuilt-invalid-cron-secret');
+    await fs.outputJson(join(cwd, '.vercel/project.json'), {
+      orgId: 'team_dummy',
+      projectId: 'deploy-prebuilt-invalid-cron-secret',
+    });
+    await fs.outputJson(join(cwd, '.vercel/output/builds.json'), {
+      target: 'preview',
+    });
+    await fs.outputJson(join(cwd, '.vercel/output/config.json'), {
+      version: 3,
+      crons: [{ path: '/api/cron', schedule: '0 0 * * *' }],
+    });
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'deploy-prebuilt-invalid-cron-secret',
+      name: 'deploy-prebuilt-invalid-cron-secret',
+    });
+
+    process.env.CRON_SECRET = 'my\nsecret';
+    try {
+      client.setArgv('deploy', cwd, '--prebuilt');
+      const exitCode = await deploy(client);
+      expect(exitCode, 'exit code for "deploy"').toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'The `CRON_SECRET` environment variable contains characters that are not valid in HTTP headers'
+      );
+    } finally {
+      delete process.env.CRON_SECRET;
+    }
+  });
+
+  it('should reject deploys when vercel.json has crons and CRON_SECRET is invalid', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'static',
+      name: 'static',
+    });
+
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.localConfig = {
+      [fileNameSymbol]: 'vercel.json',
+      version: 2,
+      crons: [{ path: '/api/cron', schedule: '0 0 * * *' }],
+    };
+    process.env.CRON_SECRET = 'mysecret🔐';
+    try {
+      client.setArgv('deploy');
+      const exitCode = await deploy(client);
+      expect(exitCode, 'exit code for "deploy"').toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'The `CRON_SECRET` environment variable contains characters that are not valid in HTTP headers'
+      );
+    } finally {
+      delete process.env.CRON_SECRET;
+    }
+  });
+
+  it('should reject deploys when CRON_SECRET is invalid, even without crons configured', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'static',
+      name: 'static',
+    });
+
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    process.env.CRON_SECRET = 'my\nsecret';
+    try {
+      client.setArgv('deploy');
+      const exitCode = await deploy(client);
+      expect(exitCode, 'exit code for "deploy"').toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'The `CRON_SECRET` environment variable contains characters that are not valid in HTTP headers'
+      );
+    } finally {
+      delete process.env.CRON_SECRET;
+    }
+  });
+
   it('should reject deploying "version: 1"', async () => {
     client.setArgv('deploy');
     client.localConfig = {
@@ -2978,6 +3064,27 @@ describe('deploy', () => {
         target: 'production',
         deploymentApiUrl: `${client.apiUrl}/v13/deployments/${deploymentId}`,
       });
+    });
+
+    it('should reject deploy init when prebuilt output has crons and CRON_SECRET is invalid', async () => {
+      const cwd = setupUnitFixture('commands/deploy/static');
+      await fs.outputJson(join(cwd, '.vercel/output/config.json'), {
+        version: 3,
+        crons: [{ path: '/api/cron', schedule: '0 0 * * *' }],
+      });
+
+      process.env.CRON_SECRET = 'my\nsecret';
+      try {
+        client.cwd = cwd;
+        client.setArgv('deploy', 'init', '--json');
+        const exitCode = await deploy(client);
+        expect(exitCode).toEqual(1);
+        expect(client.stderr.getFullOutput()).toContain(
+          'The `CRON_SECRET` environment variable contains characters that are not valid in HTTP headers'
+        );
+      } finally {
+        delete process.env.CRON_SECRET;
+      }
     });
   });
 


### PR DESCRIPTION
Validate CRON_SECRET in build, deploy, deploy --prebuilt, and deploy init flows. Add tests for cron and non-cron paths.

Follow up of https://github.com/vercel/vercel/pull/14576