### PR TITLE
[examples] Fix broken Vercel docs link in NestJS example

### DIFF
--- a/examples/nestjs/src/app.service.ts
+++ b/examples/nestjs/src/app.service.ts
@@ -80,12 +80,12 @@ export class AppService {
     </head>
     <body>
       <div class="container">
-        <img src="https://api-frameworks.vercel.sh/framework-logos/nestjs.svg" alt="Nitro logo" class="logo" />
+        <img src="https://api-frameworks.vercel.sh/framework-logos/nestjs.svg" alt="NestJS logo" class="logo" />
         <h1>Welcome to NestJS</h1>
         <p>A progressive Node.js framework running on Vercel</p>
         <div class="features">
           <div class="feature">
-            <a href="https://vercel.com/docs/frameworks/nestjs" target="_blank" rel="noreferrer">Vercel docs</a>
+            <a href="https://vercel.com/docs/frameworks/backend/nestjs" target="_blank" rel="noreferrer">Vercel docs</a>
           </div>
           <div class="feature">
             <a href="https://docs.nestjs.com" target="_blank" rel="noreferrer">NestJS docs</a>


### PR DESCRIPTION
The "Vercel docs" link in the NestJS example points to `https://vercel.com/docs/frameworks/nestjs`, which 404s now that the backend framework docs got moved under `/docs/frameworks/backend/`. Pointed it at `https://vercel.com/docs/frameworks/backend/nestjs` instead.

Also fixed the logo `alt` while I was in there, it still said "Nitro logo".

Easy to check for yourselves: the old link 404s (https://vercel.com/docs/frameworks/nestjs) while the new one loads fine (https://vercel.com/docs/frameworks/backend/nestjs). Or just hit the "Vercel docs" button straight from the demo: https://nestjs-vercel-example-demo.vercel.app/

Here's the button on the demo:

<img width="1718" height="803" alt="NestJS example landing page" src="https://github.com/user-attachments/assets/35ae4436-19ad-4e74-9cfd-b02df8462a79" />

And here's where it takes you right now:

<img width="1737" height="763" alt="Vercel docs page returning a 404" src="https://github.com/user-attachments/assets/c90081b8-0dbe-4021-b6c9-c4b8bb6a4392" />