### PR TITLE
Add Cloud Agent development environment setup

### DIFF
--- a/.changeset/cloud-agent-environment-setup.md
+++ b/.changeset/cloud-agent-environment-setup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Cloud Agent development environment configuration (`.cursor/environment.json` and install script) that provisions a modern Rust toolchain, pins `uv`, installs dependencies, and builds all packages.

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Vercel Monorepo",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for the Vercel monorepo.
+# Idempotent: safe to re-run against cached or partially prepared state.
+set -euo pipefail
+
+# Avoid corepack's interactive "Do you want to continue?" download prompt.
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+# uv installs here; keep it on PATH for the rest of this script.
+export PATH="$HOME/.local/bin:$PATH"
+
+# pnpm is pinned via package.json "packageManager"; corepack provisions it.
+corepack enable
+
+# The Rust workspace (crates/vercel_runtime) uses edition 2024 and resolver 3,
+# which require Rust >= 1.85. Turbo runs `cargo metadata` on every build, so a
+# modern stable toolchain must be the default before any JS build runs.
+if command -v rustup >/dev/null 2>&1; then
+  rustup toolchain install stable --profile minimal
+  rustup default stable
+else
+  echo "warning: rustup not found; Rust-based tasks may fail" >&2
+fi
+
+# Turbo needs the `uv` binary to resolve the Python workspace task graph.
+# Pin to the version used in CI (.github/workflows/test.yml).
+UV_VERSION="0.10.11"
+if ! command -v uv >/dev/null 2>&1 || [ "$(uv --version 2>/dev/null | awk '{print $2}')" != "$UV_VERSION" ]; then
+  curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+fi
+
+# Install JS dependencies from the committed lockfile, then build all packages.
+pnpm install --frozen-lockfile
+pnpm build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment configuration for the Vercel monorepo so future agents boot into a fully working, buildable workspace.

Without this, a fresh Cloud Agent fails to build the monorepo because:
- Turbo runs `cargo metadata` on the Rust workspace, which uses `edition = "2024"` / `resolver = "3"` and requires Rust >= 1.85. The default image ships Rust 1.83.
- Turbo needs the `uv` binary to resolve the Python workspace task graph, and `uv` is not preinstalled.

## Changes

- `.cursor/environment.json` — points `install` at the setup script.
- `.cursor/install.sh` — idempotent bootstrap that:
  1. enables `corepack` (pnpm is pinned via `packageManager`),
  2. installs and defaults to the latest stable Rust toolchain via `rustup` (for edition 2024),
  3. installs `uv` pinned to `0.10.11` (the version used in CI),
  4. runs `pnpm install --frozen-lockfile`,
  5. runs `pnpm build`.
- `.changeset/cloud-agent-environment-setup.md` — changeset with empty frontmatter (non-package change).

## Validation

- `pnpm install` — succeeded.
- `pnpm build` — 68/68 turbo tasks successful after installing Rust stable + uv.
- Built Vercel CLI runs: `Vercel CLI 59.11.7`, `--help` renders the command list.
- `@vercel/error-utils` unit tests: 19/19 passed.
- Install script re-run for idempotence: succeeded (64/68 build tasks cached).
- Clean draft environment build triggered from this branch to validate the install script from scratch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b41dcc6-d474-4e9a-861b-e7e101e3f094?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b41dcc6-d474-4e9a-861b-e7e101e3f094&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

