### PR TITLE
[cli] pass invocation id to the bundled sandbox CLI

### DIFF
--- a/.changeset/sandbox-cli-invocation-id.md
+++ b/.changeset/sandbox-cli-invocation-id.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Pass the CLI invocation id to the bundled `sandbox` CLI via `VERCEL_CLI_INVOCATION_ID` so its telemetry can be joined back to the `vercel sandbox` invocation.

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -46,6 +46,7 @@ export default async function sandbox(client: Client) {
   ];
   const originalCwd = process.cwd();
   const originalAuthToken = process.env.VERCEL_AUTH_TOKEN;
+  const originalInvocationId = process.env.VERCEL_CLI_INVOCATION_ID;
 
   try {
     if (token) {
@@ -55,6 +56,11 @@ export default async function sandbox(client: Client) {
     } else if (!process.env.VERCEL_AUTH_TOKEN && client.authConfig.token) {
       process.env.VERCEL_AUTH_TOKEN = client.authConfig.token;
     }
+
+    // The sandbox CLI emits its own telemetry; passing our invocation id lets
+    // those events be joined back to this `vercel sandbox` invocation.
+    process.env.VERCEL_CLI_INVOCATION_ID =
+      client.telemetryEventStore.currentInvocationId;
 
     process.chdir(client.cwd);
 
@@ -75,6 +81,12 @@ export default async function sandbox(client: Client) {
       process.env.VERCEL_AUTH_TOKEN = originalAuthToken;
     } else {
       delete process.env.VERCEL_AUTH_TOKEN;
+    }
+
+    if (typeof originalInvocationId === 'string') {
+      process.env.VERCEL_CLI_INVOCATION_ID = originalInvocationId;
+    } else {
+      delete process.env.VERCEL_CLI_INVOCATION_ID;
     }
   }
 }

--- a/packages/cli/test/unit/commands/sandbox/index.test.ts
+++ b/packages/cli/test/unit/commands/sandbox/index.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import sandbox from '../../../../src/commands/sandbox';
+
+const run = vi.fn<(args: string[]) => Promise<void>>();
+
+vi.mock('sandbox', () => ({
+  createApp: vi.fn(() => ({ run })),
+}));
+
+describe('sandbox', () => {
+  let invocationIdSeenByChild: string | undefined;
+
+  beforeEach(() => {
+    invocationIdSeenByChild = undefined;
+    run.mockImplementation(async () => {
+      invocationIdSeenByChild = process.env.VERCEL_CLI_INVOCATION_ID;
+    });
+  });
+
+  afterEach(() => {
+    run.mockReset();
+    delete process.env.VERCEL_CLI_INVOCATION_ID;
+  });
+
+  it('passes the invocation id to the sandbox CLI and restores the env afterwards', async () => {
+    client.setArgv('sandbox', 'list');
+
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toEqual(0);
+    expect(run).toHaveBeenCalledWith(['list']);
+    expect(invocationIdSeenByChild).toEqual(
+      client.telemetryEventStore.currentInvocationId
+    );
+    expect(process.env.VERCEL_CLI_INVOCATION_ID).toBeUndefined();
+  });
+
+  it('restores a pre-existing VERCEL_CLI_INVOCATION_ID after the sandbox CLI exits', async () => {
+    process.env.VERCEL_CLI_INVOCATION_ID = 'outer-invocation';
+    client.setArgv('sandbox', 'list');
+
+    await sandbox(client);
+
+    expect(invocationIdSeenByChild).toEqual(
+      client.telemetryEventStore.currentInvocationId
+    );
+    expect(process.env.VERCEL_CLI_INVOCATION_ID).toEqual('outer-invocation');
+  });
+
+  it('restores the env when the sandbox CLI throws', async () => {
+    run.mockRejectedValueOnce(new Error('boom'));
+    client.setArgv('sandbox', 'list');
+
+    const exitCode = await sandbox(client);
+
+    expect(exitCode).toEqual(1);
+    expect(process.env.VERCEL_CLI_INVOCATION_ID).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`vercel sandbox` hands off to the bundled `sandbox` CLI in-process. vercel/sandbox#319 adds telemetry to that CLI and reads `process.env.VERCEL_CLI_INVOCATION_ID` so embedded runs can be joined back to the Vercel CLI invocation that spawned them, but nothing sets the variable yet.

This sets it from `client.telemetryEventStore.currentInvocationId` around the `createApp` call and restores the previous value afterwards, the same way `VERCEL_AUTH_TOKEN` is handled.

## Why

Today `subcommand` is null on 99.8% of `command='sandbox'` rows in the warehouse (234k over 30 days) because the Vercel CLI stops parsing at `sandbox`. The sandbox CLI's own stream fixes that, but without this id the two streams can't be joined, so the sandbox-side subcommand, `sbx_` session id and exit code can't be attached to the user, team, device and project context the Vercel CLI already emits.

Context: https://vercel.slack.com/archives/C0AT82L6NJE/p1787853783075499

## Testing

New unit test covers: the child sees the current invocation id, the env is restored when the child exits normally, when a pre-existing value was present, and when the child throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
