### PR TITLE
[deps] upgrade smol-toml to 1.8.0

### DIFF
--- a/.changeset/safe-tomls-smile.md
+++ b/.changeset/safe-tomls-smile.md
@@ -1,0 +1,11 @@
+---
+'@vercel/build-utils': patch
+'@vercel/rust': patch
+'@vercel/python-analysis': patch
+'@vercel/python': patch
+'vercel': patch
+'@vercel/frameworks': patch
+'@vercel/fs-detectors': patch
+---
+
+Upgrade `smol-toml` from 1.5.2 to 1.8.0 to address a security vulnerability and allow downstream projects to remove temporary dependency overrides.

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -57,7 +57,7 @@
     "ms": "2.1.3",
     "multistream": "2.1.1",
     "semver": "6.3.1",
-    "smol-toml": "1.5.2",
+    "smol-toml": "1.8.0",
     "vitest": "4.1.10",
     "typescript": "4.9.5",
     "yazl": "2.5.1"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,7 +78,7 @@
     "jsonc-parser": "3.3.1",
     "luxon": "^3.4.0",
     "sandbox": "4.1.0",
-    "smol-toml": "1.5.2",
+    "smol-toml": "1.8.0",
     "undici": "5.29.0",
     "uuid": "14.0.1",
     "zod": "4.1.11"

--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -19,7 +19,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "smol-toml": "1.5.2",
+    "smol-toml": "1.8.0",
     "js-yaml": "3.13.1",
     "@vercel/error-utils": "workspace:*"
   },

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -30,7 +30,7 @@
     "json5": "2.2.2",
     "minimatch": "3.1.2",
     "semver": "6.3.1",
-    "smol-toml": "1.5.2"
+    "smol-toml": "1.8.0"
   },
   "devDependencies": {
     "@types/glob": "7.2.0",

--- a/packages/python-analysis/package.json
+++ b/packages/python-analysis/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "11.1.1",
     "js-yaml": "4.1.1",
     "minimatch": "10.1.1",
-    "smol-toml": "1.5.2",
+    "smol-toml": "1.8.0",
     "zod": "3.22.4"
   },
   "devDependencies": {

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -46,7 +46,7 @@
     "minimatch": "10.1.1",
     "pip-requirements-js": "1.0.2",
     "semver": "6.3.1",
-    "smol-toml": "1.5.2",
+    "smol-toml": "1.8.0",
     "vitest": "4.1.10",
     "which": "3.0.0"
   }

--- a/packages/rust/package.json
+++ b/packages/rust/package.json
@@ -21,7 +21,7 @@
     "bin"
   ],
   "dependencies": {
-    "smol-toml": "1.5.2",
+    "smol-toml": "1.8.0",
     "execa": "5",
     "get-port": "5.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,8 +660,8 @@ importers:
         specifier: 6.3.1
         version: 6.3.1
       smol-toml:
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.8.0
+        version: 1.8.0
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -790,8 +790,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       smol-toml:
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.8.0
+        version: 1.8.0
       undici:
         specifier: 5.29.0
         version: 5.29.0
@@ -1601,8 +1601,8 @@ importers:
         specifier: 3.13.1
         version: 3.13.1
       smol-toml:
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.8.0
+        version: 1.8.0
     devDependencies:
       '@types/js-yaml':
         specifier: 3.12.1
@@ -1656,8 +1656,8 @@ importers:
         specifier: 6.3.1
         version: 6.3.1
       smol-toml:
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.8.0
+        version: 1.8.0
     devDependencies:
       '@types/glob':
         specifier: 7.2.0
@@ -2413,8 +2413,8 @@ importers:
         specifier: 6.3.1
         version: 6.3.1
       smol-toml:
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.8.0
+        version: 1.8.0
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@20.11.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@20.11.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -2440,8 +2440,8 @@ importers:
         specifier: 10.1.1
         version: 10.1.1
       smol-toml:
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.8.0
+        version: 1.8.0
       zod:
         specifier: 3.22.4
         version: 3.22.4
@@ -2663,8 +2663,8 @@ importers:
         specifier: 5.1.1
         version: 5.1.1
       smol-toml:
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.8.0
+        version: 1.8.0
     devDependencies:
       '@types/ms':
         specifier: ^0.7.31
@@ -12091,8 +12091,8 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  smol-toml@1.5.2:
-    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   socks@2.8.9:
@@ -23437,7 +23437,7 @@ snapshots:
   smart-buffer@4.2.0:
     optional: true
 
-  smol-toml@1.5.2: {}
+  smol-toml@1.8.0: {}
 
   socks@2.8.9:
     dependencies:


### PR DESCRIPTION
This PR upgrades `smol-toml` from 1.5.2 to 1.8.0 across all seven affected package manifests. The primary motivation for this PR is to address [CVE-2026-85730](https://www.cve.org/CVERecord?id=CVE-2026-85730).

- Update the pnpm lockfile and add patch changesets for the published packages.
- Address the uncontrolled-recursion denial-of-service vulnerability in crafted TOML input.
- Allow downstream projects to remove temporary dependency overrides.

A previous PR, #16652, addressed the same vulnerability but did not update every affected manifest, the lockfile, or changesets.

## Testing

- `pnpm run lint`
- `pnpm run format:check`
- `pnpm exec syncpack lint`
- `pnpm type-check`
- Frozen-lockfile validation
- Relevant unit tests for build-utils, CLI TOML handling, frameworks, fs-detectors, Python, Python analysis, and Rust