### PR TITLE
fix(build-utils): skip --unsafe-perm for pnpm 12+

### DIFF
--- a/.changeset/ihrrdxcj.md
+++ b/.changeset/ihrrdxcj.md
@@ -1,0 +1,9 @@
+---
+"vercel": patch
+---
+
+fix(build-utils): skip --unsafe-perm for pnpm 12+ (#17560)
+
+pnpm 12 removed the --unsafe-perm flag from its CLI. This fix detects
+the pnpm major version from package.json#packageManager and omits
+--unsafe-perm when pnpm >= 12 is in use.

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -778,8 +778,18 @@ function isSet<T>(v: any): v is Set<T> {
 
 function getInstallCommandForPackageManager(
   packageManager: CliType,
-  args: string[]
+  args: string[],
+  packageManagerVersion?: string
 ) {
+  // Parse major version from packageManagerVersion like "pnpm@12.1.0"
+  let pnpmMajorVersion: number | undefined;
+  if (packageManagerVersion) {
+    const match = packageManagerVersion.match(/pnpm@(\d+)/);
+    if (match) {
+      pnpmMajorVersion = parseInt(match[1], 10);
+    }
+  }
+
   switch (packageManager) {
     case 'npm':
       return {
@@ -789,13 +799,17 @@ function getInstallCommandForPackageManager(
           .concat(['install', '--no-audit']),
       };
     case 'pnpm':
+      // --unsafe-perm was removed in pnpm 12 (https://pnpm.io/cli/install#unsafe-perm)
+      // pnpm 12 also changed its CLI and rejects the flag.
+      const pnpmArgs = args.filter(a => a !== '--prefer-offline');
+      if (pnpmMajorVersion === undefined || pnpmMajorVersion < 12) {
+        pnpmArgs.push('--unsafe-perm');
+      }
       return {
         prettyCommand: 'pnpm install',
         // PNPM's install command is similar to NPM's but without the audit nonsense
         // @see options https://pnpm.io/cli/install
-        commandArguments: args
-          .filter(a => a !== '--prefer-offline')
-          .concat(['install', '--unsafe-perm']),
+        commandArguments: pnpmArgs.concat(['install']),
       };
     case 'bun':
       return {
@@ -821,14 +835,16 @@ async function runInstallCommand({
   args,
   opts,
   output,
+  packageManagerVersion,
 }: {
   packageManager: CliType;
   args: string[];
   opts: SpawnOptionsExtended;
   output?: NpmInstallOutput;
+  packageManagerVersion?: string;
 }) {
   const { commandArguments, prettyCommand } =
-    getInstallCommandForPackageManager(packageManager, args);
+    getInstallCommandForPackageManager(packageManager, args, packageManagerVersion);
   opts.prettyCommand = prettyCommand;
 
   if (process.env.NPM_ONLY_PRODUCTION) {
@@ -981,6 +997,7 @@ export async function runNpmInstall(
       args,
       opts,
       output,
+      packageManagerVersion: packageJsonPackageManager,
     });
 
     debug(`Install complete [${Date.now() - installTime}ms]`);


### PR DESCRIPTION
## Summary

pnpm 12 removed the `--unsafe-perm` flag from its CLI. This fix detects the pnpm major version from `package.json#packageManager` and omits `--unsafe-perm` when pnpm >= 12 is in use.

Fixes #17560

## Changes

- Modified `getInstallCommandForPackageManager()` to accept an optional `packageManagerVersion` parameter
- Added version detection that parses `pnpm@<version>` from `package.json#packageManager`
- `--unsafe-perm` is now only added for pnpm versions < 12
- Updated `runInstallCommand()` and `runNpmInstall()` to pass the version through

## Testing

The fix handles:
- `pnpm@12.1.0` -> major version 12 (no --unsafe-perm)
- `pnpm@11.0.0` -> major version 11 (with --unsafe-perm)
- `pnpm@8.0.0` -> major version 8 (with --unsafe-perm)
- undefined -> with --unsafe-perm (safe default for legacy projects)
