### PR TITLE
fix: make path-to-regexp key comparison detect content changes

### DIFF
--- a/.changeset/compare-keys-detects-content-changes.md
+++ b/.changeset/compare-keys-detects-content-changes.md
@@ -1,0 +1,7 @@
+---
+'@vercel/routing-utils': patch
+'@vercel/remix-builder': patch
+'@vercel/node': patch
+---
+
+Make the path-to-regexp key comparison detect content changes, not just a different number of keys.

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -17,12 +17,19 @@ function cloneKeys(keys: Key[] | undefined): Key[] | undefined {
   return keys.slice(0);
 }
 
-function compareKeys(left: Key[] | undefined, right: Key[] | undefined) {
-  const leftSerialized =
-    typeof left === 'undefined' ? 'undefined' : left.toString();
-  const rightSerialized =
-    typeof right === 'undefined' ? 'undefined' : right.toString();
-  return leftSerialized === rightSerialized;
+function serializeKeys(keys: Key[] | undefined): string {
+  // `Array.prototype.toString()` renders every `Key` as "[object Object]", so
+  // joining the array only reflects how many keys there are. Serializing the
+  // fields keeps renamed parameters, changed patterns and changed modifiers
+  // visible to the comparison below.
+  return typeof keys === 'undefined' ? 'undefined' : JSON.stringify(keys);
+}
+
+export function compareKeys(
+  left: Key[] | undefined,
+  right: Key[] | undefined
+) {
+  return serializeKeys(left) === serializeKeys(right);
 }
 
 // run the updated version of path-to-regexp, compare the results, and log if different

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -22,12 +22,19 @@ function cloneKeys(keys: Key[] | undefined): Key[] | undefined {
   return keys.slice(0);
 }
 
-function compareKeys(left: Key[] | undefined, right: Key[] | undefined) {
-  const leftSerialized =
-    typeof left === 'undefined' ? 'undefined' : left.toString();
-  const rightSerialized =
-    typeof right === 'undefined' ? 'undefined' : right.toString();
-  return leftSerialized === rightSerialized;
+function serializeKeys(keys: Key[] | undefined): string {
+  // `Array.prototype.toString()` renders every `Key` as "[object Object]", so
+  // joining the array only reflects how many keys there are. Serializing the
+  // fields keeps renamed parameters, changed patterns and changed modifiers
+  // visible to the comparison below.
+  return typeof keys === 'undefined' ? 'undefined' : JSON.stringify(keys);
+}
+
+export function compareKeys(
+  left: Key[] | undefined,
+  right: Key[] | undefined
+) {
+  return serializeKeys(left) === serializeKeys(right);
 }
 
 // run the updated version of path-to-regexp, compare the results, and log if different

--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -31,12 +31,19 @@ function cloneKeys(keys: Key[] | undefined): Key[] | undefined {
   return keys.slice(0);
 }
 
-function compareKeys(left: Key[] | undefined, right: Key[] | undefined) {
-  const leftSerialized =
-    typeof left === 'undefined' ? 'undefined' : left.toString();
-  const rightSerialized =
-    typeof right === 'undefined' ? 'undefined' : right.toString();
-  return leftSerialized === rightSerialized;
+function serializeKeys(keys: Key[] | undefined): string {
+  // `Array.prototype.toString()` renders every `Key` as "[object Object]", so
+  // joining the array only reflects how many keys there are. Serializing the
+  // fields keeps renamed parameters, changed patterns and changed modifiers
+  // visible to the comparison below.
+  return typeof keys === 'undefined' ? 'undefined' : JSON.stringify(keys);
+}
+
+export function compareKeys(
+  left: Key[] | undefined,
+  right: Key[] | undefined
+) {
+  return serializeKeys(left) === serializeKeys(right);
 }
 
 // run the updated version of path-to-regexp, compare the results, and log if different

--- a/packages/routing-utils/test/compare-keys.spec.ts
+++ b/packages/routing-utils/test/compare-keys.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { Key } from 'path-to-regexp';
+
+import { compareKeys } from '../src/superstatic';
+
+function key(overrides: Partial<Key>): Key {
+  return {
+    name: 'id',
+    prefix: '/',
+    suffix: '',
+    pattern: '[^\/#\?]+?',
+    modifier: '',
+    ...overrides,
+  } as Key;
+}
+
+describe('compareKeys', () => {
+  it('treats identical key lists as equal', () => {
+    expect(compareKeys([key({})], [key({})])).toBe(true);
+  });
+
+  it('detects a different number of keys', () => {
+    expect(compareKeys([key({})], [key({}), key({ name: 'other' })])).toBe(
+      false
+    );
+  });
+
+  it('detects a renamed parameter', () => {
+    expect(compareKeys([key({ name: 'id' })], [key({ name: 'slug' })])).toBe(
+      false
+    );
+  });
+
+  it('detects a changed pattern', () => {
+    expect(
+      compareKeys([key({ pattern: '[^/]+' })], [key({ pattern: '.*' })])
+    ).toBe(false);
+  });
+
+  it('detects a changed modifier', () => {
+    expect(compareKeys([key({ modifier: '' })], [key({ modifier: '*' })])).toBe(
+      false
+    );
+  });
+
+  it('handles undefined on either side', () => {
+    expect(compareKeys(undefined, undefined)).toBe(true);
+    expect(compareKeys(undefined, [key({})])).toBe(false);
+    expect(compareKeys([key({})], undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
### What

`compareKeys`, the helper used by the temporary double-install of path-to-regexp, compares two key lists with `Array.prototype.toString()`:

```ts
const leftSerialized =
  typeof left === 'undefined' ? 'undefined' : left.toString();
```

`Key` is a plain object, so an array of keys always renders as `"[object Object],[object Object]"` no matter what the keys contain. The comparison therefore only reports a difference when the **number** of keys changes.

```js
const a = [{ name: 'id',   prefix: '/', suffix: '', pattern: '[^/]+', modifier: ''  }];
const b = [{ name: 'slug', prefix: '/', suffix: '', pattern: '.*',    modifier: '*' }];

a.toString() === b.toString(); // true
```

A renamed parameter, a changed pattern and a changed modifier all compare as equal, so `PATH TO REGEXP KEYS DIFF` never fires for any of them.

### Why it matters

This comparison exists to measure the impact of moving from `path-to-regexp@6.1.0` to `6.3.0` across real deployments (ZERO-3067). As written it can only observe one of the ways the two versions may disagree, so the collected signal understates the difference.

The regex comparison next to it is fine: `RegExp.prototype.toString()` does serialize the pattern. Only the key comparison was affected.

### Change

Serialize the key fields before comparing. The helper is duplicated in three packages and is fixed identically in each:

- `packages/routing-utils/src/superstatic.ts`
- `packages/node/src/utils.ts`
- `packages/remix/src/utils.ts`

### Tests

Added `packages/routing-utils/test/compare-keys.spec.ts`.

Run against the previous implementation it fails on exactly the three content cases and passes the rest, which is what pins the behaviour down:

```
Tests  3 failed | 3 passed (6)
  x detects a renamed parameter
  x detects a changed pattern
  x detects a changed modifier
  v treats identical key lists as equal
  v detects a different number of keys
  v handles undefined on either side
```

With this change all six pass, and the full `@vercel/routing-utils` suite (142 tests) still passes.

### Notes

`compareKeys` is now exported from the three modules so it can be tested directly. Happy to keep it private and test through `pathToRegexp` instead if you prefer, or to fold the three copies into one shared helper.
