### PR TITLE
fix(cli): fix vercel env pull adding duplicate .gitignore rules on Windows

### DIFF
--- a/.changeset/texpuznh.md
+++ b/.changeset/texpuznh.md
@@ -1,0 +1,11 @@
+---
+"vercel": patch
+---
+
+fix(cli): fix vercel env pull adding duplicate .gitignore rules on Windows (#17556)
+
+The addToGitIgnore function incorrectly detected line endings by checking
+if \r\n appeared anywhere in the file, causing CRLF line endings in
+comments to be detected even when the file was LF-terminated. The fix
+uses a dominant-EOL heuristic to correctly detect the file's line ending
+style and uses a simple substring check for duplicate detection.

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -16,7 +16,7 @@ import {
 import { VERCEL_OIDC_TOKEN } from '../../util/env/constants';
 import { updateOidcTokenContents } from '../../util/env/update-oidc-token-contents';
 import { isErrnoException } from '@vercel/error-utils';
-import { addToGitIgnore } from '../../util/link/add-to-gitignore';
+import { addToGitIgnore } from '../../util/add-to-gitignore';
 import JSONparse from 'json-parse-better-errors';
 import { formatProject } from '../../util/projects/format-project';
 import type { ProjectLinked } from '@vercel-internals/types';

--- a/packages/cli/src/util/add-to-gitignore.ts
+++ b/packages/cli/src/util/add-to-gitignore.ts
@@ -1,0 +1,30 @@
+import { join } from 'path';
+import { readFile, writeFile } from 'fs-extra';
+import { VERCEL_DIR } from './projects/link';
+import getDominantEOL from './get-dominant-eol';
+
+export async function addToGitIgnore(path: string, ignore = VERCEL_DIR) {
+  let isGitIgnoreUpdated = false;
+  try {
+    const gitIgnorePath = join(path, '.gitignore');
+
+    let gitIgnore: string =
+      (await readFile(gitIgnorePath, 'utf8').catch(() => null)) ?? '';
+
+    if (gitIgnore.includes(ignore)) return isGitIgnoreUpdated;
+
+    const EOL = getDominantEOL(gitIgnore);
+
+    gitIgnore = gitIgnore.concat(
+      gitIgnore.endsWith('\n') || gitIgnore.length === 0 ? '' : EOL,
+      ignore,
+      EOL
+    );
+
+    await writeFile(gitIgnorePath, gitIgnore);
+    isGitIgnoreUpdated = true;
+  } catch (error) {
+    // ignore errors since this is non-critical
+  }
+  return isGitIgnoreUpdated;
+}

--- a/packages/cli/src/util/get-dominant-eol.ts
+++ b/packages/cli/src/util/get-dominant-eol.ts
@@ -1,0 +1,17 @@
+import os from 'os';
+
+export default function getDominantEOL(text: string) {
+  const lines = (text.match(/\r\n|\n/g) ?? []) as Array<'\r\n' | '\n'>;
+
+  const { '\n': LFCount, '\r\n': CRLFCount } = lines.reduce(
+    (counter, lineEnding) => {
+      counter[lineEnding] += 1;
+      return counter;
+    },
+    { '\n': 0, '\r\n': 0 }
+  );
+
+  const dominantEOL = LFCount > CRLFCount ? '\n' : '\r\n';
+
+  return LFCount === CRLFCount ? os.EOL : dominantEOL;
+}

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -12,7 +12,7 @@ import { getRemoteUrls } from '../create-git-meta';
 import link from '../output/link';
 import type { EmojiLabel } from '../emoji';
 import selectOrg from '../input/select-org';
-import { addToGitIgnore } from './add-to-gitignore';
+import { addToGitIgnore } from '../add-to-gitignore';
 import type Client from '../client';
 import type { Framework } from '@vercel/frameworks';
 import type { Project } from '@vercel-internals/types';

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -21,7 +21,7 @@ import { NowBuildError, getPlatformEnv } from '@vercel/build-utils';
 import outputCode from '../output/code';
 import { isErrnoException, isError } from '@vercel/error-utils';
 import { findProjectsFromPath, getRepoLink } from '../link/repo';
-import { addToGitIgnore } from '../link/add-to-gitignore';
+import { addToGitIgnore } from '../add-to-gitignore';
 import type { RepoProjectConfig } from '../link/repo';
 import output from '../../output-manager';
 import { printAlignedLabel } from '../output/print-aligned-label';


### PR DESCRIPTION
## Summary

On Windows with LF line endings configured, running `vercel env pull` for a project with `.env.local` would add duplicate `.env*` entries to `.gitignore`.

**Root cause:** The `addToGitIgnore` function detected line endings by checking if `
` appeared anywhere in the file content. This caused CRLF to be detected even when the file's actual line endings were LF (because comments or other content had CRLF), leading to incorrect EOL handling and duplicate entries.

**Fix:**
1. Added `getDominantEOL()` helper that counts actual LF vs CRLF occurrences to determine the dominant line ending
2. Moved `addToGitIgnore` to `packages/cli/src/util/add-to-gitignore.ts` with the fix
3. Uses simple `gitIgnore.includes(ignore)` for duplicate detection instead of `split(EOL).includes(ignore)`
4. Updated imports in `pull.ts`, `repo.ts`, and `projects/link.ts`

Fixes #17556

## Changes

- **New file:** `packages/cli/src/util/get-dominant-eol.ts` - Dominant line ending detector
- **New file:** `packages/cli/src/util/add-to-gitignore.ts` - Fixed implementation
- **Modified:** `packages/cli/src/commands/env/pull.ts` - Updated import
- **Modified:** `packages/cli/src/util/link/repo.ts` - Updated import
- **Modified:** `packages/cli/src/util/projects/link.ts` - Updated import
