### PR TITLE
fix(cli): error instead of creating a project for a nonexistent `vc link --project` name

### DIFF
--- a/.changeset/quiet-buses-yell.md
+++ b/.changeset/quiet-buses-yell.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vercel link --project <name>` silently creating a new project when the name does not match any existing project. It now errors with `Project "<name>" was not found in the current scope` instead.

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -508,7 +508,10 @@ export type ProjectLinkedError = {
     | 'TEAM_DELETED'
     | 'PATH_IS_FILE'
     | 'INVALID_ROOT_DIRECTORY'
-    | 'TOO_MANY_PROJECTS';
+    | 'TOO_MANY_PROJECTS'
+    | 'PROJECT_NOT_FOUND';
+  /** The org a `PROJECT_NOT_FOUND` lookup was attempted against, if resolved. */
+  orgId?: string;
 };
 
 export type ProjectLinkResult =

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -179,11 +179,17 @@ async function linkProject(client: Client) {
     const linkNonInteractive =
       client.nonInteractive || client.argv.includes('--non-interactive');
 
+    const projectName = parsedArgs.flags['--project'];
+
     const link = await ensureLink('link', client, cwd, {
       autoConfirm: yes,
       forceDelete: true,
       selectedOrg,
-      projectName: parsedArgs.flags['--project'],
+      projectName,
+      // An explicit `--project` name is validated against the API instead
+      // of silently creating a new project when it doesn't match anything
+      // (see `ensureLink`'s `forceDelete` + explicit-name handling).
+      failIfNotFound: !!projectName,
       successEmoji: 'success',
       nonInteractive: linkNonInteractive,
       pullEnv: false,

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -233,7 +233,15 @@ export default async function inputProject(
   gitRemoteOptions?: {
     remoteNames: string[];
     currentRemoteName?: string;
-  }
+  },
+  /**
+   * When true, `detectedProjectName` came from an explicit user-supplied
+   * name (e.g. `--project`) instead of a folder-name fallback: throw
+   * `ProjectNotFound` instead of offering to create a new project when it
+   * doesn't resolve, so a typo fails fast rather than silently creating an
+   * unwanted project.
+   */
+  failIfNotFound = false
 ): Promise<
   | Project
   | CrossTeamMatch
@@ -268,6 +276,10 @@ export default async function inputProject(
     }
 
     output.stopSpinner();
+  }
+
+  if (failIfNotFound && !detectedProject) {
+    throw new ProjectNotFound(detectedProjectName);
   }
 
   if (autoConfirm) {

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -67,7 +67,11 @@ export async function ensureLink(
       // When `forceDelete` is enabled we will always run the interactive
       // setup/link flow. Avoid an eager `getLinkedProject()` call, since it can
       // trigger additional prompts (for example when `.vercel/repo.json` exists
-      // and the repo-linked project is ambiguous).
+      // and the repo-linked project is ambiguous). An explicit `--project` name
+      // is still validated: `setupAndLink` -> `inputProject` throws
+      // `ProjectNotFound` for it once the org is resolved (see the
+      // `PROJECT_NOT_FOUND` handling below), instead of silently offering to
+      // create a new project for a typo.
       link = { status: 'not_linked', org: null, project: null };
     } else {
       // `failIfNotFound` doubles as the opt-in for API-based name/ID
@@ -91,7 +95,12 @@ export async function ensureLink(
   ) {
     // Explicit `--project` was provided but could not be resolved; bail out
     // before `setupAndLink` would offer to create a new project for a typo.
+    // Skipped for `forceDelete`: its placeholder `link` is always
+    // `not_linked` (see above), not a real signal, so that path is validated
+    // later instead, once `setupAndLink` has resolved the org (see the
+    // `PROJECT_NOT_FOUND` handling below).
     if (
+      !opts.forceDelete &&
       link.status === 'not_linked' &&
       opts.failIfNotFound &&
       opts.projectName
@@ -122,6 +131,20 @@ export async function ensureLink(
   }
 
   if (link.status === 'error') {
+    // `setupAndLink` -> `inputProject` throws `ProjectNotFound` for an
+    // explicit `--project` name once the org is resolved (the `forceDelete`
+    // path can't validate this earlier without duplicating org resolution;
+    // see the comment above). Report it the same way as the eager check
+    // above, since `setupAndLink` doesn't have `commandName` to do so itself.
+    if (link.reason === 'PROJECT_NOT_FOUND' && opts.projectName) {
+      await printProjectNotFoundError(
+        client,
+        opts.projectName,
+        commandName,
+        link.orgId
+      );
+      return 1;
+    }
     if (link.reason === 'HEADLESS') {
       if (nonInteractive) {
         outputActionRequired(

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -42,7 +42,7 @@ import {
   type PartialProjectSettings,
 } from '../input/edit-project-settings';
 import type { EmojiLabel } from '../emoji';
-import { CantParseJSONFile, isAPIError } from '../errors-ts';
+import { CantParseJSONFile, isAPIError, ProjectNotFound } from '../errors-ts';
 import output from '../../output-manager';
 import { detectProjects } from '../projects/detect-projects';
 import readConfig from '../config/read-config';
@@ -302,6 +302,7 @@ export default async function setupAndLink(
     nonInteractive = false,
     pullEnv = true,
     v0,
+    failIfNotFound = false,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResultWithGitGuidance> {
   const { config } = client;
@@ -445,9 +446,22 @@ export default async function setupAndLink(
         {
           remoteNames: gitRemoteNames,
           currentRemoteName: currentGitRemoteName,
-        }
+        },
+        Boolean(gitProjectName && failIfNotFound)
       );
     } catch (err) {
+      if (err instanceof ProjectNotFound) {
+        // Explicit `--project` name didn't resolve under the now-known org;
+        // bail instead of falling through to project creation for a typo.
+        // `ensureLink` reports this (it has `commandName`, which this
+        // function doesn't receive).
+        return {
+          status: 'error',
+          exitCode: 1,
+          reason: 'PROJECT_NOT_FOUND',
+          orgId: org.id,
+        };
+      }
       if (
         err instanceof Error &&
         (err as NodeJS.ErrnoException).code === 'HEADLESS'

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -733,6 +733,85 @@ describe('link', () => {
         },
       ]);
     });
+
+    it('should error instead of creating a project when `--project` does not match an existing project', async () => {
+      const cwd = setupTmpDir();
+      useUser({ version: 'northstar' });
+      useTeams('team_dummy');
+      let createCalled = false;
+      client.scenario.post(`/:version/projects`, (_req, _res, next) => {
+        createCalled = true;
+        next();
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('--project', 'my-proejct', '--yes');
+      const exitCode = await link(client);
+
+      expect(exitCode, 'exit code for "link"').toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Project "my-proejct" was not found in the current scope'
+      );
+      expect(createCalled).toBe(false);
+      expect(await pathExists(join(cwd, '.vercel/project.json'))).toBe(false);
+    });
+
+    it("should error instead of creating a project for a typo'd `--project` name, interactively", async () => {
+      const cwd = setupTmpDir();
+      useUser({ version: 'northstar' });
+      useTeams('team_dummy');
+      let createCalled = false;
+      client.scenario.post(`/:version/projects`, (_req, _res, next) => {
+        createCalled = true;
+        next();
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('--project', 'my-proejct');
+      const exitCode = await link(client);
+
+      expect(exitCode, 'exit code for "link"').toEqual(1);
+      expect(client.stderr.getFullOutput()).toContain(
+        'Project "my-proejct" was not found in the current scope'
+      );
+      // The interactive "Project?" create-or-link picker must never be
+      // reached for an explicit, unresolved `--project` name.
+      expect(client.stderr.getFullOutput()).not.toContain('Project?');
+      expect(createCalled).toBe(false);
+      expect(await pathExists(join(cwd, '.vercel/project.json'))).toBe(false);
+    });
+
+    it('should re-link `--project` to a different existing project without wrongly reporting not-found', async () => {
+      const cwd = setupTmpDir();
+      useUser({ version: 'northstar' });
+      const [team] = useTeams('team_dummy') as Team[];
+      const { project } = useProject({
+        ...defaultProject,
+        id: 'new-project',
+        name: 'new-project',
+      });
+      useUnknownProject();
+
+      // Directory is already linked to a different project; `--project`
+      // asks to re-link it to `new-project` instead.
+      await mkdirp(join(cwd, '.vercel'));
+      await writeJSON(join(cwd, '.vercel/project.json'), {
+        orgId: 'org_before',
+        projectId: 'proj_before',
+      });
+
+      client.cwd = cwd;
+      client.setArgv('--project', project.name!, '--yes');
+      const exitCode = await link(client);
+
+      expect(exitCode, 'exit code for "link"').toEqual(0);
+      expect(await readJSON(join(cwd, '.vercel/project.json'))).toMatchObject({
+        orgId: team.id,
+        projectId: project.id,
+      });
+    });
   });
 
   describe('--yes', () => {

--- a/packages/cli/test/unit/util/input/input-project.test.ts
+++ b/packages/cli/test/unit/util/input/input-project.test.ts
@@ -48,4 +48,75 @@ describe('inputProject', () => {
       inputProject(client, org, 'my-app', false, false)
     ).rejects.toMatchObject({ code: 'HEADLESS' });
   });
+
+  describe('failIfNotFound', () => {
+    it('throws ProjectNotFound instead of returning the name when auto-confirmed', async () => {
+      mockedGetProject.mockResolvedValue(new ProjectNotFound('my-proejct'));
+
+      await expect(
+        inputProject(
+          client,
+          org,
+          'my-proejct',
+          true, // autoConfirm
+          false,
+          false,
+          false,
+          [],
+          undefined,
+          true // failIfNotFound
+        )
+      ).rejects.toBeInstanceOf(ProjectNotFound);
+    });
+
+    it('throws ProjectNotFound instead of prompting to create/link when interactive', async () => {
+      mockedGetProject.mockResolvedValue(new ProjectNotFound('my-proejct'));
+
+      await expect(
+        inputProject(
+          client,
+          org,
+          'my-proejct',
+          false, // autoConfirm
+          false,
+          false,
+          false,
+          [],
+          undefined,
+          true // failIfNotFound
+        )
+      ).rejects.toBeInstanceOf(ProjectNotFound);
+    });
+
+    it('still returns the resolved project when the name does exist', async () => {
+      const project = {
+        id: 'prj_1',
+        name: 'my-app',
+        accountId: org.id,
+        createdAt: 0,
+        updatedAt: 0,
+      };
+      mockedGetProject.mockImplementation(async (_c, name: string) => {
+        if (name === 'my-app') {
+          return project as Awaited<ReturnType<typeof getProjectByIdOrName>>;
+        }
+        return new ProjectNotFound(name);
+      });
+
+      await expect(
+        inputProject(
+          client,
+          org,
+          'my-app',
+          true, // autoConfirm
+          false,
+          false,
+          false,
+          [],
+          undefined,
+          true // failIfNotFound
+        )
+      ).resolves.toEqual(project);
+    });
+  });
 });

--- a/packages/cli/test/unit/util/link/ensure-link.test.ts
+++ b/packages/cli/test/unit/util/link/ensure-link.test.ts
@@ -88,6 +88,72 @@ describe('ensureLink', () => {
     expect(getLinkedProject.mock.calls[0][1].skipRemoteLookup).toBe(true);
   });
 
+  it('reports PROJECT_NOT_FOUND from setupAndLink via printProjectNotFoundError (forceDelete path)', async () => {
+    vi.mocked(setupAndLink).mockResolvedValue({
+      status: 'error',
+      exitCode: 1,
+      reason: 'PROJECT_NOT_FOUND',
+      orgId: 'team_1',
+    });
+    const projectNotFoundModule = await import(
+      '../../../../src/util/projects/project-not-found-error'
+    );
+    const printSpy = vi
+      .spyOn(projectNotFoundModule, 'printProjectNotFoundError')
+      .mockResolvedValue(undefined);
+
+    const result = await ensureLink('link', client, '/cwd', {
+      forceDelete: true,
+      projectName: 'my-proejct',
+      failIfNotFound: true,
+    });
+
+    expect(getLinkedProject).not.toHaveBeenCalled();
+    expect(printSpy).toHaveBeenCalledWith(
+      client,
+      'my-proejct',
+      'link',
+      'team_1'
+    );
+    expect(result).toBe(1);
+
+    printSpy.mockRestore();
+  });
+
+  it('does not eagerly call getLinkedProject for forceDelete with an explicit --project name', async () => {
+    vi.mocked(setupAndLink).mockResolvedValue({
+      status: 'linked',
+      org: { id: 'o1', slug: 'team', type: 'team' as const },
+      project: { id: 'p1', name: 'proj' },
+    });
+
+    const result = await ensureLink('link', client, '/cwd', {
+      forceDelete: true,
+      projectName: 'proj',
+      failIfNotFound: true,
+    });
+
+    // The `not_linked` placeholder link is used as-is; existence is
+    // validated later by `setupAndLink` -> `inputProject`, once the org is
+    // resolved (see `PROJECT_NOT_FOUND` handling).
+    expect(getLinkedProject).not.toHaveBeenCalled();
+    expect(setupAndLink).toHaveBeenCalledWith(
+      client,
+      '/cwd',
+      expect.objectContaining({
+        link: { status: 'not_linked', org: null, project: null },
+        forceDelete: true,
+        projectName: 'proj',
+        failIfNotFound: true,
+      })
+    );
+    expect(result).toEqual({
+      status: 'linked',
+      org: { id: 'o1', slug: 'team', type: 'team' },
+      project: { id: 'p1', name: 'proj' },
+    });
+  });
+
   it('returns action_required payload when not linked and setupAndLink returns action_required', async () => {
     const actionRequiredPayload = {
       status: 'action_required' as const,


### PR DESCRIPTION
Fixes #17605

### Root cause

`vc link --project <name>` never validated the name against the API before
falling through to `setupAndLink`, unlike every other command that accepts an
explicit `--project`/`--project-id` (`deploy`, `pull`, `build`,
`git connect`/`disconnect`, `target ls`, `buy purchase-custom-environment-capacity`).
Those all pass `failIfNotFound: !!projectName` to `ensureLink`, which calls
`getLinkedProject` up front and bails with a "Project ... was not found"
error when the API lookup misses.

`vc link` is the one command that also passes `forceDelete: true`. In
`ensureLink`, `forceDelete` intentionally skips the eager `getLinkedProject()`
call (to avoid extra `.vercel/repo.json` disambiguation prompts) and always
sets `link = { status: 'not_linked', ... }`. Since `link.status` is therefore
*always* `not_linked` under `forceDelete`, `ensureLink`'s existing
"explicit `--project` not found" check could never distinguish a real miss
from that placeholder — so `vc link` never had the guard at all, and a
typo'd `--project` fell straight into `setupAndLink`, which offers to create
a new project when the name isn't found.

### The naive fix, and why it doesn't work

The obvious fix — call `getLinkedProject` for `forceDelete` too, whenever an
explicit project name needs validating — regresses valid names. `forceDelete`
skips `getLinkedProject` specifically because `setupAndLink`'s own org
resolution (single-team auto-select, `--scope`, `VERCEL_ORG_ID`) hasn't run
yet. `getLinkedProject` only knows `client.config.currentTeam`, so for the
common case of a single-team account with no `--scope`, it would look the
project up under the wrong (or no) team and report a false "not found" for a
perfectly valid `--project <existing-name>`.

### Fix

Instead of validating earlier (before the org is known), this defers
validation to where the org *is* already correctly resolved:
`setupAndLink` → `inputProject`, which looks up the explicit project name via
`getProjectByIdOrName(client, name, org.id)` after `org` has gone through the
normal resolution (single-team bypass, `--scope`, team picker, etc.) that
every other part of `vc link` already relies on.

- `inputProject` gains a `failIfNotFound` param: when the name doesn't
  resolve, it throws `ProjectNotFound(name)` instead of falling through to
  the auto-confirm/interactive paths that eventually return the raw string
  (which `setupAndLink` uses to create a new project).
- `setupAndLink` passes `Boolean(gitProjectName && failIfNotFound)` (true
  only for an explicit `--project`) and converts a caught `ProjectNotFound`
  into a typed `{ status: 'error', reason: 'PROJECT_NOT_FOUND', orgId }`
  result — `setupAndLink` doesn't have the `commandName` needed to print the
  final message itself.
- `ensureLink` reports `PROJECT_NOT_FOUND` via the existing
  `printProjectNotFoundError` helper (same message every other command
  already uses), and no longer runs its *eager* not-found check for
  `forceDelete` (since that placeholder link is never a real signal).
- `commands/link/index.ts` now passes `failIfNotFound: !!projectName` like
  every other command that accepts an explicit project name.

### Regression coverage

- `--project <typo>` → errors with `Project "<typo>" was not found in the
  current scope`, and does **not** create a project (both `--yes` and fully
  interactive; the interactive create/link picker is never shown for an
  unresolved explicit name).
- `--project <valid-existing-name>` → still links successfully, including
  re-linking a directory that's currently linked to a *different* project
  (the exact `forceDelete` scenario the naive fix would have broken).
- Added unit tests in `ensure-link.test.ts`, `input-project.test.ts`, and
  `commands/link/index.test.ts`; ran the full existing suites for
  `link`, `pull`, `deploy`, `build`, `git connect`/`disconnect`, and
  `target ls` (all consumers of `ensureLink`'s `failIfNotFound`) to confirm
  no regressions.

### Testing

```
pnpm run lint
pnpm run format:check
cd packages/cli && pnpm vitest run test/unit/commands/link test/unit/util/link \
  test/unit/util/projects/link.test.ts test/unit/util/input/input-project.test.ts
```
All pass. Also ran `test/unit/commands/{pull,deploy,git,target}` as a broader
regression check on `ensureLink`'s shared `failIfNotFound` path.