### PR TITLE
docs(skills): clarify CLI project and output contracts

### DIFF
--- a/.changeset/clear-skill-cli-contracts.md
+++ b/.changeset/clear-skill-cli-contracts.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clarify project targeting, flags inspect output, and environment stdin examples in the CLI skill.

--- a/skills/vercel-cli/SKILL.md
+++ b/skills/vercel-cli/SKILL.md
@@ -15,9 +15,9 @@ In agent/non-interactive mode, many commands report errors and required confirma
 
 ## Critical: Project Linking
 
-Project context depends on the command's working directory. Before a consequential read or mutation, run `vercel project inspect --non-interactive` from the intended directory and confirm the reported owner and project. This command resolves only existing context in non-interactive mode; stop on `link_required` or a target mismatch instead of linking automatically.
+Project context depends on the command's working directory. When relying on a local link for a consequential read or mutation, run `vercel project inspect --non-interactive` from the intended directory and confirm the reported owner and project. This command resolves only existing context in non-interactive mode; stop on `link_required` or a target mismatch instead of linking automatically.
 
-Many project-aware commands also accept `--project <name-or-id>` with `--scope <team>` for an explicit, one-command target. Confirm that target and scope preserve the user's intent before using them.
+Many project-aware commands also accept `--project <name-or-id>` with `--scope <team>` for an explicit, one-command target without a local link. Confirm that target and scope preserve the user's intent before using them.
 
 - **`<cwd>/.vercel/project.json`**: Created by `vercel link`. This exact working-directory link wins over a repository link. The CLI does not generally inherit a root `project.json` when run from an arbitrary subdirectory.
 - **`<repo-root>/.vercel/repo.json`**: Created by `vercel link --repo`. The CLI selects the deepest project directory that contains the working directory.

--- a/skills/vercel-cli/references/environment-variables.md
+++ b/skills/vercel-cli/references/environment-variables.md
@@ -25,11 +25,13 @@ If CLI output does not include required metadata, use `vercel api` after checkin
 ```bash
 vercel env add API_KEY production                              # interactive prompt for value
 vercel env add API_KEY production --value "secret" --yes       # non-interactive
-echo "secret" | vercel env add TOKEN production --yes          # pipe value from stdin
+printf %s "$VALUE" | vercel env add TOKEN production --yes          # pipe value from stdin
 vercel env ls                                                  # list all
 vercel env update API_KEY production --value "new-secret" --yes  # non-interactive update
 vercel env rm API_KEY preview --yes                            # remove from preview
 ```
+
+Use `printf %s` for stdin values to avoid adding a newline at the source.
 
 Note: `environment` is a **positional argument**, not a flag.
 

--- a/skills/vercel-cli/references/flags.md
+++ b/skills/vercel-cli/references/flags.md
@@ -1,6 +1,6 @@
 # Feature Flags
 
-`vercel flags` manages [Vercel Flags](https://vercel.com/docs/flags/vercel-flags) for the linked project.
+`vercel flags` manages [Vercel Flags](https://vercel.com/docs/flags/vercel-flags) for an explicitly selected or linked project.
 
 `--help` is the source of truth for options and examples. Run `vercel flags --help` for the current subcommand list and `vercel flags <cmd> --help` before using a subcommand. The map below routes by task and carries no options on purpose.
 
@@ -41,8 +41,8 @@ vercel flags open [flag]          # open the dashboard
 
 ## CLI Contracts
 
-- Flags commands need a linked project. Confirm the target with `vercel project inspect --non-interactive` first (see `SKILL.md`).
-- Use `--json` where a subcommand offers it and parse only stdout.
+- Use `--project <name-or-id>` with `--scope <team>` for an explicit target without a local link. When relying on a local link, confirm its owner and project with `vercel project inspect --non-interactive` first (see `SKILL.md`).
+- `inspect` prints human-readable details to stderr and has no `--json` option. Use `--json` where another subcommand offers it and parse only stdout as JSON.
 - Commands that ask for confirmation (`archive`, `unarchive`, `rm`, `sdk-keys rm`, and others that list `--yes` in `--help`) need `--yes` in non-interactive runs.
 
 ## Flags SDK Skill


### PR DESCRIPTION
Superseded by [vercel/vercel-internal#862](https://github.com/vercel/vercel-internal/pull/862). Related to [EXP-2762](https://linear.app/vercel/issue/EXP-2762/vercel-agent-should-know-about-vercel-flags).

The CLI skill requires a local project link even though flag commands accept `--project` and `--scope`. Limit link verification to commands that use a local link, and document explicit targeting.

Also clarify that `flags inspect` prints human-readable details to stderr and has no `--json` option. Use `printf %s` in the environment stdin example to avoid adding a newline at the source; the current CLI already normalizes trailing newlines.

Validation: checked against the project resolver, inspect options/output, and environment-input implementation. Changed Markdown passes Prettier and local-reference checks; includes an empty changeset. Full CLI lint, type-check, and unit-test validation is incomplete in the sparse checkout (missing paths/dependencies and incompatible global Turbo).
