### PR TITLE
Update package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -79,7 +79,7 @@
     "luxon": "^3.4.0",
     "sandbox": "3.4.0",
     "smol-toml": "1.5.2",
-    "undici": "5.29.0",
+    "undici": "7.24.0",
     "zod": "4.1.11"
   },
   "builders": {


### PR DESCRIPTION
The undici WebSocket client is vulnerable to a denial-of-service attack via unbounded memory consumption during permessage-deflate decompression. When a WebSocket connection negotiates the permessage-deflate extension, the client decompresses incoming compressed frames without enforcing any limit on the decompressed data size. A malicious WebSocket server can send a small compressed frame (a "decompression bomb") that expands to an extremely large size in memory, causing the Node.js process to exhaust available memory and crash or become unresponsive. The vulnerability exists in the PerMessageDeflate.decompress() method, which accumulates all decompressed chunks in memory and concatenates them into a single Buffer without checking whether the total size exceeds a safe threshold.

