### PR TITLE
[@vercel/python-analysis] Upgrade js-yaml to 4.3.2

### DIFF
--- a/.changeset/clean-yamls-parse.md
+++ b/.changeset/clean-yamls-parse.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-analysis': patch
+---
+
+Update `js-yaml` to 4.3.2 to address CVE-2026-84375.

--- a/packages/python-analysis/package.json
+++ b/packages/python-analysis/package.json
@@ -40,7 +40,7 @@
     "@bytecodealliance/preview2-shim": "0.17.6",
     "@renovatebot/pep440": "4.2.1",
     "fs-extra": "11.1.1",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.3.2",
     "minimatch": "10.1.1",
     "smol-toml": "1.5.2",
     "zod": "3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2434,8 +2434,8 @@ importers:
         specifier: 11.1.1
         version: 11.1.1
       js-yaml:
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.3.2
+        version: 4.3.2
       minimatch:
         specifier: 10.1.1
         version: 10.1.1
@@ -10033,6 +10033,10 @@ packages:
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsesc@3.0.2:
@@ -21039,6 +21043,10 @@ snapshots:
       argparse: 2.0.1
 
   js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

- Update `@vercel/python-analysis`'s exact `js-yaml` pin from 4.1.1 to 4.3.2 and regenerate the affected lockfile entries.
- Add a patch changeset for `@vercel/python-analysis`.
- Leave unrelated js-yaml consumers unchanged.

Version 4.3.2 contains the fix for [GHSA-2883-xcg3-v3hh / CVE-2026-84375](https://github.com/advisories/GHSA-2883-xcg3-v3hh), implemented in [nodeca/js-yaml#797](https://github.com/nodeca/js-yaml/pull/797).

Closes https://github.com/vercel/vercel/issues/17598.

## Testing

- Built the Python-analysis WASM artifacts.
- `pnpm --dir packages/python-analysis build` passed.
- `pnpm --dir packages/python-analysis test-unit` passed: 498 tests across 10 files.
- `pnpm --dir packages/python-analysis type-check` passed.
- `pnpm install --lockfile-only --frozen-lockfile` passed.
- `pnpm exec prettier --check packages/python-analysis/package.json pnpm-lock.yaml .changeset/clean-yamls-parse.md` passed.
- `pnpm exec changeset status` recognized the patch release.

Validation is scoped to Python-analysis and the changed files; the full monorepo test suite was not run.
