### PR TITLE
[cli] add deploy turbo flag

### DIFF
--- a/.changeset/tidy-build-machines.md
+++ b/.changeset/tidy-build-machines.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add a hidden `--build-machine` option to `vercel deploy`.

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -200,6 +200,15 @@ export const deployCommand = {
         'Specify environment variables during build-time (e.g. `-b KEY1=value1 -b KEY2=value2`)',
     },
     {
+      name: 'build-machine',
+      shorthand: null,
+      type: String,
+      argument: 'basic|standard|enhanced|turbo',
+      deprecated: false,
+      description: 'Select the build machine size',
+      hidden: true,
+    },
+    {
       name: 'meta',
       shorthand: 'm',
       type: [String],

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -19,7 +19,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import ms from 'ms';
 import { join, resolve } from 'path';
-import Now, { type CreateOptions } from '../../util';
+import Now, { type BuildMachine, type CreateOptions } from '../../util';
 import type Client from '../../util/client';
 import { readLocalConfig } from '../../util/config/files';
 import { compileVercelConfig } from '../../util/compile-vercel-config';
@@ -100,6 +100,20 @@ const COMMAND_CONFIG = {
   init: getCommandAliases(initSubcommand),
   continue: getCommandAliases(continueSubcommand),
 };
+
+const BUILD_MACHINES: BuildMachine[] = [
+  'basic',
+  'standard',
+  'enhanced',
+  'turbo',
+];
+
+function parseBuildMachine(
+  value: string | undefined
+): BuildMachine | undefined {
+  if (value === undefined) return undefined;
+  return BUILD_MACHINES.find(buildMachine => buildMachine === value);
+}
 
 export default async (client: Client): Promise<number> => {
   const telemetryClient = new DeployTelemetryClient({
@@ -951,7 +965,18 @@ async function handleDefaultDeploy(
     return 1;
   }
 
+  const buildMachine = parseBuildMachine(
+    parsedArguments.flags['--build-machine']
+  );
+  if (parsedArguments.flags['--build-machine'] && !buildMachine) {
+    output.error(
+      `\`--build-machine\` must be one of: ${BUILD_MACHINES.join(', ')}`
+    );
+    return 1;
+  }
+
   telemetryClient.trackCliOptionArchive(parsedArguments.flags['--archive']);
+  telemetryClient.trackCliOptionBuildMachine(buildMachine);
   telemetryClient.trackCliOptionEnv(parsedArguments.flags['--env']);
   telemetryClient.trackCliOptionBuildEnv(parsedArguments.flags['--build-env']);
   telemetryClient.trackCliOptionMeta(parsedArguments.flags['--meta']);
@@ -1398,6 +1423,7 @@ async function handleDefaultDeploy(
       name,
       env: deploymentEnv as Dictionary<string>,
       build: { env: deploymentBuildEnv as Dictionary<string> },
+      buildMachine,
       forceNew: parsedArguments.flags['--force'],
       withCache: parsedArguments.flags['--with-cache'],
       prebuilt: parsedArguments.flags['--prebuilt'],

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -19,6 +19,7 @@ export interface CommandOption {
   readonly argument?: string;
   readonly deprecated: boolean;
   readonly description?: string;
+  readonly hidden?: true;
 }
 export interface CommandArgument {
   readonly name: string;
@@ -149,7 +150,8 @@ export function buildCommandOptionLines(
 ) {
   // Filter out deprecated and intentionally undocumented options
   const filteredCommandOptions = commandOptions.filter(
-    option => !option.deprecated && option.description !== undefined
+    option =>
+      !option.deprecated && !option.hidden && option.description !== undefined
   );
 
   if (filteredCommandOptions.length === 0) {

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -26,6 +26,8 @@ export interface NowOptions {
   withCache?: boolean;
 }
 
+export type BuildMachine = 'basic' | 'standard' | 'enhanced' | 'turbo';
+
 export interface CreateOptions {
   // Legacy
   nowConfig?: VercelConfig;
@@ -42,6 +44,7 @@ export interface CreateOptions {
   quiet?: boolean;
   env: Dictionary<string>;
   build: { env: Dictionary<string> };
+  buildMachine?: BuildMachine;
   forceNew?: boolean;
   withCache?: boolean;
   target?: string | null;
@@ -120,6 +123,7 @@ export default class Now {
       quiet = false,
       env,
       build,
+      buildMachine,
       forceNew = false,
       withCache = false,
       target = null,
@@ -141,6 +145,7 @@ export default class Now {
       ...nowConfig,
       env,
       build,
+      buildMachine,
       name,
       project,
       meta,

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -30,6 +30,14 @@ export class DeployTelemetryClient
       });
     }
   }
+  trackCliOptionBuildMachine(buildMachine: string | undefined) {
+    if (buildMachine) {
+      this.trackCliOption({
+        option: 'build-machine',
+        value: buildMachine,
+      });
+    }
+  }
   trackCliOptionBuildEnv(buildEnv: string[] | undefined) {
     if (buildEnv && buildEnv.length > 0) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -98,6 +98,7 @@ describe('deploy', () => {
       const helpOutput = client.stderr.getFullOutput();
       expect(helpOutput).toContain('--dry');
       expect(helpOutput).toContain('vercel deploy --dry --json');
+      expect(helpOutput).not.toContain('--build-machine');
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
@@ -105,6 +106,47 @@ describe('deploy', () => {
         },
       ]);
     });
+  });
+
+  it('rejects an invalid --build-machine value', async () => {
+    client.setArgv('deploy', '--build-machine', 'large');
+
+    const exitCode = await deploy(client);
+
+    expect(exitCode).toEqual(1);
+    expect(client.stderr.getFullOutput()).toContain(
+      'Error: `--build-machine` must be one of: basic, standard, enhanced, turbo'
+    );
+  });
+
+  it('sends buildMachine in the deployment creation request', async () => {
+    const user = useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+    });
+
+    let body: Record<string, unknown> | undefined;
+    client.scenario.post(`/v13/deployments`, (req, res) => {
+      body = req.body;
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_build_machine_test',
+        readyState: 'BUILDING',
+        url: 'build-machine-test.vercel.app',
+      });
+    });
+
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.setArgv('deploy', '--build-machine', 'enhanced', '--no-wait');
+
+    expect(await deploy(client)).toEqual(0);
+    expect(body).toMatchObject({ buildMachine: 'enhanced' });
   });
 
   it('should reject deploying a single file', async () => {
@@ -1488,6 +1530,24 @@ describe('deploy', () => {
         { key: 'target_environment', value: 'preview' },
         { key: 'output:deployment-id', value: 'dpl_archive_test' },
       ]);
+    });
+    it.each([
+      'basic',
+      'standard',
+      'enhanced',
+      'turbo',
+    ] as const)('--build-machine=%s', async buildMachine => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--build-machine', buildMachine);
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      expect(mock).toHaveBeenCalledWith(
+        ...Object.values({
+          ...baseCreateDeployArgs,
+          createArgs: expect.objectContaining({ buildMachine }),
+        })
+      );
     });
     it('--env', async () => {
       client.cwd = setupUnitFixture('commands/deploy/static');

--- a/packages/cli/test/unit/util/deploy/create-deploy.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-deploy.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Org } from '@vercel-internals/types';
+import type Client from '../../../../src/util/client';
+import type Now from '../../../../src/util';
+import type { CreateOptions } from '../../../../src/util';
+
+const generateCertForDeploy = vi.hoisted(() => vi.fn());
+vi.mock('../../../../src/util/deploy/generate-cert-for-deploy', () => ({
+  default: generateCertForDeploy,
+}));
+
+import createDeploy from '../../../../src/util/deploy/create-deploy';
+
+const org: Org = { type: 'user', id: 'user_1', slug: 'acme' };
+
+function createOptions(): CreateOptions {
+  return {
+    name: 'my-project',
+    meta: {},
+    env: {},
+    build: { env: {} },
+    buildMachine: 'turbo',
+    deployStamp: () => '',
+  };
+}
+
+describe('createDeploy()', () => {
+  it('retains buildMachine when retrying after certificate generation', async () => {
+    const createArgs = createOptions();
+    const certMissingError = Object.assign(new Error('Certificate missing'), {
+      status: 400,
+      code: 'cert_missing',
+      value: 'my-project.example.com',
+    });
+    const now = {
+      create: vi
+        .fn()
+        .mockRejectedValueOnce(certMissingError)
+        .mockResolvedValueOnce({ id: 'dpl_test' }),
+    } as unknown as Now;
+
+    await createDeploy(
+      {} as Client,
+      now,
+      'acme',
+      '/project',
+      createArgs,
+      org,
+      false
+    );
+
+    expect(generateCertForDeploy).toHaveBeenCalledOnce();
+    expect(now.create).toHaveBeenCalledTimes(2);
+    expect(now.create).toHaveBeenNthCalledWith(
+      2,
+      '/project',
+      createArgs,
+      org,
+      false,
+      undefined
+    );
+    expect(createArgs.buildMachine).toBe('turbo');
+  });
+});

--- a/packages/cli/test/unit/util/now-size-limit-warning.test.ts
+++ b/packages/cli/test/unit/util/now-size-limit-warning.test.ts
@@ -36,6 +36,24 @@ describe('Now.create — size_limit_exceeded warning', () => {
   // Previously this branch crashed on `hashes[sha].names.pop()` (`hashes` was
   // never populated), so the warning and upgrade CTA were unreachable. Now it
   // should warn about the skipped file and surface the plan upgrade link.
+  it('serializes buildMachine in the deployment creation request', async () => {
+    processDeployment.mockResolvedValue({ id: 'dpl_test' });
+    const now = new Now({ client });
+
+    await now.create(
+      '/tmp/whatever',
+      { ...baseCreateOptions(), buildMachine: 'enhanced' },
+      org,
+      false
+    );
+
+    expect(processDeployment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestBody: expect.objectContaining({ buildMachine: 'enhanced' }),
+      })
+    );
+  });
+
   it('warns about the skipped file and prints the upgrade CTA', async () => {
     // The API returns the deployment with a per-file size warning instead of
     // failing the whole deploy.


### PR DESCRIPTION
Adds `vc deploy --turbo` and sends `buildMachine: "turbo"` in deployment creation requests, including retries. Other build-machine selections are not exposed.

The API contract is implemented by https://github.com/vercel/api/pull/89951. Feature-flag and ACL handling remain server-side; disabled or unauthorized overrides are silently ignored without failing deployment.