### PR TITLE
[connect] resolve lazy provisioned connectors

### DIFF
--- a/.changeset/quiet-lamps-provision.md
+++ b/.changeset/quiet-lamps-provision.md
@@ -1,0 +1,5 @@
+---
+'@vercel/connect': minor
+---
+
+Support resolved managed OAuth connector identities, canonical service provisioning metadata, and structured explicit-setup responses in the Eve adapter.

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -52,13 +52,18 @@ import {
   revokeToken,
   UserAuthorizationRequiredError,
 } from '../token.js';
-import { provisionEveOAuthConnector } from './provision-oauth-connector.js';
+import {
+  ExplicitSetupRequiredError,
+  provisionEveOAuthConnector,
+  type EveOAuthProvisioningIdentity,
+} from './provision-oauth-connector.js';
 
 /**
  * Authorization phase passed to {@link EveAuthorizationOptions.onError}
  * so consumers can branch their error translation per callback.
  */
 export type ConnectAuthorizationPhase =
+  | 'provisioning'
   | 'getToken'
   | 'startAuthorization'
   | 'completeAuthorization';
@@ -139,6 +144,12 @@ export interface EveAuthorizationOptions {
   readonly principalType?: 'app' | 'user';
 
   /**
+   * Identity used by managed OAuth lazy provisioning. Registry entries should
+   * provide `service`; a canonical name is not necessarily the final UID.
+   */
+  readonly provisioning?: EveOAuthProvisioningIdentity;
+
+  /**
    * Extra parameters forwarded to every `getTokenResponse` /
    * `startAuthorization` call, minus `subject` — the helper derives
    * `subject` from the framework-resolved principal.
@@ -191,10 +202,10 @@ export interface EveAuthorizationOptions {
    * `true`.
    *
    * The provision request is authenticated with the deployment OIDC token
-   * and carries the eve connection's `url` plus this connector UID. Connect
-   * creates the managed OAuth connector when missing, links an existing
-   * OAuth connector when the UID already exists, and scopes the new project
-   * link to the OIDC token's environment and higher promotion targets.
+   * and carries the Eve connection URL, canonical name, service, and
+   * principal type. Connect resolves a compatible team connector, creates or
+   * links it atomically, and returns its canonical identity. Ambiguous or
+   * administratively restricted cases require explicit setup instead.
    *
    * Set this to `false` for callers that intentionally manage the connector
    * linkage elsewhere. Opaque connector ids (`scl_...`) and connections
@@ -395,6 +406,17 @@ function makeEvict(
 }) => Promise<void> {
   return async ({ principal, connection, revoke }) => {
     const params = await buildTokenParams(options, principal, connection);
+    // Eviction can be called without Eve's connection context. Use the
+    // resolved identity when context is available, otherwise retain the
+    // authored identifier as a best-effort backwards-compatible fallback.
+    let connector = options.connector;
+    if (connection !== undefined) {
+      try {
+        connector = await autoProvisionConnectorIfEnabled(options, connection);
+      } catch {
+        // A provisioning conflict must not prevent local cache eviction.
+      }
+    }
     if (revoke) {
       try {
         // Destructive: tears down the grant at Vercel Connect (refresh
@@ -402,7 +424,7 @@ function makeEvict(
         // a failed or duplicate revoke must not mask the auth error that
         // triggered eviction.
         await revokeToken(
-          options.connector,
+          connector,
           {
             subject: params.subject,
             installationId: params.installationId,
@@ -415,7 +437,7 @@ function makeEvict(
         // gone even when the server-side revoke failed.
       }
     }
-    deleteTokenCacheEntry(options.connector, params);
+    deleteTokenCacheEntry(connector, params);
   };
 }
 
@@ -439,9 +461,12 @@ function buildInteractiveDefinition(
       connection,
     }: GetTokenOptions): Promise<TokenResult> {
       try {
-        await autoProvisionConnectorIfEnabled(options, connection);
+        const connector = await autoProvisionConnectorIfEnabled(
+          options,
+          connection
+        );
         const response = await getTokenResponse(
-          options.connector,
+          connector,
           await buildTokenParams(options, principal, connection),
           getTokenConnectOptions(options)
         );
@@ -460,7 +485,10 @@ function buildInteractiveDefinition(
       challenge: ConnectionAuthorizationChallengeWithDisplayName;
     }> {
       try {
-        await autoProvisionConnectorIfEnabled(options, connection);
+        const connector = await autoProvisionConnectorIfEnabled(
+          options,
+          connection
+        );
         // eve's `webhook` parameter is also the browser-redirect
         // target when `callbackUrl` is absent — the orchestrator mints
         // it via `createWebhook({ respondWith:
@@ -481,7 +509,7 @@ function buildInteractiveDefinition(
         // work without an OAuth-style redirect-URI allowlist.
         const completionWebhook = connectCompletionWebhook(webhook);
         const response = await startAuthorization(
-          options.connector,
+          connector,
           await buildTokenParams(options, principal, connection),
           {
             ...options.connectOptions,
@@ -522,9 +550,12 @@ function buildInteractiveDefinition(
       connection,
     }: CompleteAuthorizationOptions): Promise<TokenResult> {
       try {
-        await autoProvisionConnectorIfEnabled(options, connection);
+        const connector = await autoProvisionConnectorIfEnabled(
+          options,
+          connection
+        );
         const response = await getTokenResponse(
-          options.connector,
+          connector,
           await buildTokenParams(options, principal, connection),
           options.connectOptions
         );
@@ -557,9 +588,12 @@ function buildNonInteractiveDefinition(
       connection,
     }: GetTokenOptions): Promise<TokenResult> {
       try {
-        await autoProvisionConnectorIfEnabled(options, connection);
+        const connector = await autoProvisionConnectorIfEnabled(
+          options,
+          connection
+        );
         const response = await getTokenResponse(
-          options.connector,
+          connector,
           await buildTokenParams(options, principal, connection),
           getTokenConnectOptions(options)
         );
@@ -574,15 +608,20 @@ function buildNonInteractiveDefinition(
 async function autoProvisionConnectorIfEnabled(
   options: EveAuthorizationOptions,
   connection: EveConnectionAuthorizationContext
-): Promise<void> {
-  if (options.autoProvision === false) {
-    return;
+): Promise<string> {
+  if (options.autoProvision === false) return options.connector;
+  try {
+    const resolved = await provisionEveOAuthConnector({
+      connector: options.connector,
+      connection,
+      principalType: options.principalType ?? 'user',
+      provisioning: options.provisioning,
+      connectOptions: options.connectOptions,
+    });
+    return resolved?.id ?? resolved?.uid ?? options.connector;
+  } catch (error) {
+    throw translate(error, 'provisioning', options);
   }
-  await provisionEveOAuthConnector({
-    connector: options.connector,
-    connection,
-    connectOptions: options.connectOptions,
-  });
 }
 
 /**
@@ -663,6 +702,14 @@ function translate(
 ): Error {
   const override = options.onError?.(error, phase);
   if (override !== undefined) return override;
+
+  if (error instanceof ExplicitSetupRequiredError) {
+    return new ConnectionAuthorizationFailedError('connect', {
+      message: error.message,
+      reason: 'explicit_setup_required',
+      retryable: false,
+    });
+  }
 
   // `UserAuthorizationRequiredError` and `NoValidTokenError` both
   // mean "Vercel Connect has no valid credential for this principal

--- a/packages/connect/src/eve/connection-authorization.ts
+++ b/packages/connect/src/eve/connection-authorization.ts
@@ -380,11 +380,44 @@ export function connect(
 > {
   const options = normalizeAuthorizationOptions(input);
   const vercelConnect: VercelConnectMetadata = { connector: options.connector };
-  const evict = makeEvict(options);
+  const connectorResolver = makeConnectorResolver(options);
+  const evict = makeEvict(options, connectorResolver);
   if (options.principalType === 'app') {
-    return { ...buildNonInteractiveDefinition(options), vercelConnect, evict };
+    return {
+      ...buildNonInteractiveDefinition(options, connectorResolver),
+      vercelConnect,
+      evict,
+    };
   }
-  return { ...buildInteractiveDefinition(options), vercelConnect, evict };
+  return {
+    ...buildInteractiveDefinition(options, connectorResolver),
+    vercelConnect,
+    evict,
+  };
+}
+
+interface ConnectorResolver {
+  readonly current: () => string;
+  readonly resolve: (
+    connection: EveConnectionAuthorizationContext
+  ) => Promise<string>;
+}
+
+function makeConnectorResolver(
+  options: EveAuthorizationOptions
+): ConnectorResolver {
+  let current = options.connector;
+  return {
+    current: () => current,
+    resolve: async connection => {
+      const resolved = await autoProvisionConnectorIfEnabled(
+        options,
+        connection
+      );
+      current = resolved;
+      return resolved;
+    },
+  };
 }
 
 /**
@@ -398,7 +431,8 @@ export function connect(
  * local cache drop if the revoke request fails).
  */
 function makeEvict(
-  options: EveAuthorizationOptions
+  options: EveAuthorizationOptions,
+  connectorResolver: ConnectorResolver
 ): (opts: {
   readonly principal: ConnectionPrincipal;
   readonly connection?: EveConnectionAuthorizationContext;
@@ -406,17 +440,17 @@ function makeEvict(
 }) => Promise<void> {
   return async ({ principal, connection, revoke }) => {
     const params = await buildTokenParams(options, principal, connection);
-    // Eviction can be called without Eve's connection context. Use the
-    // resolved identity when context is available, otherwise retain the
-    // authored identifier as a best-effort backwards-compatible fallback.
-    let connector = options.connector;
+    // Retain the last identity used to cache a token. If re-provisioning
+    // fails transiently, falling back to the authored UID would leave the
+    // rejected token cached under the resolved connector id.
     if (connection !== undefined) {
       try {
-        connector = await autoProvisionConnectorIfEnabled(options, connection);
+        await connectorResolver.resolve(connection);
       } catch {
-        // A provisioning conflict must not prevent local cache eviction.
+        // Provisioning failures must not prevent local cache eviction.
       }
     }
+    const connector = connectorResolver.current();
     if (revoke) {
       try {
         // Destructive: tears down the grant at Vercel Connect (refresh
@@ -451,7 +485,8 @@ function normalizeAuthorizationOptions(
 }
 
 function buildInteractiveDefinition(
-  options: EveAuthorizationOptions
+  options: EveAuthorizationOptions,
+  connectorResolver: ConnectorResolver
 ): InteractiveAuthorizationDefinition {
   return {
     principalType: 'user',
@@ -461,10 +496,7 @@ function buildInteractiveDefinition(
       connection,
     }: GetTokenOptions): Promise<TokenResult> {
       try {
-        const connector = await autoProvisionConnectorIfEnabled(
-          options,
-          connection
-        );
+        const connector = await connectorResolver.resolve(connection);
         const response = await getTokenResponse(
           connector,
           await buildTokenParams(options, principal, connection),
@@ -485,10 +517,7 @@ function buildInteractiveDefinition(
       challenge: ConnectionAuthorizationChallengeWithDisplayName;
     }> {
       try {
-        const connector = await autoProvisionConnectorIfEnabled(
-          options,
-          connection
-        );
+        const connector = await connectorResolver.resolve(connection);
         // eve's `webhook` parameter is also the browser-redirect
         // target when `callbackUrl` is absent — the orchestrator mints
         // it via `createWebhook({ respondWith:
@@ -550,10 +579,7 @@ function buildInteractiveDefinition(
       connection,
     }: CompleteAuthorizationOptions): Promise<TokenResult> {
       try {
-        const connector = await autoProvisionConnectorIfEnabled(
-          options,
-          connection
-        );
+        const connector = await connectorResolver.resolve(connection);
         const response = await getTokenResponse(
           connector,
           await buildTokenParams(options, principal, connection),
@@ -579,7 +605,8 @@ function connectCompletionWebhook(webhook: string | undefined): string | null {
 }
 
 function buildNonInteractiveDefinition(
-  options: EveAuthorizationOptions
+  options: EveAuthorizationOptions,
+  connectorResolver: ConnectorResolver
 ): NonInteractiveAuthorizationDefinition {
   return {
     principalType: 'app',
@@ -588,10 +615,7 @@ function buildNonInteractiveDefinition(
       connection,
     }: GetTokenOptions): Promise<TokenResult> {
       try {
-        const connector = await autoProvisionConnectorIfEnabled(
-          options,
-          connection
-        );
+        const connector = await connectorResolver.resolve(connection);
         const response = await getTokenResponse(
           connector,
           await buildTokenParams(options, principal, connection),

--- a/packages/connect/src/eve/provision-oauth-connector.ts
+++ b/packages/connect/src/eve/provision-oauth-connector.ts
@@ -10,85 +10,155 @@ const RESERVED_UID_PATTERN = /^(vc\/|[^/]*\.vercel\.com\/)/;
 const ALLOWED_RESERVED_UID_PREFIXES = ['mcp.vercel.com/'];
 const RESERVED_ID_PREFIXES = ['scl_', 'sca_', 'store_', 'ir_'];
 const INVALID_UID_CHARS = /[\s%#]/;
+const MAX_PROVISION_CACHE_ENTRIES = 100;
 
-const provisionCache = new Map<string, Promise<void>>();
+export interface EveOAuthProvisioningIdentity {
+  /** Authoritative Connect service identifier, such as `mcp.linear.app`. */
+  readonly service?: string;
+  /** Registry name used to resolve a team connector. Defaults to `connector`. */
+  readonly canonicalName?: string;
+}
+
+export interface ResolvedEveOAuthConnector {
+  readonly id: string;
+  readonly uid: string;
+  readonly service?: string;
+  readonly type: 'oauth';
+  readonly supportedSubjectTypes?: readonly string[];
+}
+
+export class ExplicitSetupRequiredError extends Error {
+  readonly reason?: string;
+  readonly connector?: { readonly id: string; readonly uid: string };
+
+  constructor(
+    message: string,
+    options: {
+      readonly reason?: string;
+      readonly connector?: { readonly id: string; readonly uid: string };
+    } = {}
+  ) {
+    super(message);
+    this.name = 'ExplicitSetupRequiredError';
+    this.reason = options.reason;
+    this.connector = options.connector;
+  }
+}
+
+interface CacheEntry {
+  readonly promise: Promise<ResolvedEveOAuthConnector | undefined>;
+  readonly expiresAt: number;
+}
+
+const provisionCache = new Map<string, CacheEntry>();
 
 interface ProvisionEveOAuthConnectorOptions {
   readonly connector: string;
   readonly connection: EveConnectionAuthorizationContext;
+  readonly principalType: string;
+  readonly provisioning?: EveOAuthProvisioningIdentity;
   readonly connectOptions?: ConnectOptions;
 }
 
 export async function provisionEveOAuthConnector({
   connector,
   connection,
+  principalType,
+  provisioning,
   connectOptions,
-}: ProvisionEveOAuthConnectorOptions): Promise<void> {
+}: ProvisionEveOAuthConnectorOptions): Promise<
+  ResolvedEveOAuthConnector | undefined
+> {
   const serverUrl = resolveServerUrl(connection);
   if (serverUrl === undefined || !isProvisionableConnectorUid(connector)) {
-    return;
+    return undefined;
   }
 
   const vercelToken =
     connectOptions?.vercelToken ?? (await getVercelOidcToken());
+  const service = provisioning?.service ?? serviceFromServerUrl(serverUrl);
   const cacheKey = JSON.stringify({
+    mode: 'managed-oauth',
     connector,
+    canonicalName: provisioning?.canonicalName ?? connector,
+    service,
+    principalType,
     serverUrl,
     token: await tokenCacheKeyPart(vercelToken),
   });
-  let promise = provisionCache.get(cacheKey);
-  if (promise === undefined) {
-    promise = provisionManagedOAuthConnector({
-      connector,
-      serverUrl,
-      vercelToken,
-    }).catch(error => {
-      if (isNonOAuthConnectorConflict(error)) {
-        return;
-      }
-      provisionCache.delete(cacheKey);
-      throw error;
-    });
-    provisionCache.set(cacheKey, promise);
+  const now = Date.now();
+  const cached = provisionCache.get(cacheKey);
+  if (cached !== undefined && cached.expiresAt > now) {
+    // Keep hot entries at the end, making eviction LRU.
+    provisionCache.delete(cacheKey);
+    provisionCache.set(cacheKey, cached);
+    return cached.promise;
   }
+  if (cached !== undefined) provisionCache.delete(cacheKey);
 
-  await promise;
+  const promise = provisionManagedOAuthConnector({
+    connector,
+    canonicalName: provisioning?.canonicalName ?? connector,
+    service,
+    principalType,
+    serverUrl,
+    vercelToken,
+  }).catch(error => {
+    if (isNonOAuthConnectorConflict(error)) return undefined;
+    provisionCache.delete(cacheKey);
+    throw error;
+  });
+  provisionCache.set(cacheKey, { promise, expiresAt: oidcExpiry(vercelToken) });
+  while (provisionCache.size > MAX_PROVISION_CACHE_ENTRIES) {
+    const oldest = provisionCache.keys().next().value;
+    if (oldest === undefined) break;
+    provisionCache.delete(oldest);
+  }
+  return promise;
 }
 
 function resolveServerUrl(
   connection: EveConnectionAuthorizationContext
 ): string | undefined {
   const url = connection.url;
-  if (typeof url !== 'string') {
-    return undefined;
-  }
+  if (typeof url !== 'string') return undefined;
   const trimmed = url.trim();
   return trimmed === '' ? undefined : trimmed;
 }
 
-function isProvisionableConnectorUid(connector: string): boolean {
-  if (connector === '' || INVALID_UID_CHARS.test(connector)) {
-    return false;
+function serviceFromServerUrl(serverUrl: string): string | undefined {
+  try {
+    return new URL(serverUrl).host || undefined;
+  } catch {
+    return undefined;
   }
+}
 
+function isProvisionableConnectorUid(connector: string): boolean {
+  if (connector === '' || INVALID_UID_CHARS.test(connector)) return false;
   for (let index = 0; index < connector.length; index++) {
     const code = connector.charCodeAt(index);
-    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
-      return false;
-    }
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return false;
   }
-
   const normalized = connector.toLowerCase();
-  if (RESERVED_ID_PREFIXES.some(prefix => normalized.startsWith(prefix))) {
+  if (RESERVED_ID_PREFIXES.some(prefix => normalized.startsWith(prefix)))
     return false;
-  }
-  if (
+  return !(
     RESERVED_UID_PATTERN.test(normalized) &&
     !ALLOWED_RESERVED_UID_PREFIXES.some(prefix => normalized.startsWith(prefix))
-  ) {
-    return false;
+  );
+}
+
+function oidcExpiry(token: string): number {
+  try {
+    const payload = JSON.parse(
+      atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/'))
+    );
+    if (typeof payload.exp === 'number') return payload.exp * 1000;
+  } catch {
+    // Opaque development tokens are still bounded, rather than living forever.
   }
-  return true;
+  return Date.now() + 5 * 60 * 1000;
 }
 
 async function tokenCacheKeyPart(token: string): Promise<string> {
@@ -102,7 +172,6 @@ async function tokenCacheKeyPart(token: string): Promise<string> {
       byte.toString(16).padStart(2, '0')
     ).join('');
   }
-
   let hash = 2166136261;
   for (let index = 0; index < token.length; index++) {
     hash ^= token.charCodeAt(index);
@@ -115,19 +184,25 @@ function isNonOAuthConnectorConflict(error: unknown): boolean {
   return (
     error instanceof ConnectError &&
     error.status === 409 &&
-    /not an OAuth connector/i.test(error.message)
+    error.code === 'unsupported_connector_type'
   );
 }
 
 async function provisionManagedOAuthConnector({
   connector,
+  canonicalName,
+  service,
+  principalType,
   serverUrl,
   vercelToken,
 }: {
   readonly connector: string;
+  readonly canonicalName: string;
+  readonly service?: string;
+  readonly principalType: string;
   readonly serverUrl: string;
   readonly vercelToken: string;
-}): Promise<void> {
+}): Promise<ResolvedEveOAuthConnector> {
   const response = await fetch(MANAGED_OAUTH_CONNECTOR_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -135,13 +210,88 @@ async function provisionManagedOAuthConnector({
       'Content-Type': 'application/json',
       Authorization: `Bearer ${vercelToken}`,
     },
-    body: JSON.stringify({ serverUrl, uid: connector }),
+    body: JSON.stringify({
+      uid: connector,
+      canonicalName,
+      ...(service ? { service } : {}),
+      serverUrl,
+      principalType,
+    }),
   });
-
   if (!response.ok) {
-    throw await createConnectErrorFromResponse(
+    // ConnectError deliberately only exposes its documented `vendor` envelope.
+    // This endpoint's structured setup details live directly under `error`, so
+    // read a clone to avoid changing error semantics for every SDK client.
+    const details = await structuredErrorDetails(response.clone());
+    const error = await createConnectErrorFromResponse(
       response,
       'Failed to provision connector'
     );
+    if (error.code === 'explicit_setup_required') {
+      const vendor = error.vendor ?? details;
+      throw new ExplicitSetupRequiredError(
+        'Vercel Connect requires explicit connector setup. Run `eve integration connect` to select or attach a compatible connector.',
+        {
+          reason: typeof vendor.reason === 'string' ? vendor.reason : undefined,
+          connector: isConnector(vendor.connector)
+            ? vendor.connector
+            : undefined,
+        }
+      );
+    }
+    throw error;
   }
+  const payload: unknown = await response.json();
+  const value =
+    isRecord(payload) && isRecord(payload.connector)
+      ? payload.connector
+      : payload;
+  if (!isConnector(value) || value.type !== 'oauth') {
+    throw new Error('Invalid managed OAuth provisioning response.');
+  }
+  if (service !== undefined && value.service !== service) {
+    throw new Error(
+      'Managed OAuth provisioning returned a connector for a different service.'
+    );
+  }
+  if (
+    service !== undefined &&
+    (value.supportedSubjectTypes === undefined ||
+      !value.supportedSubjectTypes.includes(principalType))
+  ) {
+    throw new ExplicitSetupRequiredError(
+      'The resolved connector does not support the requested principal type.',
+      { connector: value }
+    );
+  }
+  return value;
+}
+
+async function structuredErrorDetails(
+  response: Response
+): Promise<Record<string, unknown>> {
+  try {
+    const payload: unknown = await response.json();
+    if (isRecord(payload) && isRecord(payload.error)) return payload.error;
+  } catch {
+    // createConnectErrorFromResponse supplies the normal error below.
+  }
+  return {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isConnector(value: unknown): value is ResolvedEveOAuthConnector {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.uid === 'string' &&
+    typeof value.type === 'string' &&
+    (value.service === undefined || typeof value.service === 'string') &&
+    (value.supportedSubjectTypes === undefined ||
+      (Array.isArray(value.supportedSubjectTypes) &&
+        value.supportedSubjectTypes.every(type => typeof type === 'string')))
+  );
 }

--- a/packages/connect/test/eve/connection-authorization.test.ts
+++ b/packages/connect/test/eve/connection-authorization.test.ts
@@ -66,13 +66,57 @@ describe('connect() adapter provisioning', () => {
       }),
     });
     expect(JSON.parse(provisionInit.body as string)).toEqual({
-      serverUrl: CONNECTION.url,
       uid: connector,
+      canonicalName: connector,
+      service: 'mcp.example.com',
+      serverUrl: CONNECTION.url,
+      principalType: 'user',
     });
 
     const [tokenUrl] = fetchMock.mock.calls[1];
     expect(tokenUrl).toBe(
-      'https://api.vercel.com/v1/connect/token/mcp.example.com%2Fprovisioned'
+      'https://api.vercel.com/v1/connect/token/scl_provisioned'
+    );
+  });
+
+  it('sends registry provisioning identity and uses the resolved connector id', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            outcome: 'linked',
+            connector: {
+              id: 'scl_linear',
+              uid: 'mcp.linear.app/team-linear',
+              service: 'mcp.linear.app',
+              type: 'oauth',
+              supportedSubjectTypes: ['user'],
+            },
+            attachment: {
+              projectId: 'prj_example',
+              environments: ['development'],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(jsonTokenResponse('tok_linear', 'scl_linear'));
+
+    const definition = connect({
+      connector: 'linear',
+      provisioning: { service: 'mcp.linear.app', canonicalName: 'linear' },
+    }) as InteractiveAuthorizationDefinition;
+    await definition.getToken({ principal: PRINCIPAL, connection: CONNECTION });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+      uid: 'linear',
+      canonicalName: 'linear',
+      service: 'mcp.linear.app',
+      serverUrl: CONNECTION.url,
+      principalType: 'user',
+    });
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.vercel.com/v1/connect/token/scl_linear'
     );
   });
 
@@ -176,7 +220,7 @@ describe('connect() adapter provisioning', () => {
       'https://api.vercel.com/v1/connect/connectors/managed/oauth'
     );
     expect(fetchMock.mock.calls[1][0]).toBe(
-      'https://api.vercel.com/v1/connect/authorize/mcp.example.com%2Fstart-authorization'
+      'https://api.vercel.com/v1/connect/authorize/scl_provisioned'
     );
   });
 
@@ -205,7 +249,7 @@ describe('connect() adapter provisioning', () => {
         new Response(
           JSON.stringify({
             error: {
-              code: 'conflict',
+              code: 'unsupported_connector_type',
               message:
                 'A connector with uid "linear" already exists and is not an OAuth connector.',
             },
@@ -775,9 +819,18 @@ function jsonTokenResponse(
 function jsonProvisionResponse(uid: string): Response {
   return new Response(
     JSON.stringify({
-      id: 'scl_provisioned',
-      uid,
-      type: 'oauth',
+      outcome: 'created',
+      connector: {
+        id: 'scl_provisioned',
+        uid,
+        service: 'mcp.example.com',
+        type: 'oauth',
+        supportedSubjectTypes: ['user'],
+      },
+      attachment: {
+        projectId: 'prj_example',
+        environments: ['development'],
+      },
     }),
     { status: 201, headers: { 'Content-Type': 'application/json' } }
   );

--- a/packages/connect/test/eve/connection-authorization.test.ts
+++ b/packages/connect/test/eve/connection-authorization.test.ts
@@ -349,6 +349,49 @@ describe('connect() adapter evict', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('evicts by the last resolved id when re-provisioning fails', async () => {
+    const connector = 'mcp.example.com/evict-resolved';
+    vi.mocked(getVercelOidcToken)
+      .mockResolvedValueOnce('oidc_project_a')
+      .mockResolvedValueOnce('oidc_project_a')
+      .mockResolvedValueOnce('oidc_project_b')
+      .mockResolvedValueOnce('oidc_project_a')
+      .mockResolvedValueOnce('oidc_project_a');
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonProvisionResponse(connector, 'scl_evict_resolved')
+      )
+      .mockResolvedValueOnce(jsonTokenResponse('tok_stale', connector))
+      .mockRejectedValueOnce(new Error('transient provisioning failure'))
+      .mockResolvedValueOnce(jsonTokenResponse('tok_fresh', connector));
+
+    const definition = connect({
+      connector,
+    }) as InteractiveAuthorizationDefinition & {
+      readonly evict: (opts: {
+        readonly principal: ConnectionPrincipal;
+        readonly connection?: EveConnectionAuthorizationContext;
+      }) => Promise<void>;
+    };
+
+    const first = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+    await definition.evict({ principal: PRINCIPAL, connection: CONNECTION });
+    const refetched = await definition.getToken({
+      principal: PRINCIPAL,
+      connection: CONNECTION,
+    });
+
+    expect(first.token).toBe('tok_stale');
+    expect(refetched.token).toBe('tok_fresh');
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[3][0]).toBe(
+      'https://api.vercel.com/v1/connect/token/scl_evict_resolved'
+    );
+  });
+
   it('tears the grant down at Connect when called with revoke:true', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonTokenResponse('tok_initial'))
@@ -816,12 +859,12 @@ function jsonTokenResponse(
   );
 }
 
-function jsonProvisionResponse(uid: string): Response {
+function jsonProvisionResponse(uid: string, id = 'scl_provisioned'): Response {
   return new Response(
     JSON.stringify({
       outcome: 'created',
       connector: {
-        id: 'scl_provisioned',
+        id,
         uid,
         service: 'mcp.example.com',
         type: 'oauth',


### PR DESCRIPTION
## Summary
The managed OAuth provisioning endpoint creates and links a connector when the requested UID is new, but returns `409 Conflict` when an OAuth connector with that UID already exists and is not linked to the requesting project/environment.

This breaks `@vercel/connect/eve` lazy provisioning for reusable identifiers such as `connect("linear")` and `connect("notion")`. It may work for the first project in a team to claim an identifier, but subsequent projects cannot use it.

Auto-provisioning should:
1. Create a managed OAuth connector when the requested UID does not exist.
2. Link an existing compatible OAuth connector to the deploying project and environment.
3. Behave idempotently on subsequent calls.

The existing API doesn't have all the input and output it needs to support that behavior.  It contains only `uid` and `serverUrl`. It needs to distinguish the canonical authored name from the connector's actual UID, identify the expected Connect service, and specify the required principal type.

This PR extends the provisioning request to contain the canonical name to resolve, along with the service / principal information to disqualify incompatible connectors.

```
{
  "uid": "linear",
  "canonicalName": "linear",
  "service": "mcp.linear.app",
  "serverUrl": "https://mcp.linear.app/mcp",
  "principalType": "user"
}
```
