### PR TITLE
[cli] show build usage in inspect

### DIFF
--- a/.changeset/tidy-inspect-build-usage.md
+++ b/.changeset/tidy-inspect-build-usage.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Show authoritative build duration, billing usage, and machine assignment details in `vercel inspect`.

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -169,6 +169,10 @@ export type Deployment = {
   builds?: { use: string; src?: string; config?: { [key: string]: any } };
   buildErrorAt?: number;
   buildingAt: number;
+  /** Unix timestamp in milliseconds when the build container exited. */
+  buildContainerExitAt?: number;
+  /** Server-calculated billable CPU usage in CPU-core milliseconds. */
+  billedBuildCpuMs?: number;
   canceledAt?: number;
   checks?: Record<
     string,
@@ -236,7 +240,16 @@ export type Deployment = {
     | 'READY'
     | 'CANCELED';
   regions: string[];
+  resourceConfig?: {
+    buildMachine?: {
+      purchaseType?: 'basic' | 'standard' | 'enhanced' | 'turbo';
+      machineSelectionType?: 'fixed' | 'elastic';
+      cores?: number;
+    };
+  };
   routes?: RouteOrMiddleware[] | null;
+  /** Unix timestamp in milliseconds when the deployment reached its final state. */
+  readyStateAt?: number;
   source?: 'cli' | 'git' | 'import' | 'import/repo' | 'clone/repo';
   status:
     | 'BUILDING'

--- a/packages/cli/src/commands/inspect/index.ts
+++ b/packages/cli/src/commands/inspect/index.ts
@@ -472,9 +472,9 @@ function formatDuration(durationMs: number | undefined): string {
 }
 
 function formatCpuMinutes(billedBuildCpuMs: number | undefined): string {
-  return billedBuildCpuMs === undefined
-    ? 'unavailable'
-    : `${billedBuildCpuMs / 60_000} minutes`;
+  if (billedBuildCpuMs === undefined) return 'unavailable';
+  const minutes = Number((billedBuildCpuMs / 60_000).toFixed(2));
+  return `${minutes} minutes`;
 }
 
 function omitUndefined<T extends object>(value: T): Partial<T> {

--- a/packages/cli/src/commands/inspect/index.ts
+++ b/packages/cli/src/commands/inspect/index.ts
@@ -286,6 +286,32 @@ async function printDetails({
   }
   print('\n\n');
 
+  print(chalk.bold('  Build Usage\n\n'));
+  const buildUsage = getBuildUsage(deployment);
+  print(
+    `    ${chalk.cyan('build duration')}\t${formatDuration(buildUsage.buildDurationMs)}\n`
+  );
+  print(
+    `    ${chalk.cyan('post-build duration')}\t${formatDuration(buildUsage.postBuildDurationMs)}\n`
+  );
+  print(
+    `    ${chalk.cyan('billable duration')}\t${formatDuration(buildUsage.billableDurationMs)}\n`
+  );
+  print(
+    `    ${chalk.cyan('CPU Minutes Usage')}\t${formatCpuMinutes(buildUsage.billedBuildCpuMs)}\n`
+  );
+  print(
+    `    ${chalk.cyan('requested build machine')}\t${buildUsage.requestedBuildMachine ?? 'unavailable'}\n`
+  );
+  print(
+    `    ${chalk.cyan('actual assigned cores')}\t${
+      buildUsage.assignedCpuCores === undefined
+        ? 'unavailable'
+        : `${buildUsage.assignedCpuCores} vCPU (actual assignment)`
+    }\n`
+  );
+  print('\n\n');
+
   if (aliases !== undefined && aliases.length > 0) {
     print(chalk.bold('  Aliases\n\n'));
     let aliasList = '';
@@ -343,6 +369,7 @@ async function printJson({
       ? await client.fetch<{ builds: Build[] }>(`/v11/deployments/${id}/builds`)
       : { builds: [] };
 
+  const buildUsage = omitUndefined(getBuildUsage(deployment));
   const jsonOutput = {
     id,
     name,
@@ -350,6 +377,7 @@ async function printJson({
     target: customEnvironment?.slug ?? target ?? 'preview',
     readyState,
     createdAt,
+    ...(Object.keys(buildUsage).length > 0 && { buildUsage }),
     ...(aliases && aliases.length > 0 && { aliases }),
     ...(builds.length > 0 && { builds }),
     ...(Array.isArray(routes) && routes.length > 0 && { routes }),
@@ -357,6 +385,102 @@ async function printJson({
   };
 
   client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+}
+
+interface BuildUsage {
+  /** Time from the start of building until the deployment reached a final state. */
+  buildDurationMs?: number;
+  /** Time from the deployment's final state until its build container exited. */
+  postBuildDurationMs?: number;
+  /** Server-billed CPU time converted to wall-clock time using assigned cores. */
+  billableDurationMs?: number;
+  /** Server-calculated billable usage in CPU-core milliseconds. */
+  billedBuildCpuMs?: number;
+  requestedBuildMachine?: NonNullable<
+    Deployment['resourceConfig']
+  >['buildMachine'] extends infer BuildMachine
+    ? BuildMachine extends { purchaseType?: infer PurchaseType }
+      ? PurchaseType
+      : never
+    : never;
+  buildMachineSelection?: NonNullable<
+    Deployment['resourceConfig']
+  >['buildMachine'] extends infer BuildMachine
+    ? BuildMachine extends { machineSelectionType?: infer Selection }
+      ? Selection
+      : never
+    : never;
+  /** Cores actually assigned to the build, which may differ from its requested machine. */
+  assignedCpuCores?: number;
+}
+
+function getBuildUsage(deployment: Deployment): BuildUsage {
+  const buildMachine = deployment.resourceConfig?.buildMachine;
+  const billedBuildCpuMs = validNonNegativeNumber(deployment.billedBuildCpuMs);
+  const assignedCpuCores = validPositiveNumber(buildMachine?.cores);
+
+  return {
+    buildDurationMs: durationBetween(
+      deployment.buildingAt,
+      deployment.readyStateAt
+    ),
+    postBuildDurationMs: durationBetween(
+      deployment.readyStateAt,
+      deployment.buildContainerExitAt
+    ),
+    billableDurationMs:
+      billedBuildCpuMs === undefined || assignedCpuCores === undefined
+        ? undefined
+        : billedBuildCpuMs / assignedCpuCores,
+    billedBuildCpuMs,
+    requestedBuildMachine: buildMachine?.purchaseType,
+    buildMachineSelection: buildMachine?.machineSelectionType,
+    assignedCpuCores,
+  };
+}
+
+function durationBetween(
+  startedAt: number | undefined,
+  finishedAt: number | undefined
+): number | undefined {
+  if (
+    !Number.isFinite(startedAt) ||
+    !Number.isFinite(finishedAt) ||
+    finishedAt! < startedAt!
+  ) {
+    return undefined;
+  }
+  return finishedAt! - startedAt!;
+}
+
+function validNonNegativeNumber(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function validPositiveNumber(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function formatDuration(durationMs: number | undefined): string {
+  if (durationMs === undefined) return 'unavailable';
+  if (durationMs === 0) return '0ms';
+  return ms(durationMs);
+}
+
+function formatCpuMinutes(billedBuildCpuMs: number | undefined): string {
+  return billedBuildCpuMs === undefined
+    ? 'unavailable'
+    : `${billedBuildCpuMs / 60_000} minutes`;
+}
+
+function omitUndefined<T extends object>(value: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, field]) => field !== undefined)
+  ) as Partial<T>;
 }
 
 function printLogsJson(client: Client, logs: BuildLog[]): void {

--- a/packages/cli/test/unit/commands/inspect/index.test.ts
+++ b/packages/cli/test/unit/commands/inspect/index.test.ts
@@ -205,6 +205,130 @@ describe('inspect', () => {
       });
     });
 
+    describe('build usage', () => {
+      it('prints authoritative build usage and distinguishes requested machine from assigned cores', async () => {
+        const user = useUser();
+        const deployment = useDeployment({ creator: user });
+        Object.assign(deployment, {
+          buildingAt: 1_000,
+          readyStateAt: 41_000,
+          buildContainerExitAt: 46_000,
+          billedBuildCpuMs: 12 * 60_000,
+          resourceConfig: {
+            buildMachine: {
+              purchaseType: 'enhanced',
+              machineSelectionType: 'elastic',
+              cores: 12,
+            },
+          },
+        });
+
+        client.setArgv('inspect', deployment.url);
+        expect(await inspect(client)).toEqual(0);
+
+        const output = client.getFullOutput();
+        expect(output).toContain('build duration\t40s');
+        expect(output).toContain('post-build duration\t5s');
+        expect(output).toContain('billable duration\t1m');
+        expect(output).toContain('CPU Minutes Usage\t12 minutes');
+        expect(output).toContain('requested build machine\tenhanced');
+        expect(output).toContain(
+          'actual assigned cores\t12 vCPU (actual assignment)'
+        );
+      });
+
+      it('renders unavailable values instead of inferring them for a running deployment', async () => {
+        const user = useUser();
+        const deployment = useDeployment({ creator: user, state: 'BUILDING' });
+        deployment.ready = deployment.buildingAt + 30_000;
+        deployment.resourceConfig = {
+          buildMachine: { purchaseType: 'standard' },
+        };
+
+        client.setArgv('inspect', deployment.url);
+        expect(await inspect(client)).toEqual(0);
+
+        const output = client.getFullOutput();
+        expect(output).toContain('build duration\tunavailable');
+        expect(output).toContain('post-build duration\tunavailable');
+        expect(output).toContain('billable duration\tunavailable');
+        expect(output).toContain('CPU Minutes Usage\tunavailable');
+        expect(output).toContain('actual assigned cores\tunavailable');
+      });
+
+      it('omits unavailable fields from JSON and preserves millisecond units', async () => {
+        const user = useUser();
+        const deployment = useDeployment({ creator: user });
+        Object.assign(deployment, {
+          buildingAt: 1_000,
+          readyStateAt: 41_000,
+          buildContainerExitAt: 46_000,
+          billedBuildCpuMs: 720_000,
+          resourceConfig: {
+            buildMachine: {
+              purchaseType: 'enhanced',
+              machineSelectionType: 'elastic',
+              cores: 12,
+            },
+          },
+        });
+
+        client.setArgv('inspect', deployment.url, '--format=json');
+        expect(await inspect(client)).toEqual(0);
+
+        expect(JSON.parse(client.stdout.getFullOutput()).buildUsage).toEqual({
+          buildDurationMs: 40_000,
+          postBuildDurationMs: 5_000,
+          billableDurationMs: 60_000,
+          billedBuildCpuMs: 720_000,
+          requestedBuildMachine: 'enhanced',
+          buildMachineSelection: 'elastic',
+          assignedCpuCores: 12,
+        });
+      });
+
+      it('omits non-authoritative usage from JSON', async () => {
+        const user = useUser();
+        const deployment = useDeployment({ creator: user });
+        deployment.ready = deployment.buildingAt + 30_000;
+
+        client.setArgv('inspect', deployment.url, '--format=json');
+        expect(await inspect(client)).toEqual(0);
+
+        expect(JSON.parse(client.stdout.getFullOutput())).not.toHaveProperty(
+          'buildUsage'
+        );
+      });
+
+      it('refreshes final usage while waiting for deployment completion', async () => {
+        const user = useUser();
+        const deployment = useDeployment({ creator: user, state: 'BUILDING' });
+        client.setArgv('inspect', deployment.url, '--format=json', '--wait');
+
+        const runInspect = inspect(client);
+        await sleep(100);
+        Object.assign(deployment, {
+          readyState: 'READY',
+          readyStateAt: deployment.buildingAt + 40_000,
+          buildContainerExitAt: deployment.buildingAt + 45_000,
+          billedBuildCpuMs: 4 * 60_000,
+          resourceConfig: {
+            buildMachine: { purchaseType: 'standard', cores: 4 },
+          },
+        });
+
+        expect(await runInspect).toEqual(0);
+        expect(
+          JSON.parse(client.stdout.getFullOutput()).buildUsage
+        ).toMatchObject({
+          buildDurationMs: 40_000,
+          postBuildDurationMs: 5_000,
+          billedBuildCpuMs: 240_000,
+          assignedCpuCores: 4,
+        });
+      });
+    });
+
     describe('--format', async () => {
       it('tracks telemetry for --format json', async () => {
         const user = useUser();

--- a/packages/cli/test/unit/commands/inspect/index.test.ts
+++ b/packages/cli/test/unit/commands/inspect/index.test.ts
@@ -237,6 +237,18 @@ describe('inspect', () => {
         );
       });
 
+      it('formats fractional CPU minute usage concisely', async () => {
+        const user = useUser();
+        const deployment = useDeployment({ creator: user });
+        deployment.billedBuildCpuMs = 100_000;
+
+        client.setArgv('inspect', deployment.url);
+        expect(await inspect(client)).toEqual(0);
+        expect(client.getFullOutput()).toContain(
+          'CPU Minutes Usage\t1.67 minutes'
+        );
+      });
+
       it('renders unavailable values instead of inferring them for a running deployment', async () => {
         const user = useUser();
         const deployment = useDeployment({ creator: user, state: 'BUILDING' });


### PR DESCRIPTION
Show authoritative build durations, billed CPU usage, and requested versus assigned build-machine details in human-readable and JSON inspect output.

Missing values remain unavailable instead of being inferred, and `--wait` refreshes final usage after completion.

Blocked on the API contract and its generated type/package availability:
https://github.com/vercel/api/pull/91089

https://linear.app/vercel/issue/ENGINE-3875/show-build-usage-in-vercel-inspect